### PR TITLE
docs: update documentation for Transactional IVM completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,15 @@ pg_trickle brings declarative, automatically-refreshing materialized views to Po
 ## Key Features
 
 - **Declarative** — define a query and a schedule bound (or cron expression); the extension schedules and executes refreshes automatically.
+- **Three refresh modes** — `DIFFERENTIAL` (incremental delta), `FULL` (complete recomputation), and `IMMEDIATE` (synchronous in-transaction maintenance via statement-level triggers with transition tables).
 - **Differential View Maintenance (DVM)** — only processes changed rows, not the entire base table. Delta queries are derived automatically from the defining query's operator tree.
+- **Transactional IVM (IMMEDIATE mode)** — stream tables can be maintained **within the same transaction** as the base table DML, providing read-your-writes consistency. Supports window functions, LATERAL joins, scalar subqueries, cascading IMMEDIATE stream tables, and all DVM operators except recursive CTEs.
 - **CTE Support** — full support for Common Table Expressions. Non-recursive CTEs are inlined and differentiated algebraically. Multi-reference CTEs share delta computation. Recursive CTEs (`WITH RECURSIVE`) work in both FULL and DIFFERENTIAL modes.
+- **TopK support** — `ORDER BY ... LIMIT N` queries are accepted and refreshed correctly via scoped recomputation.
 - **Trigger-based CDC** — lightweight `AFTER` row-level triggers capture changes into buffer tables. No logical replication slots or `wal_level = logical` required. Triggers are created and dropped automatically.
 - **Hybrid CDC (optional)** — when `wal_level = logical` is available, the system can automatically transition from triggers to WAL-based (logical replication) capture for lower write-side overhead. Controlled by the `pg_trickle.cdc_mode` GUC (`trigger` / `auto` / `wal`).
 - **DAG-aware scheduling** — stream tables that depend on other stream tables are refreshed in topological order. `CALCULATED` schedule propagation is supported.
+- **Diamond dependency consistency** — diamond-shaped DAGs (A→B→D, A→C→D) can be refreshed atomically to prevent split-version reads.
 - **Crash-safe** — advisory locks prevent concurrent refreshes; crash recovery marks in-flight refreshes as failed and resumes normal operation.
 - **Observable** — built-in monitoring views (`pgtrickle.pg_stat_stream_tables`), refresh history, slot health checks, staleness reporting, and `NOTIFY`-based alerting.
 
