### PR TITLE
docs: use named arguments in all SQL function call examples

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -239,11 +239,11 @@ Check your provider's documentation for custom extension support. Services that 
 
 ```sql
 SELECT pgtrickle.create_stream_table(
-    'order_totals',                                           -- name
-    'SELECT customer_id, SUM(amount) AS total
-     FROM orders GROUP BY customer_id',                       -- defining query
-    '5m',                                                     -- refresh schedule
-    'DIFFERENTIAL'                                            -- refresh mode
+    name         => 'order_totals',
+    query        => 'SELECT customer_id, SUM(amount) AS total
+     FROM orders GROUP BY customer_id',
+    schedule     => '5m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -375,7 +375,7 @@ SELECT pg_reload_conf();
 
 ### What happens if all stream tables in the DAG have a CALCULATED schedule?
 
-When every stream table uses a CALCULATED schedule (`schedule => NULL`), there
+When every stream table uses a CALCULATED schedule (`schedule => 'calculated'`), there
 are no explicit schedules for the resolution algorithm to derive from. The
 CALCULATED logic works by propagating `MIN(effective_schedule)` from downstream
 dependents upward through the DAG. If **no** node has an explicit duration:
@@ -394,14 +394,18 @@ resolve to something meaningful:
 
 ```sql
 -- Leaf ST with an explicit schedule
-SELECT pgtrickle.create_stream_table('daily_summary',
-    'SELECT region, SUM(total) FROM pgtrickle.order_totals GROUP BY region',
-    schedule => '10m');
+SELECT pgtrickle.create_stream_table(
+    name     => 'daily_summary',
+    query    => 'SELECT region, SUM(total) FROM pgtrickle.order_totals GROUP BY region',
+    schedule => '10m'
+);
 
 -- Upstream ST inherits that 10 m schedule via CALCULATED
-SELECT pgtrickle.create_stream_table('order_totals',
-    'SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id',
-    schedule => NULL);
+SELECT pgtrickle.create_stream_table(
+    name     => 'order_totals',
+    query    => 'SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id',
+    schedule => 'calculated'
+);
 ```
 
 You can inspect the resolved effective schedules with:
@@ -417,14 +421,20 @@ FROM pgtrickle.pgt_stream_tables;
 
 ```sql
 -- ST1: aggregates orders
