### PR TITLE
devcontainer: stabilize unit-test workflow and document container dev flow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,70 @@
+# =============================================================================
+# Devcontainer Dockerfile for pg_trickle development
+#
+# Based on postgres:18.1 to get matching PG headers + pg_config, then layers
+# Rust toolchain, cargo-pgrx, and development tools on top.
+# =============================================================================
+FROM postgres:18.1
+
+ARG USERNAME=vscode
+ARG USER_UID=1000
+ARG USER_GID=${USER_UID}
+
+# ── System dependencies ─────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        # Build essentials
+        build-essential \
+        pkg-config \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        # PostgreSQL dev headers (pgrx bindgen)
+        postgresql-server-dev-18 \
+        libreadline-dev \
+        zlib1g-dev \
+        libssl-dev \
+        # clang/llvm (pgrx bindgen requirement)
+        libclang-dev \
+        clang \
+        # Useful dev tools
+        sudo \
+        locales \
+        less \
+        procps \
+        lsb-release \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Locale ───────────────────────────────────────────────────────────────────
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+# ── Non-root user ────────────────────────────────────────────────────────────
+RUN groupadd --gid ${USER_GID} ${USERNAME} \
+    && useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} -s /bin/bash \
+    && echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/${USERNAME} \
+    && chmod 0440 /etc/sudoers.d/${USERNAME}
+
+# ── Rust toolchain (installed for vscode user) ──────────────────────────────
+USER ${USERNAME}
+ENV HOME=/home/${USERNAME}
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain stable --component clippy,rustfmt
+ENV PATH="${HOME}/.cargo/bin:${PATH}"
+
+# ── cargo-pgrx ──────────────────────────────────────────────────────────────
+RUN cargo install --locked cargo-pgrx --version 0.17.0
+
+# ── just (command runner) ───────────────────────────────────────────────────
+RUN cargo install just
+
+# ── Ensure pg_config is on PATH ─────────────────────────────────────────────
+ENV PATH="/usr/lib/postgresql/18/bin:${PATH}"
+
+USER root
+
+# ── Default working directory ────────────────────────────────────────────────
+WORKDIR /workspaces/pg-stream

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,67 @@
+// pg_trickle devcontainer configuration
+// https://containers.dev/implementors/json_reference/
+{
+  "name": "pg_trickle Dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+
+  // Run as non-root vscode user
+  "remoteUser": "vscode",
+  "containerUser": "vscode",
+
+  // ── Features ──────────────────────────────────────────────────────────────
+  "features": {
+    // Docker-in-Docker for testcontainers (integration tests) and E2E image builds
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "dockerDashComposeVersion": "v2"
+    }
+  },
+
+  // ── Lifecycle Commands ────────────────────────────────────────────────────
+  // Initialize pgrx with the system pg_config (runs once after container create)
+  "postCreateCommand": "cargo pgrx init --pg18 /usr/lib/postgresql/18/bin/pg_config",
+
+  // ── Persistent Volumes ────────────────────────────────────────────────────
+  "mounts": [
+    // Cache cargo registry across container rebuilds
+    "source=pg-trickle-cargo-registry,target=/home/vscode/.cargo/registry,type=volume",
+    // Cache cargo git checkouts across container rebuilds
+    "source=pg-trickle-cargo-git,target=/home/vscode/.cargo/git,type=volume",
+    // Cache pgrx home (compiled PG instance) across container rebuilds
+    "source=pg-trickle-pgrx-home,target=/home/vscode/.pgrx,type=volume",
+    // Cache build artifacts across container rebuilds
+    "source=pg-trickle-target,target=${containerWorkspaceFolder}/target,type=volume"
+  ],
+
+  // ── VS Code Customizations ────────────────────────────────────────────────
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "serayuzgur.crates",
+        "vadimcn.vscode-lldb",
+        "streetsidesoftware.code-spell-checker"
+      ],
+      "settings": {
+        "rust-analyzer.cargo.features": ["pg18"],
+        "rust-analyzer.check.command": "clippy",
+        "rust-analyzer.check.extraArgs": ["--features", "pg18"],
+        "editor.formatOnSave": true,
+        "[rust]": {
+          "editor.defaultFormatter": "rust-lang.rust-analyzer"
+        }
+      }
+    }
+  },
+
+  // ── Environment Variables ──────────────────────────────────────────────────
+  "containerEnv": {
+    "CARGO_TERM_COLOR": "always"
+  },
+
+  // ── Forward PostgreSQL port (for pgrx run) ────────────────────────────────
+  "forwardPorts": [28818]
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+target/
+.git/
+.github/
+
+# Docs and generated site
+book/
+docs/
+plans/
+
+# Local/editor/devcontainer metadata
+.devcontainer/
+.vscode/
+.idea/
+
+# Project subtrees not needed for extension build images
+dbt-pgtrickle/
+cnpg/
+tests/
+scripts/
+benches/
+
+# Misc large/noisy files
+*.log
+*.tmp
+*.swp
+*.swo
+
+# Keep the specific Dockerfiles used by builds
+!tests/Dockerfile.e2e
+!cnpg/Dockerfile.ext-build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,31 @@ just test-e2e           # full E2E (builds Docker image)
 
 Full setup instructions are in [INSTALL.md](INSTALL.md).
 
