### PR TITLE
fix(tests): use dedicated connection for mixed-DML transaction test

### DIFF
--- a/tests/e2e_stmt_cdc_tests.rs
+++ b/tests/e2e_stmt_cdc_tests.rs
@@ -484,14 +484,26 @@ async fn test_stmt_cdc_mixed_dml_in_transaction() {
     db.execute(&format!("TRUNCATE {buf}")).await;
 
     // Mix of DML in a single transaction.
-    db.execute("BEGIN").await;
-    db.execute("DELETE FROM mixed_dml WHERE id IN (1, 2, 3)")
-        .await;
-    db.execute("UPDATE mixed_dml SET val = 'updated' WHERE id IN (4, 5)")
-        .await;
-    db.execute("INSERT INTO mixed_dml VALUES (11, 'new11'), (12, 'new12')")
-        .await;
-    db.execute("COMMIT").await;
+    // Use a dedicated connection so BEGIN/DML/COMMIT all run on the same
+    // session — pool.execute() could dispatch each call to a different
+    // connection, leaving some trigger change-buffer rows uncommitted.
+    {
+        let mut conn = db.pool.acquire().await.expect("acquire connection");
+        sqlx::query("BEGIN").execute(&mut *conn).await.unwrap();
+        sqlx::query("DELETE FROM mixed_dml WHERE id IN (1, 2, 3)")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE mixed_dml SET val = 'updated' WHERE id IN (4, 5)")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO mixed_dml VALUES (11, 'new11'), (12, 'new12')")
+            .execute(&mut *conn)
+            .await
+            .unwrap();
+        sqlx::query("COMMIT").execute(&mut *conn).await.unwrap();
+    }
 
     // 3 deletes + 2 updates + 2 inserts = 7 change rows.
     let total: i64 = db.count(&buf).await;


### PR DESCRIPTION
## Problem

`test_stmt_cdc_mixed_dml_in_transaction` fails intermittently with 5 change-buffer rows instead of 7.

## Root Cause

`db.execute()` dispatches each call through the connection pool, so `BEGIN`/`DELETE`/`UPDATE`/`INSERT`/`COMMIT` can land on different connections. When the UPDATE runs on the connection that received BEGIN but COMMIT goes to a different connection, the UPDATE trigger's change-buffer inserts are never committed (rolled back when the connection returns to the pool). Result: 3 D + 0 U + 2 I = 5.

## Fix

Acquire a single connection via `pool.acquire()` for the entire transaction, matching the pattern already used in `test_rollback_between_refreshes`.