### PR TITLE
infra: SHA-based Docker image tags for E2E test isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,11 +117,11 @@ jobs:
         run: ./tests/build_e2e_image.sh
 
       - name: Run E2E test suite
-        run: cargo test --test 'e2e_*' -- --test-threads=1
+        run: PGS_E2E_IMAGE=$(cat .e2e-image-tag) cargo test --test 'e2e_*' -- --test-threads=1
 
       - name: Run TPC-H-derived correctness tests
         run: |
-          cargo test --test e2e_tpch_tests -- \
+          PGS_E2E_IMAGE=$(cat .e2e-image-tag) cargo test --test e2e_tpch_tests -- \
             --ignored --test-threads=1 --nocapture
 
   # ── Upgrade completeness check (every PR) ───────────────────────────────
@@ -163,11 +163,10 @@ jobs:
 
       - name: Run upgrade E2E tests
         env:
-          PGS_E2E_IMAGE: pg_trickle_upgrade_e2e:latest
           PGS_UPGRADE_FROM: "0.1.3"
           PGS_UPGRADE_TO: "0.2.1"
         run: |
-          cargo test --test e2e_upgrade_tests -- \
+          PGS_E2E_IMAGE=$(cat .e2e-upgrade-image-tag) cargo test --test e2e_upgrade_tests -- \
             --ignored --test-threads=1 --nocapture
 
   # ── Benchmarks (non-blocking, Linux only) ───────────────────────────────
@@ -219,7 +218,7 @@ jobs:
             --name pgtrickle-dbt-test \
             -e POSTGRES_PASSWORD=postgres \
             -p 5432:5432 \
-            pg_trickle_e2e:latest
+            "$(cat .e2e-image-tag)"
 
           # Wait for PostgreSQL to accept connections
           echo "Waiting for PostgreSQL to be ready..."

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ book/
 
 # dbt separate venv (Python 3.13, not committed)
 .venv-dbt/
+
+# E2E Docker image tag files (written by build_e2e_image.sh / build_e2e_upgrade_image.sh)
+.e2e-image-tag
+.e2e-upgrade-image-tag

--- a/justfile
+++ b/justfile
@@ -75,12 +75,15 @@ build-e2e-image:
 # Run E2E tests (rebuilds Docker image first)
 [group: "test"]
 test-e2e: build-e2e-image
-    cargo test --test 'e2e_*' -- --test-threads=1
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test 'e2e_*' -- --test-threads=1
 
 # Run E2E tests, skip Docker image rebuild
 [group: "test"]
 test-e2e-fast:
-    cargo test --test 'e2e_*' -- --test-threads=1
+    @test -f .e2e-image-tag || (echo "ERROR: .e2e-image-tag missing — run 'just build-e2e-image' first" && exit 1)
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test 'e2e_*' -- --test-threads=1
 
 # Run tests via pgrx against a pgrx-managed postgres
 [group: "test"]
@@ -96,17 +99,21 @@ test-all: test-unit test-integration test-e2e test-pgrx
 # Run TPC-H correctness tests at SF-0.01 (~2 min, rebuilds Docker image)
 [group: "tpch"]
 test-tpch: build-e2e-image
-    cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
 
 # Run TPC-H tests, skip Docker image rebuild
 [group: "tpch"]
 test-tpch-fast:
-    cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
+    @test -f .e2e-image-tag || (echo "ERROR: .e2e-image-tag missing — run 'just build-e2e-image' first" && exit 1)
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
 
 # Run TPC-H tests at larger scale: SF-0.1 (~5 min, rebuilds Docker image)
 [group: "tpch"]
 test-tpch-large: build-e2e-image
-    TPCH_SCALE=0.1 cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        TPCH_SCALE=0.1 cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
 
 # ── dbt Tests ─────────────────────────────────────────────────────────────
 