+### Devcontainer / Containerized Development
+
+If you are developing in a devcontainer, use the default non-root `vscode` user
+and run the normal commands from the workspace root:
+
+```bash
+just fmt
+just lint
+just test-unit
+```
+
+`just test-unit` uses `scripts/run_unit_tests.sh`, which now selects a writable
+and cache-friendly target directory in this order:
+
+1. `target/` (preferred)
+2. `.cargo-target/` (project-local fallback)
+3. `$HOME/.cache/pg_trickle-target`
+4. `${TMPDIR:-/tmp}/pg_trickle-target` (last resort)
+
+This avoids permission failures on bind mounts and preserves incremental builds
+when source or test files change.
+
+If you see permission errors in containerized runs, verify you are not forcing a
+different container user/UID than expected by your workspace mount.
+
 ## Making a Pull Request
 
 1. Fork the repository and create a branch: `git checkout -b fix/my-fix`

--- a/plans/INDEX.md
+++ b/plans/INDEX.md
@@ -53,6 +53,7 @@ new entries when creating documents.
 | [PLAN_PARTITIONING_SHARDING.md](infra/PLAN_PARTITIONING_SHARDING.md) | PLAN | Research | PostgreSQL partitioning & sharding compatibility |
 | [PLAN_PACKAGING.md](infra/PLAN_PACKAGING.md) | PLAN | Draft | Distribution packaging |
 | [PLAN_PG19_COMPAT.md](infra/PLAN_PG19_COMPAT.md) | PLAN | Draft | PostgreSQL 19 forward-compatibility |
+| [PLAN_DEVCONTAINER_UNIT_TEST_WORKFLOW.md](infra/PLAN_DEVCONTAINER_UNIT_TEST_WORKFLOW.md) | PLAN | Implemented | Devcontainer unit-test stability and build reuse |
 | [REPORT_PGWIRE_PROXY.md](infra/REPORT_PGWIRE_PROXY.md) | REPORT | Research | pgwire proxy / intercept analysis |
 | [PLAN_PG_BACKCOMPAT.md](infra/PLAN_PG_BACKCOMPAT.md) | PLAN | Research | Supporting older PostgreSQL versions (13–17) |
 | [PLAN_VERSIONING.md](infra/PLAN_VERSIONING.md) | PLAN | Draft | Semantic versioning & compatibility policy |

