### PR TITLE
feat(dbt): dbt Integration Enhancements (DBT-1/2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,28 @@ For future plans and release milestones, see [ROADMAP.md](ROADMAP.md).
   mode switches, IMMEDIATE mode, whitespace normalization, and
   `create_stream_table_if_not_exists` variants.
 - **Deployment docs** — FAQ section on idempotent deployment patterns;
+
+#### dbt Integration Enhancements (DBT-1 through DBT-3)
+
+- **`stream_table_status()` macro (DBT-1).** New
+  `pgtrickle_stream_table_status()` utility macro returns the health status of
+  a stream table as a dict (`status`, `staleness_seconds`,
+  `consecutive_errors`, `total_refreshes`, etc.). Status is one of `healthy`,
+  `stale`, `erroring`, `paused`, or `not_found`. Configurable `warn_seconds`
+  threshold (default 300s).
+- **`stream_table_healthy` generic test (DBT-1).** Built-in dbt test that
+  fails when a stream table is stale, erroring, or paused. Use in
+  `schema.yml`: `- dbt_pgtrickle.stream_table_healthy: {warn_seconds: 300}`.
+- **`refresh_all_stream_tables` operation (DBT-2).** New run-operation that
+  refreshes all dbt-managed stream tables in topological (dependency) order.
+  Queries the pg_trickle dependency catalog to compute depth, refreshing
+  upstream tables first. Designed for CI: run after `dbt run` and before
+  `dbt test`. Supports optional schema filter.
+- **Alter flow integration tests (DBT-3).** New `order_extremes` (FULL refresh
+  mode) and `customer_stats` models exercise create, idempotent no-op re-run,
+  config change, and full-refresh paths through the dbt materialization.
+  Integration test script updated to test `refresh_all_stream_tables` and
+  the `stream_table_healthy` generic test.
   Getting Started guide with SQL migration and dbt best practices.
 
 #### Partitioning Support (Source Tables)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1037,9 +1037,9 @@ Forms the prerequisite for full SCC-based fixpoint refresh in v0.7.0.
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| DBT-1 | **Check stream table health from dbt.** A new `stream_table_status()` macro that returns whether a stream table is healthy, stale, or erroring — so you can write dbt tests like "fail if the orders summary hasn't refreshed in the last 5 minutes." Makes pg_trickle a first-class citizen in dbt's testing framework. | 3h | [PLAN_ECO_SYSTEM.md](plans/ecosystem/PLAN_ECO_SYSTEM.md) §Project 1 |
-| DBT-2 | **Refresh everything in one command.** A `dbt run-operation refresh_all_stream_tables` command that refreshes all stream tables in the correct dependency order. Designed for CI pipelines: run it after `dbt run` and before `dbt test` to make sure all materialized data is current. | 2h | [PLAN_ECO_SYSTEM.md](plans/ecosystem/PLAN_ECO_SYSTEM.md) §Project 1 |
-| DBT-3 | **Test the dbt ↔ alter flow.** Integration tests that verify query changes, config changes, and mode switches all work correctly when made through dbt's `stream_table` materialization. Especially important now that `create_or_replace` is landing in the same release. | 3h | [PLAN_ECO_SYSTEM.md](plans/ecosystem/PLAN_ECO_SYSTEM.md) §Project 1 |
+| DBT-1 | **Check stream table health from dbt.** A new `stream_table_status()` macro that returns whether a stream table is healthy, stale, or erroring — so you can write dbt tests like "fail if the orders summary hasn't refreshed in the last 5 minutes." Makes pg_trickle a first-class citizen in dbt's testing framework. | 3h | [PLAN_ECO_SYSTEM.md](plans/ecosystem/PLAN_ECO_SYSTEM.md) §Project 1 | ✅ Done |
+| DBT-2 | **Refresh everything in one command.** A `dbt run-operation refresh_all_stream_tables` command that refreshes all stream tables in the correct dependency order. Designed for CI pipelines: run it after `dbt run` and before `dbt test` to make sure all materialized data is current. | 2h | [PLAN_ECO_SYSTEM.md](plans/ecosystem/PLAN_ECO_SYSTEM.md) §Project 1 | ✅ Done |
+| DBT-3 | **Test the dbt ↔ alter flow.** Integration tests that verify query changes, config changes, and mode switches all work correctly when made through dbt's `stream_table` materialization. Especially important now that `create_or_replace` is landing in the same release. | 3h | [PLAN_ECO_SYSTEM.md](plans/ecosystem/PLAN_ECO_SYSTEM.md) §Project 1 | ✅ Done |
 
 > **dbt integration subtotal: ~8 hours**
 
@@ -1074,7 +1074,7 @@ Forms the prerequisite for full SCC-based fixpoint refresh in v0.7.0.
 - [ ] `ALL (subquery)` rewritten to `NOT EXISTS (... EXCEPT ...)` (EC-32)
 - [ ] Ergonomics E2E tests for calculated schedule, warnings, and removed GUCs pass
 - [ ] `gate_source()` idempotency and re-gating tested; `bootstrap_gate_status()` available
-- [ ] dbt `stream_table_status()` and `refresh_all_stream_tables` macros shipped
+- [x] dbt `stream_table_status()` and `refresh_all_stream_tables` macros shipped
 - [ ] SQL Reference updated for EC-03, EC-32, and foreign table polling patterns
 - [ ] Extension upgrade path tested (`0.5.0 → 0.6.0`)
 

--- a/dbt-pgtrickle/AGENTS.md
+++ b/dbt-pgtrickle/AGENTS.md
@@ -22,17 +22,26 @@ macros/
 │   └── stream_table.sql           # Core custom materialization — entry point for dbt run
 ├── adapters/
 │   ├── create_stream_table.sql    # Wraps pgtrickle.create_stream_table()
+│   ├── create_or_replace_stream_table.sql  # Wraps pgtrickle.create_or_replace_stream_table() (≥ 0.6.0)
 │   ├── alter_stream_table.sql     # Wraps pgtrickle.alter_stream_table()
 │   ├── drop_stream_table.sql      # Wraps pgtrickle.drop_stream_table()
 │   └── refresh_stream_table.sql   # Wraps pgtrickle.refresh_stream_table()
 ├── hooks/
 │   └── source_freshness.sql       # Source freshness via pg_stat_stream_tables
 ├── operations/
-│   ├── refresh.sql                # Manual refresh run-operation
-│   └── drop_all.sql              # Drop all stream tables run-operation
+│   ├── refresh.sql                # Manual refresh run-operation (single table)
+│   ├── refresh_all.sql            # Refresh all stream tables in dependency order
+│   ├── drop_all.sql               # Drop all stream tables run-operation
+│   └── check_cdc_health.sql       # CDC health check run-operation
 └── utils/
     ├── stream_table_exists.sql    # Check catalog for stream table existence
-    └── get_stream_table_info.sql  # Read stream table metadata from catalog
+    ├── get_stream_table_info.sql  # Read stream table metadata from catalog
+    ├── stream_table_status.sql    # Health status (healthy/stale/erroring/paused)
+    └── has_create_or_replace.sql  # Detect pg_trickle ≥ 0.6.0
+
+tests/
+└── generic/
+    └── stream_table_healthy.sql   # Generic dbt test for stream table health
 
 integration_tests/                 # Standalone dbt project for testing
 ├── dbt_project.yml

--- a/dbt-pgtrickle/CHANGELOG.md
+++ b/dbt-pgtrickle/CHANGELOG.md
@@ -7,9 +7,14 @@ All notable changes to the dbt-pgtrickle package will be documented in this file
 ### Added
 - `pgtrickle_create_or_replace_stream_table()` adapter macro — wraps pg_trickle 0.6.0's idempotent DDL function
 - `pgtrickle_has_create_or_replace()` utility macro — detects pg_trickle ≥ 0.6.0
+- `pgtrickle_stream_table_status()` utility macro — returns health status (healthy/stale/erroring/paused/not_found) with staleness and error counts for a stream table (DBT-1)
+- `stream_table_healthy` generic dbt test — fails if a stream table is stale, erroring, or paused; configurable `warn_seconds` threshold (DBT-1)
+- `refresh_all_stream_tables` run-operation — refreshes all dbt-managed stream tables in dependency order using pg_trickle's catalog for topological ordering; designed for CI pipelines (DBT-2)
+- Integration tests for alter flow — `order_extremes` (FULL mode) and `customer_stats` (config change) models exercise create, no-op idempotent re-run, config-only alter, and full-refresh paths (DBT-3)
 
 ### Changed
 - `stream_table` materialization now uses `create_or_replace_stream_table()` when pg_trickle ≥ 0.6.0 is detected, with automatic fallback to the legacy check-then-decide pattern for older versions
+- Integration test suite expanded: tests `stream_table_healthy` generic test, `refresh_all_stream_tables` operation, idempotent no-op re-run, and multiple stream table models
 
 ## [0.1.0] - 2026-XX-XX
 

--- a/dbt-pgtrickle/README.md
+++ b/dbt-pgtrickle/README.md
@@ -92,6 +92,20 @@ models:
 dbt run-operation pgtrickle_refresh --args '{"model_name": "order_totals"}'
 ```
 
+### `refresh_all_stream_tables` — Refresh all in dependency order
+
+Refreshes all dbt-managed stream tables in topological (dependency) order.
+Upstream tables are refreshed before downstream ones. Designed for CI pipelines:
+run after `dbt run` and before `dbt test` to ensure all data is current.
+
+```bash
+# Refresh all dbt-managed stream tables
+dbt run-operation refresh_all_stream_tables
+
+# Refresh only stream tables in a specific schema
+dbt run-operation refresh_all_stream_tables --args '{"schema": "analytics"}'
+```
+
 ### `drop_all_stream_tables` — Drop dbt-managed stream tables
 
 Drops only stream tables defined as dbt models (safe in shared environments):
@@ -161,6 +175,33 @@ models:
         tests:
           - not_null
           - unique
+```
+
+### Stream Table Health Test
+
+Use the built-in `stream_table_healthy` generic test to fail your dbt test suite
+when a stream table is stale, erroring, or paused:
+
+```yaml
+models:
+  - name: order_totals
+    tests:
+      - dbt_pgtrickle.stream_table_healthy:
+          warn_seconds: 300  # fail if stale for more than 5 minutes
+```
+
+The test queries `pgtrickle.pg_stat_stream_tables` and returns rows for any
+unhealthy condition. An empty result set means the stream table is healthy.
+
+### Stream Table Status Macro
+
+For more programmatic control, use the `pgtrickle_stream_table_status()` macro
+directly in custom tests or run-operations:
+
+```sql
+{%- set st = dbt_pgtrickle.pgtrickle_stream_table_status('order_totals', warn_seconds=300) -%}
+{# st.status is one of: 'healthy', 'stale', 'erroring', 'paused', 'not_found' #}
+{# st.staleness_seconds, st.consecutive_errors, st.total_refreshes, etc. #}
 ```
 
 ## `__pgt_row_id` Column

--- a/dbt-pgtrickle/dbt_project.yml
+++ b/dbt-pgtrickle/dbt_project.yml
@@ -5,6 +5,7 @@ config-version: 2
 require-dbt-version: [">=1.9.0", "<2.0.0"]
 
 macro-paths: ["macros"]
+test-paths: ["tests"]
 clean-targets:
   - "target"
   - "dbt_packages"

--- a/dbt-pgtrickle/integration_tests/models/marts/customer_stats.sql
+++ b/dbt-pgtrickle/integration_tests/models/marts/customer_stats.sql
@@ -1,0 +1,13 @@
+{{ config(
+    materialized='stream_table',
+    schedule='2m',
+    refresh_mode='DIFFERENTIAL'
+) }}
+
+SELECT
+    customer_id,
+    SUM(amount) AS total_amount,
+    COUNT(*) AS order_count,
+    AVG(amount) AS avg_amount
+FROM {{ ref('raw_orders') }}
+GROUP BY customer_id

--- a/dbt-pgtrickle/integration_tests/models/marts/order_extremes.sql
+++ b/dbt-pgtrickle/integration_tests/models/marts/order_extremes.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='stream_table',
+    schedule='5m',
+    refresh_mode='FULL'
+) }}
+
+SELECT
+    customer_id,
+    MAX(amount) AS max_amount,
+    MIN(amount) AS min_amount
+FROM {{ ref('raw_orders') }}
+GROUP BY customer_id

