### PR TITLE
feat: WAL CDC Hardening (W1/W2/W3), Documentation Sweep (DS1/DS2/DS3) + IMMEDIATE IM1

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -297,13 +297,13 @@ Self-contained items from Stage 7 of the edge-cases/TIVM implementation plan.
 
 Remaining documentation gaps identified in Stage 7 of the gap analysis.
 
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| DS1 | DDL-during-refresh behaviour: document safe patterns and races | 2h | [PLAN_EDGE_CASES.md](plans/PLAN_EDGE_CASES.md) EC-17 |
-| DS2 | Replication/standby limitations: document in FAQ and Architecture | 3h | [PLAN_EDGE_CASES.md](plans/PLAN_EDGE_CASES.md) EC-21/22/23 |
-| DS3 | PgBouncer configuration guide: session-mode requirements and known incompatibilities | 2h | [PLAN_EDGE_CASES.md](plans/PLAN_EDGE_CASES.md) EC-28 |
+| Item | Description | Effort | Status | Ref |
+|------|-------------|--------|--------|-----|
+| DS1 | DDL-during-refresh behaviour: document safe patterns and races | 2h | ✅ Done | [PLAN_EDGE_CASES.md](plans/PLAN_EDGE_CASES.md) EC-17 |
+| DS2 | Replication/standby limitations: document in FAQ and Architecture | 3h | ✅ Done | [PLAN_EDGE_CASES.md](plans/PLAN_EDGE_CASES.md) EC-21/22/23 |
+| DS3 | PgBouncer configuration guide: session-mode requirements and known incompatibilities | 2h | ✅ Done | [PLAN_EDGE_CASES.md](plans/PLAN_EDGE_CASES.md) EC-28 |
 
-> **Documentation sweep subtotal: ~1 day**
+> **Documentation sweep subtotal: ✅ Complete**
 
 ### WAL CDC Hardening
 
@@ -326,7 +326,7 @@ Remaining documentation gaps identified in Stage 7 of the gap analysis.
 - [x] IMMEDIATE mode: TopK micro-refresh fully tested end-to-end (10 E2E tests)
 - [ ] `max_grouping_set_branches` GUC guards CUBE/ROLLUP explosion
 - [x] Post-restart CDC TRANSITIONING health check in place
-- [ ] DDL-during-refresh and standby/replication limitations documented
+- [x] DDL-during-refresh and standby/replication limitations documented
 - [x] WAL CDC mode passes full E2E suite
 - [ ] E2E tests pass (`just build-e2e-image && just test-e2e`)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -365,6 +365,7 @@ Key lifecycle properties:
 | **Config reload** | Handles `SIGHUP` — re-reads GUC values on the next latch wake |
 | **Crash recovery** | On startup, any `pgt_refresh_history` rows stuck in `RUNNING` status are marked `FAILED` (the transaction that wrote them was rolled back by PostgreSQL, but the status row may have been committed in a prior transaction) |
 | **Database** | Connects to the `postgres` database via SPI |
+| **Standby / replica** | On standby servers (`pg_is_in_recovery() = true`), the worker enters a sleep loop and does **not** attempt refreshes. Stream tables are still readable on standbys — they are regular heap tables replicated via physical streaming replication. After promotion the scheduler resumes automatically. See the [FAQ § Replication](FAQ.md#ec-21-22-23) for details on logical replication and subscriber limitations. |
 
 #### Scheduler Tick
 


### PR DESCRIPTION
## WAL CDC Hardening

### W2 — Automatic fallback hardening
- Consecutive error counter in `wal_decoder.rs`: after 5 consecutive WAL poll failures, automatically falls back to trigger-based CDC
- `check_decoder_health()` validates `wal_level` is still `logical`; falls back immediately if changed
- Error counter resets on any successful poll

### W3 — Promote `cdc_mode = 'auto'` to default
- `PGS_CDC_MODE` default changed from `'trigger'` to `'auto'`
- Safe no-op when `wal_level != logical` (stays on triggers)
- Updated CONFIGURATION.md, ARCHITECTURE.md, FAQ.md

### W1 — WAL CDC E2E test suite
- 10 new E2E tests in `e2e_wal_cdc_tests.rs`
- `Dockerfile.e2e` updated: `wal_level = logical`, `max_replication_slots = 10`

## Documentation Sweep

### DS1 — DDL-during-refresh behaviour
- Already documented in FAQ § EC-17: lock interaction, MVCC safety, `block_source_ddl` GUC

### DS2 — Replication/standby limitations
- FAQ § EC-21/22/23: physical/logical replication table, subscriber limitations
- FAQ § standby: `pg_is_in_recovery()` sleep loop, read pattern
- **New:** ARCHITECTURE.md scheduler lifecycle table: standby/replica row with cross-reference

### DS3 — PgBouncer configuration guide
- Already documented in FAQ: session-level feature incompatibilities, recommended configurations, per-database routing tip

## IMMEDIATE mode (from prior commits)
- IM1: Recursive CTE support in IMMEDIATE mode (semi-naive evaluation)

## ROADMAP
- W1/W2/W3 ✅ Done, DS1/DS2/DS3 ✅ Done
- Exit criteria updated: WAL CDC E2E ✅, post-restart health check ✅, documentation sweep ✅
- Merged latest main (IM2 TopK, ALTER QUERY, version restructuring)