@@ -135,7 +142,7 @@ build-upgrade-image from="0.1.3" to="0.2.1": build-e2e-image
 # Run upgrade E2E tests (builds base + upgrade Docker images first)
 [group: "upgrade"]
 test-upgrade from="0.1.3" to="0.2.1": (build-upgrade-image from to)
-    PGS_E2E_IMAGE=pg_trickle_upgrade_e2e:latest \
+    PGS_E2E_IMAGE=$(cat .e2e-upgrade-image-tag) \
     PGS_UPGRADE_FROM={{from}} PGS_UPGRADE_TO={{to}} \
         cargo test --test e2e_upgrade_tests -- --ignored --test-threads=1 --nocapture
 

--- a/plans/PLAN.md
+++ b/plans/PLAN.md
@@ -2034,6 +2034,10 @@ focuses on edge-case hardening and SQL coverage expansion, tracked in
   EC-11 (scheduler falling-behind alert), EC-13 (atomic diamond consistency
   default), EC-18 (auto CDC stuck-in-TRIGGER logging), EC-34 (auto-detect
   missing WAL slot).
+- **Test Infrastructure (PLAN_TEST_ISOLATION.md):** SHA-based Docker image
+  tags replace `:latest`; build scripts write `.e2e-image-tag` and
+  `.e2e-upgrade-image-tag`; `justfile` and CI propagate `PGS_E2E_IMAGE`
+  from those files. Eliminates image-tag collisions in concurrent CI runs.
 
 **Test coverage:** 1032+ unit tests, 7 keyless E2E tests, 5 guard trigger
 E2E tests, 9+ diamond E2E tests, plus integration and TPC-H regression

--- a/plans/PLAN_EDGE_CASES.md
+++ b/plans/PLAN_EDGE_CASES.md
@@ -2,7 +2,9 @@
 
 **Status:** Proposed
 **Target milestone:** v0.3.0+
-**Last updated:** 2026-05-30
+**Last updated:** 2026-03-04
+
+> **Implementation progress:** Stages 1–2 of [PLAN_EDGE_CASES_TIVM_IMPL_ORDER.md](PLAN_EDGE_CASES_TIVM_IMPL_ORDER.md) are complete (EC-01, EC-06, EC-19 fixed; EC-11, EC-13, EC-15, EC-18, EC-25, EC-26, EC-34 hardened). Test infrastructure isolation also complete. Next: Stage 3 (SQL Coverage Expansion — EC-03, EC-04, EC-08, Part 2 Phases 1–2).
 
 ---
 

--- a/plans/PLAN_EDGE_CASES_TIVM_IMPL_ORDER.md
+++ b/plans/PLAN_EDGE_CASES_TIVM_IMPL_ORDER.md
@@ -6,7 +6,8 @@
 
 **Date:** 2026-03-04  
 **Last updated:** 2026-03-04  
-**Status:** Stages 1–2 COMPLETE (incl. bug fixes + test coverage).
+**Status:** Stages 1–2 COMPLETE (incl. bug fixes + test coverage).  
+Test infrastructure isolation (PLAN_TEST_ISOLATION.md) COMPLETE — SHA-based Docker image tags, tag-file handoff, justfile + CI propagation.  
 Next up: Stage 3 (SQL Coverage Expansion).  
 **Principle:** No SQL-surface expansion while P0 correctness bugs are open.
 

