### PR TITLE
fix(dbt): add primary key post-hook to raw_orders seed

### DIFF
--- a/dbt-pgtrickle/integration_tests/dbt_project.yml
+++ b/dbt-pgtrickle/integration_tests/dbt_project.yml
@@ -8,6 +8,11 @@ model-paths: ["models"]
 seed-paths: ["seeds"]
 test-paths: ["tests"]
 
+seeds:
+  dbt_pgtrickle_integration_tests:
+    raw_orders:
+      +post-hook: "ALTER TABLE {{ this }} ADD PRIMARY KEY (id)"
+
 clean-targets:
   - "target"
   - "dbt_packages"


### PR DESCRIPTION
WAL-based CDC (`cdc_mode = 'auto'`) requires a PRIMARY KEY or REPLICA IDENTITY FULL on source tables. The `raw_orders` seed had neither, causing stream table creation to fail with:

```
invalid argument: Source table public.raw_orders has no PRIMARY KEY and REPLICA IDENTITY is 'default'.
```

Fix: add a `post-hook` in `dbt_project.yml` that promotes the `id` column to PRIMARY KEY after the seed is loaded.