### PR TITLE
chore: upgrade PostgreSQL 18.1 → 18.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ on:
       - '.github/workflows/ci.yml'
       - '.github/actions/**'
   schedule:
-    - cron: '0 5 * * *'  # Daily 05:00 UTC — full matrix
+    - cron: '0 3 * * *'  # Daily 03:00 UTC — full matrix
   workflow_dispatch:
 
 concurrency:
@@ -102,21 +102,21 @@ jobs:
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
 
-      - name: Restore Docker image cache (postgres:18.1-alpine)
+      - name: Restore Docker image cache (postgres:18.3-alpine)
         uses: actions/cache@v5
         id: cache-docker-postgres-alpine
         with:
-          path: /tmp/docker-images/postgres-18.1-alpine.tar
-          key: docker-postgres-18.1-alpine
+          path: /tmp/docker-images/postgres-18.3-alpine.tar
+          key: docker-postgres-18.3-alpine
 
-      - name: Load or pull postgres:18.1-alpine
+      - name: Load or pull postgres:18.3-alpine
         run: |
-          if [ -f /tmp/docker-images/postgres-18.1-alpine.tar ]; then
-            docker load --input /tmp/docker-images/postgres-18.1-alpine.tar
+          if [ -f /tmp/docker-images/postgres-18.3-alpine.tar ]; then
+            docker load --input /tmp/docker-images/postgres-18.3-alpine.tar
           else
-            docker pull postgres:18.1-alpine
+            docker pull postgres:18.3-alpine
             mkdir -p /tmp/docker-images
-            docker save postgres:18.1-alpine --output /tmp/docker-images/postgres-18.1-alpine.tar
+            docker save postgres:18.3-alpine --output /tmp/docker-images/postgres-18.3-alpine.tar
           fi
 
       - name: Run integration tests
@@ -133,7 +133,7 @@ jobs:
             -- --test-threads=1
 
   # ── Light-E2E tests (stock postgres container, PR-friendly) ──────────────
-  # Uses `cargo pgrx package` + bind-mount into a stock postgres:18.1
+  # Uses `cargo pgrx package` + bind-mount into a stock postgres:18.3
   # container. No custom Docker image build needed. The curated allowlist
   # lives in scripts/run_light_e2e_tests.sh and is split across three shards
   # to reduce PR wall-clock time.
@@ -160,8 +160,8 @@ jobs:
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
 
-      - name: Pull postgres:18.1 image
-        run: docker pull postgres:18.1
+      - name: Pull postgres:18.3 image
+        run: docker pull postgres:18.3
 
       - name: Run light-E2E test suite
         run: |
@@ -184,21 +184,21 @@ jobs:
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
 
-      - name: Restore Docker image cache (postgres:18.1)
+      - name: Restore Docker image cache (postgres:18.3)
         uses: actions/cache@v5
         id: cache-docker-postgres-e2e
         with:
-          path: /tmp/docker-images/postgres-18.1.tar
-          key: docker-postgres-18.1
+          path: /tmp/docker-images/postgres-18.3.tar
+          key: docker-postgres-18.3
 
-      - name: Load or pull postgres:18.1
+      - name: Load or pull postgres:18.3
         run: |
-          if [ -f /tmp/docker-images/postgres-18.1.tar ]; then
-            docker load --input /tmp/docker-images/postgres-18.1.tar
+          if [ -f /tmp/docker-images/postgres-18.3.tar ]; then
+            docker load --input /tmp/docker-images/postgres-18.3.tar
           else
-            docker pull postgres:18.1
+            docker pull postgres:18.3
             mkdir -p /tmp/docker-images
-            docker save postgres:18.1 --output /tmp/docker-images/postgres-18.1.tar
+            docker save postgres:18.3 --output /tmp/docker-images/postgres-18.3.tar
           fi
 
       - name: Build E2E Docker image
@@ -388,7 +388,7 @@ jobs:
   #
   # Uses a transitional approach: builds the scratch-based extension image
   # (cnpg/Dockerfile.ext-build), then creates a composite image combining
-  # the extension with postgres:18.1 for the smoke test. This validates
+  # the extension with postgres:18.3 for the smoke test. This validates
   # that the extension image layout is correct and the extension works.
   #
   # Once kind supports Kubernetes 1.33 with ImageVolume feature gate, this
@@ -433,17 +433,17 @@ jobs:
 
       - name: Build composite image for smoke test
         run: |
