### PR TITLE
chore: upgrade PostgreSQL 18.1 → 18.3 (remaining files)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
 # =============================================================================
 # Devcontainer Dockerfile for pg_trickle development
 #
-# Based on postgres:18.1 to get matching PG headers + pg_config, then layers
+# Based on postgres:18.3 to get matching PG headers + pg_config, then layers
 # Rust toolchain, cargo-pgrx, and development tools on top.
 # =============================================================================
-FROM postgres:18.1
+FROM postgres:18.3
 
 ARG USERNAME=vscode
 ARG USER_UID=1000

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,7 +131,7 @@ Six test tiers, each with its own infrastructure:
 |------|----------|--------|----------|
 | Unit | `src/**` (`#[cfg(test)]`) | `just test-unit` | No |
 | Integration | `tests/*_tests.rs` (not `e2e_*`) | `just test-integration` | Yes (Testcontainers) |
-| Light E2E | `tests/e2e_*_tests.rs` (most) | `just test-light-e2e` | Yes (stock postgres:18.1) |
+| Light E2E | `tests/e2e_*_tests.rs` (most) | `just test-light-e2e` | Yes (stock postgres:18.3) |
 | Full E2E | `tests/e2e_*_tests.rs` (10 files) | `just test-e2e` | Yes (custom Docker image) |
 | TPC-H | `tests/e2e_tpch_tests.rs` (`#[ignore]`) | see below | Yes (custom Docker image) |
 | dbt | `dbt-pgtrickle/integration_tests/` | `just test-dbt` | Yes (Docker + dbt) |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,7 @@ For future plans and release milestones, see [ROADMAP.md](ROADMAP.md).
 
 - **CI test pyramid rebalanced** — PRs now run a faster three-tier gate:
   Linux unit tests, integration tests, and a curated Light E2E tier split
-  across three shards against stock `postgres:18.1`. The heavier full E2E,
+  across three shards against stock `postgres:18.3`. The heavier full E2E,
   TPC-H, dbt, CNPG smoke, and extra-platform unit jobs remain off the PR
   critical path and continue to run on push-to-main, schedule, or manual
   dispatch. The shared CI setup action now caches the `cargo-pgrx` binary,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ PR CI runs a three-tier gate:
 - **Unit tests (Linux only)**
 - **Integration tests**
 - **Light E2E** — curated PR-friendly end-to-end coverage split across three
-  shards and executed against stock `postgres:18.1`
+  shards and executed against stock `postgres:18.3`
 
 Full E2E, TPC-H tests, benchmarks, dbt, CNPG smoke, and the extra macOS /
 Windows unit jobs stay off the PR critical path and run on push-to-main,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,7 +83,7 @@ docker run --rm \
   -v $PWD/lib/pg_trickle.so:/usr/lib/postgresql/18/lib/pg_trickle.so:ro \
   -v $PWD/extension/:/tmp/ext/:ro \
   -e POSTGRES_PASSWORD=postgres \
-  postgres:18.1 \
+  postgres:18.3 \
   sh -c 'cp /tmp/ext/* /usr/share/postgresql/18/extension/ && \
          exec postgres -c shared_preload_libraries=pg_trickle'
 ```

--- a/cnpg/Dockerfile.ext-build
+++ b/cnpg/Dockerfile.ext-build
@@ -12,7 +12,7 @@
 # =============================================================================
 
 # ── Stage 1: Build the extension ────────────────────────────────────────────
-FROM postgres:18.1 AS builder
+FROM postgres:18.3 AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tests/build_e2e_image.sh
+++ b/tests/build_e2e_image.sh
@@ -4,7 +4,7 @@
 #
 # This script builds a multi-stage Docker image that:
 #   1. Compiles the extension from source (Rust + cargo-pgrx)
-#   2. Installs it into a clean postgres:18.1 image
+#   2. Installs it into a clean postgres:18.3 image
 #
 # The resulting image can be used by testcontainers-rs in the E2E tests.
 #


### PR DESCRIPTION
Follows up on the previous 18.1 → 18.3 PR with the remaining files that were missed:

| File | Change |
|---|---|
| `cnpg/Dockerfile.ext-build` | Builder stage `FROM postgres:18.3` |
| `.devcontainer/Dockerfile` | Devcontainer base image |
| `tests/build_e2e_image.sh` | Script comment |
| `INSTALL.md` | Quick-start `docker run` example |
| `AGENTS.md` | Testing tier table |
| `CONTRIBUTING.md` | PR gate description |
| `CHANGELOG.md` | Release notes reference |

Historical design docs under `plans/` are intentionally unchanged — they record what was built at those versions.