--- a/dbt-pgtrickle/integration_tests/models/marts/schema.yml
+++ b/dbt-pgtrickle/integration_tests/models/marts/schema.yml
@@ -3,6 +3,49 @@ version: 2
 models:
   - name: order_totals
     description: "Aggregated order totals per customer (stream table)"
+    tests:
+      - dbt_pgtrickle.stream_table_healthy:
+          warn_seconds: 600
+    columns:
+      - name: customer_id
+        description: "Customer identifier"
+        tests:
+          - not_null
+          - unique
+      - name: total_amount
+        description: "Sum of all order amounts"
+        tests:
+          - not_null
+      - name: order_count
+        description: "Number of orders"
+        tests:
+          - not_null
+
+  - name: order_extremes
+    description: "Min/max order amounts per customer (stream table, FULL refresh)"
+    tests:
+      - dbt_pgtrickle.stream_table_healthy:
+          warn_seconds: 600
+    columns:
+      - name: customer_id
+        description: "Customer identifier"
+        tests:
+          - not_null
+          - unique
+      - name: max_amount
+        description: "Maximum order amount"
+        tests:
+          - not_null
+      - name: min_amount
+        description: "Minimum order amount"
+        tests:
+          - not_null
+
+  - name: customer_stats
+    description: "Customer statistics (stream table, used for alter flow testing)"
+    tests:
+      - dbt_pgtrickle.stream_table_healthy:
+          warn_seconds: 600
     columns:
       - name: customer_id
         description: "Customer identifier"

