### PR TITLE
feat: Phase 5 — Append-only INSERT fast path (A-3a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,32 @@ not fire mid-load, then ungate it to pick up all the data in a single refresh.
 - **Upgrade script.** `sql/pg_trickle--0.4.0--0.5.0.sql` adds the
   `pgt_source_gates` table for incremental upgrades.
 
+#### Append-Only INSERT Fast Path — Phase 5 (v0.5.0)
+
+Performance optimization for event-sourced / append-only workloads. Stream
+tables marked as append-only skip the full MERGE pipeline (DELETE, UPDATE,
+IS DISTINCT FROM checks) and use a simple `INSERT … SELECT` from the delta,
+reducing per-refresh latency significantly.
+
+- **A-3a: `append_only` parameter.** `create_stream_table()` and
+  `alter_stream_table()` accept a new `append_only` boolean (default `false`).
+  When `true`, differential refreshes use a direct INSERT instead of MERGE.
+- **Catalog: `is_append_only` column.** New `BOOLEAN NOT NULL DEFAULT FALSE`
+  column on `pgtrickle.pgt_stream_tables`.
+- **CDC heuristic fallback.** At the start of each differential refresh, the
+  engine checks the change buffers for DELETE or UPDATE actions. If any are
+  found, `is_append_only` is reverted to `false` automatically and the
+  current refresh falls through to the standard MERGE path. A warning is
+  logged.
+- **Validation.** `append_only` is rejected for FULL, IMMEDIATE, and keyless
+  source stream tables at both creation and ALTER time.
+- **E2E tests.** New `e2e_append_only_tests.rs` with 9 tests covering:
+  basic INSERT path, data correctness, DELETE/UPDATE fallback, ALTER toggle,
+  FULL/IMMEDIATE/keyless rejection, and no-data cycles.
+- **Unit tests.** `build_append_only_insert_sql()` SQL builder tests.
+- **Upgrade script.** `sql/pg_trickle--0.4.0--0.5.0.sql` adds
+  `is_append_only` column.
+
 
 
 ## [0.4.0] — 2026-03-12

--- a/CHECKLIST_0.5.0.md
+++ b/CHECKLIST_0.5.0.md
@@ -72,7 +72,7 @@ All items are ≤ 2 h each and independent — fill gaps between the larger phas
 Scoped to the append-only fast path only. A-4, B-2, and C-4 are deferred to
 v0.6.0 where they fit better alongside the Wave 2 optimizations.
 
-- [ ] **A-3a** — Append-Only INSERT path (MERGE bypass)
+- [x] **A-3a** — Append-Only INSERT path (MERGE bypass)
   - `APPEND ONLY` declaration on `CREATE STREAM TABLE`
   - CDC heuristic fallback: use fast-path until first DELETE/UPDATE seen, then revert to MERGE
   - Catalog: `is_append_only BOOLEAN` column + upgrade SQL

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -854,7 +854,7 @@ intersects the current gated set.
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| A-3a | MERGE bypass — Append-Only INSERT path: expose `APPEND ONLY` declaration on `CREATE STREAM TABLE`; CDC heuristic fallback (fast-path until first DELETE/UPDATE seen) | 1–2 wk | [PLAN_NEW_STUFF.md §A-3](plans/performance/PLAN_NEW_STUFF.md) |
+| A-3a | MERGE bypass — Append-Only INSERT path: expose `APPEND ONLY` declaration on `CREATE STREAM TABLE`; CDC heuristic fallback (fast-path until first DELETE/UPDATE seen) | 1–2 wk | [PLAN_NEW_STUFF.md §A-3](plans/performance/PLAN_NEW_STUFF.md) | ✅ Done |
 
 > A-4, B-2, and C-4 deferred to v0.6.0 Performance Wave 2 (scope mismatch with the
 > RLS/operational-controls theme; correctness risk warrants a dedicated wave).
@@ -869,7 +869,7 @@ intersects the current gated set.
 - [x] `gate_source` / `ungate_source` operational; scheduler skips gated sources correctly
 - [ ] `quick_health` view and `create_stream_table_if_not_exists` available
 - [ ] Manual refresh calls recorded in history with `initiated_by='MANUAL'`
-- [ ] A-3a: Append-Only INSERT path eliminates MERGE for event-sourced stream tables
+- [x] A-3a: Append-Only INSERT path eliminates MERGE for event-sourced stream tables
 - [ ] Extension upgrade path tested (`0.4.0 → 0.5.0`)
 
 ---

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -94,7 +94,8 @@ pgtrickle.create_stream_table(
     initialize            bool      DEFAULT true,
     diamond_consistency   text      DEFAULT NULL,
     diamond_schedule_policy text    DEFAULT NULL,
-    cdc_mode              text      DEFAULT NULL
+    cdc_mode              text      DEFAULT NULL,
+    append_only           bool      DEFAULT false
 ) → void
 ```
 
@@ -110,6 +111,7 @@ pgtrickle.create_stream_table(
 | `diamond_consistency` | `text` | `NULL` (defaults to `'none'`) | Diamond dependency consistency mode: `'none'` (independent refresh) or `'atomic'` (SAVEPOINT-based atomic group refresh). |
 | `diamond_schedule_policy` | `text` | `NULL` (defaults to `'fastest'`) | Schedule policy for atomic diamond groups: `'fastest'` (fire when any member is due) or `'slowest'` (fire when all are due). Set on the convergence node. |
 | `cdc_mode` | `text` | `NULL` (use `pg_trickle.cdc_mode`) | Optional per-stream-table CDC override: `'auto'`, `'trigger'`, or `'wal'`. This affects all deferred TABLE sources of the stream table. |
+| `append_only` | `bool` | `false` | When `true`, differential refreshes use a fast INSERT path instead of MERGE. Skips DELETE/UPDATE/IS DISTINCT FROM checks. If a DELETE or UPDATE is later detected in the change buffer, the flag is automatically reverted to `false`. Not compatible with `FULL`, `IMMEDIATE`, or keyless sources. |
 
 When `refresh_mode => 'IMMEDIATE'`, the cluster-wide `pg_trickle.cdc_mode`
 setting is ignored. IMMEDIATE mode always uses statement-level IVM triggers
@@ -357,6 +359,14 @@ SELECT pgtrickle.create_stream_table(
     FROM totals t1
     JOIN totals t2 ON t1.user_id = t2.user_id + 1',
     schedule => '1m'
+);
+
+-- Append-only stream table (INSERT-only fast path)
+SELECT pgtrickle.create_stream_table(
+    name        => 'event_log_st',
+    query       => 'SELECT id, event_type, payload, created_at FROM events',
+    schedule    => '30s',
+    append_only => true
 );
 ```
 
@@ -645,7 +655,8 @@ pgtrickle.alter_stream_table(
     status                text      DEFAULT NULL,
     diamond_consistency   text      DEFAULT NULL,
     diamond_schedule_policy text    DEFAULT NULL,
-    cdc_mode              text      DEFAULT NULL
+    cdc_mode              text      DEFAULT NULL,
+    append_only           bool      DEFAULT NULL
 ) → void
 ```
 
@@ -661,6 +672,7 @@ pgtrickle.alter_stream_table(
 | `diamond_consistency` | `text` | `NULL` | New diamond consistency mode (`'none'` or `'atomic'`). Pass `NULL` to leave unchanged. |
 | `diamond_schedule_policy` | `text` | `NULL` | New schedule policy for atomic diamond groups (`'fastest'` or `'slowest'`). Pass `NULL` to leave unchanged. |
 | `cdc_mode` | `text` | `NULL` | New requested CDC mode override (`'auto'`, `'trigger'`, or `'wal'`). Pass `NULL` to leave unchanged. |
+| `append_only` | `bool` | `NULL` | Enable or disable the append-only INSERT fast path. Pass `NULL` to leave unchanged. When `true`, rejected for FULL, IMMEDIATE, or keyless source stream tables. |
 
 If you switch a stream table to `refresh_mode => 'IMMEDIATE'` while the
 cluster-wide `pg_trickle.cdc_mode` GUC is set to `'wal'`, pg_trickle logs an
@@ -700,6 +712,9 @@ SELECT pgtrickle.alter_stream_table('order_totals',
 
 -- Pin a deferred stream table to trigger CDC even when the global GUC is 'auto'
 SELECT pgtrickle.alter_stream_table('order_totals', cdc_mode => 'trigger');
+
+-- Enable append-only INSERT fast path
+SELECT pgtrickle.alter_stream_table('event_log_st', append_only => true);
 
 -- Suspend a stream table
 SELECT pgtrickle.alter_stream_table('order_totals', status => 'SUSPENDED');

--- a/sql/pg_trickle--0.4.0--0.5.0.sql
+++ b/sql/pg_trickle--0.4.0--0.5.0.sql
@@ -5,6 +5,7 @@
 --   Phase 2: RLS-aware refresh executor.
 --   Phase 3 (Bootstrap Source Gating): gate_source() / ungate_source() /
 --            source_gates() + scheduler skip logic.
+--   Phase 5: Append-only INSERT fast path (MERGE bypass).
 --
 -- New catalog table: pgtrickle.pgt_source_gates
 -- Tracks which source tables are currently "gated" (bootstrapping in progress).
@@ -20,3 +21,7 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_source_gates (
     ungated_at      TIMESTAMPTZ,
     gated_by        TEXT
 );
+
+-- Phase 5: Append-only INSERT fast path
+ALTER TABLE pgtrickle.pgt_stream_tables
+  ADD COLUMN IF NOT EXISTS is_append_only BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/api.rs
+++ b/src/api.rs
@@ -40,6 +40,7 @@ fn create_stream_table(
     diamond_consistency: default!(Option<&str>, "NULL"),
     diamond_schedule_policy: default!(Option<&str>, "NULL"),
     cdc_mode: default!(Option<&str>, "NULL"),
+    append_only: default!(bool, false),
 ) {
     let result = create_stream_table_impl(
         name,
@@ -50,6 +51,7 @@ fn create_stream_table(
         diamond_consistency,
         diamond_schedule_policy,
         cdc_mode,
+        append_only,
     );
     if let Err(e) = result {
         pgrx::error!("{}", e);
@@ -506,6 +508,7 @@ fn insert_catalog_and_deps(
     dc: DiamondConsistency,
     dsp: DiamondSchedulePolicy,
     requested_cdc_mode: Option<&str>,
+    is_append_only: bool,
 ) -> Result<i64, PgTrickleError> {
     let pgt_id = StreamTableMeta::insert(
         pgt_relid,
@@ -525,6 +528,7 @@ fn insert_catalog_and_deps(
         dsp,
         vq.has_keyless_source,
         requested_cdc_mode,
+        is_append_only,
     )?;
 
     // Build per-source column usage map
@@ -1226,6 +1230,7 @@ fn create_stream_table_impl(
     diamond_consistency: Option<&str>,
     diamond_schedule_policy: Option<&str>,
     requested_cdc_mode: Option<&str>,
+    append_only: bool,
 ) -> Result<(), PgTrickleError> {
     let is_auto = RefreshMode::is_auto_str(refresh_mode_str);
     let mut refresh_mode = RefreshMode::from_str(refresh_mode_str)?;
@@ -1305,6 +1310,31 @@ fn create_stream_table_impl(
     warn_source_table_properties(&vq.source_relids);
     warn_select_star(query);
 
+    // Validate append_only flag
+    if append_only {
+        if refresh_mode == RefreshMode::Full {
+            return Err(PgTrickleError::InvalidArgument(
+                "append_only is not supported with FULL refresh mode. \
+                 Use DIFFERENTIAL or AUTO refresh mode."
+                    .to_string(),
+            ));
+        }
+        if refresh_mode.is_immediate() {
+            return Err(PgTrickleError::InvalidArgument(
+                "append_only is not supported with IMMEDIATE refresh mode. \
+                 Use DIFFERENTIAL or AUTO refresh mode."
+                    .to_string(),
+            ));
+        }
+        if vq.has_keyless_source {
+            return Err(PgTrickleError::InvalidArgument(
+                "append_only is not supported for stream tables with keyless sources. \
+                 Add a PRIMARY KEY to all source tables first."
+                    .to_string(),
+            ));
+        }
+    }
+
     // Check for duplicate
     if StreamTableMeta::get_by_name(&schema, &table_name).is_ok() {
         return Err(PgTrickleError::AlreadyExists(format!(
@@ -1357,6 +1387,7 @@ fn create_stream_table_impl(
         dc,
         dsp,
         requested_cdc_mode_override.as_deref(),
+        append_only,
     )?;
 
     // ── Phase 2: CDC / IVM trigger setup ──
@@ -1440,6 +1471,7 @@ fn alter_stream_table(
     diamond_consistency: default!(Option<&str>, "NULL"),
     diamond_schedule_policy: default!(Option<&str>, "NULL"),
     cdc_mode: default!(Option<&str>, "NULL"),
+    append_only: default!(Option<bool>, "NULL"),
 ) {
     let result = alter_stream_table_impl(
         name,
@@ -1450,6 +1482,7 @@ fn alter_stream_table(
         diamond_consistency,
         diamond_schedule_policy,
         cdc_mode,
+        append_only,
     );
     if let Err(e) = result {
         pgrx::error!("{}", e);
@@ -1466,6 +1499,7 @@ fn alter_stream_table_impl(
     diamond_consistency: Option<&str>,
     diamond_schedule_policy: Option<&str>,
     cdc_mode: Option<&str>,
+    append_only: Option<bool>,
 ) -> Result<(), PgTrickleError> {
     let (schema, table_name) = parse_qualified_name(name)?;
     let mut st = StreamTableMeta::get_by_name(&schema, &table_name)?;
@@ -1729,6 +1763,32 @@ fn alter_stream_table_impl(
                 )));
             }
         }
+    }
+
+    if let Some(ao) = append_only {
+        let effective_mode = match refresh_mode {
+            Some(mode_str) => RefreshMode::from_str(mode_str)?,
+            None => st.refresh_mode,
+        };
+        if ao {
+            if effective_mode == RefreshMode::Full {
+                return Err(PgTrickleError::InvalidArgument(
+                    "append_only is not supported with FULL refresh mode.".to_string(),
+                ));
+            }
+            if effective_mode.is_immediate() {
+                return Err(PgTrickleError::InvalidArgument(
+                    "append_only is not supported with IMMEDIATE refresh mode.".to_string(),
+                ));
+            }
+            if st.has_keyless_source {
+                return Err(PgTrickleError::InvalidArgument(
+                    "append_only is not supported for stream tables with keyless sources."
+                        .to_string(),
+                ));
+            }
+        }
+        StreamTableMeta::update_append_only(st.pgt_id, ao)?;
     }
 
     shmem::signal_dag_rebuild();

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -58,6 +58,11 @@ pub struct StreamTableMeta {
     /// User-requested CDC mode override for this stream table.
     /// None means "follow the global pg_trickle.cdc_mode GUC".
     pub requested_cdc_mode: Option<String>,
+    /// Whether this stream table uses the append-only INSERT fast path.
+    /// When true, differential refresh uses INSERT instead of MERGE,
+    /// bypassing DELETE and UPDATE handling for better throughput.
+    /// Automatically reverted to false if a DELETE/UPDATE is detected.
+    pub is_append_only: bool,
 }
 
 /// CDC mode for a source dependency — tracks whether change capture uses
@@ -164,13 +169,14 @@ impl StreamTableMeta {
         diamond_schedule_policy: DiamondSchedulePolicy,
         has_keyless_source: bool,
         requested_cdc_mode: Option<&str>,
+        is_append_only: bool,
     ) -> Result<i64, PgTrickleError> {
         Spi::connect_mut(|client| {
             let row = client
                 .update(
                     "INSERT INTO pgtrickle.pgt_stream_tables \
-                     (pgt_relid, pgt_name, pgt_schema, defining_query, original_query, schedule, refresh_mode, functions_used, topk_limit, topk_order_by, topk_offset, diamond_consistency, diamond_schedule_policy, has_keyless_source, requested_cdc_mode) \
-                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) \
+                     (pgt_relid, pgt_name, pgt_schema, defining_query, original_query, schedule, refresh_mode, functions_used, topk_limit, topk_order_by, topk_offset, diamond_consistency, diamond_schedule_policy, has_keyless_source, requested_cdc_mode, is_append_only) \
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16) \
                      RETURNING pgt_id",
                     None,
                     &[
@@ -189,6 +195,7 @@ impl StreamTableMeta {
                         diamond_schedule_policy.as_str().into(),
                         has_keyless_source.into(),
                         requested_cdc_mode.into(),
+                        is_append_only.into(),
                     ],
                 )
                 .map_err(|e: pgrx::spi::SpiError| PgTrickleError::SpiError(e.to_string()))?
@@ -210,7 +217,7 @@ impl StreamTableMeta {
                      data_timestamp, consecutive_errors, needs_reinit, frontier, \
                      auto_threshold, last_full_ms, functions_used, topk_limit, topk_order_by, \
                      topk_offset, diamond_consistency, diamond_schedule_policy, \
-                     has_keyless_source, function_hashes, requested_cdc_mode \
+                     has_keyless_source, function_hashes, requested_cdc_mode, is_append_only \
                      FROM pgtrickle.pgt_stream_tables \
                      WHERE pgt_schema = $1 AND pgt_name = $2",
                     None,
@@ -236,7 +243,7 @@ impl StreamTableMeta {
                      data_timestamp, consecutive_errors, needs_reinit, frontier, \
                      auto_threshold, last_full_ms, functions_used, topk_limit, topk_order_by, \
                      topk_offset, diamond_consistency, diamond_schedule_policy, \
-                     has_keyless_source, function_hashes, requested_cdc_mode \
+                     has_keyless_source, function_hashes, requested_cdc_mode, is_append_only \
                      FROM pgtrickle.pgt_stream_tables \
                      WHERE pgt_relid = $1",
                     None,
@@ -267,7 +274,7 @@ impl StreamTableMeta {
                      data_timestamp, consecutive_errors, needs_reinit, frontier, \
                      auto_threshold, last_full_ms, functions_used, topk_limit, topk_order_by, \
                      topk_offset, diamond_consistency, diamond_schedule_policy, \
-                     has_keyless_source, function_hashes, requested_cdc_mode \
+                     has_keyless_source, function_hashes, requested_cdc_mode, is_append_only \
                      FROM pgtrickle.pgt_stream_tables \
                      WHERE pgt_id = $1",
                     None,
@@ -293,7 +300,7 @@ impl StreamTableMeta {
                      data_timestamp, consecutive_errors, needs_reinit, frontier, \
                      auto_threshold, last_full_ms, functions_used, topk_limit, topk_order_by, \
                      topk_offset, diamond_consistency, diamond_schedule_policy, \
-                     has_keyless_source, function_hashes, requested_cdc_mode \
+                     has_keyless_source, function_hashes, requested_cdc_mode, is_append_only \
                      FROM pgtrickle.pgt_stream_tables \
                      WHERE status = 'ACTIVE'",
                     None,
@@ -542,6 +549,20 @@ impl StreamTableMeta {
         .map_err(|e: pgrx::spi::SpiError| PgTrickleError::SpiError(e.to_string()))
     }
 
+    /// Update the append-only flag for a stream table.
+    ///
+    /// Called by the CDC heuristic fallback when a DELETE or UPDATE is
+    /// detected on an append-only stream table, reverting it to MERGE.
+    pub fn update_append_only(pgt_id: i64, is_append_only: bool) -> Result<(), PgTrickleError> {
+        Spi::run_with_args(
+            "UPDATE pgtrickle.pgt_stream_tables \
+             SET is_append_only = $1, updated_at = now() \
+             WHERE pgt_id = $2",
+            &[is_append_only.into(), pgt_id.into()],
+        )
+        .map_err(|e: pgrx::spi::SpiError| PgTrickleError::SpiError(e.to_string()))
+    }
+
     /// Update the per-ST adaptive fallback threshold and last FULL refresh time.
     ///
     /// Called after each differential or adaptive-fallback refresh to track
@@ -698,6 +719,7 @@ impl StreamTableMeta {
         let has_keyless_source = table.get::<bool>(23).map_err(map_spi)?.unwrap_or(false);
         let function_hashes = table.get::<String>(24).map_err(map_spi)?;
         let requested_cdc_mode = table.get::<String>(25).map_err(map_spi)?;
+        let is_append_only = table.get::<bool>(26).map_err(map_spi)?.unwrap_or(false);
 
         Ok(StreamTableMeta {
             pgt_id,
@@ -725,6 +747,7 @@ impl StreamTableMeta {
             has_keyless_source,
             function_hashes,
             requested_cdc_mode,
+            is_append_only,
         })
     }
 
@@ -807,6 +830,7 @@ impl StreamTableMeta {
         let has_keyless_source = row.get::<bool>(23).map_err(map_spi)?.unwrap_or(false);
         let function_hashes = row.get::<String>(24).map_err(map_spi)?;
         let requested_cdc_mode = row.get::<String>(25).map_err(map_spi)?;
+        let is_append_only = row.get::<bool>(26).map_err(map_spi)?.unwrap_or(false);
 
         Ok(StreamTableMeta {
             pgt_id,
@@ -834,6 +858,7 @@ impl StreamTableMeta {
             has_keyless_source,
             function_hashes,
             requested_cdc_mode,
+            is_append_only,
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_stream_tables (
     function_hashes TEXT,
     requested_cdc_mode TEXT
                      CHECK (requested_cdc_mode IN ('auto', 'trigger', 'wal')),
+    is_append_only  BOOLEAN NOT NULL DEFAULT FALSE,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -641,6 +641,69 @@ fn build_keyless_delete_template(quoted_table: &str, pgt_id: i64) -> String {
     )
 }
 
+/// Build an INSERT SQL statement for append-only stream tables.
+///
+/// Extracts the USING clause from the MERGE template and rewrites it as:
+///   INSERT INTO "schema"."table" (__pgt_row_id, user_cols...)
+///   SELECT d.__pgt_row_id, d.user_cols...
+///   FROM (...delta...) AS d
+///   WHERE d.__pgt_action = 'I'
+///
+/// This is significantly faster than MERGE for append-only workloads
+/// because it skips the DELETE, UPDATE, and IS DISTINCT FROM checks.
+fn build_append_only_insert_sql(schema: &str, name: &str, merge_sql: &str) -> String {
+    let quoted_table = format!(
+        "\"{}\".\"{}\"",
+        schema.replace('"', "\"\""),
+        name.replace('"', "\"\""),
+    );
+
+    // Parse the MERGE SQL to extract:
+    // 1. The USING clause (delta subquery)
+    // 2. The INSERT column list
+    //
+    // MERGE INTO "schema"."table" AS st USING (...) AS d ON ...
+    // ... WHEN NOT MATCHED AND d.__pgt_action = 'I' THEN
+    //   INSERT (__pgt_row_id, col1, col2, ...)
+    //   VALUES (d.__pgt_row_id, d.col1, d.col2, ...)
+
+    // Extract USING clause: between "USING " and " AS d ON"
+    let using_start = merge_sql.find("USING ").map(|p| p + 6).unwrap_or(0);
+    let using_end = merge_sql.find(" AS d ON ").unwrap_or(merge_sql.len());
+    let using_clause = &merge_sql[using_start..using_end];
+
+    // Extract column list from INSERT clause
+    let insert_marker = "INSERT (";
+    let insert_start = merge_sql
+        .rfind(insert_marker)
+        .map(|p| p + insert_marker.len())
+        .unwrap_or(0);
+    let insert_end = merge_sql[insert_start..]
+        .find(')')
+        .map(|p| insert_start + p)
+        .unwrap_or(merge_sql.len());
+    let col_list = &merge_sql[insert_start..insert_end];
+
+    // Extract VALUES column list (d.col prefixed)
+    let values_marker = "VALUES (";
+    let values_start = merge_sql
+        .rfind(values_marker)
+        .map(|p| p + values_marker.len())
+        .unwrap_or(0);
+    let values_end = merge_sql[values_start..]
+        .find(')')
+        .map(|p| values_start + p)
+        .unwrap_or(merge_sql.len());
+    let d_col_list = &merge_sql[values_start..values_end];
+
+    format!(
+        "INSERT INTO {quoted_table} ({col_list}) \
+         SELECT {d_col_list} \
+         FROM {using_clause} AS d \
+         WHERE d.__pgt_action = 'I'"
+    )
+}
+
 /// Pre-warm the delta SQL + MERGE template caches for a stream table.
 ///
 /// Called after `create_stream_table()` to avoid a cold-start penalty on
@@ -1518,6 +1581,49 @@ pub fn execute_differential_refresh(
         return Ok((0, 0));
     }
 
+    // ── A-3a: Append-only heuristic fallback ─────────────────────────
+    // When the stream table is marked append-only, check whether any
+    // DELETE or UPDATE actions appeared in the change buffers. If so,
+    // revert the flag and fall through to the normal MERGE path.
+    let mut is_append_only = st.is_append_only;
+    if is_append_only {
+        let has_non_insert = catalog_source_oids.iter().any(|oid| {
+            let prev_lsn = prev_frontier.get_lsn(*oid);
+            let new_lsn = new_frontier.get_lsn(*oid);
+            Spi::get_one::<bool>(&format!(
+                "SELECT EXISTS(\
+                   SELECT 1 FROM \"{change_schema}\".changes_{oid} \
+                   WHERE lsn > '{prev_lsn}'::pg_lsn \
+                   AND lsn <= '{new_lsn}'::pg_lsn \
+                   AND action IN ('D', 'U') \
+                   LIMIT 1\
+                 )",
+            ))
+            .unwrap_or(Some(false))
+            .unwrap_or(false)
+        });
+
+        if has_non_insert {
+            pgrx::info!(
+                "[pg_trickle] Append-only stream table {}.{} received DELETE/UPDATE — \
+                 reverting to MERGE path.",
+                schema,
+                name,
+            );
+            is_append_only = false;
+            if let Err(e) = StreamTableMeta::update_append_only(st.pgt_id, false) {
+                pgrx::warning!(
+                    "[pg_trickle] Failed to clear is_append_only for {}.{}: {}",
+                    schema,
+                    name,
+                    e,
+                );
+            }
+            // Flush MERGE template cache so next cycle rebuilds with MERGE path.
+            crate::shmem::bump_cache_generation();
+        }
+    }
+
     // ── S2: TRUNCATE detection ───────────────────────────────────────
     // If any source table was TRUNCATEd, the change buffer contains a
     // marker row with action='T'. Differential deltas cannot represent
@@ -2040,6 +2146,58 @@ pub fn execute_differential_refresh(
     // SET LOCAL hints that are automatically reset at transaction end.
     apply_planner_hints(total_change_count);
 
+    // ── A-3a: Append-only INSERT fast path ───────────────────────────
+    // When the stream table is marked append-only (and hasn't been
+    // reverted by the heuristic check above), skip MERGE entirely and
+    // use a simple INSERT … SELECT from the delta. This avoids the
+    // DELETE, UPDATE, and IS DISTINCT FROM overhead of the MERGE path.
+    if is_append_only {
+        let t_insert_start = Instant::now();
+
+        // Build INSERT SQL from the resolved MERGE SQL's USING clause.
+        // The MERGE SQL has the form:
+        //   MERGE INTO "schema"."table" AS st USING (...delta...) AS d ON ...
+        // We extract the delta subquery and wrap it in INSERT INTO.
+        let insert_sql = build_append_only_insert_sql(schema, name, &resolved.merge_sql);
+
+        let rows_inserted = Spi::connect_mut(|client| {
+            let result = client
+                .update(&insert_sql, None, &[])
+                .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
+            Ok::<i64, PgTrickleError>(result.len() as i64)
+        })?;
+
+        let t_insert = t_insert_start.elapsed();
+        pgrx::debug1!(
+            "[pg_trickle] append-only INSERT for {}.{}: {} rows in {:.1}ms",
+            schema,
+            name,
+            rows_inserted,
+            t_insert.as_secs_f64() * 1000.0,
+        );
+
+        // C-1: Defer cleanup of consumed change buffer rows.
+        let cleanup_source_oids = resolved.source_oids.clone();
+        if !cleanup_source_oids.is_empty() {
+            PENDING_CLEANUP.with(|q| {
+                q.borrow_mut().push(PendingCleanup {
+                    change_schema: change_schema.clone(),
+                    source_oids: cleanup_source_oids,
+                });
+            });
+        }
+
+        pgrx::info!(
+            "[PGS_PROFILE] decision={:.2}ms insert_exec={:.2}ms total={:.2}ms affected={} mode=APPEND_ONLY",
+            t_decision.as_secs_f64() * 1000.0,
+            t_insert.as_secs_f64() * 1000.0,
+            (t_decision + t_insert).as_secs_f64() * 1000.0,
+            rows_inserted,
+        );
+
+        return Ok((rows_inserted, 0));
+    }
+
     // ── User-trigger detection ───────────────────────────────────────
     // Determine whether to use the explicit DML path based on the GUC
     // and the presence of user-defined row-level triggers on the ST.
@@ -2405,6 +2563,7 @@ mod tests {
             has_keyless_source: false,
             function_hashes: None,
             requested_cdc_mode: None,
+            is_append_only: false,
         }
     }
 
@@ -2883,5 +3042,30 @@ mod tests {
         }
         // Should converge upward toward the cap
         assert!((threshold - 0.80).abs() < 0.01, "got {threshold}");
+    }
+
+    // ── build_append_only_insert_sql() ──────────────────────────────
+
+    #[test]
+    fn test_build_append_only_insert_sql_basic() {
+        let merge_sql = r#"MERGE INTO "public"."test_st" AS st USING (SELECT * FROM delta) AS d ON st.__pgt_row_id = d.__pgt_row_id WHEN MATCHED AND d.__pgt_action = 'D' THEN DELETE WHEN MATCHED AND d.__pgt_action = 'I' AND (st."val"::text IS DISTINCT FROM d."val"::text) THEN UPDATE SET "val" = d."val" WHEN NOT MATCHED AND d.__pgt_action = 'I' THEN INSERT (__pgt_row_id, "val") VALUES (d.__pgt_row_id, d."val")"#;
+
+        let result = build_append_only_insert_sql("public", "test_st", merge_sql);
+        assert!(result.contains(r#"INSERT INTO "public"."test_st""#));
+        assert!(result.contains("__pgt_row_id"));
+        assert!(result.contains("WHERE d.__pgt_action = 'I'"));
+        assert!(!result.contains("MERGE"));
+        assert!(!result.contains("DELETE"));
+        assert!(!result.contains("UPDATE SET"));
+    }
+
+    #[test]
+    fn test_build_append_only_insert_sql_multi_column() {
+        let merge_sql = r#"MERGE INTO "myschema"."events" AS st USING (SELECT * FROM changes) AS d ON st.__pgt_row_id = d.__pgt_row_id WHEN MATCHED AND d.__pgt_action = 'D' THEN DELETE WHEN NOT MATCHED AND d.__pgt_action = 'I' THEN INSERT (__pgt_row_id, "id", "type", "payload") VALUES (d.__pgt_row_id, d."id", d."type", d."payload")"#;
+
+        let result = build_append_only_insert_sql("myschema", "events", merge_sql);
+        assert!(result.contains(r#"INSERT INTO "myschema"."events""#));
+        assert!(result.contains(r#"__pgt_row_id, "id", "type", "payload""#));
+        assert!(result.contains(r#"d.__pgt_row_id, d."id", d."type", d."payload""#));
     }
 }

--- a/tests/e2e_append_only_tests.rs
+++ b/tests/e2e_append_only_tests.rs
@@ -1,0 +1,342 @@
+//! E2E tests for the append-only INSERT fast path (Phase 5, A-3a).
+//!
+//! Validates:
+//! - Append-only declaration on CREATE STREAM TABLE
+//! - Fast INSERT path bypasses MERGE for insert-only workloads
+//! - CDC heuristic fallback: reverts to MERGE when DELETE/UPDATE detected
+//! - ALTER STREAM TABLE to enable/disable append_only
+//! - Validation: append_only rejected for FULL, IMMEDIATE, keyless sources
+
+mod e2e;
+
+use e2e::E2eDb;
+
+/// Basic append-only creation and INSERT-only refresh.
+#[tokio::test]
+async fn test_append_only_basic_insert_path() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ao_src (id INT PRIMARY KEY, val TEXT NOT NULL)")
+        .await;
+    db.execute("INSERT INTO ao_src VALUES (1, 'a'), (2, 'b')")
+        .await;
+
+    // Create append-only stream table
+    db.execute(
+        "SELECT pgtrickle.create_stream_table('ao_basic', \
+         $$SELECT id, val FROM ao_src$$, '1m', 'DIFFERENTIAL', true, \
+         NULL, NULL, NULL, true)",
+    )
+    .await;
+
+    // Verify catalog flag is set
+    let is_ao: bool = sqlx::query_scalar(
+        "SELECT is_append_only FROM pgtrickle.pgt_stream_tables WHERE pgt_name = 'ao_basic'",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert!(is_ao, "is_append_only should be true after creation");
+
+    // Initial data should be present
+    let count: i64 = db.count("pgtrickle.ao_basic").await;
+    assert_eq!(count, 2, "initial population should have 2 rows");
+
+    // Insert more data and refresh — should use append-only INSERT path
+    db.execute("INSERT INTO ao_src VALUES (3, 'c'), (4, 'd')")
+        .await;
+    db.refresh_st("ao_basic").await;
+
+    let count: i64 = db.count("pgtrickle.ao_basic").await;
+    assert_eq!(count, 4, "after append-only refresh, should have 4 rows");
+}
+
+/// Verify append-only refresh produces correct data content.
+#[tokio::test]
+async fn test_append_only_data_correctness() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ao_data_src (id INT PRIMARY KEY, amount INT NOT NULL)")
+        .await;
+    db.execute("INSERT INTO ao_data_src VALUES (1, 100)").await;
+
+    db.execute(
+        "SELECT pgtrickle.create_stream_table('ao_data', \
+         $$SELECT id, amount FROM ao_data_src$$, '1m', 'DIFFERENTIAL', true, \
+         NULL, NULL, NULL, true)",
+    )
+    .await;
+
+    // Add rows across multiple refresh cycles
+    db.execute("INSERT INTO ao_data_src VALUES (2, 200), (3, 300)")
+        .await;
+    db.refresh_st("ao_data").await;
+
+    db.execute("INSERT INTO ao_data_src VALUES (4, 400)").await;
+    db.refresh_st("ao_data").await;
+
+    // Verify all data present
+    let sum: i64 =
+        sqlx::query_scalar("SELECT COALESCE(SUM(amount), 0)::bigint FROM pgtrickle.ao_data")
+            .fetch_one(&db.pool)
+            .await
+            .unwrap();
+    assert_eq!(sum, 1000, "sum of all amounts should be 1000");
+
+    let count: i64 = db.count("pgtrickle.ao_data").await;
+    assert_eq!(count, 4, "should have 4 rows total");
+}
+
+/// CDC heuristic fallback: DELETE on source reverts append-only to MERGE.
+#[tokio::test]
+async fn test_append_only_fallback_on_delete() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ao_fallback_src (id INT PRIMARY KEY, val TEXT NOT NULL)")
+        .await;
+    db.execute("INSERT INTO ao_fallback_src VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+        .await;
+
+    db.execute(
+        "SELECT pgtrickle.create_stream_table('ao_fallback', \
+         $$SELECT id, val FROM ao_fallback_src$$, '1m', 'DIFFERENTIAL', true, \
+         NULL, NULL, NULL, true)",
+    )
+    .await;
+
+    // Delete a row — should trigger heuristic fallback
+    db.execute("DELETE FROM ao_fallback_src WHERE id = 2").await;
+    db.refresh_st("ao_fallback").await;
+
+    // Verify the flag was reverted
+    let is_ao: bool = sqlx::query_scalar(
+        "SELECT is_append_only FROM pgtrickle.pgt_stream_tables WHERE pgt_name = 'ao_fallback'",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert!(
+        !is_ao,
+        "is_append_only should be reverted to false after DELETE detected"
+    );
+
+    // Verify data correctness after fallback
+    let count: i64 = db.count("pgtrickle.ao_fallback").await;
+    assert_eq!(
+        count, 2,
+        "should have 2 rows after delete and MERGE fallback"
+    );
+}
+
+/// CDC heuristic fallback: UPDATE on source reverts append-only to MERGE.
+#[tokio::test]
+async fn test_append_only_fallback_on_update() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ao_upd_src (id INT PRIMARY KEY, val TEXT NOT NULL)")
+        .await;
+    db.execute("INSERT INTO ao_upd_src VALUES (1, 'old'), (2, 'old')")
+        .await;
+
+    db.execute(
+        "SELECT pgtrickle.create_stream_table('ao_upd', \
+         $$SELECT id, val FROM ao_upd_src$$, '1m', 'DIFFERENTIAL', true, \
+         NULL, NULL, NULL, true)",
+    )
+    .await;
+
+    // Update a row — should trigger heuristic fallback
+    db.execute("UPDATE ao_upd_src SET val = 'new' WHERE id = 1")
+        .await;
+    db.refresh_st("ao_upd").await;
+
+    // Verify the flag was reverted
+    let is_ao: bool = sqlx::query_scalar(
+        "SELECT is_append_only FROM pgtrickle.pgt_stream_tables WHERE pgt_name = 'ao_upd'",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert!(
+        !is_ao,
+        "is_append_only should be reverted to false after UPDATE detected"
+    );
+
+    // Verify data correctness
+    let val: String = sqlx::query_scalar("SELECT val FROM pgtrickle.ao_upd WHERE id = 1")
+        .fetch_one(&db.pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        val, "new",
+        "updated value should be reflected after MERGE fallback"
+    );
+}
+
+/// ALTER STREAM TABLE: enable append_only on existing stream table.
+#[tokio::test]
+async fn test_alter_enable_append_only() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ao_alter_src (id INT PRIMARY KEY, val TEXT NOT NULL)")
+        .await;
+    db.execute("INSERT INTO ao_alter_src VALUES (1, 'x')").await;
+
+    // Create without append_only
+    db.create_st(
+        "ao_alter",
+        "SELECT id, val FROM ao_alter_src",
+        "1m",
+        "DIFFERENTIAL",
+    )
+    .await;
+
+    // Enable append_only via ALTER
+    db.alter_st("ao_alter", "append_only => true").await;
+
+    let is_ao: bool = sqlx::query_scalar(
+        "SELECT is_append_only FROM pgtrickle.pgt_stream_tables WHERE pgt_name = 'ao_alter'",
+    )
+    .fetch_one(&db.pool)
+    .await
+    .unwrap();
+    assert!(is_ao, "append_only should be true after ALTER");
+
+    // Refresh should work with append-only path
+    db.execute("INSERT INTO ao_alter_src VALUES (2, 'y')").await;
+    db.refresh_st("ao_alter").await;
+
+    let count: i64 = db.count("pgtrickle.ao_alter").await;
+    assert_eq!(count, 2);
+}
+
+/// Validation: append_only rejected for FULL refresh mode.
+#[tokio::test]
+async fn test_append_only_rejected_for_full_mode() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ao_full_src (id INT PRIMARY KEY)")
+        .await;
+
+    let result = db
+        .try_execute(
+            "SELECT pgtrickle.create_stream_table('ao_full', \
+             $$SELECT id FROM ao_full_src$$, '1m', 'FULL', true, \
+             NULL, NULL, NULL, true)",
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "append_only should be rejected for FULL refresh mode"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("FULL"),
+        "error should mention FULL mode: {}",
+        err
+    );
+}
+
+/// Validation: append_only rejected for IMMEDIATE refresh mode.
+#[tokio::test]
+async fn test_append_only_rejected_for_immediate_mode() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ao_imm_src (id INT PRIMARY KEY)")
+        .await;
+
+    let result = db
+        .try_execute(
+            "SELECT pgtrickle.create_stream_table('ao_imm', \
+             $$SELECT id FROM ao_imm_src$$, '1m', 'IMMEDIATE', true, \
+             NULL, NULL, NULL, true)",
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "append_only should be rejected for IMMEDIATE refresh mode"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("IMMEDIATE"),
+        "error should mention IMMEDIATE mode: {}",
+        err
+    );
+}
+
+/// Validation: append_only rejected for keyless sources.
+#[tokio::test]
+async fn test_append_only_rejected_for_keyless_source() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    // Create table without primary key
+    db.execute("CREATE TABLE ao_keyless_src (id INT, val TEXT)")
+        .await;
+
+    let result = db
+        .try_execute(
+            "SELECT pgtrickle.create_stream_table('ao_keyless', \
+             $$SELECT id, val FROM ao_keyless_src$$, '1m', 'DIFFERENTIAL', true, \
+             NULL, NULL, NULL, true)",
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "append_only should be rejected for keyless sources"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("keyless"),
+        "error should mention keyless: {}",
+        err
+    );
+}
+
+/// Validation: ALTER to append_only rejected for FULL mode stream table.
+#[tokio::test]
+async fn test_alter_append_only_rejected_for_full_mode() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ao_alt_full_src (id INT PRIMARY KEY)")
+        .await;
+
+    db.create_st(
+        "ao_alt_full",
+        "SELECT id FROM ao_alt_full_src",
+        "1m",
+        "FULL",
+    )
+    .await;
+
+    let result = db
+        .try_execute("SELECT pgtrickle.alter_stream_table('ao_alt_full', append_only => true)")
+        .await;
+    assert!(
+        result.is_err(),
+        "ALTER append_only=true should be rejected for FULL mode"
+    );
+}
+
+/// No-data cycle: append-only path correctly returns (0, 0) when no changes.
+#[tokio::test]
+async fn test_append_only_no_data_cycle() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE ao_nodata_src (id INT PRIMARY KEY, val TEXT NOT NULL)")
+        .await;
+    db.execute("INSERT INTO ao_nodata_src VALUES (1, 'a')")
+        .await;
+
+    db.execute(
+        "SELECT pgtrickle.create_stream_table('ao_nodata', \
+         $$SELECT id, val FROM ao_nodata_src$$, '1m', 'DIFFERENTIAL', true, \
+         NULL, NULL, NULL, true)",
+    )
+    .await;
+
+    // Refresh with no changes — should be no-op
+    db.refresh_st("ao_nodata").await;
+
+    let count: i64 = db.count("pgtrickle.ao_nodata").await;
+    assert_eq!(count, 1, "no-data cycle should not change row count");
+}


### PR DESCRIPTION
## Phase 5 — Performance Wave 1: Append-Only INSERT Fast Path

Implements the **A-3a** item from CHECKLIST_0.5.0.md — append-only MERGE bypass for event-sourced/insert-only workloads.

### Changes

**Catalog**
- New `is_append_only BOOLEAN NOT NULL DEFAULT FALSE` column on `pgt_stream_tables`
- `update_append_only()` catalog method for heuristic fallback

**API**
- `create_stream_table()` and `alter_stream_table()` accept `append_only` parameter
- Validation: rejected for FULL, IMMEDIATE, and keyless source stream tables

**Refresh Engine**
- When `is_append_only = true`, differential refresh uses `INSERT ... SELECT` from the delta instead of MERGE
- Skips DELETE, UPDATE, and IS DISTINCT FROM overhead
- **CDC heuristic fallback**: at the start of each differential refresh, checks change buffers for DELETE/UPDATE actions. If found, reverts `is_append_only` to `false` and falls through to MERGE

**Upgrade SQL**
- `sql/pg_trickle--0.4.0--0.5.0.sql` adds `is_append_only` column

### Testing
- 9 E2E tests in `e2e_append_only_tests.rs`: basic INSERT- 9 E2E tests in `e2e_append_only_tests.rs`: basic INSERT- 9 E2E tests in `e2e_append_only_tests.rs`: basic INSERT- 9tes- 9 E2E teuil- 9 E2E tenl- 9 E2E tests in `e2e_append_only_tests.rs`: basic INSERT- 9 E2E tests in `e2e_appera- 9 E2E tests in `e2e_append_only_tests.rs`: basic INSERT- 9 MAP- 9 E2HECKLIST_0.5.0.md updated