--- a/plans/infra/PLAN_DEVCONTAINER_UNIT_TEST_WORKFLOW.md
+++ b/plans/infra/PLAN_DEVCONTAINER_UNIT_TEST_WORKFLOW.md
@@ -1,0 +1,88 @@
+# Plan: Devcontainer Unit Test Workflow Stability & Build Reuse
+
+Date: 2026-03-04
+Status: IMPLEMENTED
+
+---
+
+## Overview
+
+This document captures the dev-path work completed to make unit tests reliable
+inside containerized development and to reduce unnecessary rebuilds.
+
+The original issue observed during `just test-unit` was a permission mismatch on
+the workspace `target/` directory when running in container contexts. That made
+unit tests fail before execution and also risked repeated full recompiles.
+
+---
+
+## Goals
+
+1. Ensure `just test-unit` works in devcontainer-style execution.
+2. Avoid forced full rebuilds when source/tests change.
+3. Keep scope focused on development workflow (not production packaging).
+
+---
+
+## Root Cause
+
+- `just test-unit` delegates to `scripts/run_unit_tests.sh`.
+- The script previously assumed `target/` was writable.
+- In container runs, workspace bind mounts can present UID/GID ownership that
+  makes `target/` unwritable to the container user.
+- This caused failures during stub compilation and cargo lock writes.
+
+---
+
+## Implemented Changes
+
+### 1) Unit-test target directory fallback logic
+
+Updated `scripts/run_unit_tests.sh` to select a writable target directory in a
+stable order:
+
+1. `<project>/target` (preferred)
+2. `<project>/.cargo-target` (project-local fallback)
+3. `$HOME/.cache/pg_trickle-target` (persistent user cache)
+4. `${TMPDIR:-/tmp}/pg_trickle-target` (last resort)
+
+Other script updates:
+
+- Stub library path now uses `CARGO_TARGET_DIR`.
+- Test binary discovery now resolves from `CARGO_TARGET_DIR`.
+- Fallback directory creation is non-fatal when unwritable.
+
+### 2) Devcontainer cache mount enhancement
+
+Updated `.devcontainer/devcontainer.json` mounts to add persistent Cargo git
+cache reuse:
+
+- Added mount for `/home/vscode/.cargo/git`.
+
+This complements existing registry/target/pgrx mounts and reduces dependency
+re-download/re-resolution overhead when rebuilding/reopening devcontainers.
+
+---
+
+## Validation Performed
+
+- Ran `just test-unit` inside containerized execution path.
+- Confirmed successful unit-test completion (`1007 passed`).
+- Confirmed permission-path failures were eliminated by target fallback logic.
+
+---
+
+## Scope Decisions
+
+- We intentionally kept final scope on dev workflow improvements.
+- E2E/CNPG Dockerfile optimization experiments were not retained as the primary
+  deliverable for this task.
+
+---
+
+## Follow-ups (Optional)
+
+1. Add a short note in `CONTRIBUTING.md` about container UID/GID effects on
+   bind-mounted `target/` and how fallback target selection works.
+2. Add a lightweight CI/unit check that executes `scripts/run_unit_tests.sh` in
+   a containerized environment with non-root user to guard against regressions.

--- a/scripts/run_unit_tests.sh
+++ b/scripts/run_unit_tests.sh
@@ -24,15 +24,38 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 STUB_SRC="$SCRIPT_DIR/pg_stub.c"
 FEATURES="${1:-pg18}"
 
