### PR TITLE
ci: change scheduled CI run from weekly to daily at 05:00 UTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ on:
       - '.github/workflows/ci.yml'
       - '.github/actions/**'
   schedule:
-    - cron: '0 6 * * 1'  # Weekly Monday 06:00 UTC — full matrix
+    - cron: '0 5 * * *'  # Daily 05:00 UTC — full matrix
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Change the `schedule` trigger in `ci.yml` from weekly Monday 06:00 UTC to daily 05:00 UTC for faster feedback on the full test matrix.