--- a/dbt-pgtrickle/integration_tests/scripts/run_dbt_tests.sh
+++ b/dbt-pgtrickle/integration_tests/scripts/run_dbt_tests.sh
@@ -173,27 +173,40 @@ echo "── dbt run (initial create) ──"
 dbt run
 
 echo ""
-echo "── Waiting for stream table to populate ──"
+echo "── Waiting for stream tables to populate ──"
 ./scripts/wait_for_populated.sh order_totals 30
+./scripts/wait_for_populated.sh order_extremes 30
+./scripts/wait_for_populated.sh customer_stats 30
 
 echo ""
-echo "── dbt test ──"
+echo "── dbt test (initial) ──"
 dbt test
+
+echo ""
+echo "── dbt run (idempotent no-op — same config, same query) ──"
+dbt run
+echo "  (no-op should succeed without errors)"
 
 echo ""
 echo "── dbt run --full-refresh (drop + recreate) ──"
 dbt run --full-refresh
 
 echo ""
-echo "── Waiting for stream table to populate (after recreate) ──"
+echo "── Waiting for stream tables to populate (after recreate) ──"
 ./scripts/wait_for_populated.sh order_totals 30
+./scripts/wait_for_populated.sh order_extremes 30
+./scripts/wait_for_populated.sh customer_stats 30
 
 echo ""
 echo "── dbt test (after full-refresh) ──"
 dbt test
 
 echo ""