@@ -91,8 +95,9 @@ Every operator listed here works in `DIFFERENTIAL` mode (incremental delta compu
 | **Source tables** | Tables without primary key | ✅ Full | Content-hash row identity via all columns |
 | **Source tables** | Views as sources | ✅ Full | Auto-inlined as subqueries; CDC triggers land on base tables |
 | **Source tables** | Materialized views | ❌ DIFF / ✅ FULL | Rejected in DIFFERENTIAL (stale snapshot); allowed in FULL |
-| **Ordering** | `ORDER BY` | ⚠️ Ignored | Accepted but silently discarded; storage row order is undefined |
-| **Ordering** | `LIMIT` / `OFFSET` | ❌ Rejected | Not supported — stream tables materialize the full result set |
+| **TopK** | `ORDER BY ... LIMIT N` | ✅ Full | TopK stream tables store only the top-N rows; scoped recomputation via MERGE |
+| **Ordering** | `ORDER BY` (without LIMIT) | ⚠️ Ignored | Accepted but silently discarded; storage row order is undefined |
+| **Ordering** | `LIMIT` / `OFFSET` (without ORDER BY) | ❌ Rejected | Not supported — stream tables materialize the full result set |
 
 See [docs/DVM_OPERATORS.md](docs/DVM_OPERATORS.md) for the full differentiation rules and CTE tiers.
 
@@ -166,7 +171,7 @@ INSERT INTO orders VALUES
     (1, 'US', 100), (2, 'EU', 200),
     (3, 'US', 300), (4, 'APAC', 50);
 
--- Create a stream table with 1-minute schedule
+-- Create a stream table with 1-minute schedule (DIFFERENTIAL mode)
 SELECT pgtrickle.create_stream_table(
     'regional_totals',
     'SELECT region, SUM(amount) AS total, COUNT(*) AS cnt
@@ -175,7 +180,16 @@ SELECT pgtrickle.create_stream_table(
     'DIFFERENTIAL'
 );
 
--- Or use a cron schedule (e.g., every hour)
+-- Or use IMMEDIATE mode: updated within the same transaction as DML
+SELECT pgtrickle.create_stream_table(
+    'regional_totals_live',
+    'SELECT region, SUM(amount) AS total, COUNT(*) AS cnt
+     FROM orders GROUP BY region',
+    NULL,          -- no schedule needed
+    'IMMEDIATE'
+);
+
+-- Or use a cron schedule with FULL refresh
 SELECT pgtrickle.create_stream_table(
     'hourly_totals',
     'SELECT region, SUM(amount) AS total FROM orders GROUP BY region',
@@ -236,8 +250,9 @@ The following SQL features are **rejected with clear error messages** explaining
 | Materialized views in DIFFERENTIAL | CDC triggers cannot track `REFRESH MATERIALIZED VIEW` | Use the underlying query directly, or use FULL mode |
 | `TABLESAMPLE` | Stream tables materialize the complete result set; sampling at define-time is not meaningful | Use `WHERE random() < fraction` in the consuming query |
 | Window functions in expressions | Window functions inside `CASE`, `COALESCE`, arithmetic, etc. cannot be differentially maintained | Move window function to a separate column |
-| `LIMIT` / `OFFSET` | Stream tables materialize the full result set | Apply when querying the stream table |
+| `LIMIT` / `OFFSET` without `ORDER BY` | Stream tables materialize the full result set; arbitrary row subsets are non-deterministic | Use `ORDER BY ... LIMIT N` for TopK, or apply LIMIT when querying the stream table |
 | `FOR UPDATE` / `FOR SHARE` | Row-level locking not applicable | Remove the locking clause |
+| Recursive CTEs in IMMEDIATE mode | Semi-naive fixpoint iteration not validated with transition tables | Use DIFFERENTIAL mode for recursive CTEs |
 
 ### Stream Table Restrictions
 
@@ -257,6 +272,8 @@ See [SQL Reference — Restrictions & Interoperability](docs/SQL_REFERENCE.md#re
 
 ## How It Works
 
+### DIFFERENTIAL / FULL Mode (scheduled)
+
 1. **Create** — `pgtrickle.create_stream_table()` parses the defining query into an operator tree, creates a storage table, installs lightweight CDC triggers on source tables, and registers the ST in the catalog.
 
 2. **Capture** — Changes to base tables are captured via the hybrid CDC layer. By default, `AFTER INSERT/UPDATE/DELETE` row-level triggers write to per-source change buffer tables in the `pgtrickle_changes` schema. With `pg_trickle.cdc_mode = 'auto'`, the system transitions to WAL-based capture (logical replication) after the first successful refresh for lower write-side overhead.
@@ -268,6 +285,17 @@ See [SQL Reference — Restrictions & Interoperability](docs/SQL_REFERENCE.md#re
 5. **Apply** — The delta query is executed and its results (INSERT/DELETE actions with row IDs) are merged into the storage table.
 
 6. **Version** — Each refresh records a frontier (per-source LSN positions) and a data timestamp, implementing a simplified Data Versioning System (DVS).
+
+### IMMEDIATE Mode (transactional)
+
+When `refresh_mode = 'IMMEDIATE'`, the stream table is maintained **within the same transaction** as the base table DML:
+
+1. **BEFORE triggers** acquire an advisory lock on the stream table.
+2. **AFTER triggers** (with `REFERENCING NEW TABLE AS ... OLD TABLE AS ...`) copy transition tables to temp tables.
+3. The DVM engine computes the delta from the transition tables (via `DeltaSource::TransitionTable`).
+4. The delta is applied to the stream table via DELETE + INSERT ON CONFLICT.
+
+No change buffer tables, no scheduler, no WAL infrastructure. The stream table is always up-to-date within the current transaction.
 
 ## Architecture
 
@@ -300,7 +328,7 @@ See [SQL Reference — Restrictions & Interoperability](docs/SQL_REFERENCE.md#re
 │       │                                     │
 │  ┌────▼─────────────────────────────┐       │
 │  │     Refresh Executor             │       │
-│  │     Full / Differential          │       │
+│  │  Full / Differential / Immediate │       │
 │  └────┬─────────────────────────────┘       │
 │       │                                     │
 │  ┌────▼─────────────────────────────┐       │
@@ -329,7 +357,7 @@ cargo test
 cargo bench
 ```
 
-**Test counts:** ~963 unit tests + 32 integration tests + 34 E2E test suites (~460 E2E tests).
+**Test counts:** ~992 unit tests + 32 integration tests + 40+ E2E test suites (~510 E2E tests).
 
 ### Code Coverage
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # pg_trickle — Project Roadmap
 
-> **Last updated:** 2026-03-02
+> **Last updated:** 2026-03-03
 > **Current version:** 0.1.3
 
 For a concise description of what pg_trickle is and why it exists, read
@@ -19,13 +19,13 @@ phases are complete. This roadmap tracks the path from the v0.1.x series to
 1.0 and beyond.
 
 ```
-                                      We are here
-                                           │
-                                           ▼
+                                                    We are here
+                                                         │
+                                                         ▼
  ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐
  │  0.1.x   │   │  0.2.0   │   │  0.3.0   │──▶│  0.4.0   │──▶│  1.0.0   │──▶│  1.x+    │
- │ Released │   │ Active   │   │ Prod-    │   │ Observ-  │   │ Stable   │   │ Scale &  │
- │ ✅       │   │ 🔜       │   │ ready    │   │ ability  │   │ Release  │   │ Ecosystem│
+ │ Released │   │ Complete │   │ Prod-    │   │ Observ-  │   │ Stable   │   │ Scale &  │
+ │ ✅       │   │ ✅       │   │ ready    │   │ ability  │   │ Release  │   │ Ecosystem│
  └──────────┘   └──────────┘   └──────────┘   └──────────┘   └──────────┘   └──────────┘
 ```
 
@@ -72,7 +72,7 @@ See [CHANGELOG.md](CHANGELOG.md) for the full feature list.
 
 ## v0.2.0 — TopK, Diamond Consistency & Transactional IVM
 
-**Status: TopK and Diamond Dependency Consistency implemented; Transactional IVM Phase 1 in progress.**
+**Status: All features implemented. Ready for release.**
 
 The 51-item SQL_GAPS_7 correctness plan was completed in v0.1.x. v0.2.0 delivers
 three major feature additions. The one remaining SQL_GAPS_7 item (F40 — extension
@@ -137,41 +137,44 @@ Atomic refresh groups eliminate the inconsistency window in diamond DAGs
 
 See [PLAN_DIAMOND_DEPENDENCY_CONSISTENCY.md](plans/sql/PLAN_DIAMOND_DEPENDENCY_CONSISTENCY.md).
 
-### Transactional IVM — Phase 1 (Immediate Mode MVP)
+### Transactional IVM — IMMEDIATE Mode ✅
 
-Add an `IMMEDIATE` refresh mode that updates stream tables **within the same
+New `IMMEDIATE` refresh mode that updates stream tables **within the same
 transaction** as base table DML, using statement-level AFTER triggers with
-transition tables. This makes pg_trickle a **drop-in replacement for pg_ivm**
-and provides read-your-writes consistency. Only Phase 1 (core engine + single-
-and multi-table immediate IVM) is in scope; the pg_ivm compatibility layer
-(Phase 2), extended SQL support (Phase 3), and performance optimizations
-(Phase 4) are deferred to post-1.0.
+transition tables. Phase 1 (core engine) and Phase 3 (extended SQL support)
+are complete. Phase 2 (pg_ivm compatibility layer) is postponed. Phase 4
+(performance optimizations) has partial completion (delta SQL template caching).
 
-The DVM engine is ~90% reusable — only the `Scan` operator needs a dual-path
-for reading from transition-table ENRs instead of change buffer tables. All
-other operators (Join, Aggregate, Filter, TopK, etc.) are source-agnostic.
+| Item | Description | Status |
+|------|-------------|--------|
+| TI1 | `RefreshMode::Immediate` enum, catalog CHECK, API validation | ✅ Done |
+| TI2 | Statement-level IVM trigger functions with transition tables | ✅ Done |
+| TI3 | `DeltaSource::TransitionTable` — Scan operator dual-path | ✅ Done |
+| TI4 | Delta application (DELETE + INSERT ON CONFLICT) | ✅ Done |
+| TI5 | Advisory lock-based concurrency (`IvmLockMode`) | ✅ Done |
+| TI6 | TRUNCATE handling (full refresh of stream table) | ✅ Done |
+| TI7 | `alter_stream_table` mode switching (DIFFERENTIAL↔IMMEDIATE, FULL↔IMMEDIATE) | ✅ Done |
+| TI8 | Query restriction validation (`validate_immediate_mode_support`) | ✅ Done |
+| TI9 | Delta SQL template caching (thread-local `IVM_DELTA_CACHE`) | ✅ Done |
+| TI10 | Window functions, LATERAL, scalar subqueries in IMMEDIATE mode | ✅ Done |
+| TI11 | Cascading IMMEDIATE stream tables (ST_A → ST_B) | ✅ Done |
+| TI12 | 29 E2E tests + 8 unit tests | ✅ Done |
+| TI13 | Documentation (SQL Reference, Architecture, FAQ, CHANGELOG) | ✅ Done |
 
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| TI1 | Add `IMMEDIATE` to `RefreshMode` enum, catalog CHECK constraint, API validation | 4h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) §3.1, §3.6–3.8 |
-| TI2 | Statement-level IVM trigger functions (`pgt_ivm_before` / `pgt_ivm_after`) with transition table access | 12h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) §3.2, §6.1 |
-| TI3 | In-memory trigger state management (before/after counting, tuplestore collection, `RegisterXactCallback` cleanup) | 4h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) §6.2 |
-| TI4 | ENR registration for transition tables in SPI context | 6h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) §6.3 |
-| TI5 | `Scan` operator dual-path: `DeltaSource::TransitionTable` vs `DeltaSource::ChangeBuffer` | 4h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) §3.3 |
-| TI6 | Concurrency: ExclusiveLock on stream table during IMMEDIATE maintenance + TRUNCATE handling | 2–4h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) §3.5, §5 Phase 1.5–1.6 |
-| TI7 | E2E tests: INSERT/UPDATE/DELETE immediate consistency, concurrent transactions, isolation levels | 8–12h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) §10 |
-| TI8 | Documentation (SQL Reference, Architecture, FAQ, CHANGELOG) | 2–4h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) |
+> Remaining performance optimizations (ENR-based transition table access,
+> aggregate fast-path, C-level trigger functions, prepared statement reuse)
+> are tracked under post-1.0 A2.
 
-> **Transactional IVM Phase 1 subtotal: ~32–48 hours**
->
-> Phases 2–4 (pg_ivm compat wrappers, extended SQL in IMMEDIATE mode,
-> C-level trigger optimization) are tracked under post-1.0 A2.
+See [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md).
 
 **Exit criteria:**
 - [x] `ORDER BY ... LIMIT N` (TopK) defining queries accepted and refreshed correctly
 - [x] TPC-H queries Q2, Q3, Q10, Q18, Q21 pass with original LIMIT restored
 - [x] Diamond dependency consistency (D1–D8) implemented and E2E-tested
-- [ ] IMMEDIATE refresh mode: INSERT/UPDATE/DELETE on base table updates stream table within the same transaction
+- [x] IMMEDIATE refresh mode: INSERT/UPDATE/DELETE on base table updates stream table within the same transaction
+- [x] Window functions, LATERAL, scalar subqueries work in IMMEDIATE mode
+- [x] Cascading IMMEDIATE stream tables (ST_A → ST_B) propagate correctly
+- [x] Concurrent transaction tests pass
 
 ---
 
@@ -356,7 +359,7 @@ These are not gated on 1.0 but represent the longer-term horizon.
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
 | A1 | Circular dependency support (SCC fixpoint iteration) | ~40h | [CIRCULAR_REFERENCES.md](plans/sql/CIRCULAR_REFERENCES.md) |
-| A2 | Transactional IVM Phases 2–4 (pg_ivm compat layer, extended SQL, C-level triggers) | ~36–54h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) |
+| A2 | Transactional IVM Phase 4 remaining (ENR-based transition tables, aggregate fast-path, C-level triggers, prepared stmt reuse) | ~36–54h | [PLAN_TRANSACTIONAL_IVM.md](plans/sql/PLAN_TRANSACTIONAL_IVM.md) |
 | A3 | PostgreSQL 19 forward-compatibility | TBD | [PLAN_PG19_COMPAT.md](plans/infra/PLAN_PG19_COMPAT.md) |
 | A4 | PostgreSQL 14–15 backward compatibility | ~40h | [PLAN_PG_BACKCOMPAT.md](plans/infra/PLAN_PG_BACKCOMPAT.md) |
 | A5 | Partitioned stream table storage (opt-in) | ~60–80h | [PLAN_PARTITIONING_SHARDING.md](plans/infra/PLAN_PARTITIONING_SHARDING.md) §4 |
@@ -368,7 +371,7 @@ These are not gated on 1.0 but represent the longer-term horizon.
 | Milestone | Effort estimate | Cumulative | Status |
 |-----------|-----------------|------------|--------|
 | v0.1.x — Core engine + correctness | ~30h actual | 30h | ✅ Released |
-| v0.2.0 — TopK, Diamond & Transactional IVM | ~32–48h remaining | 62–78h | 🔜 Next |
+| v0.2.0 — TopK, Diamond & Transactional IVM | ✔️ Complete | 62–78h | ✅ Done |
 | v0.3.0 — Production ready | 175–261h | 237–339h | |
 | v0.4.0 — Observability & Integration | 18–27h | 223–318h | |
 | v1.0.0 — Stable release | 18–27h | 241–345h | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -90,7 +90,7 @@ erDiagram
         text defining_query
         text original_query "User's original SQL (pre-inlining)"
         text schedule "Duration or cron expression"
-        text refresh_mode "FULL | DIFFERENTIAL"
+        text refresh_mode "FULL | DIFFERENTIAL | IMMEDIATE"
         text status "INITIALIZING | ACTIVE | SUSPENDED | ERROR"
         boolean is_populated
         timestamptz data_timestamp "Freshness watermark"


### PR DESCRIPTION
Update project documentation to reflect that Transactional IVM (Phase 1 + 3) is fully implemented and merged.

## Changes

### README.md
- Added IMMEDIATE mode, TopK support, and Diamond dependency consistency to Key Features
- Added TopK row to SQL support table; split LIMIT/OFFSET into ordered vs unordered
- Added IMMEDIATE mode usage example alongside existing DIFFERENTIAL/FULL examples
- Split "How It Works" into scheduled (DIFFERENTIAL/FULL) and transactional (IMMEDIATE) subsections
- Updated architecture diagram: Full / Differential / Immediate
- Updated test counts: ~992 unit + 40+ E2E suites (~510 E2E tests)
- Updated Known Limitations for LIMIT/OFFSET and recursive CTEs in IMMEDIATE mode

### ROADMAP.md
- Marked v0.2.0 as complete in status line, timeline diagram, and effort summary
- Replaced Phase 1 task estimates (TI1–TI8) with actual completed items (TI1–TI13)
- Updated exit criteria: all items checked including extended SQL support and cascading
- Updated post-1.0 A2 to reflect only Phase 4 performance optimizations remain
- Updated last-updated date

### docs/ARCHITECTURE.md
- Added IMMEDIATE to `refresh_mode` ERD field (`FULL | DIFFERENTIAL | IMMEDIATE`)