### PR TITLE
Serialize shared-postgres E2E tests and harden reset teardown

### DIFF
--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -36,7 +36,7 @@ pub use light::E2eDb;
 use sqlx::{PgPool, postgres::PgPoolOptions};
 #[cfg(not(feature = "light-e2e"))]
 use std::sync::{
-    Mutex,
+    Arc, LazyLock, Mutex,
     atomic::{AtomicUsize, Ordering},
 };
 #[cfg(not(feature = "light-e2e"))]
@@ -55,6 +55,9 @@ static SHARED_DB_COUNTER: AtomicUsize = AtomicUsize::new(1);
 #[cfg(not(feature = "light-e2e"))]
 static SHARED_CONTAINER: tokio::sync::OnceCell<SharedContainer> =
     tokio::sync::OnceCell::const_new();
+#[cfg(not(feature = "light-e2e"))]
+static SHARED_POSTGRES_DB_LOCK: LazyLock<Arc<tokio::sync::Mutex<()>>> =
+    LazyLock::new(|| Arc::new(tokio::sync::Mutex::new(())));
 
 #[cfg(not(feature = "light-e2e"))]
 struct SharedContainer {
@@ -152,15 +155,15 @@ async fn create_database(admin_connection_string: &str, db_name: &str) {
 #[cfg(not(feature = "light-e2e"))]
 async fn terminate_other_backends(admin_pool: &PgPool) {
     // Shared-db tests reuse `postgres`, so the previous test's sqlx pool and
-    // the per-database scheduler worker can still hold locks when the next
-    // test starts its reset. Terminate them first to keep cleanup deterministic.
+    // pg_trickle background workers can still hold locks when the next test
+    // starts its reset. Terminate them first to keep cleanup deterministic.
     sqlx::query(
         "SELECT pg_terminate_backend(pid) \
          FROM pg_stat_activity \
          WHERE datname = current_database() \
                      AND pid <> pg_backend_pid() \
                      AND (backend_type = 'client backend' \
-                                OR application_name = 'pg_trickle scheduler')",
+                                OR application_name IN ('pg_trickle scheduler', 'pg_trickle launcher'))",
     )
     .execute(admin_pool)
     .await
@@ -173,7 +176,7 @@ async fn terminate_other_backends(admin_pool: &PgPool) {
              WHERE datname = current_database() \
                              AND pid <> pg_backend_pid() \
                              AND (backend_type = 'client backend' \
-                                        OR application_name = 'pg_trickle scheduler')",
+                                        OR application_name IN ('pg_trickle scheduler', 'pg_trickle launcher'))",
         )
         .fetch_one(admin_pool)
         .await
@@ -192,7 +195,7 @@ async fn terminate_other_backends(admin_pool: &PgPool) {
          WHERE datname = current_database() \
                      AND pid <> pg_backend_pid() \
                      AND (backend_type = 'client backend' \
-                                OR application_name = 'pg_trickle scheduler')",
+                                OR application_name IN ('pg_trickle scheduler', 'pg_trickle launcher'))",
     )
     .fetch_one(admin_pool)
     .await
@@ -213,21 +216,13 @@ async fn reset_postgres_database(admin_connection_string: &str) {
 
     terminate_other_backends(&admin_pool).await;
 
-    // Background-worker tests share the `postgres` database and use
-    // `ALTER SYSTEM` to speed up the scheduler. Those changes persist in
-    // `postgresql.auto.conf`, so clear them before recreating the extension
-    // to keep each test independent of execution order.
-    sqlx::query("ALTER SYSTEM RESET ALL")
-        .execute(&admin_pool)
-        .await
-        .unwrap_or_else(|e| panic!("Failed to reset shared postgres ALTER SYSTEM state: {e}"));
-    sqlx::query("SELECT pg_reload_conf()")
-        .execute(&admin_pool)
-        .await
-        .unwrap_or_else(|e| panic!("Failed to reload config during postgres reset: {e}"));
-
+    // Drop the extension before reloading config. A pre-drop pg_reload_conf()
+    // wakes the shared launcher worker, which can respawn a scheduler for
+    // `postgres` while reset is still in progress.
     for sql in [
         "DROP EXTENSION IF EXISTS pg_trickle CASCADE",
+        "ALTER SYSTEM RESET ALL",
+        "SELECT pg_reload_conf()",
         "DROP SCHEMA IF EXISTS public CASCADE",
         "CREATE SCHEMA public",
         "GRANT ALL ON SCHEMA public TO postgres",
@@ -294,6 +289,7 @@ pub struct E2eDb {
     pub pool: PgPool,
     connection_string: String,
     container_id: String,
+    _shared_postgres_db_guard: Option<tokio::sync::OwnedMutexGuard<()>>,
     _container: ContainerLease,
 }
 
@@ -315,6 +311,7 @@ impl E2eDb {
             pool,
             connection_string,
             container_id: shared.container_id.clone(),
+            _shared_postgres_db_guard: None,
             _container: ContainerLease::Shared { _shared: shared },
         }
     }
@@ -326,6 +323,7 @@ impl E2eDb {
     /// so the extension + STs must live in the `postgres` database for the
     /// scheduler to see them.
     pub async fn new_on_postgres_db() -> Self {
+        let shared_postgres_db_guard = SHARED_POSTGRES_DB_LOCK.clone().lock_owned().await;
         let shared = shared_container().await;
         reset_postgres_database(&shared.admin_connection_string).await;
         let pool = Self::connect_with_retry(&shared.admin_connection_string, 15).await;
@@ -334,6 +332,7 @@ impl E2eDb {
             pool,
             connection_string: shared.admin_connection_string.clone(),
             container_id: shared.container_id.clone(),
+            _shared_postgres_db_guard: Some(shared_postgres_db_guard),
             _container: ContainerLease::Shared { _shared: shared },
         }
     }
@@ -440,6 +439,7 @@ impl E2eDb {
             pool,
             connection_string,
             container_id: container.id().to_string(),
+            _shared_postgres_db_guard: None,
             _container: ContainerLease::Dedicated {
                 _container: Box::new(container),
             },
@@ -486,6 +486,7 @@ impl E2eDb {
             pool,
             connection_string,
             container_id: container.id().to_string(),
+            _shared_postgres_db_guard: None,
             _container: ContainerLease::Dedicated {
                 _container: Box::new(container),
             },


### PR DESCRIPTION
## Summary
- serialize shared-postgres E2E tests for the full test lifetime
- terminate launcher and scheduler backends during shared-db reset
- drop the extension before reloading config to avoid scheduler respawn races

## Testing
- just fmt
- just lint
- just build-e2e-image
- cargo test --test e2e_bgworker_tests -- --nocapture