### PR TITLE
fix(test): use ALTER SYSTEM SET for user_triggers GUC in E2E tests

### DIFF
--- a/tests/e2e_user_trigger_tests.rs
+++ b/tests/e2e_user_trigger_tests.rs
@@ -437,8 +437,10 @@ async fn test_guc_off_suppresses_triggers() {
     }
     db.execute("TRUNCATE audit_log").await;
 
-    // Set GUC to 'off' — should suppress triggers (use MERGE path)
-    db.execute("SET pg_trickle.user_triggers = 'off'").await;
+    // Set GUC to 'off' globally — session-level SET is unreliable with
+    // connection pools (the refresh may run on a different connection).
+    db.alter_system_set_and_wait("pg_trickle.user_triggers", "'off'", "off")
+        .await;
 
     // Modify source and refresh
     db.execute("INSERT INTO src_guc_off VALUES (2, 'b')").await;
@@ -455,6 +457,10 @@ async fn test_guc_off_suppresses_triggers() {
         "Audit log should be empty when GUC is 'off', got {} entries",
         audit_count
     );
+
+    // Reset to default so other tests are not affected.
+    db.alter_system_reset_and_wait("pg_trickle.user_triggers", "auto")
+        .await;
 }
 
 // ── GUC: auto detects triggers ─────────────────────────────────────────
@@ -528,7 +534,9 @@ async fn test_guc_on_alias_detects_triggers() {
     }
     db.execute("TRUNCATE audit_log").await;
 
-    db.execute("SET pg_trickle.user_triggers = 'on'").await;
+    // Use ALTER SYSTEM SET so the value is visible across all pool connections.
+    db.alter_system_set_and_wait("pg_trickle.user_triggers", "'on'", "on")
+        .await;
 
     db.execute("INSERT INTO src_guc_on VALUES (2, 'b')").await;
     db.refresh_st("st_guc_on").await;
@@ -541,6 +549,10 @@ async fn test_guc_on_alias_detects_triggers() {
         "Deprecated 'on' alias should still detect trigger and fire it, got {} INSERT entries",
         insert_count
     );
+
+    // Reset to default so other tests are not affected.
+    db.alter_system_reset_and_wait("pg_trickle.user_triggers", "auto")
+        .await;
 }
 
 // ── FULL refresh suppresses row-level triggers ─────────────────────────


### PR DESCRIPTION
## Problem

`test_guc_off_suppresses_triggers` fails intermittently because it uses session-level `SET pg_trickle.user_triggers = 'off'` which only applies to the specific pooled connection that executed it. When `refresh_st()` runs on a different connection from the sqlx `PgPool`, the GUC still has its default value (`'auto'`), so the refresh detects the user trigger and uses the explicit DML path — causing the audit trigger to fire and the assertion to fail (1 entry instead of 0).

## Fix

Replace session-level `SET` with `ALTER SYSTEM SET` + config reload (`alter_system_set_and_wait`) so the GUC change applies globally to all connections. Reset the GUC to its default after each test to avoid cross-test contamination.

Also fixes `test_guc_on_alias_detects_triggers` which had the same issue (it passed by coincidence since `'on'` maps to `'auto'`, the default).

## Tests

- All 11 `e2e_user_tri- All 11 `e2e_user_tri- All 11 `e2e_user_tri- All 11 `e2e_user_tri- All 11 \ri- All 11 `e2e_usermt` and `just lint` pass cleanly