### PR TITLE
fix: pg_notify type mismatch and wrong schema refs in E2E tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ dependencies = [
  "pgrx-tests",
  "postgres",
  "proptest",
+ "regex-lite",
  "serde",
  "serde_json",
  "sha2",
@@ -2654,6 +2655,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"

--- a/src/api.rs
+++ b/src/api.rs
@@ -2726,7 +2726,7 @@ fn gate_source(source: &str) -> Result<(), PgTrickleError> {
     // Signal the scheduler that the gate set has changed.
     let payload = format!("{}", source_relid.to_u32());
     Spi::run(&format!(
-        "SELECT pg_notify('pgtrickle_source_gate', {})",
+        "SELECT pg_notify('pgtrickle_source_gate', '{}')",
         &payload
     ))
     .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
@@ -2751,7 +2751,7 @@ fn ungate_source(source: &str) -> Result<(), PgTrickleError> {
     // Signal the scheduler that the gate set has changed.
     let payload = format!("{}", source_relid.to_u32());
     Spi::run(&format!(
-        "SELECT pg_notify('pgtrickle_source_gate', {})",
+        "SELECT pg_notify('pgtrickle_source_gate', '{}')",
         &payload
     ))
     .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;

--- a/tests/e2e_append_only_tests.rs
+++ b/tests/e2e_append_only_tests.rs
@@ -39,7 +39,7 @@ async fn test_append_only_basic_insert_path() {
     assert!(is_ao, "is_append_only should be true after creation");
 
     // Initial data should be present
-    let count: i64 = db.count("pgtrickle.ao_basic").await;
+    let count: i64 = db.count("public.ao_basic").await;
     assert_eq!(count, 2, "initial population should have 2 rows");
 
     // Insert more data and refresh — should use append-only INSERT path
@@ -47,7 +47,7 @@ async fn test_append_only_basic_insert_path() {
         .await;
     db.refresh_st("ao_basic").await;
 
-    let count: i64 = db.count("pgtrickle.ao_basic").await;
+    let count: i64 = db.count("public.ao_basic").await;
     assert_eq!(count, 4, "after append-only refresh, should have 4 rows");
 }
 
@@ -77,13 +77,13 @@ async fn test_append_only_data_correctness() {
 
     // Verify all data present
     let sum: i64 =
-        sqlx::query_scalar("SELECT COALESCE(SUM(amount), 0)::bigint FROM pgtrickle.ao_data")
+        sqlx::query_scalar("SELECT COALESCE(SUM(amount), 0)::bigint FROM public.ao_data")
             .fetch_one(&db.pool)
             .await
             .unwrap();
     assert_eq!(sum, 1000, "sum of all amounts should be 1000");
 
-    let count: i64 = db.count("pgtrickle.ao_data").await;
+    let count: i64 = db.count("public.ao_data").await;
     assert_eq!(count, 4, "should have 4 rows total");
 }
 
@@ -121,7 +121,7 @@ async fn test_append_only_fallback_on_delete() {
     );
 
     // Verify data correctness after fallback
-    let count: i64 = db.count("pgtrickle.ao_fallback").await;
+    let count: i64 = db.count("public.ao_fallback").await;
     assert_eq!(
         count, 2,
         "should have 2 rows after delete and MERGE fallback"
@@ -163,7 +163,7 @@ async fn test_append_only_fallback_on_update() {
     );
 
     // Verify data correctness
-    let val: String = sqlx::query_scalar("SELECT val FROM pgtrickle.ao_upd WHERE id = 1")
+    let val: String = sqlx::query_scalar("SELECT val FROM public.ao_upd WHERE id = 1")
         .fetch_one(&db.pool)
         .await
         .unwrap();
@@ -206,7 +206,7 @@ async fn test_alter_enable_append_only() {
     db.execute("INSERT INTO ao_alter_src VALUES (2, 'y')").await;
     db.refresh_st("ao_alter").await;
 
-    let count: i64 = db.count("pgtrickle.ao_alter").await;
+    let count: i64 = db.count("public.ao_alter").await;
     assert_eq!(count, 2);
 }
 
@@ -337,6 +337,6 @@ async fn test_append_only_no_data_cycle() {
     // Refresh with no changes — should be no-op
     db.refresh_st("ao_nodata").await;
 
-    let count: i64 = db.count("pgtrickle.ao_nodata").await;
+    let count: i64 = db.count("public.ao_nodata").await;
     assert_eq!(count, 1, "no-data cycle should not change row count");
 }

--- a/tests/e2e_bootstrap_gating_tests.rs
+++ b/tests/e2e_bootstrap_gating_tests.rs
@@ -209,7 +209,7 @@ async fn test_manual_refresh_not_blocked_by_gate() {
     // Manual refresh must succeed even though the source is gated.
     db.refresh_st("man_st").await;
 
-    let count: i64 = db.count("pgtrickle.man_st").await;
+    let count: i64 = db.count("public.man_st").await;
     assert_eq!(
         count, 2,
         "manual refresh must succeed even when source is gated"

--- a/tests/e2e_rls_tests.rs
+++ b/tests/e2e_rls_tests.rs
@@ -49,7 +49,7 @@ async fn test_rls_on_source_does_not_filter_stream_table() {
     // Refresh the stream table — should contain ALL rows despite RLS
     db.refresh_st("rls_src_st").await;
 
-    let count: i64 = db.count("pgtrickle.rls_src_st").await;
+    let count: i64 = db.count("public.rls_src_st").await;
     assert_eq!(
         count, 3,
         "stream table should contain all 3 rows despite RLS on source"
@@ -85,7 +85,7 @@ async fn test_rls_on_source_differential_mode() {
 
     db.refresh_st("rls_diff_st").await;
 
-    let count: i64 = db.count("pgtrickle.rls_diff_st").await;
+    let count: i64 = db.count("public.rls_diff_st").await;
     assert_eq!(
         count, 2,
         "DIFFERENTIAL stream table should contain all rows despite RLS"
@@ -96,7 +96,7 @@ async fn test_rls_on_source_differential_mode() {
         .await;
     db.refresh_st("rls_diff_st").await;
 
-    let count: i64 = db.count("pgtrickle.rls_diff_st").await;
+    let count: i64 = db.count("public.rls_diff_st").await;
     assert_eq!(
         count, 3,
         "DIFFERENTIAL refresh should see all rows including RLS-filtered ones"
@@ -129,23 +129,23 @@ async fn test_rls_on_stream_table_filters_reads() {
     db.refresh_st("rls_st_test").await;
 
     // Verify all rows present before RLS
-    let total: i64 = db.count("pgtrickle.rls_st_test").await;
+    let total: i64 = db.count("public.rls_st_test").await;
     assert_eq!(total, 4, "stream table should have all 4 rows");
 
     // Enable RLS on the stream table
-    db.execute("ALTER TABLE pgtrickle.rls_st_test ENABLE ROW LEVEL SECURITY")
+    db.execute("ALTER TABLE public.rls_st_test ENABLE ROW LEVEL SECURITY")
         .await;
 
     // Create a test role and grant access
     db.execute("CREATE ROLE rls_reader LOGIN").await;
-    db.execute("GRANT USAGE ON SCHEMA pgtrickle TO rls_reader")
+    db.execute("GRANT USAGE ON SCHEMA public TO rls_reader")
         .await;
-    db.execute("GRANT SELECT ON pgtrickle.rls_st_test TO rls_reader")
+    db.execute("GRANT SELECT ON public.rls_st_test TO rls_reader")
         .await;
 
     // Create a policy that only allows tenant_id = 10
     db.execute(
-        "CREATE POLICY tenant_filter ON pgtrickle.rls_st_test \
+        "CREATE POLICY tenant_filter ON public.rls_st_test \
          FOR SELECT TO rls_reader \
          USING (tenant_id = 10)",
     )
@@ -154,7 +154,7 @@ async fn test_rls_on_stream_table_filters_reads() {
     // Query as the restricted role — should only see tenant 10 rows
     let filtered_count: i64 = db
         .query_scalar(
-            "SELECT count(*) FROM pgtrickle.rls_st_test \
+            "SELECT count(*) FROM public.rls_st_test \
              WHERE current_user = current_user", // dummy where just to ensure query executes
         )
         .await;
@@ -198,16 +198,16 @@ async fn test_rls_on_stream_table_immediate_mode() {
     .await;
 
     // Verify the initial population
-    let count: i64 = db.count("pgtrickle.rls_imm_st").await;
+    let count: i64 = db.count("public.rls_imm_st").await;
     assert_eq!(count, 2, "initial population should have 2 rows");
 
     // Enable RLS on the stream table
-    db.execute("ALTER TABLE pgtrickle.rls_imm_st ENABLE ROW LEVEL SECURITY")
+    db.execute("ALTER TABLE public.rls_imm_st ENABLE ROW LEVEL SECURITY")
         .await;
 
     // Create a policy
     db.execute(
-        "CREATE POLICY imm_tenant ON pgtrickle.rls_imm_st \
+        "CREATE POLICY imm_tenant ON public.rls_imm_st \
          USING (tenant_id = 10)",
     )
     .await;
@@ -218,7 +218,7 @@ async fn test_rls_on_stream_table_immediate_mode() {
         .await;
 
     // As superuser, we bypass RLS and should see all 3 rows
-    let total: i64 = db.count("pgtrickle.rls_imm_st").await;
+    let total: i64 = db.count("public.rls_imm_st").await;
     assert_eq!(
         total, 3,
         "IMMEDIATE mode should propagate insert despite RLS on stream table"
@@ -228,7 +228,7 @@ async fn test_rls_on_stream_table_immediate_mode() {
     db.execute("INSERT INTO rls_imm_src VALUES (4, 20, 'd')")
         .await;
 
-    let total: i64 = db.count("pgtrickle.rls_imm_st").await;
+    let total: i64 = db.count("public.rls_imm_st").await;
     assert_eq!(
         total, 4,
         "all rows should be in stream table regardless of RLS policy"
@@ -343,7 +343,7 @@ async fn test_enable_rls_on_source_triggers_reinit() {
     // Initial refresh so the snapshot is stored.
     db.refresh_st("rls_ddl_st").await;
 
-    let count: i64 = db.count("pgtrickle.rls_ddl_st").await;
+    let count: i64 = db.count("public.rls_ddl_st").await;
     assert_eq!(count, 2, "initial refresh should populate 2 rows");
 
     // Verify not marked for reinit before the DDL.
@@ -372,7 +372,7 @@ async fn test_enable_rls_on_source_triggers_reinit() {
     // contain all rows (superuser context bypasses RLS).
     db.refresh_st("rls_ddl_st").await;
 
-    let count: i64 = db.count("pgtrickle.rls_ddl_st").await;
+    let count: i64 = db.count("public.rls_ddl_st").await;
     assert_eq!(
         count, 2,
         "stream table should still contain all rows after reinit"


### PR DESCRIPTION
Fixes bugs found during full E2E testing:

1. pg_notify type mismatch in gate_source/ungate_source: payload was passed as unquoted integer. Fixed by quoting as text literal.
2. Wrong schema refs in E2E tests: stream tables live in public schema, not pgtrickle. Fixed in append_only, gating, and RLS tests.
3. Cargo.lock update for regex-lite dev dependency.

Note: test_scheduler_logs_skip_when_source_gated fails locally (pre-existing on main).