### PR TITLE
docs: fix mdBook edit URL template path duplication

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -7,7 +7,7 @@ language    = "en"
 [output.html]
 default-theme       = "navy"
 git-repository-url  = "https://github.com/grove/pg-stream"
-edit-url-template   = "https://github.com/grove/pg-stream/edit/main/docs/{path}"
+edit-url-template   = "https://github.com/grove/pg-stream/edit/main/{path}"
 site-url            = "/pg-stream/"
 
 [output.html.search]


### PR DESCRIPTION
## Summary
Fix broken mdBook **Edit this page** links that were generating `docs/docs/...` paths.

## Problem
The docs source directory is set to `docs`, but the edit URL template also hardcoded `/docs/`.  
This produced URLs like:

`https://github.com/grove/pg-stream/edit/main/docs/docs/research/PRIOR_ART.md`

## Change
Update the mdBook `edit-url-template` to remove the extra `docs/` segment so `{path}` resolves correctly from repository root.

## Result
Edit links now resolve correctly, for example:

`https://github.com/grove/pg-stream/edit/main/docs/research/PRIOR_ART.md`

## Verification
- Ran `mdbook build`
- Spot-checked generated page edit links
- Confirmed there are no `docs/docs` occurrences in built output