### PR TITLE
justfile: add test-bench-e2e convenience targets

### DIFF
--- a/justfile
+++ b/justfile
@@ -158,6 +158,16 @@ test-upgrade from="0.1.3" to="0.2.1": (build-upgrade-image from to)
 bench:
     ./scripts/run_benchmarks.sh
 
+# Run database-level E2E benchmark suite (rebuilds Docker image)
+[group: "bench"]
+test-bench-e2e: build-e2e-image
+    cargo test --test e2e_bench_tests --features pg18 -- --ignored --test-threads=1 --nocapture
+
+# Run E2E benchmarks, skip Docker image rebuild
+[group: "bench"]
+test-bench-e2e-fast:
+    cargo test --test e2e_bench_tests --features pg18 -- --ignored --test-threads=1 --nocapture
+
 # Run diff-operator benchmarks only
 [group: "bench"]
 bench-diff:


### PR DESCRIPTION
## Summary

Adds two `just` targets for the 19 ignored E2E database benchmark tests in `tests/e2e_bench_tests.rs`, giving them the same ergonomics as `just test-tpch` / `just test-tpch-fast`.

| Target | Description |
|---|---|
| `just test-bench-e2e` | Rebuilds Docker image, then runs all 19 bench tests |
| `just test-bench-e2e-fast` | Skips Docker rebuild — faster for iteration |

Previously these could only be invoked via the long-form `cargo test --test e2e_bench_tests --features pg18 -- --ignored --nocapture` noted in the file's module doc comment.

## Testing
- `just lint` passes (justfile-only change)
- No behaviour change to existing targets