--- a/plans/PLAN_TEST_ISOLATION.md
+++ b/plans/PLAN_TEST_ISOLATION.md
@@ -1,0 +1,240 @@
+# PLAN_TEST_ISOLATION
+
+## Goal
+
+Allow `just build-e2e-image` and `just test-e2e` to run simultaneously on the
+same laptop (shared Docker daemon) without colliding. Also allows running
+multiple parallel test sessions (e.g. two branches checked out side-by-side).
+
+---
+
+## Problem Summary
+
+The current setup hardcodes the image tag as `pg_trickle_e2e:latest` in
+`tests/build_e2e_image.sh`. Both `just build-e2e-image` and `just test-e2e`
+(which calls `build-e2e-image` first) reference the same mutable tag. This
+causes two failure modes:
+
+| Failure mode | How it happens |
+|---|---|
+| **Image tag clobber** | A background `build-e2e-image` overwrites `:latest` while an in-flight `test-e2e` session is still spinning up containers from it |
+| **BuildKit cache thrash** | Two concurrent `docker build` runs targeting the same tag fight over the layer cache, causing one to produce a corrupt or stale image |
+
+The upgrade image (`pg_trickle_upgrade_e2e:latest`) has the same problem
+because it is built on top of the base image by tag name.
+
+---
+
+## Solution: Git-SHA image tags + tag-file handoff
+
+Tag every built image with the short git SHA of the working tree at build
+time. Write that tag to a `.e2e-image-tag` file in the project root so that
+`just test-e2e-fast` and the upgrade build can consume the same tag without
+rebuilding.
+
+```
+build-e2e-image  →  pg_trickle_e2e:<sha>  →  .e2e-image-tag
+test-e2e-fast    ←  reads .e2e-image-tag  →  PGS_E2E_IMAGE=pg_trickle_e2e:<sha>
+```
+
+---
+
+## Changes Required
+
+### 1. `tests/build_e2e_image.sh`
+
+- Compute `GIT_SHA=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)`.
+- If the working tree is dirty append `-dirty` so images from uncommitted
+  changes do not collide with clean-SHA images.
+- Set `IMAGE_TAG="${GIT_SHA}"` instead of `"latest"`.
+- After a successful build write the full `name:tag` string to
+  `"$PROJECT_ROOT/.e2e-image-tag"`.
+- Keep printing the tag prominently so the caller can see what was built.
+
+```bash
+# Pseudocode — concrete diff in §Implementation Notes
+GIT_SHA=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD)
+DIRTY=$(git -C "$PROJECT_ROOT" status --porcelain | wc -l)
+[[ "$DIRTY" -gt 0 ]] && GIT_SHA="${GIT_SHA}-dirty"
+
+IMAGE_TAG="${GIT_SHA}"
+IMAGE_REF="${IMAGE_NAME}:${IMAGE_TAG}"
+
+docker build -t "$IMAGE_REF" -f "${SCRIPT_DIR}/Dockerfile.e2e" ${EXTRA_ARGS} "${PROJECT_ROOT}"
+
+echo "$IMAGE_REF" > "$PROJECT_ROOT/.e2e-image-tag"
+echo "  Tag file written: .e2e-image-tag → $IMAGE_REF"
+```
+
+### 2. `tests/build_e2e_upgrade_image.sh`
+
+- Read the base image from `.e2e-image-tag` if `PGS_E2E_BASE_IMAGE` is not
+  already set (it already honours that env var — just fall back to the file):
+
+```bash
+BASE_IMAGE="${PGS_E2E_BASE_IMAGE:-}"
+if [[ -z "$BASE_IMAGE" ]] && [[ -f "$PROJECT_ROOT/.e2e-image-tag" ]]; then
+    BASE_IMAGE=$(cat "$PROJECT_ROOT/.e2e-image-tag")
+fi
+BASE_IMAGE="${BASE_IMAGE:-pg_trickle_e2e:latest}"
+```
+
+- Tag the upgrade image with the same SHA suffix:
+  `pg_trickle_upgrade_e2e:<sha>`.
+- Write to `.e2e-upgrade-image-tag` for symmetry.
+
+### 3. `justfile`
+
+`test-e2e` currently depends on `build-e2e-image` and then runs cargo tests
+without propagating the tag. Change it to:
+
+```makefile
+# Build the E2E image and record its tag
+build-e2e-image:
+    ./tests/build_e2e_image.sh
+
+# Run E2E tests — builds image first, then reads .e2e-image-tag
+test-e2e: build-e2e-image
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test 'e2e_*' -- --test-threads=1
+
+# Run E2E tests without rebuilding — uses the last built image tag
+test-e2e-fast:
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test 'e2e_*' -- --test-threads=1
+
+# Pipeline subset
+test-pipeline: build-e2e-image
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test e2e_pipeline_dag_tests -- --test-threads=1 --nocapture
+
+test-pipeline-fast:
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test e2e_pipeline_dag_tests -- --test-threads=1 --nocapture
+
+# TPC-H
+test-tpch: build-e2e-image
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
+
+test-tpch-fast:
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
+
+test-tpch-large: build-e2e-image
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        TPCH_SCALE=0.1 cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
+
+# Upgrade
+build-upgrade-image from="0.1.3" to="0.2.1": build-e2e-image
+    ./tests/build_e2e_upgrade_image.sh {{from}} {{to}}
+
+test-upgrade: build-upgrade-image
+    PGS_E2E_IMAGE=$(cat .e2e-upgrade-image-tag) \
+        cargo test --test e2e_upgrade_tests -- --ignored --test-threads=1 --nocapture
+```
+
+### 4. `tests/e2e/mod.rs`
+
+No Rust changes are needed. The `PGS_E2E_IMAGE` env-var override already
+exists and works. The justfile propagates the correct tag via that variable.
+
+For documentation, update the module docstring to mention the tag-file
+mechanism:
+
+```rust
+//! The Docker image tag is written to `.e2e-image-tag` by `build_e2e_image.sh`
+//! and propagated by `just test-e2e` via the `PGS_E2E_IMAGE` env var.
+//! To override: `PGS_E2E_IMAGE=pg_trickle_e2e:<tag> cargo test ...`
+```
+
+### 5. `.gitignore`
+
+Add:
+
+```
+.e2e-image-tag
+.e2e-upgrade-image-tag
+```
+
+---
+
+## How Parallel Runs Become Safe
+
+| Scenario | Before | After |
+|---|---|---|
+| `build-e2e-image` races `test-e2e` | Both touch `:latest`; clobber risk | Build writes `:<sha-A>`, test reads `:<sha-A>` from file — independent |
+| Two branches building at once | Both overwrite `:latest` | Branch A writes `:<sha-A>`, Branch B writes `:<sha-B>`; no overlap |
+| Re-run without rebuild (`test-e2e-fast`) | Already works | Still works — reads the tag file, no rebuild triggered |
+| Dirty working tree | Same tag as last clean image | Gets a `-dirty` suffix, won't overwrite and won't be confused with clean builds |
+
+---
+
+## Migration / Compatibility Notes
+
+- `docker-build-e2e` (alias in `justfile`) calls the same script; no extra
+  changes needed.
+- CI (`ci.yml`) workflow steps that call `build_e2e_image.sh` directly will
+  automatically pick up the new behaviour; any subsequent `cargo test` step
+  must be updated to pass `PGS_E2E_IMAGE=$(cat .e2e-image-tag)`.
+- Old `:latest` images remain in the local Docker cache; run
+  `docker image prune` periodically to reclaim space.
+- If `.e2e-image-tag` is absent and `test-e2e-fast` is invoked, the `cat`
+  command will fail with a clear error. A guard can be added:
+
+```makefile
+test-e2e-fast:
+    @test -f .e2e-image-tag || (echo "ERROR: .e2e-image-tag missing — run 'just build-e2e-image' first" && exit 1)
+    PGS_E2E_IMAGE=$(cat .e2e-image-tag) \
+        cargo test --test 'e2e_*' -- --test-threads=1
+```
+
+---
+
+## Isolation Audit: All Test Tiers
+
+### Unit tests — fully isolated ✅
+
+`just test-unit` compiles and runs a test binary with no database and no
+containers. Multiple simultaneous invocations are unconditionally safe.
+
+### Integration tests — fully isolated ✅
+
+`just test-integration` uses `testcontainers_modules::postgres::Postgres`
+(the official `postgres` image). Testcontainers assigns a fresh, random
+container UUID and a random ephemeral host port for every run. Nothing is
+shared between concurrent runs.
+
+### E2E tests — containers isolated ✅, image tag not ⚠️
+
+`just test-e2e` also uses Testcontainers for container lifecycle, so
+concurrent test sessions get independent containers and ports. The only
+collision risk is the `:latest` image tag being overwritten mid-run by a
+simultaneous `build-e2e-image` — which is precisely what this plan fixes.
+
+### pgrx tests — NOT isolated ⚠️ (known, low-priority)
+
+`just test-pgrx` runs `cargo pgrx test pg18`, which starts a PostgreSQL
+server against a single shared data directory: `~/.pgrx/data-18/`. A second
+simultaneous invocation will attempt to start a second server against the
+same directory, causing one or both runs to fail with a lock or socket
+conflict.
+
+**Impact**: only triggered by manually launching two `just test-pgrx` shells
+at the same time. `just test-all` runs all tiers sequentially so it is not
+affected. No fix is planned here.
+
+**Workaround if needed**: maintain two separate `cargo pgrx init --datadir`
+paths via the `PGRX_HOME` environment variable and configure each workspace to
+point at a different one. This is an upstream pgrx limitation.
+
+---
+
+## File Checklist
+
+- [x] `tests/build_e2e_image.sh` — SHA tag + write `.e2e-image-tag`
+- [x] `tests/build_e2e_upgrade_image.sh` — read base tag from file; write `.e2e-upgrade-image-tag`
+- [x] `justfile` — propagate `PGS_E2E_IMAGE` from tag file for all e2e targets
+- [x] `tests/e2e/mod.rs` — update module docstring only
+- [x] `.gitignore` — exclude both tag files
+- [x] `.github/workflows/ci.yml` — propagate `PGS_E2E_IMAGE` in any step that runs e2e tests after the build step

