### PR TITLE
release: v0.3.0 — DVM Correctness, SAST & TPC-H Hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ For future plans and release milestones, see [ROADMAP.md](ROADMAP.md).
 
 ---
 
-## [Unreleased]
+## [0.3.0] — 2026-03-11
 
 ### Fixed
 
@@ -161,6 +161,32 @@ run without `#[ignore]`:
 - `test_scalar_subquery_null_result_differential` — correlated SUM with
   NULL-producing category that has no lookup match
 
+#### Backend Worker Detection Fix (PG 18)
+
+Fixed a critical bug where `health_check()` and the scheduler's active-worker
+detection returned zero results on PostgreSQL 18. In PG 18,
+`BackgroundWorkerBuilder::new(name)` sets `bgw_name` which maps to
+`pg_stat_activity.backend_type`, not `application_name`. All queries checking
+for `'pg_trickle scheduler'` and `'pg_trickle launcher'` were using
+`application_name` and finding zero matches.
+
+Fixed in `src/scheduler.rs` (launcher detection), `src/monitor.rs`
+(`health_check()` scheduler count), `tests/e2e/mod.rs` (`wait_for_scheduler()`),
+and `tests/e2e_bgworker_tests.rs` (diagnostic dump queries).
+
+#### Scheduler Launcher Thundering-Herd Prevention
+
+Fixed an infinite back-off loop where concurrent test databases calling
+`create_stream_table()` each bumped the DAG rebuild signal, which previously
+called `last_attempt.clear()` on every bump. This wiped all per-database
+back-off timers (including `postgres`), causing the launcher to immediately
+re-probe, fail (extension not yet installed), and reset the timer — an
+infinite loop preventing the 15 s retry TTL from ever expiring.
+
+Fixed by retaining `last_attempt` entries whose elapsed time is still within
+`retry_ttl` on a DAG signal. Only entries older than `retry_ttl` (already
+expired) are evicted, so recently-failed probes stay protected by back-off.
+
 ### Changed
 
 - **Test count:** All 18 previously-ignored DVM-correctness E2E tests have been
@@ -168,9 +194,23 @@ run without `#[ignore]`:
   (already un-ignored before this release), 5 FULL JOIN tests, 1 EXISTS+HAVING
   test, and 2 correlated scalar subquery tests account for the full recovery.
 
+- **PostgreSQL 18.1 → 18.3** — CI pipelines, Dockerfiles, and the test harness
+  have been updated to use `postgres:18.3`. This is a maintenance release of
+  PostgreSQL 18 with bug fixes and no API changes.
+
+- **Dependency updates** — `tokio` 1.49 → 1.50; GitHub Actions updated:
+  `docker/build-push-action` 6→7, `actions/cache` 4→5,
+  `docker/login-action` 3→4, `docker/setup-buildx-action` 3→4,
+  `actions/setup-python` 5→6.
+
 ---
 
 ### Added