-          # Transitional: combine extension image with postgres:18.1
+          # Transitional: combine extension image with postgres:18.3
           # until kind supports K8s 1.33 ImageVolume feature gate.
           # This image is NOT shipped — only used for CI validation.
           #
           # CNPG runs containers as UID 26 (postgres in RHEL/CNPG operand
-          # images). The Docker Hub postgres:18.1 image uses UID 999.
+          # images). The Docker Hub postgres:18.3 image uses UID 999.
           # Remap so initdb (which CNPG runs as UID 26) can resolve its
           # user identity from /etc/passwd.
           cat > /tmp/Dockerfile.cnpg-smoke <<'DOCKERFILE'
           FROM pg_trickle-ext:ci AS ext
-          FROM postgres:18.1
+          FROM postgres:18.3
           RUN sed -i 's/^postgres:x:999:999:/postgres:x:26:26:/' /etc/passwd && \
               sed -i 's/^postgres:x:999:/postgres:x:26:/' /etc/group && \
               chown -R 26:26 /var/lib/postgresql /var/run/postgresql
@@ -451,10 +451,10 @@ jobs:
           COPY --from=ext /share/extension/ /usr/share/postgresql/18/extension/
           DOCKERFILE
 
-          docker build -t pg_trickle:18.1 -f /tmp/Dockerfile.cnpg-smoke .
+          docker build -t pg_trickle:18.3 -f /tmp/Dockerfile.cnpg-smoke .
 
       - name: Load image into kind
-        run: kind load docker-image pg_trickle:18.1 --name cnpg-test
+        run: kind load docker-image pg_trickle:18.3 --name cnpg-test
 
       - name: Install CNPG operator
         run: |
@@ -484,7 +484,7 @@ jobs:
             name: pg-trickle-demo
           spec:
             instances: 1
-            imageName: pg_trickle:18.1
+            imageName: pg_trickle:18.3
             imagePullPolicy: Never
             bootstrap:
               initdb:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
           # actually works with PostgreSQL. This image is NOT shipped.
           cat > /tmp/Dockerfile.smoke <<'DOCKERFILE'
           FROM pg_trickle-ext:test AS ext
-          FROM postgres:18.1
+          FROM postgres:18.3
           COPY --from=ext /lib/ /usr/lib/postgresql/18/lib/
           COPY --from=ext /share/extension/ /usr/share/postgresql/18/extension/
           DOCKERFILE

--- a/tests/Dockerfile.builder
+++ b/tests/Dockerfile.builder
@@ -21,7 +21,7 @@
 # For CI it can be pushed to ghcr.io to skip the builder build entirely.
 # =============================================================================
 
-FROM postgres:18.1
+FROM postgres:18.3
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tests/Dockerfile.e2e
+++ b/tests/Dockerfile.e2e
@@ -3,7 +3,7 @@
 # Multi-stage Dockerfile for pg_trickle E2E integration tests.
 #
 # Stage 1 (builder): Compiles the extension from source.
-# Stage 2 (runtime): Copies the compiled artifacts into a clean postgres:18.1.
+# Stage 2 (runtime): Copies the compiled artifacts into a clean postgres:18.3.
 #
 # Usage:
 #   # Fast build — uses pre-built builder image (Rust + cargo-pgrx pre-baked):
@@ -11,7 +11,7 @@
 #   just build-e2e-image       # ~2-3 min cold, ~30s warm
 #
 #   # Self-contained build (no pre-built builder, downloads everything, ~10 min):
-#   BUILDER_IMAGE=postgres:18.1 just build-e2e-image
+#   BUILDER_IMAGE=postgres:18.3 just build-e2e-image
 #
 # The build context must be the project root (parent of tests/).
 #
@@ -25,7 +25,7 @@
 
 # ── Stage 1: Build the extension ────────────────────────────────────────────
 # Default to the pre-built builder image (see tests/Dockerfile.builder).
-# Override with BUILDER_IMAGE=postgres:18.1 for a self-contained build.
+# Override with BUILDER_IMAGE=postgres:18.3 for a self-contained build.
 ARG BUILDER_IMAGE=pg_trickle_builder:pg18
 FROM ${BUILDER_IMAGE} AS builder
 
@@ -73,10 +73,10 @@ RUN echo "=== Package artifacts ===" && \
     echo "========================="
 
 # ── Stage 2: Runtime image with extension installed ─────────────────────────
-FROM postgres:18.1
+FROM postgres:18.3
 
 LABEL org.opencontainers.image.title="pg_trickle E2E test image"