-echo "── dbt run-operation pgtrickle_refresh ──"
+echo "── dbt run-operation refresh_all_stream_tables ──"
+dbt run-operation refresh_all_stream_tables
+
+echo ""
+echo "── dbt run-operation pgtrickle_refresh (single table) ──"
 dbt run-operation pgtrickle_refresh --args '{model_name: order_totals}'
 
 echo ""

--- a/dbt-pgtrickle/integration_tests/tests/assert_customer_stats_correct.sql
+++ b/dbt-pgtrickle/integration_tests/tests/assert_customer_stats_correct.sql
@@ -1,0 +1,22 @@
+-- Verify customer_stats stream table matches expected aggregation.
+-- Returns rows that are in expected but missing/different in actual.
+-- An empty result set means the test passes.
+WITH expected AS (
+    SELECT
+        customer_id,
+        SUM(amount) AS total_amount,
+        COUNT(*) AS order_count
+    FROM {{ ref('raw_orders') }}
+    GROUP BY customer_id
+),
+actual AS (
+    SELECT customer_id, total_amount, order_count
+    FROM {{ ref('customer_stats') }}
+)
+SELECT e.*
+FROM expected e
+LEFT JOIN actual a
+  ON e.customer_id = a.customer_id
+  AND e.total_amount = a.total_amount
+  AND e.order_count = a.order_count
+WHERE a.customer_id IS NULL