+DEFAULT_TARGET_DIR="$PROJECT_DIR/target"
+if [[ ! -d "$DEFAULT_TARGET_DIR" ]] || [[ ! -w "$DEFAULT_TARGET_DIR" ]]; then
+    FALLBACK_TARGET_DIR="$PROJECT_DIR/.cargo-target"
+    mkdir -p "$FALLBACK_TARGET_DIR" 2>/dev/null || true
+
+    if [[ -d "$FALLBACK_TARGET_DIR" ]] && [[ -w "$FALLBACK_TARGET_DIR" ]]; then
+        export CARGO_TARGET_DIR="$FALLBACK_TARGET_DIR"
+    else
+        HOME_FALLBACK_TARGET_DIR="${HOME:-/tmp}/.cache/pg_trickle-target"
+        mkdir -p "$HOME_FALLBACK_TARGET_DIR" 2>/dev/null || true
+
+        if [[ -d "$HOME_FALLBACK_TARGET_DIR" ]] && [[ -w "$HOME_FALLBACK_TARGET_DIR" ]]; then
+            export CARGO_TARGET_DIR="$HOME_FALLBACK_TARGET_DIR"
+        else
+            export CARGO_TARGET_DIR="${TMPDIR:-/tmp}/pg_trickle-target"
+        fi
+
+        mkdir -p "$CARGO_TARGET_DIR"
+    fi
+else
+    export CARGO_TARGET_DIR="$DEFAULT_TARGET_DIR"
+fi
+
 OS="$(uname)"
 case "$OS" in
     Darwin)
-        STUB_LIB="$PROJECT_DIR/target/libpg_stub.dylib"
+        STUB_LIB="$CARGO_TARGET_DIR/libpg_stub.dylib"
         STUB_CC_FLAGS="-shared -install_name @rpath/libpg_stub.dylib"
         PRELOAD_VAR="DYLD_INSERT_LIBRARIES"
         ;;
     *)
-        STUB_LIB="$PROJECT_DIR/target/libpg_stub.so"
+        STUB_LIB="$CARGO_TARGET_DIR/libpg_stub.so"
         STUB_CC_FLAGS="-shared -fPIC"
         PRELOAD_VAR="LD_PRELOAD"
         ;;
@@ -65,19 +88,19 @@ TEST_BIN=$(echo "$CARGO_OUTPUT" \
            | head -1)
 
 if [[ -n "$TEST_BIN" ]]; then
-    TEST_BIN="$PROJECT_DIR/$TEST_BIN"
+    TEST_BIN="$CARGO_TARGET_DIR/${TEST_BIN#target/}"
 fi
 
 if [[ -z "${TEST_BIN:-}" ]] || [[ ! -x "$TEST_BIN" ]]; then
     # Fallback: pick the newest executable pg_trickle- binary
     if [[ "$OS" == "Darwin" ]]; then
-        TEST_BIN=$(find "$PROJECT_DIR/target/debug/deps" \
+        TEST_BIN=$(find "$CARGO_TARGET_DIR/debug/deps" \
                         -maxdepth 1 -name 'pg_trickle-*' -type f -perm +111 \
                         2>/dev/null \
                    | xargs ls -t 2>/dev/null \
                    | head -1)
     else
-        TEST_BIN=$(find "$PROJECT_DIR/target/debug/deps" \
+        TEST_BIN=$(find "$CARGO_TARGET_DIR/debug/deps" \
                         -maxdepth 1 -name 'pg_trickle-*' -type f -executable \
                         2>/dev/null \
                    | xargs ls -t 2>/dev/null \
@@ -86,7 +109,7 @@ if [[ -z "${TEST_BIN:-}" ]] || [[ ! -x "$TEST_BIN" ]]; then
 fi
 
 if [[ -z "${TEST_BIN:-}" ]]; then
-    echo "ERROR: Could not find the test binary in target/debug/deps/" >&2
+    echo "ERROR: Could not find the test binary in $CARGO_TARGET_DIR/debug/deps/" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Add a dedicated `.devcontainer` setup for PostgreSQL 18 + Rust/pgrx development.
- Add persistent devcontainer mounts for Cargo registry/git, pgrx home, and build target reuse.
- Harden `scripts/run_unit_tests.sh` with writable target-dir fallback for container permission mismatches.
- Document containerized contributor workflow in `CONTRIBUTING.md`.
- Add `.dockerignore` to reduce noisy Docker build context.
- Add and index an implementation plan record for this workflow.

## Validation
- Ran `just test-unit` inside the containerized execution path.
- Verified successful run (`1007 passed`) in the devcontainer image.
