### PR TITLE
fix(ci): use CREATE EXTENSION IF NOT EXISTS in dbt CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Create pg_trickle extension
         run: |
           docker exec pgtrickle-dbt-test \
-            psql -U postgres -c "CREATE EXTENSION pg_trickle;"
+            psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS pg_trickle;"
 
       - uses: actions/setup-python@v5
         with:

--- a/dbt-pgtrickle/integration_tests/scripts/run_dbt_tests.sh
+++ b/dbt-pgtrickle/integration_tests/scripts/run_dbt_tests.sh
@@ -123,7 +123,7 @@ done
 
 echo "Creating pg_trickle extension..."
 docker exec "$CONTAINER_NAME" \
-  psql -U postgres -c "CREATE EXTENSION pg_trickle;"
+  psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS pg_trickle;"
 
 # ── Set up dbt Python environment ─────────────────────────────────────────
 # dbt-core 1.10 requires Python <=3.13 (mashumaro dependency incompatible with 3.14).


### PR DESCRIPTION
## Problem

The dbt integration CI job was failing with:

```
ERROR:  extension "pg_trickle" already exists
Error: Process completed with exit code 1.
```

The E2E Docker image is configured with `shared_preload_libraries = 'pg_trickle'`, which causes PostgreSQL to load the library at startup. If the image also auto-creates the extension (or a prior step does), the explicit `CREATE EXTENSION pg_trickle;` step in CI then fails on the duplicate.

## Fix

Changed both the GitHub Actions workflow step and the local `run_dbt_tests.sh` script to use `CREATE EXTENSION IF NOT EXISTS pg_trickle;`. A pre-existing installation becomes a silent no-op.

## Files changed

- `.github/workflows/ci.yml` — `Create pg_trickle extension` step
- `dbt-pgtrickle/integration_tests/scripts/run_dbt_tests.sh` — same fix for local runs