-LABEL org.opencontainers.image.description="PostgreSQL 18.1 with pg_trickle extension for integration testing"
+LABEL org.opencontainers.image.description="PostgreSQL 18.3 with pg_trickle extension for integration testing"
 
 # Copy extension artifacts from the builder stage
 COPY --from=builder \

--- a/tests/Dockerfile.e2e-coverage
+++ b/tests/Dockerfile.e2e-coverage
@@ -17,7 +17,7 @@
 # =============================================================================
 
 # ── Stage 1: Build the extension with coverage instrumentation ──────────────
-FROM postgres:18.1 AS builder
+FROM postgres:18.3 AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -98,10 +98,10 @@ RUN SYSROOT="$(rustc --print sysroot)" && \
     fi
 
 # ── Stage 2: Runtime image with instrumented extension ──────────────────────
-FROM postgres:18.1
+FROM postgres:18.3
 
 LABEL org.opencontainers.image.title="pg_trickle E2E coverage image"
-LABEL org.opencontainers.image.description="PostgreSQL 18.1 with coverage-instrumented pg_trickle"
+LABEL org.opencontainers.image.description="PostgreSQL 18.3 with coverage-instrumented pg_trickle"
 
 # Copy extension artifacts from the builder stage
 COPY --from=builder \

--- a/tests/Dockerfile.e2e-upgrade
+++ b/tests/Dockerfile.e2e-upgrade
@@ -32,7 +32,7 @@ ARG FROM_VERSION=0.1.3
 ARG TO_VERSION=0.2.3
 
 LABEL org.opencontainers.image.title="pg_trickle upgrade E2E test image"
-LABEL org.opencontainers.image.description="PostgreSQL 18.1 with pg_trickle for upgrade path testing (${FROM_VERSION} → ${TO_VERSION})"
+LABEL org.opencontainers.image.description="PostgreSQL 18.3 with pg_trickle for upgrade path testing (${FROM_VERSION} → ${TO_VERSION})"
 
 # Copy the old version's full install SQL so that
 #   CREATE EXTENSION pg_trickle VERSION '<FROM_VERSION>'

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -116,7 +116,7 @@ SELECT st.*,
 FROM pgtrickle.pgt_stream_tables st;
 "#;
 
