### PR TITLE
planning: move D-1 UNLOGGED change buffers to v0.12.0, flip default to opt-in

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -856,10 +856,16 @@ intersects the current gated set.
 |------|-------------|--------|-----|
 | A-3a | MERGE bypass — Append-Only INSERT path: expose `APPEND ONLY` declaration on `CREATE STREAM TABLE`; CDC heuristic fallback (fast-path until first DELETE/UPDATE seen) | 1–2 wk | [PLAN_NEW_STUFF.md §A-3](plans/performance/PLAN_NEW_STUFF.md) |
 | A-4 | Index-Aware MERGE Planning — planner hint injection (`enable_seqscan = off` for small-delta / large-target); covering index auto-creation on `__pgt_row_id` | 1–2 wk | [PLAN_NEW_STUFF.md §A-4](plans/performance/PLAN_NEW_STUFF.md) |
+| B-2 | Delta Predicate Pushdown — push WHERE predicates from defining query into change-buffer `delta_scan` CTE; `OR old_col` handling for deletions; 5–10× delta-row-volume reduction for selective queries | 2–3 wk | [PLAN_NEW_STUFF.md §B-2](plans/performance/PLAN_NEW_STUFF.md) |
+| C-4 | Change Buffer Compaction — net-change compaction (INSERT+DELETE=no-op; UPDATE+UPDATE=single row); run when buffer exceeds `pg_trickle.compact_threshold`; use advisory lock to serialise with refresh | 2–3 wk | [PLAN_NEW_STUFF.md §C-4](plans/performance/PLAN_NEW_STUFF.md) |
 
-> **Performance foundations subtotal: ~30–80h**
+> ⚠️ C-4: The compaction DELETE **must use `seq` (the sequence primary key) not `ctid`** as
+> the stable row identifier. `ctid` changes under VACUUM and will silently delete the wrong
+> rows. See the corrected SQL and risk analysis in PLAN_NEW_STUFF.md §C-4.
 
-> **v0.5.0 total: ~51–107h**
+> **Performance foundations subtotal: ~30–80h (A-3a, A-4) + ~40–80h (B-2, C-4)**
+
+> **v0.5.0 total: ~91–187h**
 
 **Exit criteria:**
 - [ ] RLS semantics documented; change buffers RLS-hardened; IVM triggers SECURITY DEFINER
@@ -869,6 +875,8 @@ intersects the current gated set.
 - [ ] Manual refresh calls recorded in history with `initiated_by='MANUAL'`
 - [ ] A-3a: Append-Only INSERT path eliminates MERGE for event-sourced stream tables
 - [ ] A-4: Covering index auto-created on `__pgt_row_id`; planner hint prevents seq-scan on small delta
+- [ ] B-2: Predicate pushdown reduces delta volume for selective queries (E2E benchmark)
+- [ ] C-4: Compaction uses `seq` PK; correct under concurrent VACUUM; serialised with advisory lock
 - [ ] Extension upgrade path tested (`0.4.0 → 0.5.0`)
 
 ---
@@ -979,27 +987,16 @@ Forms the prerequisite for full SCC-based fixpoint refresh in v0.7.0.
 
 ### Core Refresh Optimizations (Wave 2)
 
-> Items from [PLAN_NEW_STUFF.md](plans/performance/PLAN_NEW_STUFF.md) Wave 2. Read risk
-> analyses before implementing — in particular the C-4 SQL bug note.
+> B-2 and C-4 moved to v0.5.0. Only B-4 remains here.
+> Read risk analyses in [PLAN_NEW_STUFF.md](plans/performance/PLAN_NEW_STUFF.md) before implementing.
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| B-2 | Delta Predicate Pushdown — push WHERE predicates from defining query into change-buffer `delta_scan` CTE; `OR old_col` handling for deletions; 5–10× delta-row-volume reduction for selective queries | 2–3 wk | [PLAN_NEW_STUFF.md §B-2](plans/performance/PLAN_NEW_STUFF.md) |
 | B-4 | Cost-Based Refresh Strategy — replace fixed `differential_max_change_ratio` with a history-driven cost model fitted on `pgt_refresh_history`; cold-start fallback to fixed threshold | 2–3 wk | [PLAN_NEW_STUFF.md §B-4](plans/performance/PLAN_NEW_STUFF.md) |