+
+- **`test_tpch_immediate_correctness`** — new TPC-H test that validates the
+  IMMEDIATE mode IVM trigger path end-to-end, verifying that stream tables
+  maintained via statement-level AFTER triggers produce the same results as
+  a full recompute after RF1/RF2/RF3 mutations.
 
 - **SAST — Narrow `rust.panic-in-sql-path` scope** (`sast-review-2` branch):
   Semgrep cannot detect `#[cfg(test)]` block boundaries inside Rust files,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2074,7 +2074,7 @@ dependencies = [
 
 [[package]]
 name = "pg_trickle"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg_trickle"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2024"
 description = "Streaming Stream Tables for PostgreSQL 18 with differential view maintenance"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ SELECT pgtrickle.drop_stream_table('regional_totals');
 | [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | System architecture and data flow |
 | [docs/DVM_OPERATORS.md](docs/DVM_OPERATORS.md) | Supported operators and differentiation rules |
 | [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | GUC variables and tuning guide |
-| [ROADMAP.md](ROADMAP.md) | Release milestones and future plans (current milestone: v0.2.3, tag pending) |
+| [ROADMAP.md](ROADMAP.md) | Release milestones and future plans (current milestone: v0.4.0) |
 
 ### Research & Plans
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # pg_trickle — Project Roadmap
 
 > **Last updated:** 2026-03-11
-> **Latest release:** 0.2.3 (scheduled)
-> **Current milestone:** v0.3.0 — DVM Correctness, SAST & Test Coverage
+> **Latest release:** 0.3.0 (2026-03-11)
+> **Current milestone:** v0.4.0 — Parallel Refresh & Performance Hardening
 
 For a concise description of what pg_trickle is and why it exists, read
 [ESSENCE.md](ESSENCE.md) — it explains the core problem (full `REFRESH
@@ -20,13 +20,13 @@ phases are complete. This roadmap tracks the path from the v0.1.x series to
 1.0 and beyond.
 
 ```
-                                                                    We are here
-                                                                     │
-                                                                     ▼
+                                                                               We are here
+                                                                                │
+                                                                                ▼
  ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐
  │ 0.1.x  │ │ 0.2.0  │ │ 0.2.1  │ │ 0.2.2  │ │ 0.2.3  │ │ 0.3.0  │ │ 0.4.0  │ │ 0.5.0  │ │ 0.6.0  │
- │Released│─│Released│─│Released│─│Released│─│Mode & │─│DVM Fix │─│Parallel│─│  RLS & │─│Partn., │
- │ ✅      │ │ ✅      │ │ ✅      │ │ ✅      │ │Ops Gap│ │SAST&TPC│ │&Perf.  │ │Op.Ctrl │ │DDL&Fuse│
+ │Released│─│Released│─│Released│─│Released│─│Released│─│Released│─│Parallel│─│  RLS & │─│Partn., │
+ │ ✅      │ │ ✅      │ │ ✅      │ │ ✅      │ │ ✅      │ │ ✅      │ │&Perf.  │ │Op.Ctrl │ │DDL&Fuse│
  └────────┘ └────────┘ └────────┘ └────────┘ └────────┘ └────────┘ └────────┘ └────────┘ └────────┘
       │
       └─ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐ ┌────────┐
@@ -455,7 +455,7 @@ validations, resource leaks, and observability holes. Phased from quick wins
 - [x] Per-table `cdc_mode` override functional in SQL API and dbt adapter (G1)
 - [x] Extension upgrade path tested (`0.2.2 → 0.2.3`)
 
-**Status: Ready for release (tag pending).**
+**Status: Released (2026-03-09).**
 
 ---
 
@@ -511,7 +511,9 @@ with rollback, mode-comparison, single-row, and DAG tests.
 - [x] All 18 previously-ignored DVM correctness E2E tests re-enabled
 - [x] SAST Phases 1–3 deployed; unsafe baseline committed; CodeQL zero findings
 - [x] TPC-H T1–T6 implemented; rollback, differential-vs-immediate, single-row, and DAG tests pass
-- [ ] Extension upgrade path tested (`0.2.3 → 0.3.0`)
+- [x] Extension upgrade path tested (`0.2.3 → 0.3.0`)
+
+**Status: Released (2026-03-11).**
 
 ---
 
@@ -978,7 +980,7 @@ These are not gated on 1.0 but represent the longer-term horizon.
 | v0.2.1 — Upgrade Infrastructure & Documentation | ~8h | 70–86h | ✅ Released |
 | v0.2.2 — OFFSET Support, ALTER QUERY & Upgrade Tooling | ~50–70h | 120–156h | ✅ Released |
 | v0.2.3 — Non-Determinism, CDC/Mode Gaps & Operational Polish | 45–66h | 165–222h | ✅ Released |
-| v0.3.0 — DVM Correctness, SAST & Test Coverage | ~20–30h | 185–252h | |
+| v0.3.0 — DVM Correctness, SAST & Test Coverage | ~20–30h | 185–252h | ✅ Released |
 | v0.4.0 — Parallel Refresh & Performance Hardening | ~60–94h | 245–346h | |
 | v0.5.0 — Row-Level Security & Operational Controls | ~21–27h | 266–373h | |
 | v0.6.0 — Partitioning, Idempotent DDL & Anomaly Detection | ~45–62h | 311–435h | |

--- a/sql/pg_trickle--0.2.3--0.3.0.sql
+++ b/sql/pg_trickle--0.2.3--0.3.0.sql
@@ -1,0 +1,27 @@
+-- pg_trickle 0.2.3 -> 0.3.0 upgrade script
+--
+-- v0.3.0 is a correctness and hardening release with no catalog schema changes:
+--
+--   DVM correctness fixes (DC1-DC4):
+--     - HAVING threshold-crossing differential correctness (COUNT(*) rewrite,
+--       per-group rescan on upward threshold crossing)
+--     - FULL OUTER JOIN differential correctness (row-id mismatch, compound
+--       GROUP BY expression resolution/quoting, SUM NULL semantics, rescan CTE)
+--     - Correlated EXISTS with HAVING differential correctness (parser GROUP BY
+--       /HAVING handling, SemiJoin row-id, diff_project recomputation)
+--     - Correlated scalar subquery differential correctness (rewrite to LEFT JOIN
+--       before DVM parsing; inner table qualifier stripping)
+--
+--   Scheduler hardening:
+--     - BGW detection uses backend_type instead of application_name (PG 18)
+--     - Launcher thundering-herd prevention on DAG signal
+--
+--   SAST program (Phases 1-3): CodeQL, cargo-deny, Semgrep, unsafe inventory
+--
+--   TPC-H test suite enhancements (T1-T6): rollback, mode-comparison,
+--     single-row mutations, DAG chain / multi-parent tests
+--
+-- No catalog tables, columns, functions, or views were added or removed.
+-- ALTER EXTENSION pg_trickle UPDATE is a no-op for schema objects.
+
+-- (intentionally empty — all changes are internal to the compiled .so)


### PR DESCRIPTION
## Summary

This PR prepares the **v0.3.0** release. All functional changes were merged
to `main` via individual PRs (#128–#158); this PR contains only the release
bookkeeping.

## Changes

### New file
- `sql/pg_trickle--0.2.3--0.3.0.sql` — upgrade migration script.
  v0.3.0 is a correctness-and-hardening release with **no catalog schema
  changes**, so the upgrade script is intentionally a no-op (comment only).
  `ALTER EXTENSION pg_trickle UPDATE` from 0.2.3 → 0.3.0 is safe.

### Updated files
- `Cargo.toml` / `Cargo.lock` — version 0.2.3 → 0.3.0
- `CHANGELOG.md` — promoted `[Unreleased]` → `[0.3.0] — 2026-03-11`;
  added missing changelog entries for:
  - BGW `backend_type` detection fix for PostgreSQL 18 (#150)
  - Scheduler launcher thundering-herd prevention (#147)
  - PostgreSQL 18.1 → 18.3 platform upgrade (#146, #148)
  - `test_tpch_immediate_correctne  - `test_tpch_immediate_cDependency version bumps (tokio, GitHub Actions)
- `ROADMAP.md` — v0.3.0- `ROADMAP.md` ��0.2.3 status cleaned up;
  current milestone advanced to v0.4.0; ASCII timeline  current milestone advanced to v0.4.0; ASCII timeline  current milestone advare  current mate  current.0
  current m.3.0 delivers (already merged)

| Area | Items | PRs |
|------|-------|-----|
| DVM correctness | HAVING (5 tests), FULL JOIN (5), EXISTS+HAVING| DVM correctness | HAVING (5 tests), FULL JOIN (5), EXISTS+HAVING| DVM cocheduler hardening | `backend_type` BGW detection (PG 18); thundering-h| DVM correctnes #| DVM correctness | HAVING (5 tests), FULL JOIN (5), EXISTS+sa| DVM correctness | HAVING (5 tests), FULL JOIN (5), EXISTS+HAVING| DVM correctback, differential-vs-immediate, single-row, DAG tests | #136, #144 |
| Platform | PostgreSQL 18.1 → 18.3; dependency bumps | #146, #148, #137–#142 |

## Exit## Exit## Exit## Exit## Exit## Exipreviously-ignored DVM correctness E2E tests re-enabled
- [x] SAST Phases 1–3 deployed; CodeQL zero findings
- [x] TPC-H T1–T6 imple- [x] TPC-H T1–T6 imple- [x] TPC-H T1–T6 imple- [x] TPC-H T1–T6ested (no-op migration)