-/// A test database backed by a Testcontainers PostgreSQL 18.1 instance.
+/// A test database backed by a Testcontainers PostgreSQL 18.3 instance.
 ///
 /// The container is automatically cleaned up when `TestDb` is dropped.
 pub struct TestDb {
@@ -126,13 +126,13 @@ pub struct TestDb {
 
 #[allow(dead_code)]
 impl TestDb {
-    /// Start a fresh PostgreSQL 18.1 container and connect to it.
+    /// Start a fresh PostgreSQL 18.3 container and connect to it.
     pub async fn new() -> Self {
         let container = Postgres::default()
-            .with_tag("18.1-alpine")
+            .with_tag("18.3-alpine")
             .start()
             .await
-            .expect("Failed to start PostgreSQL 18.1 container");
+            .expect("Failed to start PostgreSQL 18.3 container");
 
         let port = container
             .get_host_port_ipv4(5432)

--- a/tests/e2e/light.rs
+++ b/tests/e2e/light.rs
@@ -7,7 +7,7 @@
 //! 1. `cargo pgrx package` produces compiled extension artifacts in
 //!    `target/release/pg_trickle-pg18/`.
 //! 2. The artifacts are bind-mounted to `/tmp/pg_ext` inside a stock
-//!    `postgres:18.1` container.
+//!    `postgres:18.3` container.
 //! 3. An `exec` copies the files to the standard PostgreSQL extension
 //!    directories.
 //! 4. `CREATE EXTENSION pg_trickle` loads the extension on-demand.
@@ -125,7 +125,7 @@ async fn shared_container() -> &'static SharedContainer {
             let ext_dir = find_extension_dir();
             let run_id = std::env::var("PGT_LIGHT_E2E_RUN_ID").ok();
 
-            let mut image = GenericImage::new("postgres", "18.1")
+            let mut image = GenericImage::new("postgres", "18.3")
                 .with_exposed_port(5432_u16.tcp())
                 .with_wait_for(WaitFor::message_on_stderr(
                     "database system is ready to accept connections",
@@ -143,7 +143,7 @@ async fn shared_container() -> &'static SharedContainer {
 
             let container = image.start().await.expect(
                 "Failed to start shared light-e2e container.\n\
-                     Ensure Docker is running and postgres:18.1 is available.",
+                     Ensure Docker is running and postgres:18.3 is available.",
             );
 
             container
@@ -174,7 +174,7 @@ async fn shared_container() -> &'static SharedContainer {
         .await
 }
 
-/// A test database backed by a stock PostgreSQL 18.1 container with
+/// A test database backed by a stock PostgreSQL 18.3 container with
 /// the compiled pg_trickle extension bind-mounted and installed
 /// **without** `shared_preload_libraries`.
 ///
@@ -190,7 +190,7 @@ pub struct E2eDb {
 
 #[allow(dead_code)]
 impl E2eDb {
-    /// Start a fresh PostgreSQL 18.1 container, install the extension
+    /// Start a fresh PostgreSQL 18.3 container, install the extension
     /// artifacts via bind-mount, and create the extension.
     pub async fn new() -> Self {
         let shared = shared_container().await;

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,4 +1,4 @@
-//! E2E test harness that boots a PostgreSQL 18.1 container with
+//! E2E test harness that boots a PostgreSQL 18.3 container with
 //! the pg_trickle extension pre-installed.
 //!
 //! # Harness Selection
@@ -6,7 +6,7 @@
 //! - **Full (default)**: Custom Docker image with `shared_preload_libraries`,
 //!   background worker, and shared memory.  Requires
 //!   `./tests/build_e2e_image.sh`.
-//! - **Light** (`--features light-e2e`): Stock `postgres:18.1` container with
+//! - **Light** (`--features light-e2e`): Stock `postgres:18.3` container with
 //!   bind-mounted extension artifacts.  No background worker or scheduler.
 //!   Much faster to build — only needs `cargo pgrx package`.
 //!
@@ -292,7 +292,7 @@ async fn shared_container() -> &'static SharedContainer {
         .await
 }
 
-/// A test database backed by a PostgreSQL 18.1 container with
+/// A test database backed by a PostgreSQL 18.3 container with
 /// the compiled pg_trickle extension installed and
 /// `shared_preload_libraries` configured.
 ///
@@ -309,7 +309,7 @@ pub struct E2eDb {
 #[cfg(not(feature = "light-e2e"))]
 #[allow(dead_code)]
 impl E2eDb {
-    /// Start a fresh PostgreSQL 18.1 container with the extension installed.
+    /// Start a fresh PostgreSQL 18.3 container with the extension installed.
     ///
     /// The container is ready to accept connections but the extension is NOT
     /// yet created. Call [`with_extension`] to run `CREATE EXTENSION`.

--- a/tests/e2e_smoke_tests.rs
+++ b/tests/e2e_smoke_tests.rs
@@ -15,7 +15,7 @@ use e2e::E2eDb;
 async fn test_container_starts_with_extension_image() {
     let db = E2eDb::new().await;
 
-    // Verify PostgreSQL 18.1 is running
+    // Verify PostgreSQL 18.3 is running
     let version: String = db.query_scalar("SELECT version()").await;
     assert!(
         version.contains("PostgreSQL 18"),

--- a/tests/extension_tests.rs
+++ b/tests/extension_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests that replace the former `#[pg_test]` tests.
 //!
 //! These tests verify that the pg_trickle catalog schema, tables, views, and
-//! hash function logic work correctly inside a real PostgreSQL 18.1
+//! hash function logic work correctly inside a real PostgreSQL 18.3
 //! container managed by Testcontainers.
 //!
 //! Replaces the previous `#[pg_test]` tests from `lib.rs`:

--- a/tests/smoke_tests.rs
+++ b/tests/smoke_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests for basic PostgreSQL connectivity via Testcontainers.
 //!
 //! These tests verify the Testcontainers setup works correctly with
-//! PostgreSQL 18.1 before running more complex extension tests.
+//! PostgreSQL 18.3 before running more complex extension tests.
 
 mod common;
 

--- a/tests/trigger_detection_tests.rs
+++ b/tests/trigger_detection_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests for user-trigger detection logic.
 //!
 //! Validates the SQL queries used by `has_user_triggers()` and the trigger
-//! detection plumbing against a real PostgreSQL 18.1 container. These tests
+//! detection plumbing against a real PostgreSQL 18.3 container. These tests
 //! do NOT require the pg_trickle extension — they exercise the raw SQL
 //! patterns used internally.
 //!


### PR DESCRIPTION
- Bump all Docker image references from `postgres:18.1` to `postgres:18.3` (Dockerfiles, CI workflows, test harness)
- Change CI scheduled run from 05:00 UTC to 03:00 UTC