### PR TITLE
fix(ci): add runner.arch to arch-sensitive cache keys

### DIFF
--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -45,10 +45,10 @@ runs:
       uses: actions/cache@v4
       with:
         path: target
-        key: v1-cargo-build-pgrx0.17-${{ runner.os }}-${{ env.ImageOS || 'unknown' }}-${{ hashFiles('**/Cargo.lock') }}
+        key: v2-cargo-build-pgrx0.17-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS || 'unknown' }}-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          v1-cargo-build-pgrx0.17-${{ runner.os }}-${{ env.ImageOS || 'unknown' }}-
-          v1-cargo-build-pgrx0.17-${{ runner.os }}-
+          v2-cargo-build-pgrx0.17-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS || 'unknown' }}-
+          v2-cargo-build-pgrx0.17-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Cache cargo-pgrx binary
       id: cache-cargo-pgrx
@@ -59,14 +59,14 @@ runs:
           ~/.cargo/bin/cargo-pgrx.exe
           ~/.cargo/.crates2.json
           ~/.cargo/.crates.toml
-        key: v2-cargo-pgrx-bin-0.17.0-${{ runner.os }}-${{ env.ImageOS || 'unknown' }}
+        key: v3-cargo-pgrx-bin-0.17.0-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS || 'unknown' }}
 
     - name: Cache pgrx home directory (~/.pgrx)
       id: cache-pgrx-home
       uses: actions/cache@v4
       with:
         path: ~/.pgrx
-        key: pgrx-home-${{ runner.os }}-${{ env.ImageOS || 'unknown' }}-pg${{ inputs.pg-version }}-${{ inputs.pg-install-mode }}-pgrx0.17.0
+        key: pgrx-home-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS || 'unknown' }}-pg${{ inputs.pg-version }}-${{ inputs.pg-install-mode }}-pgrx0.17.0
 
     # ── PostgreSQL headers (Linux) ────────────────────────────────────────
     - name: Install PostgreSQL ${{ inputs.pg-version }} (Linux)


### PR DESCRIPTION
## Problem

The `cargo-pgrx` binary, build artifacts, and pgrx home caches were keyed only on `runner.os` + `ImageOS`. An `x86_64`-built `cargo-pgrx` ELF binary cached as `Linux-unknown` was being restored on `aarch64` runners, producing the error:

```
/home/runner/.cargo/bin/cargo-pgrx: 1: ELF: not found
Syntax error: "(" unexpected
Error: Process completed with exit code 2.
```

## Fix

Add `${{ runner.arch }}` to all architecture-sensitive cache keys in `.github/actions/setup-pgrx/action.yml`:

| Cache | Key change |
|---|---|
| Cargo build artifacts | `v1` → `v2`, added `runner.arch` |
| cargo-pgrx binary | `v2` → `v3`, added `runner.arch` |
| pgrx home | added `runner.arch` |

Version prefix bumps prevent stale cross-arch entries from being matched via `restore-keys` fallback on first run after this change. The cargo registry cache (source tarballs) is architecture-independent and is left unchanged.