### PR TITLE
Start CDC/refresh mode gap work for IMMEDIATE and WAL CDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ For future plans and release milestones, see [ROADMAP.md](ROADMAP.md).
 
 ### Changed
 
+- **IMMEDIATE/WAL CDC interaction clarified** — `create_stream_table()` and
+  `alter_stream_table()` now emit an INFO message when
+  `pg_trickle.cdc_mode = 'wal'` is in effect but the requested
+  `refresh_mode = 'IMMEDIATE'`. IMMEDIATE mode continues to use
+  statement-level IVM triggers and does not install CDC triggers or create WAL
+  replication slots. Unit tests and E2E coverage now lock in that behavior for
+  both create and alter flows.
+
 - **CI test pyramid rebalanced** — PRs now run a faster three-tier gate:
   Linux unit tests, integration tests, and a curated Light E2E tier split
   across three shards against stock `postgres:18.1`. The heavier full E2E,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -371,13 +371,19 @@ validations, resource leaks, and observability holes. Phased from quick wins
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
 | G6 | Defensive `is_populated` + empty-frontier check in `execute_differential_refresh()` | 2h | [PLAN_CDC_MODE_REFRESH_MODE_GAPS.md](plans/sql/PLAN_CDC_MODE_REFRESH_MODE_GAPS.md) §G6 |
-| G2 | Validate `IMMEDIATE` + `cdc_mode='wal'` — reject explicit combination, INFO for implicit | 2–3h | [PLAN_CDC_MODE_REFRESH_MODE_GAPS.md](plans/sql/PLAN_CDC_MODE_REFRESH_MODE_GAPS.md) §G2 |
+| G2 | Validate `IMMEDIATE` + `cdc_mode='wal'` — INFO for implicit global-GUC path shipped; explicit per-table rejection pending G1 | 2–3h | [PLAN_CDC_MODE_REFRESH_MODE_GAPS.md](plans/sql/PLAN_CDC_MODE_REFRESH_MODE_GAPS.md) §G2 |
 | G3 | Advance WAL replication slot after FULL refresh; flush change buffers | 4–6h | [PLAN_CDC_MODE_REFRESH_MODE_GAPS.md](plans/sql/PLAN_CDC_MODE_REFRESH_MODE_GAPS.md) §G3 |
 | G4 | Flush change buffers after AUTO→FULL adaptive fallback (prevents ping-pong) | 3–4h | [PLAN_CDC_MODE_REFRESH_MODE_GAPS.md](plans/sql/PLAN_CDC_MODE_REFRESH_MODE_GAPS.md) §G4 |
 | G5 | `pgtrickle.pgt_cdc_status` view + NOTIFY on CDC transitions | 4–6h | [PLAN_CDC_MODE_REFRESH_MODE_GAPS.md](plans/sql/PLAN_CDC_MODE_REFRESH_MODE_GAPS.md) §G5 |
 | G1 | Per-table `cdc_mode` override (SQL API, catalog, dbt, migration) | 2–3d | [PLAN_CDC_MODE_REFRESH_MODE_GAPS.md](plans/sql/PLAN_CDC_MODE_REFRESH_MODE_GAPS.md) §G1 |
 
 > **CDC/refresh mode gaps subtotal: ~4–6 days**
+>
+> **Progress:** G2 phase 1 is now implemented in `Unreleased`: when the
+> cluster-wide `pg_trickle.cdc_mode` is `'wal'`, creating or switching a
+> stream table to `refresh_mode = 'IMMEDIATE'` logs an INFO and continues with
+> statement-level IVM triggers. The explicit rejection path depends on the
+> per-table `cdc_mode` override tracked as G1.
 
 ### Operational
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -99,6 +99,12 @@ CDC (Change Data Capture) mechanism selection.
 
 **Default:** `'auto'`
 
