### PR TITLE
fix(ci): remove dbt 1.11 test step — dbt-postgres 1.11 does not exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,9 @@ jobs:
 
   # ── dbt-pgtrickle integration tests (Linux only) ──────────────────────────
   # Cost-optimized: single job builds the Docker image once, then tests
-  # against dbt-core min (1.9) and max (1.11). Intermediate versions are
+  # against dbt-core min (1.9) and max (1.10). Intermediate versions are
   # skipped — if both boundary versions pass, the middle ones will too.
+  # dbt-postgres 1.11 does not exist; 1.10 is the latest paired release.
   # Runs on weekly schedule and manual dispatch only (slow Docker build).
   dbt-integration:
     name: dbt integration
@@ -214,7 +215,7 @@ jobs:
           dbt run-operation pgtrickle_check_freshness
           dbt run-operation drop_all_stream_tables
 
-      - name: Test with dbt 1.10
+      - name: Test with dbt 1.10 (latest supported)
         env:
           PGHOST: localhost
           PGPORT: '5432'
@@ -223,30 +224,6 @@ jobs:
           PGDATABASE: postgres
         run: |
           pip install "dbt-core~=1.10.0" "dbt-postgres~=1.10.0"
-          echo "=== dbt version ==="
-          dbt --version
-          cd dbt-pgtrickle/integration_tests
-          dbt deps
-          dbt seed
-          dbt run
-          ./scripts/wait_for_populated.sh order_totals 30
-          dbt test
-          dbt run --full-refresh
-          ./scripts/wait_for_populated.sh order_totals 30
-          dbt test
-          dbt run-operation pgtrickle_refresh --args '{model_name: order_totals}'
-          dbt run-operation pgtrickle_check_freshness
-          dbt run-operation drop_all_stream_tables
-
-      - name: Test with dbt 1.11 (latest supported)
-        env:
-          PGHOST: localhost
-          PGPORT: '5432'
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PGDATABASE: postgres
-        run: |
-          pip install "dbt-core~=1.11.0" "dbt-postgres~=1.11.0"
           echo "=== dbt version ==="
           dbt --version
           cd dbt-pgtrickle/integration_tests


### PR DESCRIPTION
## Problem

The CI `dbt-integration` job was failing on the "Test with dbt 1.11" step:

```
ERROR: No matching distribution found for dbt-postgres~=1.11.0
```

`dbt-postgres` tops out at **1.10.0**. Starting with dbt-core 1.11+, dbt Labs bundles the postgres adapter internally and no longer publishes a separate `dbt-postgres` package for that version series.

## Fix

- Remove the "Test with dbt 1.11" step from `.github/workflows/ci.yml`
- Rename "Test with dbt 1.10" → "Test with dbt 1.10 (latest supported)"
- Update the job comment to reflect min=1.9 / max=1.10 and explain why 1.11 doesn't exist
- Update default `DBT_VERSION` in `run_dbt_tests.sh` from `1.9` → `1.10`
- Update version references in `dbt-pgtrickle/AGENTS.md`