### PR TITLE
docs: fix GETTING_STARTED manual refresh order and monitoring columns

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -478,6 +478,8 @@ UPDATE departments SET name = 'R&D' WHERE id = 2;
 Refresh:
 
 ```sql
+SELECT pgtrickle.refresh_stream_table('department_tree');
+SELECT pgtrickle.refresh_stream_table('department_stats');
 SELECT pgtrickle.refresh_stream_table('department_report');
 ```
 
@@ -517,6 +519,7 @@ DELETE FROM employees WHERE name = 'Bob';
 
 ```sql
 SELECT pgtrickle.refresh_stream_table('department_stats');
+SELECT pgtrickle.refresh_stream_table('department_report');
 SELECT * FROM department_stats WHERE department_name = 'Backend';
 ```
 
@@ -573,7 +576,7 @@ FROM pgtrickle.pgt_status();
 
 ```sql
 -- Detailed performance stats
-SELECT table_name, refresh_count, avg_refresh_ms, rows_affected_last
+SELECT pgt_name, total_refreshes, avg_duration_ms, total_rows_inserted
 FROM pgtrickle.pg_stat_stream_tables;
 ```
 


### PR DESCRIPTION
- Step 4c: show all three refresh calls (manual refresh doesn't cascade)
- Step 4d: add missing department_report refresh call
- Step 5: fix pg_stat_stream_tables column names to match actual view

## Summary

<!-- One or two sentences describing what this PR does. -->

Fixes # <!-- issue number, if applicable -->

## Changes

<!-- Bullet list of what changed and why. -->

-

## Testing

<!-- How was this tested? Which test tiers were run? -->

- [ ] `just test-unit` passes
- [ ] `just test-integration` passes (if DB-facing code changed)
- [ ] `just test-e2e` passes (if SQL API or CDC changed)
- [ ] New tests added for the changed behaviour

## Code review checklist

- [ ] No `unwrap()` / `panic!()` in non-test code
- [ ] All `unsafe` blocks have `// SAFETY:` comments
- [ ] New SQL functions use `#[pg_extern(schema = "pgtrickle")]`
- [ ] `just fmt && just lint` passes with zero warnings
- [ ] Error messages include context (table name, query fragment, etc.)
- [ ] CHANGELOG.md updated under `## [Unreleased]` if user-visible

## Notes for reviewer

<!-- Anything the reviewer should pay particular attention to, open questions, or follow-up work. -->
