### PR TITLE
fix(dbt): remove adapter.cache_new/cache_added calls that break on dbt 1.6

### DIFF
--- a/dbt-pgtrickle/macros/materializations/stream_table.sql
+++ b/dbt-pgtrickle/macros/materializations/stream_table.sql
@@ -56,12 +56,6 @@
     {{ dbt_pgtrickle.pgtrickle_create_stream_table(
          qualified_name, defining_query, schedule, refresh_mode, initialize
        ) }}
-    {# cache_new was added in dbt 1.7; fall back to cache_added for 1.6.x #}
-    {% if adapter.cache_new is callable %}
-      {% do adapter.cache_new(this.incorporate(type='table')) %}
-    {% else %}
-      {% do adapter.cache_added(this.incorporate(type='table')) %}
-    {% endif %}
   {% else %}
     {# -- UPDATE: stream table exists — check if query changed -- #}
     {%- set current_info = dbt_pgtrickle.pgtrickle_get_stream_table_info(qualified_name) -%}


### PR DESCRIPTION
The `adapter.cache_new` and `adapter.cache_added` methods are internal adapter methods not exposed through dbt's `RuntimeDatabaseWrapper`. Accessing them raises `AttributeError` in dbt 1.6, causing stream_table materialization to fail with:

```
'dbt.context.providers.RuntimeDatabaseWrapper object' has no attribute 'cache_new'
```

**Fix:** Remove the cache update block entirely. The relation is already registered with dbt's cache via `return({'relations': [target_relation]})` at the end of the materialization.

Fixes compatibility with dbt-core 1.6.x.