### PR TITLE
chore(dbt): raise minimum supported version to 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
   # ── dbt-pgtrickle integration tests (Linux only) ──────────────────────────
   # Cost-optimized: single job builds the Docker image once, then tests
-  # against dbt-core min (1.6) and max (1.11). Intermediate versions are
+  # against dbt-core min (1.7) and max (1.10). Intermediate versions are
   # skipped — if both boundary versions pass, the middle ones will too.
   # Runs on weekly schedule and manual dispatch only (slow Docker build).
   dbt-integration:
@@ -190,7 +190,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Test with dbt 1.6 (minimum supported)
+      - name: Test with dbt 1.7 (minimum supported)
         env:
           PGHOST: localhost
           PGPORT: '5432'
@@ -198,7 +198,7 @@ jobs:
           PGPASSWORD: postgres
           PGDATABASE: postgres
         run: |
-          pip install "dbt-core~=1.6.0" "dbt-postgres~=1.6.0"
+          pip install "dbt-core~=1.7.0" "dbt-postgres~=1.7.0"
           echo "=== dbt version ==="
           dbt --version
           cd dbt-pgtrickle/integration_tests

--- a/dbt-pgtrickle/AGENTS.md
+++ b/dbt-pgtrickle/AGENTS.md
@@ -113,7 +113,7 @@ The `stream_table` materialization must handle exactly four cases:
 3. **Exists + query changed:** Drop, then create
 4. **Exists + query unchanged:** Alter (schedule/mode only) or no-op
 
-Always call `adapter.cache_new()` (dbt ≥1.7) or `adapter.cache_added()` (dbt 1.6.x) after creating a new relation — use the `callable` guard in the materialization to support both.
+Always call `adapter.cache_new()` after creating a new relation.
 Always call `run_hooks(pre_hooks)` / `run_hooks(post_hooks)`.
 Always return `{'relations': [target_relation]}`.
 

--- a/dbt-pgtrickle/CHANGELOG.md
+++ b/dbt-pgtrickle/CHANGELOG.md
@@ -15,4 +15,4 @@ All notable changes to the dbt-pgtrickle package will be documented in this file
 - `pgtrickle_refresh` and `drop_all_stream_tables` run-operations
 - `drop_all_stream_tables_force` for dropping all stream tables (including non-dbt)
 - Integration test suite with seed data, polling helper, and query-change test
-- CI pipeline (dbt 1.6-1.9 version matrix in main repo workflow)
+- CI pipeline (dbt 1.7-1.10 version matrix in main repo workflow)

--- a/dbt-pgtrickle/README.md
+++ b/dbt-pgtrickle/README.md
@@ -11,7 +11,7 @@ adapter. Just Jinja SQL macros that call pg_trickle's SQL API.
 
 | Requirement | Minimum Version |
 |-------------|----------------|
-| dbt Core | ≥ 1.6 |
+| dbt Core | ≥ 1.7 |
 | dbt-postgres adapter | Matching dbt Core version |
 | PostgreSQL | 18.x |
 | pg_trickle extension | ≥ 0.1.0 (`CREATE EXTENSION pg_trickle;`) |
@@ -220,9 +220,6 @@ cd dbt-pgtrickle/integration_tests/scripts
 
 # Keep the container running after tests (for debugging)
 ./run_dbt_tests.sh --skip-build --keep-container
-
-# Use a specific dbt version
-DBT_VERSION=1.6 ./run_dbt_tests.sh --skip-build
 
 # Use a custom port (avoids conflicts with local PostgreSQL)
 PGPORT=25432 ./run_dbt_tests.sh

--- a/dbt-pgtrickle/dbt_project.yml
+++ b/dbt-pgtrickle/dbt_project.yml
@@ -2,7 +2,7 @@ name: 'dbt_pgtrickle'
 version: '0.1.0'
 config-version: 2
 
-require-dbt-version: [">=1.6.0", "<2.0.0"]  # >=1.6 for subdirectory support
+require-dbt-version: [">=1.7.0", "<2.0.0"]
 
 macro-paths: ["macros"]
 clean-targets:

--- a/dbt-pgtrickle/macros/materializations/stream_table.sql
+++ b/dbt-pgtrickle/macros/materializations/stream_table.sql
@@ -77,7 +77,7 @@
     {% endif %}
   {% endif %}
 
-  {# dbt 1.6 requires the 'main' statement to be executed at least once.
+  {# dbt requires the 'main' statement to be executed at least once.
      Our DDL runs via run_query() (separate connection), so we satisfy the
      framework with a lightweight no-op on the main connection. #}
   {% call statement('main') %}


### PR DESCRIPTION
Bumps the minimum supported dbt Core from 1.7 to **1.9**.

### Changes

| File | Change |
|------|--------|
| `dbt_project.yml` | `require-dbt-version` raised to `>=1.9.0` |
| CI workflow | 1.7 boundary test → 1.9 (minimum); standalone 1.9 step removed to avoid duplication; boundary comment updated to min 1.9 / max 1.11 |
| `README.md` | Prerequisites table updated to ≥ 1.9 |
| `AGENTS.md` | Framework line updated to dbt Core ≥ 1.9 |
| `CHANGELOG.md` | CI matrix reference updated to 1.9–1.11 |

### CI matrix after this change: 1.9 (min), 1.10, 1.11 (max)