### PR TITLE
fix(dbt): remove cache_new/cache_added calls and add main statement for dbt 1.6

### DIFF
--- a/dbt-pgtrickle/macros/materializations/stream_table.sql
+++ b/dbt-pgtrickle/macros/materializations/stream_table.sql
@@ -56,12 +56,6 @@
     {{ dbt_pgtrickle.pgtrickle_create_stream_table(
          qualified_name, defining_query, schedule, refresh_mode, initialize
        ) }}
-    {# cache_new was added in dbt 1.7; fall back to cache_added for 1.6.x #}
-    {% if adapter.cache_new is callable %}
-      {% do adapter.cache_new(this.incorporate(type='table')) %}
-    {% else %}
-      {% do adapter.cache_added(this.incorporate(type='table')) %}
-    {% endif %}
   {% else %}
     {# -- UPDATE: stream table exists — check if query changed -- #}
     {%- set current_info = dbt_pgtrickle.pgtrickle_get_stream_table_info(qualified_name) -%}
@@ -82,6 +76,13 @@
          ) }}
     {% endif %}
   {% endif %}
+
+  {# dbt 1.6 requires the 'main' statement to be executed at least once.
+     Our DDL runs via run_query() (separate connection), so we satisfy the
+     framework with a lightweight no-op on the main connection. #}
+  {% call statement('main') %}
+    SELECT 1
+  {% endcall %}
 
   {{ run_hooks(post_hooks) }}
 


### PR DESCRIPTION
Fixes two dbt 1.6 compatibility issues in the stream_table materialization:

1. **Remove `adapter.cache_new`/`cache_added` calls** — these internal adapter methods are not exposed through dbt's `RuntimeDatabaseWrapper`, causing `AttributeError`:
   ```
   'dbt.context.providers.RuntimeDatabaseWrapper object' has no attribute 'cache_new'
   ```
   The relation is already registered via `return({'relations': [target_relation]})`.

2. **Add `call statement('main')` with a no-op `SELECT 1`** — dbt 1.6 requires the main connection to execute at least one statement. Our DDL runs via `run_query()` on a separate connection, leaving the main connection idle, which triggers:
   ```
   main is not being called during running model
   ```

Both fixes are backward-compatible with dbt 1.9, 1.10, and 1.11.