### PR TITLE
chore(dbt): raise minimum supported version to 1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
 
   # ── dbt-pgtrickle integration tests (Linux only) ──────────────────────────
   # Cost-optimized: single job builds the Docker image once, then tests
-  # against dbt-core min (1.7) and max (1.10). Intermediate versions are
+  # against dbt-core min (1.9) and max (1.11). Intermediate versions are
   # skipped — if both boundary versions pass, the middle ones will too.
   # Runs on weekly schedule and manual dispatch only (slow Docker build).
   dbt-integration:
@@ -190,31 +190,7 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Test with dbt 1.7 (minimum supported)
-        env:
-          PGHOST: localhost
-          PGPORT: '5432'
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGDATABASE: postgres
-        run: |
-          pip install "dbt-core~=1.7.0" "dbt-postgres~=1.7.0"
-          echo "=== dbt version ==="
-          dbt --version
-          cd dbt-pgtrickle/integration_tests
-          dbt deps
-          dbt seed
-          dbt run
-          ./scripts/wait_for_populated.sh order_totals 30
-          dbt test
-          dbt run --full-refresh
-          ./scripts/wait_for_populated.sh order_totals 30
-          dbt test
-          dbt run-operation pgtrickle_refresh --args '{model_name: order_totals}'
-          dbt run-operation pgtrickle_check_freshness
-          dbt run-operation drop_all_stream_tables
-
-      - name: Test with dbt 1.9
+      - name: Test with dbt 1.9 (minimum supported)
         env:
           PGHOST: localhost
           PGPORT: '5432'

--- a/dbt-pgtrickle/AGENTS.md
+++ b/dbt-pgtrickle/AGENTS.md
@@ -7,7 +7,7 @@ dbt package providing a `stream_table` custom materialization for the
 SQL macros — no Python adapter code. Works with stock `dbt-postgres`.
 
 - **Language:** Jinja2 SQL (dbt macros)
-- **Framework:** dbt Core ≥ 1.7, dbt-postgres adapter
+- **Framework:** dbt Core ≥ 1.9, dbt-postgres adapter
 - **Target database:** PostgreSQL 18 with pg_trickle extension
 - **Package name:** `dbt_pg_trickle`
 - **License:** Apache 2.0

--- a/dbt-pgtrickle/CHANGELOG.md
+++ b/dbt-pgtrickle/CHANGELOG.md
@@ -15,4 +15,4 @@ All notable changes to the dbt-pgtrickle package will be documented in this file
 - `pgtrickle_refresh` and `drop_all_stream_tables` run-operations
 - `drop_all_stream_tables_force` for dropping all stream tables (including non-dbt)
 - Integration test suite with seed data, polling helper, and query-change test
-- CI pipeline (dbt 1.7-1.10 version matrix in main repo workflow)
+- CI pipeline (dbt 1.9–1.11 version matrix in main repo workflow)

--- a/dbt-pgtrickle/README.md
+++ b/dbt-pgtrickle/README.md
@@ -11,7 +11,7 @@ adapter. Just Jinja SQL macros that call pg_trickle's SQL API.
 
 | Requirement | Minimum Version |
 |-------------|----------------|
-| dbt Core | ≥ 1.7 |
+| dbt Core | ≥ 1.9 |
 | dbt-postgres adapter | Matching dbt Core version |
 | PostgreSQL | 18.x |
 | pg_trickle extension | ≥ 0.1.0 (`CREATE EXTENSION pg_trickle;`) |

--- a/dbt-pgtrickle/dbt_project.yml
+++ b/dbt-pgtrickle/dbt_project.yml
@@ -2,7 +2,7 @@ name: 'dbt_pgtrickle'
 version: '0.1.0'
 config-version: 2
 
-require-dbt-version: [">=1.7.0", "<2.0.0"]
+require-dbt-version: [">=1.9.0", "<2.0.0"]
 
 macro-paths: ["macros"]
 clean-targets:


### PR DESCRIPTION
Bumps the minimum supported dbt Core from 1.7 to **1.9**.

### Changes

| File | Change |
|------|--------|
| `dbt_project.yml` | `require-dbt-version` raised to `>=1.9.0` |
| CI workflow | 1.7 boundary test → 1.9 (minimum); standalone 1.9 step removed to avoid duplication; boundary comment updated to min 1.9 / max 1.11 |
| `README.md` | Prerequisites table updated to ≥ 1.9 |
| `AGENTS.md` | Framework line updated to dbt Core ≥ 1.9 |
| `CHANGELOG.md` | CI matrix reference updated to 1.9–1.11 |

### CI matrix after this change: 1.9 (min), 1.10, 1.11 (max)