+`pg_trickle.cdc_mode` only affects deferred refresh modes (`'AUTO'`, `'FULL'`,
+and `'DIFFERENTIAL'`). `refresh_mode = 'IMMEDIATE'` bypasses CDC entirely and
+always uses statement-level IVM triggers. If the GUC is set to `'wal'` when a
+stream table is created or altered to `IMMEDIATE`, pg_trickle logs an INFO and
+continues with IVM triggers instead of creating CDC triggers or WAL slots.
+
 ```sql
 -- Enable automatic trigger → WAL transition (default)
 SET pg_trickle.cdc_mode = 'auto';

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -107,6 +107,10 @@ pgtrickle.create_stream_table(
 | `diamond_consistency` | `text` | `NULL` (defaults to `'none'`) | Diamond dependency consistency mode: `'none'` (independent refresh) or `'atomic'` (SAVEPOINT-based atomic group refresh). |
 | `diamond_schedule_policy` | `text` | `NULL` (defaults to `'fastest'`) | Schedule policy for atomic diamond groups: `'fastest'` (fire when any member is due) or `'slowest'` (fire when all are due). Set on the convergence node. |
 
+When `refresh_mode => 'IMMEDIATE'`, the cluster-wide `pg_trickle.cdc_mode`
+setting is ignored. IMMEDIATE mode always uses statement-level IVM triggers
+instead of CDC triggers or WAL replication slots.
+
 **Duration format:**
 
 | Unit | Suffix | Example |
@@ -639,6 +643,10 @@ pgtrickle.alter_stream_table(
 | `status` | `text` | `NULL` | New status (`'ACTIVE'`, `'SUSPENDED'`). Pass `NULL` to leave unchanged. Resuming resets consecutive errors to 0. |
 | `diamond_consistency` | `text` | `NULL` | New diamond consistency mode (`'none'` or `'atomic'`). Pass `NULL` to leave unchanged. |
 | `diamond_schedule_policy` | `text` | `NULL` | New schedule policy for atomic diamond groups (`'fastest'` or `'slowest'`). Pass `NULL` to leave unchanged. |
+
+If you switch a stream table to `refresh_mode => 'IMMEDIATE'` while the
+cluster-wide `pg_trickle.cdc_mode` GUC is set to `'wal'`, pg_trickle logs an
+INFO and proceeds with IVM triggers. WAL CDC does not apply to IMMEDIATE mode.
 
 **Examples:**
 

--- a/plans/sql/PLAN_CDC_MODE_REFRESH_MODE_GAPS.md
+++ b/plans/sql/PLAN_CDC_MODE_REFRESH_MODE_GAPS.md
@@ -1,8 +1,8 @@
 # Plan: CDC Mode / Refresh Mode Interaction Gaps
 
 Date: 2026-03-07
-Status: PROPOSED
-Last Updated: 2026-03-07
+Status: IN PROGRESS
+Last Updated: 2026-03-08
 
 ---
 
@@ -159,10 +159,27 @@ has an `if refresh_mode.is_immediate() { ... } else { ... }` branch. The
 `else` branch calls `setup_cdc_for_source()`. The `if` branch calls
 `ivm::setup_ivm_triggers()`. No validation rejects the combination.
 
+**Progress (2026-03-08).** Phase 1 is implemented: when the cluster-wide
+`pg_trickle.cdc_mode` GUC is `'wal'` and a stream table is created or altered
+to `refresh_mode = 'IMMEDIATE'`, pg_trickle now emits an INFO explaining that
+WAL CDC is ignored and that statement-level IVM triggers will be used instead.
+The explicit rejection path is still pending because there is not yet a
+per-table `cdc_mode` override surface; that arrives with G1.
+
 #### Implementation Steps
 
-1. **Validation in `create_stream_table_impl()`** (`src/api.rs:1090`)
-   - After parsing `refresh_mode` and determining effective `cdc_mode`:
+1. **Phase 1 — INFO for implicit global-GUC mismatch** (`src/api.rs`)
+   - If `refresh_mode = 'IMMEDIATE'` and the effective `cdc_mode` comes from
+     the global GUC with value `'wal'`, emit:
+     ```text
+     INFO: cdc_mode 'wal' has no effect for IMMEDIATE refresh mode — using IVM triggers
+     ```
+   - Implement in both `create_stream_table_impl()` and
+     `alter_stream_table_impl()`.
+
+2. **Phase 2 — Explicit rejection once G1 exists** (`src/api.rs`)
+   - After parsing `refresh_mode` and determining an explicit per-table
+     `cdc_mode` override:
      ```rust
      if refresh_mode.is_immediate() && effective_cdc_mode == "wal" {
          return Err(PgTrickleError::InvalidArgument(
@@ -173,17 +190,15 @@ has an `if refresh_mode.is_immediate() { ... } else { ... }` branch. The
          ));
      }
      ```
-   - Same check in `alter_stream_table_impl()` when altering refresh mode
-     or cdc mode.
-
-2. **INFO log for implicit override**
-   - When `cdc_mode` GUC is `wal` but refresh mode is `IMMEDIATE` (and no
-     explicit per-table override), emit:
-     ```
-     INFO: cdc_mode 'wal' has no effect for IMMEDIATE refresh mode — using IVM triggers
-     ```
+   - Same check in `alter_stream_table_impl()` when altering refresh mode or
+     cdc mode.
 
 3. **Tests**
+   - Phase 1 E2E test: GUC `wal` + `IMMEDIATE` create path succeeds and does
+     not install CDC triggers or WAL slots.
+   - Phase 1 E2E test: GUC `wal` + `ALTER ... refresh_mode='IMMEDIATE'`
+     succeeds, leaves no WAL slots behind, and preserves synchronous
+     IMMEDIATE propagation on subsequent DML.
    - Integration test: explicit `cdc_mode => 'wal'` + `IMMEDIATE` → error.
    - Integration test: GUC `wal` + `IMMEDIATE` (no per-table override) → 
      success with INFO log.

--- a/src/api.rs
+++ b/src/api.rs
@@ -100,6 +100,58 @@ struct ValidatedQuery {
     source_relids: Vec<(pg_sys::Oid, String)>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CdcModeRequestSource {
+    GlobalGuc,
+    ExplicitOverride,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CdcRefreshModeInteraction {
+    None,
+    IgnoreWalForImmediate,
+    RejectWalForImmediate,
+}
+
+fn classify_cdc_refresh_mode_interaction(
+    refresh_mode: RefreshMode,
+    requested_cdc_mode: &str,
+    source: CdcModeRequestSource,
+) -> CdcRefreshModeInteraction {
+    if !refresh_mode.is_immediate() || !requested_cdc_mode.eq_ignore_ascii_case("wal") {
+        return CdcRefreshModeInteraction::None;
+    }
+
+    match source {
+        CdcModeRequestSource::GlobalGuc => CdcRefreshModeInteraction::IgnoreWalForImmediate,
+        CdcModeRequestSource::ExplicitOverride => CdcRefreshModeInteraction::RejectWalForImmediate,
+    }
+}
+
+fn enforce_cdc_refresh_mode_interaction(
+    stream_table_name: &str,
+    refresh_mode: RefreshMode,
+    requested_cdc_mode: &str,
+    source: CdcModeRequestSource,
+) -> Result<(), PgTrickleError> {
+    match classify_cdc_refresh_mode_interaction(refresh_mode, requested_cdc_mode, source) {
+        CdcRefreshModeInteraction::None => Ok(()),
+        CdcRefreshModeInteraction::IgnoreWalForImmediate => {
+            pgrx::info!(
+                "pg_trickle: cdc_mode 'wal' has no effect for IMMEDIATE refresh mode on {} — using IVM triggers instead of CDC.",
+                stream_table_name,
+            );
+            Ok(())
+        }
+        CdcRefreshModeInteraction::RejectWalForImmediate => Err(PgTrickleError::InvalidArgument(
+            "refresh_mode = 'IMMEDIATE' is incompatible with cdc_mode = 'wal'. \
+             IMMEDIATE uses in-transaction IVM triggers; WAL-based CDC is async. \
+             Use cdc_mode = 'trigger' or 'auto', or choose a deferred refresh_mode."
+                .to_string(),
+        )),
+    }
+}
+
 /// Validate a rewritten query and parse it for DVM. This runs the LIMIT 0
 /// check, TopK detection, unsupported construct rejection, DVM parsing,
 /// volatility checks, and source relation extraction.
@@ -804,7 +856,7 @@ fn alter_stream_table_query(
             } else {
                 let old_dep = old_deps.iter().find(|d| d.source_relid == *source_oid);
                 let cdc_mode = old_dep.map(|d| d.cdc_mode).unwrap_or(CdcMode::Trigger);
-                if let Err(e) = cleanup_cdc_for_source(*source_oid, cdc_mode) {
+                if let Err(e) = cleanup_cdc_for_source(*source_oid, cdc_mode, Some(st.pgt_id)) {
                     pgrx::warning!(
                         "Failed to clean up CDC for removed source {}: {}",
                         source_oid.to_u32(),
@@ -1132,6 +1184,7 @@ fn create_stream_table_impl(
 
     // Parse schema.name
     let (schema, table_name) = parse_qualified_name(name)?;
+    let qualified_name = format!("{schema}.{table_name}");
 
     // Parse and validate schedule
     let schedule_str = if refresh_mode.is_immediate() {
@@ -1150,6 +1203,14 @@ fn create_stream_table_impl(
             }
         }
     };
+
+    let requested_cdc_mode = config::pg_trickle_cdc_mode();
+    enforce_cdc_refresh_mode_interaction(
+        &qualified_name,
+        refresh_mode,
+        &requested_cdc_mode,
+        CdcModeRequestSource::GlobalGuc,
+    )?;
 
     // ── Query rewrite pipeline ─────────────────────────────────────
     let original_query = query.to_string();
@@ -1319,6 +1380,7 @@ fn alter_stream_table_impl(
 ) -> Result<(), PgTrickleError> {
     let (schema, table_name) = parse_qualified_name(name)?;
     let st = StreamTableMeta::get_by_name(&schema, &table_name)?;
+    let qualified_name = format!("{schema}.{table_name}");
 
     // ── Query migration (must run first, before other parameter changes) ──
     if let Some(new_query) = query {
@@ -1349,6 +1411,14 @@ fn alter_stream_table_impl(
         let old_mode = st.refresh_mode;
 
         if new_mode != old_mode {
+            let requested_cdc_mode = config::pg_trickle_cdc_mode();
+            enforce_cdc_refresh_mode_interaction(
+                &qualified_name,
+                new_mode,
+                &requested_cdc_mode,
+                CdcModeRequestSource::GlobalGuc,
+            )?;
+
             // ── Validate mode switch ────────────────────────────────
             // TopK tables: check limit threshold for IMMEDIATE mode.
             if let (true, Some(topk_limit)) = (new_mode.is_immediate(), st.topk_limit) {
@@ -1396,8 +1466,11 @@ fn alter_stream_table_impl(
                     if new_mode.is_immediate() {
                         for dep in &deps {
                             if dep.source_type == "TABLE"
-                                && let Err(e) =
-                                    cleanup_cdc_for_source(dep.source_relid, dep.cdc_mode)
+                                && let Err(e) = cleanup_cdc_for_source(
+                                    dep.source_relid,
+                                    dep.cdc_mode,
+                                    Some(st.pgt_id),
+                                )
                             {
                                 pgrx::warning!(
                                     "Failed to clean up CDC for oid {}: {}",
@@ -1604,7 +1677,7 @@ fn drop_stream_table_impl(name: &str) -> Result<(), PgTrickleError> {
                     );
                 }
             } else {
-                cleanup_cdc_for_source(dep.source_relid, dep.cdc_mode)?;
+                cleanup_cdc_for_source(dep.source_relid, dep.cdc_mode, None)?;
             }
         }
     }
@@ -2414,16 +2487,31 @@ fn setup_cdc_for_source(
 fn cleanup_cdc_for_source(
     source_oid: pg_sys::Oid,
     cdc_mode: CdcMode,
+    excluding_pgt_id: Option<i64>,
 ) -> Result<(), PgTrickleError> {
-    // Check if any other STs still reference this source
-    let still_referenced = Spi::get_one_with_args::<bool>(
-        "SELECT EXISTS( \
-            SELECT 1 FROM pgtrickle.pgt_dependencies WHERE source_relid = $1 \
-        )",
-        &[source_oid.into()],
-    )
-    .unwrap_or(Some(false))
-    .unwrap_or(false);
+    // Check if any other STs still reference this source. During ALTER flows,
+    // the current ST's dependency row still exists while cleanup runs, so it
+    // must be excluded from the reference check.
+    let still_referenced = if let Some(pgt_id) = excluding_pgt_id {
+        Spi::get_one_with_args::<bool>(
+            "SELECT EXISTS( \
+                SELECT 1 FROM pgtrickle.pgt_dependencies \
+                WHERE source_relid = $1 AND pgt_id <> $2 \
+            )",
+            &[source_oid.into(), pgt_id.into()],
+        )
+        .unwrap_or(Some(false))
+        .unwrap_or(false)
+    } else {
+        Spi::get_one_with_args::<bool>(
+            "SELECT EXISTS( \
+                SELECT 1 FROM pgtrickle.pgt_dependencies WHERE source_relid = $1 \
+            )",
+            &[source_oid.into()],
+        )
+        .unwrap_or(Some(false))
+        .unwrap_or(false)
+    };
 
     if !still_referenced {
         let change_schema = config::pg_trickle_change_buffer_schema();
@@ -4160,5 +4248,53 @@ mod tests {
     fn test_detect_select_star_no_from() {
         // No FROM clause — should not crash, just return false
         assert!(!detect_select_star("SELECT 1"));
+    }
+
+    #[test]
+    fn test_classify_cdc_refresh_mode_interaction_global_wal_immediate() {
+        assert_eq!(
+            classify_cdc_refresh_mode_interaction(
+                RefreshMode::Immediate,
+                "wal",
+                CdcModeRequestSource::GlobalGuc,
+            ),
+            CdcRefreshModeInteraction::IgnoreWalForImmediate
+        );
+    }
+
+    #[test]
+    fn test_classify_cdc_refresh_mode_interaction_explicit_wal_immediate() {
+        assert_eq!(
+            classify_cdc_refresh_mode_interaction(
+                RefreshMode::Immediate,
+                "wal",
+                CdcModeRequestSource::ExplicitOverride,
+            ),
+            CdcRefreshModeInteraction::RejectWalForImmediate
+        );
+    }
+
+    #[test]
+    fn test_classify_cdc_refresh_mode_interaction_non_immediate_is_none() {
+        assert_eq!(
+            classify_cdc_refresh_mode_interaction(
+                RefreshMode::Differential,
+                "wal",
+                CdcModeRequestSource::GlobalGuc,
+            ),
+            CdcRefreshModeInteraction::None
+        );
+    }
+
+    #[test]
+    fn test_classify_cdc_refresh_mode_interaction_immediate_non_wal_is_none() {
+        assert_eq!(
+            classify_cdc_refresh_mode_interaction(
+                RefreshMode::Immediate,
+                "auto",
+                CdcModeRequestSource::GlobalGuc,
+            ),
+            CdcRefreshModeInteraction::None
+        );
     }
 }

--- a/tests/e2e_alter_tests.rs
+++ b/tests/e2e_alter_tests.rs
@@ -59,6 +59,75 @@ async fn test_alter_refresh_mode() {
 }
 
 #[tokio::test]
+async fn test_alter_to_immediate_ignores_wal_cdc_guc() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE al_mode_wal_src (id INT PRIMARY KEY, val TEXT)")
+        .await;
+    db.execute("INSERT INTO al_mode_wal_src VALUES (1, 'a')")
+        .await;
+
+    db.create_st(
+        "al_mode_wal_st",
+        "SELECT id, val FROM al_mode_wal_src",
+        "1m",
+        "FULL",
+    )
+    .await;
+
+    let source_oid = db.table_oid("al_mode_wal_src").await;
+    let cdc_trigger_name = format!("pg_trickle_cdc_{}", source_oid);
+    assert!(
+        db.trigger_exists(&cdc_trigger_name, "al_mode_wal_src")
+            .await,
+        "Deferred mode should start with CDC trigger infrastructure"
+    );
+
+    db.execute(
+        "WITH wal_mode AS (\
+            SELECT set_config('pg_trickle.cdc_mode', 'wal', true)\
+         )\
+         SELECT pgtrickle.alter_stream_table(\
+            'al_mode_wal_st',\
+            refresh_mode => 'IMMEDIATE'\
+         )\
+         FROM wal_mode",
+    )
+    .await;
+
+    let (_, mode_after, populated, errors) = db.pgt_status("al_mode_wal_st").await;
+    assert_eq!(mode_after, "IMMEDIATE");
+    assert!(populated, "ST should remain populated after mode switch");
+    assert_eq!(errors, 0);
+
+    let schedule_is_null: bool = db
+        .query_scalar(
+            "SELECT schedule IS NULL FROM pgtrickle.pgt_stream_tables WHERE pgt_name = 'al_mode_wal_st'",
+        )
+        .await;
+    assert!(schedule_is_null, "IMMEDIATE mode should clear the schedule");
+
+    let slot_exists: bool = db
+        .query_scalar(&format!(
+            "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = 'pgtrickle_{}')",
+            source_oid
+        ))
+        .await;
+    assert!(
+        !slot_exists,
+        "Switching to IMMEDIATE should not leave WAL replication slots behind"
+    );
+
+    db.execute("INSERT INTO al_mode_wal_src VALUES (2, 'b')")
+        .await;
+    assert_eq!(
+        db.count("public.al_mode_wal_st").await,
+        2,
+        "After switching under cdc_mode='wal', IMMEDIATE mode should still propagate DML synchronously"
+    );
+}
+
+#[tokio::test]
 async fn test_alter_suspend() {
     let db = E2eDb::new().await.with_extension().await;
 

--- a/tests/e2e_create_tests.rs
+++ b/tests/e2e_create_tests.rs
@@ -371,6 +371,57 @@ async fn test_create_cdc_trigger_installed() {
 }
 
 #[tokio::test]
+async fn test_create_immediate_ignores_wal_cdc_guc() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE imm_wal_src (id INT, val TEXT)")
+        .await;
+    db.execute("INSERT INTO imm_wal_src VALUES (1, 'a'), (2, 'b')")
+        .await;
+
+    db.execute(
+        "WITH wal_mode AS (\
+            SELECT set_config('pg_trickle.cdc_mode', 'wal', true)\
+         )\
+         SELECT pgtrickle.create_stream_table(\
+            name => 'imm_wal_st',\
+            query => $$SELECT id, val FROM imm_wal_src$$,\
+            refresh_mode => 'IMMEDIATE'\
+         )\
+         FROM wal_mode",
+    )
+    .await;
+
+    let (status, mode, populated, errors) = db.pgt_status("imm_wal_st").await;
+    assert_eq!(status, "ACTIVE");
+    assert_eq!(mode, "IMMEDIATE");
+    assert!(
+        populated,
+        "IMMEDIATE ST should still initialize successfully"
+    );
+    assert_eq!(errors, 0);
+    assert_eq!(db.count("public.imm_wal_st").await, 2);
+
+    let source_oid = db.table_oid("imm_wal_src").await;
+    let cdc_trigger_name = format!("pg_trickle_cdc_{}", source_oid);
+    assert!(
+        !db.trigger_exists(&cdc_trigger_name, "imm_wal_src").await,
+        "IMMEDIATE mode should not install CDC triggers even when cdc_mode='wal'"
+    );
+
+    let slot_exists: bool = db
+        .query_scalar(&format!(
+            "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = 'pgtrickle_{}')",
+            source_oid
+        ))
+        .await;
+    assert!(
+        !slot_exists,
+        "IMMEDIATE mode should not create a WAL replication slot"
+    );
+}
+
+#[tokio::test]
 async fn test_create_change_buffer_exists() {
     let db = E2eDb::new().await.with_extension().await;
 


### PR DESCRIPTION
## Summary
- start G2 from the 0.2.3 CDC / Refresh Mode Interaction Gaps roadmap item
- log an INFO when pg_trickle.cdc_mode is wal but refresh_mode is IMMEDIATE
- keep IMMEDIATE on the statement-level IVM path instead of CDC/WAL infrastructure
- add unit coverage and targeted E2E coverage for create and alter flows
- update the changelog, roadmap, SQL reference, configuration docs, and CDC gap plan

## Validation
- just fmt
- just lint
- just test-unit
- cargo test --test e2e_create_tests test_create_immediate_ignores_wal_cdc_guc -- --nocapture
- cargo test --test e2e_alter_tests test_alter_to_immediate_ignores_wal_cdc_guc -- --nocapture

## Follow-up
- explicit rejection for per-table cdc_mode='wal' remains pending until G1 adds the override surface