### PR TITLE
ci: upgrade actions/checkout v4 → v5 (Node.js 24)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -88,7 +88,7 @@ jobs:
     outputs:
       docker: ${{ steps.filter.outputs.docker }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: dorny/paths-filter@v3
         id: filter
@@ -119,7 +119,7 @@ jobs:
             archive_ext: tar.gz
           # Windows build available via manual CI workflow
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -177,7 +177,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -68,7 +68,7 @@ jobs:
     runs-on: macos-14
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -83,7 +83,7 @@ jobs:
     timeout-minutes: 15
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -155,7 +155,7 @@ jobs:
             shard_count: 3
             shard_name: 3/3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -179,7 +179,7 @@ jobs:
     if: github.event_name != 'pull_request'
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -220,7 +220,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Validate upgrade script completeness
         run: |
@@ -240,7 +240,7 @@ jobs:
     needs: [e2e-tests]
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -269,7 +269,7 @@ jobs:
     timeout-minutes: 20
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -298,7 +298,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Build E2E Docker image
         run: ./tests/build_e2e_image.sh
@@ -401,7 +401,7 @@ jobs:
     timeout-minutes: 20
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create kind cluster
         uses: helm/kind-action@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -86,7 +86,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx

--- a/.github/workflows/dependency-policy.yml
+++ b/.github/workflows/dependency-policy.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install mdBook
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
             artifact_suffix: windows-amd64
             archive_ext: zip
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download Linux artifact
         uses: actions/download-artifact@v8
@@ -282,7 +282,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all release artifacts
         uses: actions/download-artifact@v8
@@ -351,7 +351,7 @@ jobs:
             artifact_suffix: linux-arm64
             platform_tag: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download ${{ matrix.artifact_suffix }} artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run cargo audit
         uses: rustsec/audit-check@v2

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/unsafe-inventory.yml
+++ b/.github/workflows/unsafe-inventory.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run unsafe inventory
         run: |


### PR DESCRIPTION
## Problem

The `Upgrade completeness` CI job (and all other workflows) emit:

> Node.js 20 actions are deprecated. The following actions are running on
> Node.js 20 and may not work as expected: **actions/checkout@v4**.
> Actions will be forced to run with Node.js 24 by default starting
> **June 2, 2026**.

## Fix

Replace all 29 occurrences of `actions/checkout@v4` with `actions/checkout@v5`
across 11 workflow files. `v5` ships Node.js 24 and is a drop-in replacement.

**Affected files:**
`benchmarks.yml`, `build.yml`, `ci.yml`, `codeql.yml`, `coverage.yml`,
`dependency-policy.yml`, `docs.yml`, `lint.yml`, `release.yml`,
`security.yml`, `semgrep.yml`, `unsafe-inventory.yml`

No functional changes.