### PR TITLE
fix(ci): pass dummy command to docker create for scratch images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
 
       - name: Verify extension image layout
         run: |
-          ID=$(docker create pg_stream-ext:ci)
+          ID=$(docker create pg_stream-ext:ci true)
           mkdir -p /tmp/ext-verify
           docker cp "$ID:/lib/" /tmp/ext-verify/lib/
           docker cp "$ID:/share/" /tmp/ext-verify/share/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           #   /lib/pg_stream.so
           #   /share/extension/pg_stream.control
           #   /share/extension/pg_stream--<ver>.sql
-          ID=$(docker create pg_stream-ext:test)
+          ID=$(docker create pg_stream-ext:test true)
           mkdir -p /tmp/ext-verify
           docker cp "$ID:/lib/" /tmp/ext-verify/lib/
           docker cp "$ID:/share/" /tmp/ext-verify/share/

--- a/plans/ecosystem/PLAN_CLOUDNATIVEPG.md
+++ b/plans/ecosystem/PLAN_CLOUDNATIVEPG.md
@@ -333,7 +333,7 @@ Changes:
    (extract tar, check file tree), then validate the Docker image layout:
    ```bash
    docker build -t pg_stream-ext:test -f cnpg/Dockerfile.ext dist/
-   ID=$(docker create pg_stream-ext:test)
+   ID=$(docker create pg_stream-ext:test true)
    docker cp "$ID:/lib/" /tmp/ext-lib/
    docker cp "$ID:/share/" /tmp/ext-share/
    docker rm "$ID"
@@ -583,7 +583,7 @@ docker build -t pg_stream-ext:test -f cnpg/Dockerfile.ext-build .
 docker images pg_stream-ext:test
 
 # Verify file layout
-ID=$(docker create pg_stream-ext:test)
+ID=$(docker create pg_stream-ext:test true)
 docker cp "$ID:/lib/" /tmp/ext-lib/
 docker cp "$ID:/share/" /tmp/ext-share/
 docker rm "$ID"


### PR DESCRIPTION
scratch-based images have no CMD/ENTRYPOINT, causing 'no command specified' error. The command is never executed — docker create only creates the container layer for file extraction via docker cp.

## Summary

<!-- One or two sentences describing what this PR does. -->

Fixes # <!-- issue number, if applicable -->

## Changes

<!-- Bullet list of what changed and why. -->

-

## Testing

<!-- How was this tested? Which test tiers were run? -->

- [ ] `just test-unit` passes
- [ ] `just test-integration` passes (if DB-facing code changed)
- [ ] `just test-e2e` passes (if SQL API or CDC changed)
- [ ] New tests added for the changed behaviour

## Code review checklist

- [ ] No `unwrap()` / `panic!()` in non-test code
- [ ] All `unsafe` blocks have `// SAFETY:` comments
- [ ] New SQL functions use `#[pg_extern(schema = "pgstream")]`
- [ ] `just fmt && just lint` passes with zero warnings
- [ ] Error messages include context (table name, query fragment, etc.)
- [ ] CHANGELOG.md updated under `## [Unreleased]` if user-visible

## Notes for reviewer

<!-- Anything the reviewer should pay particular attention to, open questions, or follow-up work. -->