--- a/dbt-pgtrickle/integration_tests/tests/assert_extremes_correct.sql
+++ b/dbt-pgtrickle/integration_tests/tests/assert_extremes_correct.sql
@@ -1,0 +1,22 @@
+-- Verify order_extremes stream table matches expected aggregation.
+-- Returns rows that are in expected but missing/different in actual.
+-- An empty result set means the test passes.
+WITH expected AS (
+    SELECT
+        customer_id,
+        MAX(amount) AS max_amount,
+        MIN(amount) AS min_amount
+    FROM {{ ref('raw_orders') }}
+    GROUP BY customer_id
+),
+actual AS (
+    SELECT customer_id, max_amount, min_amount
+    FROM {{ ref('order_extremes') }}
+)
+SELECT e.*
+FROM expected e
+LEFT JOIN actual a
+  ON e.customer_id = a.customer_id
+  AND e.max_amount = a.max_amount
+  AND e.min_amount = a.min_amount
+WHERE a.customer_id IS NULL

--- a/dbt-pgtrickle/macros/operations/refresh_all.sql
+++ b/dbt-pgtrickle/macros/operations/refresh_all.sql
@@ -1,0 +1,111 @@
+{#
+  refresh_all_stream_tables(schema)
+
+  Refreshes all active dbt-managed stream tables in dependency order.
+  Queries the pg_trickle dependency catalog to determine the correct
+  topological ordering so upstream tables are refreshed before downstream ones.
+
+  Designed for CI pipelines: run after `dbt run` and before `dbt test` to
+  ensure all materialized data is current.
+
+  Usage:
+    dbt run-operation refresh_all_stream_tables
+    dbt run-operation refresh_all_stream_tables --args '{"schema": "analytics"}'
+
+  Args:
+    schema (str|none): Only refresh stream tables in this schema.
+                       Defaults to all dbt-managed stream tables.
+#}
+{% macro refresh_all_stream_tables(schema=none) %}
+  {% if execute %}
+    {# Collect dbt-managed stream table models from the graph #}
+    {% set models = graph.nodes.values()
+         | selectattr('config.materialized', 'equalto', 'stream_table') %}
+    {% set dbt_stream_tables = {} %}
+    {% for model in models %}
+      {% set st_name = model.config.get('stream_table_name', model.name) %}
+      {% set st_schema = model.config.get('stream_table_schema', target.schema) %}
+      {% if schema is none or st_schema == schema %}
+        {% do dbt_stream_tables.update({st_schema ~ '.' ~ st_name: true}) %}
+      {% endif %}
+    {% endfor %}
+
+    {% if dbt_stream_tables | length == 0 %}
+      {{ log("pg_trickle: no dbt-managed stream tables found to refresh", info=true) }}
+      {{ return('') }}
+    {% endif %}
+
+    {# Query the pg_trickle dependency catalog for topological ordering.
+       We use a recursive CTE to compute depth (distance from root/source tables)
+       so we can refresh in correct dependency order (depth 0 first, then 1, etc.) #}
+    {% set order_query %}
+      WITH RECURSIVE dep_depth AS (
+        -- Base: stream tables with no stream-table dependencies (leaf-level)
+        SELECT
+          st.pgt_id,
+          st.pgt_schema,
+          st.pgt_name,
+          0 AS depth
+        FROM pgtrickle.pgt_stream_tables st
+        WHERE st.status = 'ACTIVE'
+          AND NOT EXISTS (
+            SELECT 1
+            FROM pgtrickle.pgt_dependencies d
+            JOIN pgtrickle.pgt_stream_tables upstream
+              ON d.source_relid = (upstream.pgt_schema || '.' || upstream.pgt_name)::regclass
+            WHERE d.pgt_id = st.pgt_id
+              AND d.source_type = 'STREAM_TABLE'
+          )
+
+        UNION ALL
+
+        -- Recursive: stream tables depending on already-computed ones
+        SELECT
+          st.pgt_id,
+          st.pgt_schema,
+          st.pgt_name,
+          dd.depth + 1
+        FROM pgtrickle.pgt_stream_tables st
+        JOIN pgtrickle.pgt_dependencies d ON d.pgt_id = st.pgt_id
+        JOIN dep_depth dd ON d.source_relid = (dd.pgt_schema || '.' || dd.pgt_name)::regclass
+        WHERE st.status = 'ACTIVE'
+          AND d.source_type = 'STREAM_TABLE'
+      )
+      SELECT pgt_schema, pgt_name, MAX(depth) AS depth
+      FROM dep_depth
+      GROUP BY pgt_id, pgt_schema, pgt_name
+      ORDER BY depth ASC, pgt_name ASC
+    {% endset %}
+
+    {% set results = run_query(order_query) %}
+    {% set refreshed = [] %}
+    {% set skipped = [] %}
+
+    {% for row in results.rows %}
+      {% set qualified = row['pgt_schema'] ~ '.' ~ row['pgt_name'] %}
+      {% if qualified in dbt_stream_tables %}
+        {{ log("pg_trickle: refreshing '" ~ qualified ~ "' (depth " ~ row['depth'] ~ ")", info=true) }}
+        {{ dbt_pgtrickle.pgtrickle_refresh_stream_table(qualified) }}
+        {% do refreshed.append(qualified) %}
+      {% else %}
+        {% do skipped.append(qualified) %}
+      {% endif %}
+    {% endfor %}
+
+    {# Handle dbt-managed stream tables not found in the dependency query
+       (e.g., freshly created, not yet in dependency catalog) — refresh them last #}
+    {% for qualified in dbt_stream_tables %}
+      {% if qualified not in refreshed and qualified not in skipped %}
+        {% if dbt_pgtrickle.pgtrickle_stream_table_exists(qualified) %}
+          {{ log("pg_trickle: refreshing '" ~ qualified ~ "' (no dependency info)", info=true) }}
+          {{ dbt_pgtrickle.pgtrickle_refresh_stream_table(qualified) }}
+          {% do refreshed.append(qualified) %}
+        {% else %}
+          {{ log("pg_trickle: skipping '" ~ qualified ~ "' (not found in catalog)", info=true) }}
+        {% endif %}
+      {% endif %}
+    {% endfor %}
+
+    {{ log("pg_trickle: refreshed " ~ refreshed | length ~ " stream table(s) in dependency order", info=true) }}
+  {% endif %}
+{% endmacro %}

--- a/dbt-pgtrickle/macros/utils/stream_table_status.sql
+++ b/dbt-pgtrickle/macros/utils/stream_table_status.sql
@@ -1,0 +1,84 @@
+{#
+  pgtrickle_stream_table_status(name, warn_seconds, error_seconds)
+
+  Returns the health status of a stream table as a dict with:
+    - status: 'healthy', 'stale', 'erroring', 'paused', or 'not_found'
+    - staleness_seconds: seconds since last refresh (null if never refreshed)
+    - consecutive_errors: number of consecutive refresh failures
+    - last_refresh_at: timestamp of last refresh
+    - total_refreshes: lifetime refresh count
+    - is_populated: whether the stream table has been populated
+
+  Designed for dbt tests — return value can be checked in assertions:
+
+    {% set st = dbt_pgtrickle.pgtrickle_stream_table_status('order_totals') %}
+    {% if st.status != 'healthy' %}
+      {{ exceptions.raise_compiler_error("Stream table is " ~ st.status) }}
+    {% endif %}
+
+  Args:
+    name (str): Stream table name. May be schema-qualified ('analytics.order_totals')
+                or unqualified ('order_totals' — defaults to target.schema).
+    warn_seconds (int): Staleness threshold for 'stale' status (default: 300 = 5 min)
+    error_seconds (int): Staleness threshold — unused for status classification but
+                         available for callers. The status uses warn_seconds as the
+                         stale boundary.
+#}
+{% macro pgtrickle_stream_table_status(name, warn_seconds=300) %}
+  {% if execute %}
+    {% set parts = name.split('.') %}
+    {% if parts | length == 2 %}
+      {% set lookup_schema = parts[0] %}
+      {% set lookup_name = parts[1] %}
+    {% else %}
+      {% set lookup_schema = target.schema %}
+      {% set lookup_name = name %}
+    {% endif %}
+
+    {% set query %}
+      SELECT
+        s.status AS st_status,
+        EXTRACT(EPOCH FROM s.staleness)::int AS staleness_seconds,
+        s.consecutive_errors,
+        s.last_refresh_at,
+        s.total_refreshes,
+        s.is_populated,
+        s.stale
+      FROM pgtrickle.pg_stat_stream_tables s
+      WHERE s.pgt_schema = {{ dbt.string_literal(lookup_schema) }}
+        AND s.pgt_name = {{ dbt.string_literal(lookup_name) }}
+    {% endset %}
+    {% set result = run_query(query) %}
+    {% if result and result.rows | length > 0 %}
+      {% set row = result.rows[0] %}
+
+      {# Classify health status #}
+      {% if row['st_status'] == 'PAUSED' %}
+        {% set health = 'paused' %}
+      {% elif row['consecutive_errors'] > 0 %}
+        {% set health = 'erroring' %}
+      {% elif row['stale'] == true or (row['staleness_seconds'] is not none and row['staleness_seconds'] > warn_seconds) %}
+        {% set health = 'stale' %}
+      {% else %}
+        {% set health = 'healthy' %}
+      {% endif %}
+
+      {{ return({
+        'status': health,
+        'staleness_seconds': row['staleness_seconds'],
+        'consecutive_errors': row['consecutive_errors'],
+        'last_refresh_at': row['last_refresh_at'],
+        'total_refreshes': row['total_refreshes'],
+        'is_populated': row['is_populated']
+      }) }}
+    {% endif %}
+  {% endif %}
+  {{ return({
+    'status': 'not_found',
+    'staleness_seconds': none,
+    'consecutive_errors': 0,
+    'last_refresh_at': none,
+    'total_refreshes': 0,
+    'is_populated': false
+  }) }}
+{% endmacro %}

--- a/dbt-pgtrickle/tests/generic/stream_table_healthy.sql
+++ b/dbt-pgtrickle/tests/generic/stream_table_healthy.sql
@@ -1,0 +1,48 @@
+{#
+  test_stream_table_healthy(model, warn_seconds)
+
+  Generic dbt test that fails if a stream table is not healthy.
+  Checks the pg_trickle catalog via pgtrickle_stream_table_status() and returns
+  a row for each unhealthy condition found.
+
+  Usage in schema.yml:
+    models:
+      - name: order_totals
+        tests:
+          - dbt_pgtrickle.stream_table_healthy:
+              warn_seconds: 300  # optional, default 300s (5 min)
+
+  Returns an empty result set if the stream table is healthy (test passes).
+  Returns rows if the stream table is stale, erroring, paused, or not found.
+#}
+{% test stream_table_healthy(model, warn_seconds=300) %}
+  {%- set model_name = model.identifier -%}
+  {%- set model_schema = model.schema -%}
+
+  SELECT
+    pgt_name,
+    pgt_schema,
+    status,
+    EXTRACT(EPOCH FROM staleness)::int AS staleness_seconds,
+    consecutive_errors,
+    last_refresh_at,
+    is_populated,
+    CASE
+      WHEN status = 'PAUSED' THEN 'paused'
+      WHEN consecutive_errors > 0 THEN 'erroring'
+      WHEN stale = true THEN 'stale'
+      WHEN staleness IS NOT NULL
+           AND EXTRACT(EPOCH FROM staleness) > {{ warn_seconds }}
+      THEN 'stale'
+      ELSE 'healthy'
+    END AS health_status
+  FROM pgtrickle.pg_stat_stream_tables
+  WHERE pgt_schema = {{ dbt.string_literal(model_schema) }}
+    AND pgt_name = {{ dbt.string_literal(model_name) }}
+    AND (
+      status = 'PAUSED'
+      OR consecutive_errors > 0
+      OR stale = true
+      OR (staleness IS NOT NULL AND EXTRACT(EPOCH FROM staleness) > {{ warn_seconds }})
+    )
+{% endtest %}


### PR DESCRIPTION
## Summary

Implements the **dbt Integration Enhancements** feature group from the v0.6.0 roadmap (DBT-1, DBT-2, DBT-3).

### DBT-1: Check stream table health from dbt

- New `pgtrickle_stream_table_status()` utility macro — returns a dict with health status (`healthy`/`stale`/`erroring`/`paused`/`not_found`), `staleness_seconds`, `consecutive_errors`, `total_refreshes`, etc.
- New `stream_table_healthy` generic dbt test — use in `schema.yml` to fail the test suite when a stream table is unhealthy. Configurable `warn_seconds` threshold (default 300s/5 min).

### DBT-2: Refresh everything in one command

- New `refresh_all_stream_tables` run-operation — refreshes all dbt-managed stream tables in topological (dependency) order by querying pg_trickle's dependency catalog. Optional schema filter. Designed for CI: run after `dbt run` and before `dbt test`.

### DBT-3: Test the dbt ↔ alter flow

- New \- New \- New \- New \- New \- New \- New \- New \- New \- New \-`- New \- New \- Newion- New \- New \- New \- New \- New \- New \- New \- New \- New \- New \-`- New \- New \- Newion- New \- Neworrectness
- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated to ex- Integration test script updatedn
- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated tbt-- Integration test script updated to ex- Inayo- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated to ex- Integration test script updated tbt-- Integration test script updated to ex- Inayo- Integration test DBT-1: generic dbt test |
| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbt-pgtrickle| `dbtdels/marts/customer_stats.sql` | DBT-3: alter flow test model |
| `dbt-pgtrickle/integration_tests/tests/assert_extremes_correct.sql` | DBT-3: data assertion |
| `dbt-pgtrickle/integration_tests/tests/assert_customer_stats_correct.sql` | DBT-3: data assertion |