-SELECT pgtrickle.create_stream_table('order_totals',
-    'SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id',
-    '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'order_totals',
+    query        => 'SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 
 -- ST2: filters ST1
-SELECT pgtrickle.create_stream_table('big_customers',
-    'SELECT customer_id, total FROM pgtrickle.order_totals WHERE total > 1000',
-    '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'big_customers',
+    query        => 'SELECT customer_id, total FROM pgtrickle.order_totals WHERE total > 1000',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 ### How do I change a stream table's schedule or mode?
@@ -449,10 +459,13 @@ Not directly — the defining query is fixed at creation time. To change it, you
 
 ```sql
 SELECT pgtrickle.drop_stream_table('order_totals');
-SELECT pgtrickle.create_stream_table('order_totals',
-    'SELECT customer_id, SUM(amount) AS total, COUNT(*) AS order_count
+SELECT pgtrickle.create_stream_table(
+    name         => 'order_totals',
+    query        => 'SELECT customer_id, SUM(amount) AS total, COUNT(*) AS order_count
      FROM orders GROUP BY customer_id',  -- updated query
-    '5m', 'DIFFERENTIAL');
+    schedule     => '5m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 The new stream table will perform a full initial refresh to populate itself. The original query is preserved in the catalog's `original_query` column for reference.
@@ -928,14 +941,20 @@ When a defining query has a top-level `ORDER BY … LIMIT N` (with a constant in
 TopK bypasses the DVM delta pipeline — it always re-executes the bounded query. This is efficient because the result set is bounded by N.
 
 ```sql
-SELECT pgtrickle.create_stream_table('top_customers',
-    'SELECT customer_id, total FROM order_totals ORDER BY total DESC LIMIT 100',
-    '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'top_customers',
+    query        => 'SELECT customer_id, total FROM order_totals ORDER BY total DESC LIMIT 100',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 
 -- With OFFSET — "page 2" of the leaderboard (rows 101–200):
-SELECT pgtrickle.create_stream_table('next_customers',
-    'SELECT customer_id, total FROM order_totals ORDER BY total DESC LIMIT 100 OFFSET 100',
-    '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'next_customers',
+    query        => 'SELECT customer_id, total FROM order_totals ORDER BY total DESC LIMIT 100 OFFSET 100',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 ### Does OFFSET work with TopK?
@@ -1337,9 +1356,12 @@ Dropping a column that is referenced in a stream table's defining query will cau
 
 ```sql
 SELECT pgtrickle.drop_stream_table('order_totals');
-SELECT pgtrickle.create_stream_table('order_totals',
-    'SELECT id, name FROM orders',  -- updated query without dropped column
-    '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'order_totals',
+    query        => 'SELECT id, name FROM orders',  -- updated query without dropped column
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 ### What happens when I `CREATE OR REPLACE` a view used by a stream table?
@@ -1711,7 +1733,12 @@ SELECT pgtrickle.alter_stream_table('order_totals', schedule => '10m');
 
 -- To change the defining query or column structure, drop and recreate:
 SELECT pgtrickle.drop_stream_table('order_totals');
-SELECT pgtrickle.create_stream_table('order_totals', '...', '5m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'order_totals',
+    query        => '...',
+    schedule     => '5m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 ### Does pg_trickle work with PgBouncer or other connection poolers?
@@ -2195,9 +2222,12 @@ If the schema change breaks the defining query (e.g., a column referenced in the
 
 ```sql
 SELECT pgtrickle.drop_stream_table('order_totals');
-SELECT pgtrickle.create_stream_table('order_totals',
-    'SELECT id, name FROM orders',  -- updated query reflecting new schema
-    '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'order_totals',
+    query        => 'SELECT id, name FROM orders',  -- updated query reflecting new schema
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 Check the refresh history for the specific error message:
@@ -2307,7 +2337,12 @@ If reinitialization keeps failing (e.g., the defining query references a dropped
 UPDATE pgtrickle.pgt_stream_tables SET needs_reinit = false WHERE pgt_name = 'my_st';
 -- Or drop and recreate:
 SELECT pgtrickle.drop_stream_table('my_st');
-SELECT pgtrickle.create_stream_table('my_st', 'SELECT ...', '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'my_st',
+    query        => 'SELECT ...',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 ---

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -152,8 +152,8 @@ Our first stream table flattens the department tree. For every department, it co
 
 ```sql
 SELECT pgtrickle.create_stream_table(
-    'department_tree',
-    $$
+    name         => 'department_tree',
+    query        => $$
     WITH RECURSIVE tree AS (
         -- Base case: root departments (no parent)
         SELECT id, name, parent_id, name AS path, 0 AS depth
@@ -171,8 +171,8 @@ SELECT pgtrickle.create_stream_table(
     )
     SELECT id, name, parent_id, path, depth FROM tree
     $$,
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -221,8 +221,8 @@ This demonstrates how pg_trickle builds a **DAG** — a directed acyclic graph o
 
 ```sql
 SELECT pgtrickle.create_stream_table(
-    'department_stats',
-    $$
+    name         => 'department_stats',
+    query        => $$
     SELECT
         t.id          AS department_id,
         t.name        AS department_name,
@@ -235,8 +235,8 @@ SELECT pgtrickle.create_stream_table(
     LEFT JOIN employees e ON e.department_id = t.id
     GROUP BY t.id, t.name, t.path, t.depth
     $$,
-    NULL,               -- CALCULATED: inherit schedule from downstream; see explanation below
-    'DIFFERENTIAL'
+    schedule     => 'calculated',      -- CALCULATED: inherit schedule from downstream; see explanation below
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -287,8 +287,8 @@ Now add a rollup that aggregates `department_stats` by top-level group (depth = 
 
 ```sql
 SELECT pgtrickle.create_stream_table(
-    'department_report',
-    $$
+    name         => 'department_report',
+    query        => $$
     SELECT
         split_part(full_path, ' > ', 2) AS division,
         SUM(headcount)                  AS total_headcount,
@@ -297,8 +297,8 @@ SELECT pgtrickle.create_stream_table(
     WHERE depth >= 1
     GROUP BY 1
     $$,
-    '1m',             -- this is the only explicit schedule; CALCULATED tables above inherit it
-    'DIFFERENTIAL'
+    schedule     => '1m',             -- this is the only explicit schedule; CALCULATED tables above inherit it
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -128,35 +128,34 @@ pgtrickle.create_stream_table(
 ```sql
 -- Duration-based: refresh when data is staler than 2 minutes
 SELECT pgtrickle.create_stream_table(
-    'order_totals',
-    'SELECT region, SUM(amount) AS total FROM orders GROUP BY region',
-    '2m',
-    'DIFFERENTIAL'
+    name         => 'order_totals',
+    query        => 'SELECT region, SUM(amount) AS total FROM orders GROUP BY region',
+    schedule     => '2m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Cron-based: refresh every hour
 SELECT pgtrickle.create_stream_table(
-    'hourly_summary',
-    'SELECT date_trunc(''hour'', ts), COUNT(*) FROM events GROUP BY 1',
-    '@hourly',
-    'FULL'
+    name         => 'hourly_summary',
+    query        => 'SELECT date_trunc(''hour'', ts), COUNT(*) FROM events GROUP BY 1',
+    schedule     => '@hourly',
+    refresh_mode => 'FULL'
 );
 
 -- Cron-based: refresh at 6 AM on weekdays
 SELECT pgtrickle.create_stream_table(
-    'daily_report',
-    'SELECT region, SUM(revenue) AS total FROM sales GROUP BY region',
-    '0 6 * * 1-5',
-    'FULL'
+    name         => 'daily_report',
+    query        => 'SELECT region, SUM(revenue) AS total FROM sales GROUP BY region',
+    schedule     => '0 6 * * 1-5',
+    refresh_mode => 'FULL'
 );
 
 -- Immediate mode: maintained synchronously within the same transaction
 -- No schedule needed — updates happen automatically when base table changes
 SELECT pgtrickle.create_stream_table(
-    'live_totals',
-    'SELECT region, SUM(amount) AS total FROM orders GROUP BY region',
-    NULL,
-    'IMMEDIATE'
+    name         => 'live_totals',
+    query        => 'SELECT region, SUM(amount) AS total FROM orders GROUP BY region',
+    refresh_mode => 'IMMEDIATE'
 );
 ```
 
@@ -167,20 +166,20 @@ All supported aggregate functions work in both FULL and DIFFERENTIAL modes:
 ```sql
 -- Algebraic aggregates (fully differential — no rescan needed)
 SELECT pgtrickle.create_stream_table(
-    'sales_summary',
-    'SELECT region, COUNT(*) AS cnt, SUM(amount) AS total, AVG(amount) AS avg_amount
+    name         => 'sales_summary',
+    query        => 'SELECT region, COUNT(*) AS cnt, SUM(amount) AS total, AVG(amount) AS avg_amount
      FROM orders GROUP BY region',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Semi-algebraic aggregates (MIN/MAX)
 SELECT pgtrickle.create_stream_table(
-    'salary_ranges',
-    'SELECT department, MIN(salary) AS min_sal, MAX(salary) AS max_sal
+    name         => 'salary_ranges',
+    query        => 'SELECT department, MIN(salary) AS min_sal, MAX(salary) AS max_sal
      FROM employees GROUP BY department',
-    '2m',
-    'DIFFERENTIAL'
+    schedule     => '2m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Group-rescan aggregates (BOOL_AND/OR, STRING_AGG, ARRAY_AGG, JSON_AGG, JSONB_AGG,
@@ -191,74 +190,74 @@ SELECT pgtrickle.create_stream_table(
 --                          REGR_COUNT, REGR_INTERCEPT, REGR_R2, REGR_SLOPE,
 --                          REGR_SXX, REGR_SXY, REGR_SYY, ANY_VALUE)
 SELECT pgtrickle.create_stream_table(
-    'team_members',
-    'SELECT department,
+    name         => 'team_members',
+    query        => 'SELECT department,
             STRING_AGG(name, '', '' ORDER BY name) AS members,
             ARRAY_AGG(employee_id) AS member_ids,
             BOOL_AND(active) AS all_active,
             JSON_AGG(name) AS members_json
      FROM employees
      GROUP BY department',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Bitwise aggregates
 SELECT pgtrickle.create_stream_table(
-    'permission_summary',
-    'SELECT department,
+    name         => 'permission_summary',
+    query        => 'SELECT department,
             BIT_OR(permissions) AS combined_perms,
             BIT_AND(permissions) AS common_perms,
             BIT_XOR(flags) AS xor_flags
      FROM employees
      GROUP BY department',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- JSON object aggregates
 SELECT pgtrickle.create_stream_table(
-    'config_map',
-    'SELECT department,
+    name         => 'config_map',
+    query        => 'SELECT department,
             JSON_OBJECT_AGG(setting_name, setting_value) AS settings,
             JSONB_OBJECT_AGG(key, value) AS metadata
      FROM config
      GROUP BY department',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Statistical aggregates
 SELECT pgtrickle.create_stream_table(
-    'salary_stats',
-    'SELECT department,
+    name         => 'salary_stats',
+    query        => 'SELECT department,
             STDDEV_POP(salary) AS sd_pop,
             STDDEV_SAMP(salary) AS sd_samp,
             VAR_POP(salary) AS var_pop,
             VAR_SAMP(salary) AS var_samp
      FROM employees
      GROUP BY department',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Ordered-set aggregates (MODE, PERCENTILE_CONT, PERCENTILE_DISC)
 SELECT pgtrickle.create_stream_table(
-    'salary_percentiles',
-    'SELECT department,
+    name         => 'salary_percentiles',
+    query        => 'SELECT department,
             MODE() WITHIN GROUP (ORDER BY grade) AS most_common_grade,
             PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY salary) AS median_salary,
             PERCENTILE_DISC(0.9) WITHIN GROUP (ORDER BY salary) AS p90_salary
      FROM employees
      GROUP BY department',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Regression / correlation aggregates (CORR, COVAR_*, REGR_*)
 SELECT pgtrickle.create_stream_table(
-    'regression_stats',
-    'SELECT department,
+    name         => 'regression_stats',
+    query        => 'SELECT department,
             CORR(salary, experience) AS sal_exp_corr,
             COVAR_POP(salary, experience) AS covar_pop,
             COVAR_SAMP(salary, experience) AS covar_samp,
@@ -268,30 +267,30 @@ SELECT pgtrickle.create_stream_table(
             REGR_COUNT(salary, experience) AS regr_n
      FROM employees
      GROUP BY department',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- ANY_VALUE aggregate (PostgreSQL 16+)
 SELECT pgtrickle.create_stream_table(
-    'dept_sample',
-    'SELECT department, ANY_VALUE(office_location) AS sample_office
+    name         => 'dept_sample',
+    query        => 'SELECT department, ANY_VALUE(office_location) AS sample_office
      FROM employees GROUP BY department',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- FILTER clause on aggregates
 SELECT pgtrickle.create_stream_table(
-    'order_metrics',
-    'SELECT region,
+    name         => 'order_metrics',
+    query        => 'SELECT region,
             COUNT(*) AS total,
             COUNT(*) FILTER (WHERE status = ''active'') AS active_count,
             SUM(amount) FILTER (WHERE status = ''shipped'') AS shipped_total
      FROM orders
      GROUP BY region',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -302,43 +301,43 @@ Non-recursive CTEs are fully supported in both FULL and DIFFERENTIAL modes:
 ```sql
 -- Simple CTE
 SELECT pgtrickle.create_stream_table(
-    'active_order_totals',
-    'WITH active_users AS (
+    name         => 'active_order_totals',
+    query        => 'WITH active_users AS (
         SELECT id, name FROM users WHERE active = true
     )
     SELECT a.id, a.name, SUM(o.amount) AS total
     FROM active_users a
     JOIN orders o ON o.user_id = a.id
     GROUP BY a.id, a.name',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Chained CTEs (CTE referencing another CTE)
 SELECT pgtrickle.create_stream_table(
-    'top_regions',
-    'WITH regional AS (
+    name         => 'top_regions',
+    query        => 'WITH regional AS (
         SELECT region, SUM(amount) AS total FROM orders GROUP BY region
     ),
     ranked AS (
         SELECT region, total FROM regional WHERE total > 1000
     )
     SELECT * FROM ranked',
-    '2m',
-    'DIFFERENTIAL'
+    schedule     => '2m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Multi-reference CTE (referenced twice in FROM — shared delta optimization)
 SELECT pgtrickle.create_stream_table(
-    'self_compare',
-    'WITH totals AS (
+    name         => 'self_compare',
+    query        => 'WITH totals AS (
         SELECT user_id, SUM(amount) AS total FROM orders GROUP BY user_id
     )
     SELECT t1.user_id, t1.total, t2.total AS next_total
     FROM totals t1
     JOIN totals t2 ON t1.user_id = t2.user_id + 1',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -347,8 +346,8 @@ Recursive CTEs work with both FULL and DIFFERENTIAL modes:
 ```sql
 -- Recursive CTE (hierarchy traversal)
 SELECT pgtrickle.create_stream_table(
-    'category_tree',
-    'WITH RECURSIVE cat_tree AS (
+    name         => 'category_tree',
+    query        => 'WITH RECURSIVE cat_tree AS (
         SELECT id, name, parent_id, 0 AS depth
         FROM categories WHERE parent_id IS NULL
         UNION ALL
@@ -357,22 +356,22 @@ SELECT pgtrickle.create_stream_table(
         JOIN cat_tree ct ON c.parent_id = ct.id
     )
     SELECT * FROM cat_tree',
-    '5m',
-    'FULL'  -- FULL mode: standard re-execution
+    schedule     => '5m',
+    refresh_mode => 'FULL'  -- FULL mode: standard re-execution
 );
 
 -- Recursive CTE with DIFFERENTIAL mode (incremental semi-naive / DRed)
 SELECT pgtrickle.create_stream_table(
-    'org_chart',
-    'WITH RECURSIVE reports AS (
+    name         => 'org_chart',
+    query        => 'WITH RECURSIVE reports AS (
         SELECT id, name, manager_id FROM employees WHERE manager_id IS NULL
         UNION ALL
         SELECT e.id, e.name, e.manager_id
         FROM employees e JOIN reports r ON e.manager_id = r.id
     )
     SELECT * FROM reports',
-    '2m',
-    'DIFFERENTIAL'  -- Uses semi-naive, DRed, or recomputation (auto-selected)
+    schedule     => '2m',
+    refresh_mode => 'DIFFERENTIAL'  -- Uses semi-naive, DRed, or recomputation (auto-selected)
 );
 ```
 
@@ -389,52 +388,52 @@ SELECT pgtrickle.create_stream_table(
 ```sql
 -- INTERSECT: customers who placed orders in BOTH regions
 SELECT pgtrickle.create_stream_table(
-    'bi_region_customers',
-    'SELECT customer_id FROM orders_east
+    name         => 'bi_region_customers',
+    query        => 'SELECT customer_id FROM orders_east
      INTERSECT
      SELECT customer_id FROM orders_west',
-    '2m',
-    'DIFFERENTIAL'
+    schedule     => '2m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- INTERSECT ALL: preserves duplicates (bag semantics)
 SELECT pgtrickle.create_stream_table(
-    'common_items',
-    'SELECT item_name FROM warehouse_a
+    name         => 'common_items',
+    query        => 'SELECT item_name FROM warehouse_a
      INTERSECT ALL
      SELECT item_name FROM warehouse_b',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- EXCEPT: orders not yet shipped
 SELECT pgtrickle.create_stream_table(
-    'unshipped_orders',
-    'SELECT order_id FROM orders
+    name         => 'unshipped_orders',
+    query        => 'SELECT order_id FROM orders
      EXCEPT
      SELECT order_id FROM shipments',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- EXCEPT ALL: preserves duplicate counts (bag subtraction)
 SELECT pgtrickle.create_stream_table(
-    'excess_inventory',
-    'SELECT sku FROM stock_received
+    name         => 'excess_inventory',
+    query        => 'SELECT sku FROM stock_received
      EXCEPT ALL
      SELECT sku FROM stock_shipped',
-    '5m',
-    'DIFFERENTIAL'
+    schedule     => '5m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- UNION: deduplicated merge of two sources
 SELECT pgtrickle.create_stream_table(
-    'all_contacts',
-    'SELECT email FROM customers
+    name         => 'all_contacts',
+    query        => 'SELECT email FROM customers
      UNION
      SELECT email FROM newsletter_subscribers',
-    '5m',
-    'DIFFERENTIAL'
+    schedule     => '5m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -445,54 +444,54 @@ Set-returning functions (SRFs) in the FROM clause are supported in both FULL and
 ```sql
 -- Flatten JSONB arrays into rows
 SELECT pgtrickle.create_stream_table(
-    'flat_children',
-    'SELECT p.id, child.value AS val
+    name         => 'flat_children',
+    query        => 'SELECT p.id, child.value AS val
      FROM parent_data p,
      jsonb_array_elements(p.data->''children'') AS child',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Expand JSONB key-value pairs (multi-column SRF)
 SELECT pgtrickle.create_stream_table(
-    'flat_properties',
-    'SELECT d.id, kv.key, kv.value
+    name         => 'flat_properties',
+    query        => 'SELECT d.id, kv.key, kv.value
      FROM documents d,
      jsonb_each(d.metadata) AS kv',
-    '2m',
-    'DIFFERENTIAL'
+    schedule     => '2m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Unnest arrays
 SELECT pgtrickle.create_stream_table(
-    'flat_tags',
-    'SELECT t.id, tag.tag
+    name         => 'flat_tags',
+    query        => 'SELECT t.id, tag.tag
      FROM tagged_items t,
      unnest(t.tags) AS tag(tag)',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- SRF with WHERE filter
 SELECT pgtrickle.create_stream_table(
-    'high_value_items',
-    'SELECT p.id, (e.value)::int AS amount
+    name         => 'high_value_items',
+    query        => 'SELECT p.id, (e.value)::int AS amount
      FROM products p,
      jsonb_array_elements(p.prices) AS e
      WHERE (e.value)::int > 100',
-    '5m',
-    'DIFFERENTIAL'
+    schedule     => '5m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- SRF combined with aggregation
 SELECT pgtrickle.create_stream_table(
-    'element_counts',
-    'SELECT a.id, count(*) AS cnt
+    name         => 'element_counts',
+    query        => 'SELECT a.id, count(*) AS cnt
      FROM arrays a,
      jsonb_array_elements(a.data) AS e
      GROUP BY a.id',
-    '1m',
-    'FULL'
+    schedule     => '1m',
+    refresh_mode => 'FULL'
 );
 ```
 
@@ -503,8 +502,8 @@ LATERAL subqueries in the FROM clause are supported in both FULL and DIFFERENTIA
 ```sql
 -- Top-N per group: latest item per order
 SELECT pgtrickle.create_stream_table(
-    'latest_items',
-    'SELECT o.id, o.customer, latest.amount
+    name         => 'latest_items',
+    query        => 'SELECT o.id, o.customer, latest.amount
      FROM orders o,
      LATERAL (
          SELECT li.amount
@@ -513,36 +512,36 @@ SELECT pgtrickle.create_stream_table(
          ORDER BY li.created_at DESC
          LIMIT 1
      ) AS latest',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Correlated aggregate
 SELECT pgtrickle.create_stream_table(
-    'dept_summaries',
-    'SELECT d.id, d.name, stats.total, stats.cnt
+    name         => 'dept_summaries',
+    query        => 'SELECT d.id, d.name, stats.total, stats.cnt
      FROM departments d,
      LATERAL (
          SELECT SUM(e.salary) AS total, COUNT(*) AS cnt
          FROM employees e
          WHERE e.dept_id = d.id
      ) AS stats',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- LEFT JOIN LATERAL: preserve outer rows with NULLs when subquery returns no rows
 SELECT pgtrickle.create_stream_table(
-    'dept_stats_all',
-    'SELECT d.id, d.name, stats.total
+    name         => 'dept_stats_all',
+    query        => 'SELECT d.id, d.name, stats.total
      FROM departments d
      LEFT JOIN LATERAL (
          SELECT SUM(e.salary) AS total
          FROM employees e
          WHERE e.dept_id = d.id
      ) AS stats ON true',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -553,51 +552,51 @@ Subqueries in the `WHERE` clause are automatically transformed into semi-join, a
 ```sql
 -- EXISTS subquery: customers who have placed orders
 SELECT pgtrickle.create_stream_table(
-    'active_customers',
-    'SELECT c.id, c.name
+    name         => 'active_customers',
+    query        => 'SELECT c.id, c.name
      FROM customers c
      WHERE EXISTS (SELECT 1 FROM orders o WHERE o.customer_id = c.id)',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- NOT EXISTS: customers with no orders
 SELECT pgtrickle.create_stream_table(
-    'inactive_customers',
-    'SELECT c.id, c.name
+    name         => 'inactive_customers',
+    query        => 'SELECT c.id, c.name
      FROM customers c
      WHERE NOT EXISTS (SELECT 1 FROM orders o WHERE o.customer_id = c.id)',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- IN subquery: products that have been ordered
 SELECT pgtrickle.create_stream_table(
-    'ordered_products',
-    'SELECT p.id, p.name
+    name         => 'ordered_products',
+    query        => 'SELECT p.id, p.name
      FROM products p
      WHERE p.id IN (SELECT product_id FROM order_items)',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- NOT IN subquery: products never ordered
 SELECT pgtrickle.create_stream_table(
-    'unordered_products',
-    'SELECT p.id, p.name
+    name         => 'unordered_products',
+    query        => 'SELECT p.id, p.name
      FROM products p
      WHERE p.id NOT IN (SELECT product_id FROM order_items)',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Scalar subquery in SELECT list
 SELECT pgtrickle.create_stream_table(
-    'products_with_max_price',
-    'SELECT p.id, p.name, (SELECT max(price) FROM products) AS max_price
+    name         => 'products_with_max_price',
+    query        => 'SELECT p.id, p.name, (SELECT max(price) FROM products) AS max_price
      FROM products p',
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -1327,9 +1326,12 @@ pg_trickle transparently rewrites certain SQL constructs before parsing. These r
 `HAVING` is fully supported. The filter predicate is applied on top of the aggregate delta computation — groups that pass the HAVING condition are included in the stream table.
 
 ```sql
-SELECT pgtrickle.create_stream_table('big_departments',
-  'SELECT department, COUNT(*) AS cnt FROM employees GROUP BY department HAVING COUNT(*) > 10',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'big_departments',
+    query        => 'SELECT department, COUNT(*) AS cnt FROM employees GROUP BY department HAVING COUNT(*) > 10',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 ### Tables Without Primary Keys (Keyless Tables)
@@ -1341,9 +1343,12 @@ though at the cost of being unable to distinguish truly duplicate rows (rows wit
 ```sql
 -- No primary key — pg_trickle uses content hashing for row identity
 CREATE TABLE events (ts TIMESTAMPTZ, payload JSONB);
-SELECT pgtrickle.create_stream_table('event_summary',
-  'SELECT payload->>''type'' AS event_type, COUNT(*) FROM events GROUP BY 1',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'event_summary',
+    query        => 'SELECT payload->>''type'' AS event_type, COUNT(*) FROM events GROUP BY 1',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 > **Known Limitation — Duplicate Rows in Keyless Tables (G7.1)**
@@ -1375,9 +1380,12 @@ FULL mode accepts all volatility classes since it re-evaluates the entire query 
 `COLLATE` clauses on expressions are supported:
 
 ```sql
-SELECT pgtrickle.create_stream_table('sorted_names',
-  'SELECT name COLLATE "C" AS c_name FROM users',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'sorted_names',
+    query        => 'SELECT name COLLATE "C" AS c_name FROM users',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 ### IS JSON Predicate (PostgreSQL 16+)
@@ -1386,17 +1394,23 @@ The `IS JSON` predicate validates whether a value is valid JSON. All variants ar
 
 ```sql
 -- Filter rows with valid JSON
-SELECT pgtrickle.create_stream_table('valid_json_events',
-  'SELECT id, payload FROM events WHERE payload::text IS JSON',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'valid_json_events',
+    query        => 'SELECT id, payload FROM events WHERE payload::text IS JSON',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 
 -- Type-specific checks
-SELECT pgtrickle.create_stream_table('json_objects_only',
-  'SELECT id, data IS JSON OBJECT AS is_obj,
+SELECT pgtrickle.create_stream_table(
+    name         => 'json_objects_only',
+    query        => 'SELECT id, data IS JSON OBJECT AS is_obj,
           data IS JSON ARRAY AS is_arr,
           data IS JSON SCALAR AS is_scalar
    FROM json_data',
-  '1m', 'FULL');
+    schedule     => '1m',
+    refresh_mode => 'FULL'
+);
 ```
 
 Supported variants: `IS JSON`, `IS JSON OBJECT`, `IS JSON ARRAY`, `IS JSON SCALAR`, `IS NOT JSON` (all forms), `WITH UNIQUE KEYS`.
@@ -1407,14 +1421,20 @@ SQL-standard JSON constructor functions are supported in both FULL and DIFFERENT
 
 ```sql
 -- JSON_OBJECT: construct a JSON object from key-value pairs
-SELECT pgtrickle.create_stream_table('user_json',
-  'SELECT id, JSON_OBJECT(''name'' : name, ''age'' : age) AS data FROM users',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'user_json',
+    query        => 'SELECT id, JSON_OBJECT(''name'' : name, ''age'' : age) AS data FROM users',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 
 -- JSON_ARRAY: construct a JSON array from values
-SELECT pgtrickle.create_stream_table('value_arrays',
-  'SELECT id, JSON_ARRAY(a, b, c) AS arr FROM measurements',
-  '1m', 'FULL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'value_arrays',
+    query        => 'SELECT id, JSON_ARRAY(a, b, c) AS arr FROM measurements',
+    schedule     => '1m',
+    refresh_mode => 'FULL'
+);
 
 -- JSON(): parse a text value as JSON
 -- JSON_SCALAR(): wrap a scalar value as JSON
@@ -1429,8 +1449,9 @@ SELECT pgtrickle.create_stream_table('value_arrays',
 
 ```sql
 -- Extract structured data from a JSON column
-SELECT pgtrickle.create_stream_table('user_phones',
-  $$SELECT u.id, j.phone_type, j.phone_number
+SELECT pgtrickle.create_stream_table(
+    name         => 'user_phones',
+    query        => $$SELECT u.id, j.phone_type, j.phone_number
     FROM users u,
          JSON_TABLE(u.contact_info, '$.phones[*]'
            COLUMNS (
@@ -1438,7 +1459,9 @@ SELECT pgtrickle.create_stream_table('user_phones',
              phone_number TEXT PATH '$.number'
            )
          ) AS j$$,
-  '1m', 'DIFFERENTIAL');
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 Supported column types:
@@ -1472,14 +1495,20 @@ Stream tables **can** reference other stream tables in their defining query. Thi
 
 ```sql
 -- ST1 reads from a base table
-SELECT pgtrickle.create_stream_table('order_totals',
-  'SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'order_totals',
+    query        => 'SELECT customer_id, SUM(amount) AS total FROM orders GROUP BY customer_id',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 
 -- ST2 reads from ST1
-SELECT pgtrickle.create_stream_table('big_customers',
-  'SELECT customer_id, total FROM pgtrickle.order_totals WHERE total > 1000',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'big_customers',
+    query        => 'SELECT customer_id, total FROM pgtrickle.order_totals WHERE total > 1000',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 ### Views as Sources in Defining Queries
@@ -1491,9 +1520,12 @@ CREATE VIEW active_orders AS
   SELECT * FROM orders WHERE status = 'active';
 
 -- This works in DIFFERENTIAL mode:
-SELECT pgtrickle.create_stream_table('order_summary',
-  'SELECT customer_id, COUNT(*) FROM active_orders GROUP BY customer_id',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'order_summary',
+    query        => 'SELECT customer_id, COUNT(*) FROM active_orders GROUP BY customer_id',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 -- Internally, 'active_orders' is replaced with:
 --   (SELECT ... FROM orders WHERE status = 'active') AS active_orders
 ```
@@ -1520,9 +1552,12 @@ CREATE TABLE orders_us PARTITION OF orders FOR VALUES IN ('US');
 CREATE TABLE orders_eu PARTITION OF orders FOR VALUES IN ('EU');
 
 -- Works — inserts into any partition are captured:
-SELECT pgtrickle.create_stream_table('order_summary',
-  'SELECT region, SUM(amount) FROM orders GROUP BY region',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'order_summary',
+    query        => 'SELECT region, SUM(amount) FROM orders GROUP BY region',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 > **Note:** pg_trickle targets PostgreSQL 18. On PostgreSQL 12 or earlier (not supported), parent triggers do **not** fire for partition-routed rows, which would cause silent data loss.
@@ -1614,9 +1649,12 @@ the delta query may fail to emit the required DELETE from the stream table:
 
 ```sql
 -- Stream table joining orders with customers
-SELECT pgtrickle.create_stream_table('order_details',
-  'SELECT o.id, c.name FROM orders o JOIN customers c ON o.cust_id = c.id',
-  '1m', 'DIFFERENTIAL');
+SELECT pgtrickle.create_stream_table(
+    name         => 'order_details',
+    query        => 'SELECT o.id, c.name FROM orders o JOIN customers c ON o.cust_id = c.id',
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 
 -- Scenario that exposes the limitation:
 -- In the same transaction (or same refresh interval):
@@ -1649,10 +1687,13 @@ memory usage during query generation. Use explicit `GROUPING SETS(...)` instead:
 ```sql
 -- Rejected: CUBE(a, b, c, d, e, f, g) would generate 128 branches
 -- Use instead:
-SELECT pgtrickle.create_stream_table('multi_dim',
-  'SELECT a, b, c, SUM(v) FROM t
+SELECT pgtrickle.create_stream_table(
+    name         => 'multi_dim',
+    query        => 'SELECT a, b, c, SUM(v) FROM t
    GROUP BY GROUPING SETS ((a, b, c), (a, b), (a), ())',
-  '5m', 'DIFFERENTIAL');
+    schedule     => '5m',
+    refresh_mode => 'DIFFERENTIAL'
+);
 ```
 
 ### What Is NOT Allowed

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -8,9 +8,9 @@ stay fresh.
 ```sql
 -- Declare a stream table — a view that maintains itself
 SELECT pgtrickle.create_stream_table(
-    'active_orders',
-    'SELECT * FROM orders WHERE status = ''active''',
-    '30s'
+    name     => 'active_orders',
+    query    => 'SELECT * FROM orders WHERE status = ''active''',
+    schedule => '30s'
 );
 
 -- Insert a row — the stream table updates automatically on the next refresh

--- a/docs/tutorials/WHAT_HAPPENS_ON_DELETE.md
+++ b/docs/tutorials/WHAT_HAPPENS_ON_DELETE.md
@@ -16,13 +16,13 @@ CREATE TABLE orders (
 );
 
 SELECT pgtrickle.create_stream_table(
-    'customer_totals',
-    $$
+    name         => 'customer_totals',
+    query        => $$
       SELECT customer, SUM(amount) AS total, COUNT(*) AS order_count
       FROM orders GROUP BY customer
     $$,
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Seed some data
@@ -360,14 +360,14 @@ CREATE TABLE orders (
 );
 
 SELECT pgtrickle.create_stream_table(
-    'order_details',
-    $$
+    name         => 'order_details',
+    query        => $$
       SELECT c.name, c.tier, o.amount
       FROM orders o
       JOIN customers c ON o.customer_id = c.id
     $$,
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 

--- a/docs/tutorials/WHAT_HAPPENS_ON_INSERT.md
+++ b/docs/tutorials/WHAT_HAPPENS_ON_INSERT.md
@@ -16,13 +16,13 @@ CREATE TABLE orders (
 
 -- Stream table: always-fresh customer totals
 SELECT pgtrickle.create_stream_table(
-    'customer_totals',
-    $$
+    name         => 'customer_totals',
+    query        => $$
       SELECT customer, SUM(amount) AS total, COUNT(*) AS order_count
       FROM orders GROUP BY customer
     $$,
-    '1m',           -- refresh when data is staler than 1 minute
-    'DIFFERENTIAL'  -- only process changed rows, not the full table
+    schedule     => '1m',           -- refresh when data is staler than 1 minute
+    refresh_mode => 'DIFFERENTIAL'  -- only process changed rows, not the full table
 );
 ```
 

--- a/docs/tutorials/WHAT_HAPPENS_ON_TRUNCATE.md
+++ b/docs/tutorials/WHAT_HAPPENS_ON_TRUNCATE.md
@@ -16,13 +16,13 @@ CREATE TABLE orders (
 );
 
 SELECT pgtrickle.create_stream_table(
-    'customer_totals',
-    $$
+    name         => 'customer_totals',
+    query        => $$
       SELECT customer, SUM(amount) AS total, COUNT(*) AS order_count
       FROM orders GROUP BY customer
     $$,
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Seed some data
@@ -206,14 +206,14 @@ CREATE TABLE orders (
 );
 
 SELECT pgtrickle.create_stream_table(
-    'order_details',
-    $$
+    name         => 'order_details',
+    query        => $$
       SELECT c.name, c.tier, o.amount
       FROM orders o
       JOIN customers c ON o.customer_id = c.id
     $$,
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -239,13 +239,13 @@ If the stream table uses `FULL` refresh mode instead of `DIFFERENTIAL`:
 
 ```sql
 SELECT pgtrickle.create_stream_table(
-    'customer_totals_full',
-    $$
+    name         => 'customer_totals_full',
+    query        => $$
       SELECT customer, SUM(amount) AS total, COUNT(*) AS order_count
       FROM orders GROUP BY customer
     $$,
-    '1m',
-    'FULL'
+    schedule     => '1m',
+    refresh_mode => 'FULL'
 );
 ```
 

--- a/docs/tutorials/WHAT_HAPPENS_ON_UPDATE.md
+++ b/docs/tutorials/WHAT_HAPPENS_ON_UPDATE.md
@@ -16,13 +16,13 @@ CREATE TABLE orders (
 );
 
 SELECT pgtrickle.create_stream_table(
-    'customer_totals',
-    $$
+    name         => 'customer_totals',
+    query        => $$
       SELECT customer, SUM(amount) AS total, COUNT(*) AS order_count
       FROM orders GROUP BY customer
     $$,
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 
 -- Seed some data
@@ -349,14 +349,14 @@ CREATE TABLE orders (
 );
 
 SELECT pgtrickle.create_stream_table(
-    'order_details',
-    $$
+    name         => 'order_details',
+    query        => $$
       SELECT c.name, c.tier, o.amount
       FROM orders o
       JOIN customers c ON o.customer_id = c.id
     $$,
-    '1m',
-    'DIFFERENTIAL'
+    schedule     => '1m',
+    refresh_mode => 'DIFFERENTIAL'
 );
 ```
 


### PR DESCRIPTION
Replace positional arguments with named/keyword arguments (`=>` syntax) in all documentation and tutorial examples for `pgtrickle.create_stream_table()` and related functions.

## Changes

- All `create_stream_table()` calls in `docs/` now use `name =>`, `query =>`, `schedule =>`, `refresh_mode =>` etc.
- Fixed `schedule => NULL` → `schedule => 'calculated'` for CALCULATED mode examples
- Removed `schedule` parameter from IMMEDIATE mode examples (not applicable)

## Files changed

- `docs/SQL_REFERENCE.md`
- `docs/FAQ.md`
- `docs/GETTING_STARTED.md`
- `docs/introduction.md`
- `docs/tutorials/WHAT_HAPPENS_ON_DELETE.md`
- `docs/tutorials/WHAT_HAPPENS_ON_INSERT.md`
- `docs/tutorials/WHAT_HAPPENS_ON_TRUNCATE.md`
- `docs/tutorials/WHAT_HAPPENS_ON_UPDATE.md`