--- a/tests/build_e2e_image.sh
+++ b/tests/build_e2e_image.sh
@@ -15,29 +15,49 @@
 set -euo pipefail
 
 IMAGE_NAME="pg_trickle_e2e"
-IMAGE_TAG="latest"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Compute a stable, collision-free image tag from the git SHA ──────────
+# Using the short SHA means concurrent builds on different branches or
+# commits produce independent tags, eliminating tag-clobber races.
+# A "-dirty" suffix marks images built from an uncommitted working tree so
+# they never overwrite a clean-SHA image.
+GIT_SHA=$(git -C "${PROJECT_ROOT}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DIRTY_COUNT=$(git -C "${PROJECT_ROOT}" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+if [[ "${DIRTY_COUNT}" -gt 0 ]]; then
+    GIT_SHA="${GIT_SHA}-dirty"
+fi
+
+IMAGE_TAG="${GIT_SHA}"
+IMAGE_REF="${IMAGE_NAME}:${IMAGE_TAG}"
+TAG_FILE="${PROJECT_ROOT}/.e2e-image-tag"
 
 # Pass through any extra args (e.g. --no-cache)
 EXTRA_ARGS="${*:-}"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  Building E2E test image: ${IMAGE_NAME}:${IMAGE_TAG}"
+echo "  Building E2E test image: ${IMAGE_REF}"
 echo "  Project root: ${PROJECT_ROOT}"
 echo "  Dockerfile:   ${SCRIPT_DIR}/Dockerfile.e2e"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 docker build \
-    -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+    -t "${IMAGE_REF}" \
     -f "${SCRIPT_DIR}/Dockerfile.e2e" \
     ${EXTRA_ARGS} \
     "${PROJECT_ROOT}"
 
+# Write the full image reference to the tag file so downstream targets
+# (test-e2e-fast, build-upgrade-image, etc.) pick up the exact tag without
+# rebuilding.
+echo "${IMAGE_REF}" > "${TAG_FILE}"
+echo "  Tag file written: .e2e-image-tag → ${IMAGE_REF}"
+
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  ✓ Image built: ${IMAGE_NAME}:${IMAGE_TAG}"
-IMAGE_SIZE=$(docker image inspect "${IMAGE_NAME}:${IMAGE_TAG}" \
+echo "  ✓ Image built: ${IMAGE_REF}"
+IMAGE_SIZE=$(docker image inspect "${IMAGE_REF}" \
     --format='{{.Size}}' 2>/dev/null || echo "0")
 if command -v numfmt &>/dev/null; then
     echo "  Image size: $(echo "${IMAGE_SIZE}" | numfmt --to=iec)"
@@ -49,7 +69,7 @@ fi
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "To test manually:"
-echo "  docker run --rm -d --name pgs-e2e -e POSTGRES_PASSWORD=postgres -p 15432:5432 ${IMAGE_NAME}:${IMAGE_TAG}"
+echo "  docker run --rm -d --name pgs-e2e -e POSTGRES_PASSWORD=postgres -p 15432:5432 ${IMAGE_REF}"
 echo "  sleep 3"
 echo "  psql -h localhost -p 15432 -U postgres -c \"CREATE EXTENSION pg_trickle;\""
 echo "  docker stop pgs-e2e"

--- a/tests/build_e2e_upgrade_image.sh
+++ b/tests/build_e2e_upgrade_image.sh
@@ -28,12 +28,29 @@ shift 2 2>/dev/null || true
 EXTRA_ARGS="${*:-}"
 
 IMAGE_NAME="pg_trickle_upgrade_e2e"
-IMAGE_TAG="latest"
-BASE_IMAGE="${PGS_E2E_BASE_IMAGE:-pg_trickle_e2e:latest}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Verify prerequisites
+# ── Resolve base image: env override → tag file → legacy :latest fallback ─
+BASE_IMAGE="${PGS_E2E_BASE_IMAGE:-}"
+if [[ -z "$BASE_IMAGE" ]] && [[ -f "${PROJECT_ROOT}/.e2e-image-tag" ]]; then
+    BASE_IMAGE=$(cat "${PROJECT_ROOT}/.e2e-image-tag")
+    echo "  Using base image from .e2e-image-tag: ${BASE_IMAGE}"
+fi
+BASE_IMAGE="${BASE_IMAGE:-pg_trickle_e2e:latest}"
+
+# ── Compute SHA tag (same scheme as build_e2e_image.sh) ──────────────────
+GIT_SHA=$(git -C "${PROJECT_ROOT}" rev-parse --short HEAD 2>/dev/null || echo "unknown")
+DIRTY_COUNT=$(git -C "${PROJECT_ROOT}" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+if [[ "${DIRTY_COUNT}" -gt 0 ]]; then
+    GIT_SHA="${GIT_SHA}-dirty"
+fi
+
+IMAGE_TAG="${GIT_SHA}"
+IMAGE_REF="${IMAGE_NAME}:${IMAGE_TAG}"
+UPGRADE_TAG_FILE="${PROJECT_ROOT}/.e2e-upgrade-image-tag"
+
+# Verify the base image is locally available.
 if ! docker image inspect "${BASE_IMAGE}" &>/dev/null; then
     echo "ERROR: Base image '${BASE_IMAGE}' not found."
     echo "       Run './tests/build_e2e_image.sh' first."
@@ -70,14 +87,14 @@ if [[ ${#chain_steps[@]} -gt 0 ]]; then
 fi
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  Building upgrade E2E image: ${IMAGE_NAME}:${IMAGE_TAG}"
+echo "  Building upgrade E2E image: ${IMAGE_REF}"
 echo "  Upgrade path: ${FROM_VERSION} → ${TO_VERSION}"
 echo "  Base image:   ${BASE_IMAGE}"
 echo "  Dockerfile:   ${SCRIPT_DIR}/Dockerfile.e2e-upgrade"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 docker build \
-    -t "${IMAGE_NAME}:${IMAGE_TAG}" \
+    -t "${IMAGE_REF}" \
     --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
     --build-arg "FROM_VERSION=${FROM_VERSION}" \
     --build-arg "TO_VERSION=${TO_VERSION}" \
@@ -85,14 +102,19 @@ docker build \
     ${EXTRA_ARGS} \
     "${PROJECT_ROOT}"
 
+# Write the full image reference so downstream consumers don't need to
+# reconstruct the tag name.
+echo "${IMAGE_REF}" > "${UPGRADE_TAG_FILE}"
+echo "  Tag file written: .e2e-upgrade-image-tag → ${IMAGE_REF}"
+
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "  ✓ Image built: ${IMAGE_NAME}:${IMAGE_TAG}"
+echo "  ✓ Image built: ${IMAGE_REF}"
 echo "  Upgrade path: ${FROM_VERSION} → ${TO_VERSION}"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""
 echo "To test manually:"
-echo "  docker run --rm -d --name pgs-upgrade -e POSTGRES_PASSWORD=postgres -p 15432:5432 ${IMAGE_NAME}:${IMAGE_TAG}"
+echo "  docker run --rm -d --name pgs-upgrade -e POSTGRES_PASSWORD=postgres -p 15432:5432 ${IMAGE_REF}"
 echo "  sleep 3"
 echo "  psql -h localhost -p 15432 -U postgres -c \"CREATE EXTENSION pg_trickle VERSION '${FROM_VERSION}';\""
 echo "  psql -h localhost -p 15432 -U postgres -c \"ALTER EXTENSION pg_trickle UPDATE TO '${TO_VERSION}';\""

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -9,6 +9,11 @@
 //! ./tests/build_e2e_image.sh
 //! ```
 //!
+//! The build script writes the fully-qualified image reference (e.g.
+//! `pg_trickle_e2e:abc1234`) to `.e2e-image-tag`.  `just test-e2e` reads
+//! that file and forwards it as `PGS_E2E_IMAGE`.  To override for a single
+//! run: `PGS_E2E_IMAGE=pg_trickle_e2e:<tag> cargo test --test 'e2e_*' ...`
+//!
 //! # Usage
 //!
 //! ```rust


### PR DESCRIPTION
## Summary

Implements [plans/PLAN_TEST_ISOLATION.md](plans/PLAN_TEST_ISOLATION.md) in full.

The `:latest` Docker image tag is overwritten by any concurrent CI job that
calls `build_e2e_image.sh`, causing races where test runs pick up the wrong
image. This PR replaces the static tag with `<git-sha>[-dirty]` and
introduces a tag-file handoff so every downstream consumer reads the exact
image that was just built.

## Changes

| File | Change |
|---|---|
| `tests/build_e2e_image.sh` | SHA tag + write `.e2e-image-tag` |
| `tests/build_e2e_upgrade_image.sh` | Resolve base from tag file; SHA tag; write `.e2e-upgrade-image-tag` |
| `justfile` | All e2e/tpch/upgrade targets read tag files; fast targets have a missing-file guard |
| `.github/workflows/ci.yml` | Propagate `PGS_E2E_IMAGE` in e2e, TPC-H, upgrade, and dbt steps |
| `.gitignore` | Exclude `.e2e-image-tag` and `.e2e-upgrade-image-tag` |
| `tests/e2e/mod.rs` | Docstring updated to document the tag-file mechanism |
| `plans/` | PLAN_TEST_ISOLATION.md checklist complete; other plan files updated |

## Testing

All changes are in shell scripts and configuration — no Rust code changed.
Unit and integration tests are unaffected. E2E tests require a Docker build.