-| C-4 | Change Buffer Compaction — net-change compaction (INSERT+DELETE=no-op; UPDATE+UPDATE=single row); run when buffer exceeds `pg_trickle.compact_threshold`; use advisory lock to serialise with refresh | 2–3 wk | [PLAN_NEW_STUFF.md §C-4](plans/performance/PLAN_NEW_STUFF.md) |
 
-> ⚠️ C-4: The compaction DELETE **must use `seq` (the sequence primary key) not `ctid`** as
-> the stable row identifier. `ctid` changes under VACUUM and will silently delete the wrong
-> rows. See the corrected SQL and risk analysis in PLAN_NEW_STUFF.md §C-4.
+> **Core refresh optimizations subtotal: ~20–40h**
 
-> **Retraction consideration (C-4):** Keep in v0.6.0 but the plan document must be corrected
-> before any implementation starts. The proposed SQL contains a data-correctness bug (`ctid`
-> instability) that would silently corrupt the change buffer under VACUUM. Fix is known and
-> low-risk, but no code should be written against the current plan text.
-
-> **Core refresh optimizations subtotal: ~60–120h**
-
-> **v0.6.0 total: ~105–182h**
+> **v0.6.0 total: ~65–104h**
 
 **Exit criteria:**
 - [ ] Partitioned source tables E2E-tested; ATTACH PARTITION detected
@@ -1007,9 +1004,7 @@ Forms the prerequisite for full SCC-based fixpoint refresh in v0.7.0.
 - [ ] `create_or_replace_stream_table` deployed; dbt macro updated
 - [ ] Fuse triggers on configurable change-count threshold; `reset_fuse()` recovers
 - [ ] SCC algorithm in place; monotonicity checker rejects non-monotone cycles
-- [ ] B-2: Predicate pushdown reduces delta volume for selective queries (E2E benchmark)
 - [ ] B-4: Cost model self-calibrates from refresh history; correctly selects FULL for join_agg at 10% change rate
-- [ ] C-4: Compaction uses `seq` PK; correct under concurrent VACUUM; serialised with advisory lock
 - [ ] Extension upgrade path tested (`0.5.0 → 0.6.0`)
 
 ---

--- a/plans/performance/PLAN_NEW_STUFF.md
+++ b/plans/performance/PLAN_NEW_STUFF.md
@@ -985,18 +985,17 @@ implementation, with dynamic column management as a follow-on.
 ### Recommended Implementation Order
 
 **Wave 1 (Quick Wins — v0.5.0):**
-- D-1: UNLOGGED Change Buffers ← Already planned (O-3 in TPC-H plan)
 - A-3a: MERGE Bypass — Append-Only INSERT path only (1–2 wk, low risk)
   - Expose `APPEND ONLY` declaration on `CREATE STREAM TABLE`
   - CDC heuristic fallback: use fast path until first DELETE/UPDATE seen
   - **Not** the TopK TRUNCATE sub-path (not worth doing — see A-3 analysis)
   - **Not** the Bulk COPY sub-path (infeasible via SPI — see A-3 analysis)
 - A-4: Index-Aware MERGE Planning
+- B-2: Delta Predicate Pushdown (moved from Wave 2; Low risk, High impact)
+- C-4: Change Buffer Compaction (moved from Wave 2; fix `ctid` → `seq` bug before implementing)
 
 **Wave 2 (Core Optimizations — v0.6.0):**
-- B-2: Delta Predicate Pushdown
 - B-4: Cost-Based Refresh Strategy Selection
-- C-4: Change Buffer Compaction
 
 **Wave 3 (Scalability — v0.7.0):**
 - A-2: Columnar Change Tracking


### PR DESCRIPTION
## Summary

After discussion, D-1 (UNLOGGED Change Buffers) was rated P0 in the prioritization matrix based on a default-on assumption. The key concerns identified:

- With default `true`, a crash forces a FULL refresh on **every** stream table simultaneously — a significant availability event for deployments with large/expensive stream tables.
- The P0 rating only makes sense if all users benefit automatically; with an opt-in default, the short-term impact is minimal and other P1 items (B-2, C-4) deliver broader value sooner.

## Changes

- **ROADMAP.md:** Remove D-1 from v0.5.0 (table + exit criteria); add D-1 to v0.12.0 with updated description noting opt-in default; update v0.12.0 effort estimate.
- **PLAN_NEW_STUFF.md:** Flip `pg_trickle.unlogged_buffers` default from `true` → `false`; update Risk section to reflect forced FULL-refresh concern for large stream tables.