### PR TITLE
Fix foreign-table polling differential frontier handling

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2139,6 +2139,8 @@ fn execute_manual_differential_refresh(
         }
     }
 
+    refresh::poll_foreign_table_sources_for_st(st)?;
+
     // Mixed-dependency guard: if ANY upstream is a STREAM_TABLE, the DVM
     // delta SQL will reference change buffers that don't exist for stream
     // tables (they have no CDC triggers). Fall back to FULL refresh,
@@ -2253,7 +2255,7 @@ fn get_source_oids_for_manual_refresh(pgt_id: i64) -> Result<Vec<pg_sys::Oid>, P
     let deps = StDependency::get_for_st(pgt_id)?;
     Ok(deps
         .into_iter()
-        .filter(|dep| dep.source_type == "TABLE")
+        .filter(|dep| dep.source_type == "TABLE" || dep.source_type == "FOREIGN_TABLE")
         .map(|dep| dep.source_relid)
         .collect())
 }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -1207,6 +1207,25 @@ pub fn post_full_refresh_cleanup(st: &StreamTableMeta) {
     cleanup_change_buffers_by_frontier(&change_schema, &source_oids);
 }
 
+/// Poll all FOREIGN_TABLE dependencies for a stream table before selecting a
+/// new differential frontier.
+///
+/// Polling writes synthetic CDC rows into the local change buffers and updates
+/// the per-source snapshot tables. Callers must do this before capturing the
+/// new upper frontier so the synthetic rows fall within the refresh window.
+pub fn poll_foreign_table_sources_for_st(st: &StreamTableMeta) -> Result<(), PgTrickleError> {
+    let change_schema = crate::config::pg_trickle_change_buffer_schema().replace('"', "\"\"");
+
+    for dep in StDependency::get_for_st(st.pgt_id)?
+        .into_iter()
+        .filter(|dep| dep.source_type == "FOREIGN_TABLE")
+    {
+        crate::cdc::poll_foreign_table_changes(dep.source_relid, &change_schema)?;
+    }
+
+    Ok(())
+}
+
 /// Execute a NO_DATA refresh: just advance the data timestamp.
 pub fn execute_no_data_refresh(st: &StreamTableMeta) -> Result<(), PgTrickleError> {
     // Record that we checked — but do NOT update data_timestamp.
@@ -1442,28 +1461,6 @@ pub fn execute_differential_refresh(
     // ensuring stale change buffer rows are removed even when the
     // thread-local queue is empty.
     cleanup_change_buffers_by_frontier(&change_schema, &catalog_source_oids);
-
-    // ── EC-05: Poll foreign table sources ────────────────────────────
-    // For any FOREIGN_TABLE source, snapshot-diff the current contents
-    // and inject delta rows into the change buffer before the decision
-    // query checks for new data.
-    {
-        let ft_deps: Vec<_> = StDependency::get_for_st(st.pgt_id)
-            .unwrap_or_default()
-            .into_iter()
-            .filter(|dep| dep.source_type == "FOREIGN_TABLE")
-            .collect();
-        for dep in &ft_deps {
-            if let Err(e) = crate::cdc::poll_foreign_table_changes(dep.source_relid, &change_schema)
-            {
-                pgrx::warning!(
-                    "[pg_trickle] EC-05: failed to poll foreign table source OID {} \
-                     for ST {schema}.{name}: {e}",
-                    dep.source_relid.to_u32(),
-                );
-            }
-        }
-    }
 
     let t_decision_start = Instant::now();
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1119,9 +1119,18 @@ fn upstream_change_state(
     )
 }
 
-/// Returns `true` if any TABLE-type upstream source has rows in its CDC change
-/// buffer that have not yet been consumed by a differential refresh.
+/// Returns `true` if any TABLE or FOREIGN_TABLE upstream source has rows in
+/// its CDC change buffer that have not yet been consumed by a refresh.
 fn has_table_source_changes(st: &StreamTableMeta) -> bool {
+    if let Err(e) = refresh::poll_foreign_table_sources_for_st(st) {
+        log!(
+            "pg_trickle: failed to poll foreign table sources for {}.{} while checking upstream changes: {}",
+            st.pgt_schema,
+            st.pgt_name,
+            e,
+        );
+    }
+
     let change_schema = config::pg_trickle_change_buffer_schema();
     let source_oids = get_source_oids_for_st(st.pgt_id);
 
@@ -1662,7 +1671,7 @@ fn get_source_oids_for_st(pgt_id: i64) -> Vec<pg_sys::Oid> {
     StDependency::get_for_st(pgt_id)
         .unwrap_or_default()
         .into_iter()
-        .filter(|dep| dep.source_type == "TABLE")
+        .filter(|dep| dep.source_type == "TABLE" || dep.source_type == "FOREIGN_TABLE")
         .map(|dep| dep.source_relid)
         .collect()
 }


### PR DESCRIPTION
## Summary
- poll foreign table sources before capturing the differential frontier
- include foreign tables in manual and scheduled source frontier tracking
- remove late foreign-table polling from the differential executor

## Testing
- not run in this session