### PR TITLE
feat: Hybrid CDC Phase 5-6 — drop/alter integration & monitoring

### DIFF
--- a/plans/sql/PLAN_HYBRID_CDC.md
+++ b/plans/sql/PLAN_HYBRID_CDC.md
@@ -1,6 +1,6 @@
 # PLAN: Hybrid CDC — Trigger Bootstrap → Logical Replication Steady-State
 
-**Status:** In Progress (Phases 1–4 implemented)  
+**Status:** Complete (all 6 phases implemented)  
 **Date:** 2026-02-24  
 **Origin:** [REPORT_TRIGGERS_VS_REPLICATION.md](REPORT_TRIGGERS_VS_REPLICATION.md) — Recommendation 6  
 **Effort:** 3–5 weeks (6 phases, incrementally deliverable)
@@ -703,7 +703,7 @@ if config::pg_stream_cdc_mode() != "trigger" {
 
 ---
 
-### Phase 5: Drop & Alter Integration (~2 days)
+### Phase 5: Drop & Alter Integration ✅ (~2 days)
 
 **Goal:** Ensure `drop_stream_table()`, `alter_stream_table()`, and DDL event
 hooks handle WAL-based CDC correctly.
@@ -743,7 +743,7 @@ the decoder can detect this and re-read `resolve_source_column_defs()`.
 
 ---
 
-### Phase 6: Monitoring & Observability (~2 days)
+### Phase 6: Monitoring & Observability ✅ (~2 days)
 
 **Goal:** Expose CDC mode and decoder health in monitoring views.
 


### PR DESCRIPTION
## Summary

Implements **Phase 5** (Drop & Alter Integration) and **Phase 6** (Monitoring & Observability) of the [Hybrid CDC plan](plans/sql/PLAN_HYBRID_CDC.md), completing all 6 phases.

### Phase 5: Drop & Alter Integration

**`drop_stream_table()` WAL cleanup** (`api.rs`):
- `cleanup_cdc_for_source()` now accepts the source's `CdcMode`
- When a WAL/TRANSITIONING source is no longer referenced by any ST, drops the replication slot and publication before cleaning up trigger resources

**DDL event hook changes** (`hooks.rs`):
- `handle_alter_table()` now detects WAL-mode sources and falls back to triggers
- New `handle_alter_table_wal_fallback()` iterates all dependencies on the altered source, calling `abort_wal_transition()` for any in WAL or TRANSITIONING mode
- This ensures schema changes don't break the WAL decoder — the transition restarts after reinitialize

**Schema-change detection** (`wal_decoder.rs`):
- New `detect_schema_mismatch()` function checks decoded pgoutput columns against expected column definitions
- Returns true when a new column appears that wasn't in the original column set
- Integrated into `poll_wal_changes()` — triggers a `WalTransitionError` on mismatch so the caller falls back to triggers

### Phase 6: Monitoring & Observability

**Enhanced `slot_health()`** (`monitor.rs`):
- Now reports actual replication slot lag bytes for WAL-mode sources (previously always returned 0)
- Merges trigger-mode and WAL-mode sources into a single view

**New `check_cdc_health()` SQL function** (`monitor.rs`):
```sql
SELECT * FROM pgstream.check_cdc_health();
```
Returns per-source:
| Column | Description |
|--------|-------------|
| `source_relid` | Source table OID |
| `source_table` | Source table name |
| `cdc_mode` | `TRIGGER` / `WAL` / `TRANSITIONING` |
| `slot_name` | Replication slot name (NULL for trigger mode) |
| `lag_bytes` | WAL lag in bytes |
| `confirmed_lsn` | Last confirmed LSN |
| `alert` | `slot_lag_exceeds_threshold` or `replication_slot_missing` |

**NOTIFY integration**:
- `NOTIFY pg_stream_cdc_transition` emitted when a source transitions between CDC modes
- JSON payload includes: source table name, old mode, new mode, slot name
- Wired into `start_wal_transition()`, `complete_wal_transition()`, and `abort_wal_transition()`

### Tests

- 4 new unit tests for `detect_schema_mismatch()` (no mismatch, new column, empty, subset)
- All **872 unit tests pass**, zero clippy warnings

### Plan completion

This PR completes all 6 phases of the Hybrid CDC plan:
- Phase 1 ✅ Catalog schema extension (#10)
- Phase 2 ✅ WAL availability detection (#10)
- Phase 3 ✅ WAL decoder background worker (#11)
- Phase 4 ✅ Transition orchestration (#11)
- Phase 5 ✅ Drop & alter integration (this PR)
- Phase 6 ✅ Monitoring & observability (this PR)