### PR TITLE
docs: SQL Documentation Gaps (DOC-1/2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,30 @@ For future plans and release milestones, see [ROADMAP.md](ROADMAP.md).
   the `stream_table_healthy` generic test.
   Getting Started guide with SQL migration and dbt best practices.
 
+#### SQL Documentation Gaps (DOC-1 through DOC-3)
+
+- **ALL (subquery) documentation (DOC-1).** SQL Reference "Subquery
+  Expressions" section now includes `ALL (subquery)` in the operator table
+  with a complete worked example: source table setup, sample data, stream
+  table creation, expected results, and explanation of the NULL-safe
+  anti-join rewrite (`col IS NULL OR NOT (x op col)`). Common patterns
+  (salary comparisons, rating thresholds) are also shown.
+- **Window functions in expressions documentation (DOC-2).** SQL Reference
+  "Auto-Rewrite Pipeline" section now documents pass #7 — automatic
+  subquery-lift of window functions nested inside expressions (e.g.,
+  `CASE WHEN ROW_NUMBER() ...`, `ABS(RANK() ...)`). Before/after examples
+  show the user's original query and the internal rewrite with synthetic
+  `__pgt_wf_N` columns. The "Unsupported Expression Types" table is updated
+  to reflect that window-in-expression is now supported.
+- **Foreign table sources tutorial (DOC-3).** New
+  `docs/tutorials/FOREIGN_TABLE_SOURCES.md` tutorial with a step-by-step
+  walkthrough: `postgres_fdw` setup, `CREATE FOREIGN TABLE`, stream table
+  creation with FULL refresh, optional polling-based CDC via
+  `pg_trickle.foreign_table_polling`, monitoring commands, a worked
+  inventory dashboard example, constraints table, and FAQ entries. SQL
+  Reference updated with a "Foreign Tables as Sources" section in
+  Restrictions & Interoperability.
+
 #### Partitioning Support (Source Tables)
 
 Stream tables now work with PostgreSQL's declarative table partitioning.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1053,9 +1053,9 @@ Forms the prerequisite for full SCC-based fixpoint refresh in v0.7.0.
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| DOC-1 | **Show users how ALL-subqueries work.** Once EC-32 lands, add a SQL Reference section explaining `WHERE price > ALL (SELECT ...)`, how pg_trickle rewrites it internally, and a complete worked example with sample data and expected output. | 2h | [GAP_SQL_OVERVIEW.md](plans/sql/GAP_SQL_OVERVIEW.md) |
-| DOC-2 | **Show the window-in-expression pattern.** Once EC-03 lands, add a before/after example to the SQL Reference: "Here's your original query with `CASE WHEN ROW_NUMBER() ...`, and here's what pg_trickle does under the hood to make it work incrementally." | 2h | [PLAN_EDGE_CASES.md](plans/PLAN_EDGE_CASES.md) EC-03 |
-| DOC-3 | **Walkthrough for foreign table sources.** A step-by-step recipe showing how to create a `postgres_fdw` foreign table, use it as a stream table source with polling-based change detection, and what to expect in terms of refresh behaviour. This feature shipped in v0.2.2 but was never properly documented with an example. | 1h | Existing feature (v0.2.2) |
+| DOC-1 | **Show users how ALL-subqueries work.** Once EC-32 lands, add a SQL Reference section explaining `WHERE price > ALL (SELECT ...)`, how pg_trickle rewrites it internally, and a complete worked example with sample data and expected output. | 2h | [GAP_SQL_OVERVIEW.md](plans/sql/GAP_SQL_OVERVIEW.md) | ✅ Done |
+| DOC-2 | **Show the window-in-expression pattern.** Once EC-03 lands, add a before/after example to the SQL Reference: "Here's your original query with `CASE WHEN ROW_NUMBER() ...`, and here's what pg_trickle does under the hood to make it work incrementally." | 2h | [PLAN_EDGE_CASES.md](plans/PLAN_EDGE_CASES.md) EC-03 | ✅ Done |
+| DOC-3 | **Walkthrough for foreign table sources.** A step-by-step recipe showing how to create a `postgres_fdw` foreign table, use it as a stream table source with polling-based change detection, and what to expect in terms of refresh behaviour. This feature shipped in v0.2.2 but was never properly documented with an example. | 1h | Existing feature (v0.2.2) | ✅ Done |
 
 > **SQL documentation subtotal: ~5 hours**
 
@@ -1075,7 +1075,7 @@ Forms the prerequisite for full SCC-based fixpoint refresh in v0.7.0.
 - [ ] Ergonomics E2E tests for calculated schedule, warnings, and removed GUCs pass
 - [x] `gate_source()` idempotency and re-gating tested; `bootstrap_gate_status()` available
 - [x] dbt `stream_table_status()` and `refresh_all_stream_tables` macros shipped
-- [ ] SQL Reference updated for EC-03, EC-32, and foreign table polling patterns
+- [x] SQL Reference updated for EC-03, EC-32, and foreign table polling patterns
 - [ ] Extension upgrade path tested (`0.5.0 → 0.6.0`)
 
 ---

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -42,7 +42,9 @@ Complete reference for all SQL functions, views, and catalog tables provided by 
   - [SQL Value Functions](#sql-value-functions)
   - [Array and Row Expressions](#array-and-row-expressions)
   - [Subquery Expressions](#subquery-expressions)
+    - [ALL (subquery) — Worked Example](#all-subquery--worked-example)
   - [Auto-Rewrite Pipeline](#auto-rewrite-pipeline)
+    - [Window Functions in Expressions (Auto-Rewrite)](#window-functions-in-expressions-auto-rewrite)
   - [HAVING Clause](#having-clause)
   - [Tables Without Primary Keys (Keyless Tables)](#tables-without-primary-keys-keyless-tables)
   - [Volatile Function Detection](#volatile-function-detection)
@@ -55,6 +57,7 @@ Complete reference for all SQL functions, views, and catalog tables provided by 
   - [Referencing Other Stream Tables](#referencing-other-stream-tables)
   - [Views as Sources in Defining Queries](#views-as-sources-in-defining-queries)
   - [Partitioned Tables as Sources](#partitioned-tables-as-sources)
+  - [Foreign Tables as Sources](#foreign-tables-as-sources)
   - [IMMEDIATE Mode Query Restrictions](#immediate-mode-query-restrictions)
   - [Logical Replication Targets](#logical-replication-targets)
   - [Views on Stream Tables](#views-on-stream-tables)
@@ -1549,13 +1552,75 @@ Subqueries are supported in the `WHERE` clause and `SELECT` list. They are parse
 | `NOT EXISTS (subquery)` | `WHERE NOT EXISTS (SELECT 1 FROM orders WHERE orders.cid = c.id)` | Anti-Join |
 | `IN (subquery)` | `WHERE id IN (SELECT product_id FROM order_items)` | Semi-Join (rewritten as equality) |
 | `NOT IN (subquery)` | `WHERE id NOT IN (SELECT product_id FROM order_items)` | Anti-Join |
+| `ALL (subquery)` | `WHERE price > ALL (SELECT price FROM competitors)` | Anti-Join (NULL-safe) |
 | Scalar subquery (SELECT) | `SELECT (SELECT max(price) FROM products) AS max_p` | Scalar Subquery |
 
 **Notes:**
 - `EXISTS` and `IN (subquery)` in the `WHERE` clause are transformed into semi-join operators. `NOT EXISTS` and `NOT IN (subquery)` become anti-join operators.
 - Multiple subqueries in the same `WHERE` clause are supported when combined with `AND`. Subqueries combined with `OR` are also supported — they are automatically rewritten into `UNION` of separate filtered queries.
 - Scalar subqueries in the `SELECT` list are supported as long as they return exactly one row and one column.
-- `ALL (subquery)` is supported — it is automatically rewritten to an anti-join via `NOT EXISTS` with the negated condition.
+- `ALL (subquery)` is supported — see the worked example below.
+
+#### ALL (subquery) — Worked Example
+
+`ALL (subquery)` tests whether a comparison holds against **every** row returned
+by the subquery. pg_trickle rewrites it to a NULL-safe anti-join so it can be
+maintained incrementally.
+
+**Comparison operators supported:** `>`, `>=`, `<`, `<=`, `=`, `<>`
+
+**Example — products cheaper than all competitors:**
+
+```sql
+-- Source tables
+CREATE TABLE products (
+    id    INT PRIMARY KEY,
+    name  TEXT,
+    price NUMERIC
+);
+CREATE TABLE competitor_prices (
+    id          INT PRIMARY KEY,
+    product_id  INT,
+    price       NUMERIC
+);
+
+-- Sample data
+INSERT INTO products VALUES (1, 'Widget', 9.99), (2, 'Gadget', 24.99), (3, 'Gizmo', 14.99);
+INSERT INTO competitor_prices VALUES (1, 1, 12.99), (2, 1, 11.50), (3, 2, 19.99), (4, 3, 14.99);
+
+-- Stream table: find products priced below ALL competitor prices
+SELECT pgtrickle.create_stream_table(
+    name  => 'cheapest_products',
+    query => $$
+        SELECT p.id, p.name, p.price
+        FROM products p
+        WHERE p.price < ALL (
+            SELECT cp.price
+            FROM competitor_prices cp
+            WHERE cp.product_id = p.id
+        )
+    $$,
+    schedule => '1m'
+);
+```
+
+**Result:** Widget (9.99 < all of [12.99, 11.50]) is included. Gadget (24.99 ≮ 19.99) is excluded. Gizmo (14.99 ≮ 14.99) is excluded.
+
+**How pg_trickle handles it internally:**
+
+1. `WHERE price < ALL (SELECT ...)` is parsed into an anti-join with a NULL-safe condition.
+2. The condition `NOT (x op col)` is wrapped as `(col IS NULL OR NOT (x op col))` to correctly handle NULL values in the subquery — if any subquery row is NULL, the ALL comparison fails (standard SQL semantics).
+3. The anti-join uses the same incremental delta computation as `NOT EXISTS`, so changes to either `products` or `competitor_prices` are propagated efficiently.
+
+**Other common patterns:**
+
+```sql
+-- Employees whose salary meets or exceeds all department maximums
+WHERE salary >= ALL (SELECT max_salary FROM department_caps)
+
+-- Orders with ratings better than all thresholds
+WHERE rating > ALL (SELECT min_rating FROM quality_thresholds)
+```
 
 ### Auto-Rewrite Pipeline
 
@@ -1570,6 +1635,72 @@ pg_trickle transparently rewrites certain SQL constructs before parsing. These r
 | #4 | Correlated scalar subquery in `SELECT` | Convert to `LEFT JOIN` with grouped inline view |
 | #5 | `EXISTS`/`IN` inside `OR` | Split into `UNION` of separate filtered queries |
 | #6 | Multiple `PARTITION BY` clauses | Split into joined subqueries, one per distinct partitioning |
+| #7 | Window functions inside expressions | Lift to inner subquery with synthetic `__pgt_wf_N` columns (see below) |
+
+#### Window Functions in Expressions (Auto-Rewrite)
+
+Window functions nested inside expressions (e.g., `CASE WHEN ROW_NUMBER() ...`,
+`ABS(RANK() OVER (...) - 5)`) are automatically rewritten. pg_trickle lifts
+each window function call into a synthetic column in an inner subquery, then
+applies the original expression in the outer SELECT.
+
+This rewrite is transparent — you write your query naturally and pg_trickle
+handles it:
+
+**Your query:**
+
+```sql
+SELECT
+    id,
+    name,
+    CASE WHEN ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary DESC) = 1
+         THEN 'top earner'
+         ELSE 'other'
+    END AS rank_label
+FROM employees
+```
+
+**What pg_trickle generates internally:**
+
+```sql
+SELECT
+    "__pgt_wf_inner".id,
+    "__pgt_wf_inner".name,
+    CASE WHEN "__pgt_wf_inner"."__pgt_wf_1" = 1
+         THEN 'top earner'
+         ELSE 'other'
+    END AS "rank_label"
+FROM (
+    SELECT *, ROW_NUMBER() OVER (PARTITION BY dept ORDER BY salary DESC) AS "__pgt_wf_1"
+    FROM employees
+) "__pgt_wf_inner"
+```
+
+The inner subquery produces the window function result as a plain column
+(`__pgt_wf_1`), which the DVM engine can maintain incrementally using its
+existing window function support. The outer expression is then a simple
+column reference.
+
+**More examples:**
+
+```sql
+-- Arithmetic with window functions
+SELECT id, ABS(RANK() OVER (ORDER BY score) - 5) AS adjusted_rank
+FROM players
+
+-- COALESCE with window function
+SELECT id, COALESCE(LAG(value) OVER (ORDER BY ts), 0) AS prev_value
+FROM sensor_readings
+
+-- Multiple window functions in expressions
+SELECT id,
+       ROW_NUMBER() OVER (ORDER BY created_at) * 100 AS seq,
+       SUM(amount) OVER (ORDER BY created_at) / COUNT(*) OVER (ORDER BY created_at) AS running_avg
+FROM transactions
+```
+
+All of these are handled automatically — each distinct window function call
+is extracted to its own `__pgt_wf_N` synthetic column.
 
 ### HAVING Clause
 
@@ -1723,9 +1854,10 @@ The following are **rejected with clear error messages** rather than producing b
 | Expression | Error Behavior | Suggested Rewrite |
 |---|---|---|
 | `TABLESAMPLE` | Rejected — stream tables materialize the complete result set | Use `WHERE random() < 0.1` if sampling is needed |
-| Window functions in expressions | Rejected — e.g., `CASE WHEN ROW_NUMBER() OVER (...) ...` | Move window function to a separate column |
 | `FOR UPDATE` / `FOR SHARE` | Rejected — stream tables do not support row-level locking | Remove the locking clause |
 | Unknown node types | Rejected with type information | — |
+
+> **Note:** Window functions inside expressions (e.g., `CASE WHEN ROW_NUMBER() OVER (...) ...`) were unsupported in earlier versions but are now **automatically rewritten** — see [Auto-Rewrite Pipeline § Window Functions in Expressions](#window-functions-in-expressions-auto-rewrite).
 
 ---
 
@@ -1813,6 +1945,42 @@ This ensures changes from child partitions are published under the parent
 table's identity, matching trigger-mode CDC behavior.
 
 > **Note:** pg_trickle targets PostgreSQL 18. On PostgreSQL 12 or earlier (not supported), parent triggers do **not** fire for partition-routed rows, which would cause silent data loss.
+
+### Foreign Tables as Sources
+
+Foreign tables (via `postgres_fdw` or other FDWs) can be used as stream table
+sources with these constraints:
+
+| CDC Method | Supported? | Why |
+|------------|-----------|-----|
+| Trigger-based | ❌ No | Foreign tables don't support row-level triggers |
+| WAL-based | ❌ No | Foreign tables don't generate local WAL entries |
+| FULL refresh | ✅ Yes | Re-executes the remote query each cycle |
+| Polling-based | ✅ Yes | When `pg_trickle.foreign_table_polling = on` |
+
+```sql
+-- Foreign table source — FULL refresh only
+SELECT pgtrickle.create_stream_table(
+    name         => 'remote_summary',
+    query        => 'SELECT region, SUM(amount) FROM remote_orders GROUP BY region',
+    schedule     => '5m',
+    refresh_mode => 'FULL'
+);
+```
+
+When pg_trickle detects a foreign table source, it emits an INFO message
+explaining the constraints. If you attempt to use DIFFERENTIAL mode without
+polling enabled, the creation will succeed but the refresh falls back to FULL.
+
+**Polling-based CDC** creates a local snapshot table and computes `EXCEPT ALL`
+differences on each refresh. Enable with:
+
+```sql
+SET pg_trickle.foreign_table_polling = on;
+```
+
+> For a complete step-by-step setup guide, see the
+> [Foreign Table Sources tutorial](tutorials/FOREIGN_TABLE_SOURCES.md).
 
 ### IMMEDIATE Mode Query Restrictions
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -37,6 +37,7 @@
 - [What Happens on TRUNCATE](tutorials/WHAT_HAPPENS_ON_TRUNCATE.md)
 - [Row-Level Security (RLS)](tutorials/ROW_LEVEL_SECURITY.md)
 - [Partitioned Tables](tutorials/PARTITIONED_TABLES.md)
+- [Foreign Table Sources](tutorials/FOREIGN_TABLE_SOURCES.md)
 
 ---
 

--- a/docs/tutorials/FOREIGN_TABLE_SOURCES.md
+++ b/docs/tutorials/FOREIGN_TABLE_SOURCES.md
@@ -1,0 +1,238 @@
+# Foreign Table Sources
+
+This tutorial shows how to use a `postgres_fdw` foreign table as a source for
+a stream table. Foreign tables let you aggregate data from remote PostgreSQL
+databases into a local stream table that refreshes automatically.
+
+## Background
+
+PostgreSQL's [Foreign Data Wrapper](https://www.postgresql.org/docs/current/postgres-fdw.html)
+(`postgres_fdw`) lets you define tables that transparently query a remote
+database. pg_trickle can use these foreign tables as stream table sources,
+but with different change-detection semantics than regular tables.
+
+**Key difference:** Foreign tables cannot use trigger-based or WAL-based CDC.
+Changes are detected either by re-scanning the entire remote table (FULL
+refresh) or by comparing a local snapshot to the remote data (polling-based
+CDC).
+
+## Step 1 — Set Up the Foreign Server
+
+```sql
+-- Enable the foreign data wrapper extension
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+-- Create a connection to the remote database
+CREATE SERVER warehouse_db
+    FOREIGN DATA WRAPPER postgres_fdw
+    OPTIONS (host 'warehouse.example.com', dbname 'analytics', port '5432');
+
+-- Map the current user to a remote user
+CREATE USER MAPPING FOR CURRENT_USER
+    SERVER warehouse_db
+    OPTIONS (user 'readonly_user', password 'secret');
+```
+
+## Step 2 — Define the Foreign Table
+
+```sql
+CREATE FOREIGN TABLE remote_orders (
+    id          INT,
+    customer_id INT,
+    amount      NUMERIC(12,2),
+    region      TEXT,
+    created_at  TIMESTAMP
+) SERVER warehouse_db
+  OPTIONS (schema_name 'public', table_name 'orders');
+```
+
+Alternatively, import an entire remote schema:
+
+```sql
+IMPORT FOREIGN SCHEMA public
+    LIMIT TO (orders, customers)
+    FROM SERVER warehouse_db
+    INTO public;
+```
+
+## Step 3 — Create a Stream Table with FULL Refresh
+
+The simplest approach uses FULL refresh mode — pg_trickle re-executes the
+query against the remote table on every refresh cycle:
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    name         => 'orders_by_region',
+    query        => $$
+        SELECT
+            region,
+            COUNT(*)        AS order_count,
+            SUM(amount)     AS total_revenue,
+            AVG(amount)     AS avg_order_value
+        FROM remote_orders
+        GROUP BY region
+    $$,
+    schedule     => '5m',
+    refresh_mode => 'FULL'
+);
+```
+
+pg_trickle will emit an informational message:
+
+```
+INFO: pg_trickle: source table remote_orders is a foreign table.
+Foreign tables cannot use trigger-based or WAL-based CDC —
+only FULL refresh mode or polling-based change detection is supported.
+```
+
+**How FULL refresh works with foreign tables:**
+
+1. Every 5 minutes, pg_trickle executes the defining query.
+2. The query is sent to the remote database via `postgres_fdw`.
+3. The complete result set replaces the stream table contents.
+4. This is equivalent to a `MATERIALIZED VIEW` refresh, but automated.
+
+## Step 4 — Polling-Based CDC (Optional)
+
+If the remote table is large and changes are small, FULL refresh becomes
+expensive because it transfers the entire result set every cycle. Polling-based
+CDC provides a more efficient alternative:
+
+```sql
+-- Enable polling globally (or per-session)
+SET pg_trickle.foreign_table_polling = on;
+
+-- Now create with DIFFERENTIAL mode — pg_trickle will use polling
+SELECT pgtrickle.create_stream_table(
+    name         => 'orders_by_region_polling',
+    query        => $$
+        SELECT
+            region,
+            COUNT(*)        AS order_count,
+            SUM(amount)     AS total_revenue,
+            AVG(amount)     AS avg_order_value
+        FROM remote_orders
+        GROUP BY region
+    $$,
+    schedule     => '5m',
+    refresh_mode => 'FULL'
+);
+```
+
+**How polling works:**
+
+1. On the first refresh, pg_trickle creates a local **snapshot table** that
+   mirrors the remote table's data.
+2. On subsequent refreshes, it fetches the current remote data and computes
+   an `EXCEPT ALL` difference against the snapshot.
+3. Only the changed rows are written to the change buffer and processed through
+   the incremental delta pipeline.
+4. The snapshot table is updated to reflect the new remote state.
+5. When the stream table is dropped, the snapshot table is cleaned up.
+
+**Trade-offs:**
+
+| Aspect | FULL Refresh | Polling CDC |
+|--------|-------------|-------------|
+| **Network transfer** | Full result set every cycle | Full remote scan, but only diffs applied |
+| **Local storage** | Stream table only | Stream table + snapshot table |
+| **Best for** | Small remote tables | Large remote tables with small change rates |
+| **GUC required** | No | `pg_trickle.foreign_table_polling = on` |
+
+## Step 5 — Verify and Monitor
+
+```sql
+-- Check stream table status
+SELECT * FROM pgtrickle.pgt_status('orders_by_region');
+
+-- Check CDC health (will show foreign table constraints)
+SELECT * FROM pgtrickle.check_cdc_health();
+
+-- View refresh history
+SELECT * FROM pgtrickle.get_refresh_history('orders_by_region', 5);
+
+-- Monitor staleness
+SELECT * FROM pgtrickle.get_staleness('orders_by_region');
+```
+
+## Worked Example — Remote Inventory Dashboard
+
+This example aggregates inventory data from a remote warehouse database into a
+local dashboard table:
+
+```sql
+-- Remote table definition
+CREATE FOREIGN TABLE remote_inventory (
+    sku         TEXT,
+    warehouse   TEXT,
+    quantity    INT,
+    updated_at  TIMESTAMP
+) SERVER warehouse_db
+  OPTIONS (schema_name 'inventory', table_name 'stock_levels');
+
+-- Dashboard: inventory summary by warehouse
+SELECT pgtrickle.create_stream_table(
+    name     => 'inventory_dashboard',
+    query    => $$
+        SELECT
+            warehouse,
+            COUNT(DISTINCT sku)  AS unique_products,
+            SUM(quantity)        AS total_units,
+            MIN(updated_at)      AS oldest_update,
+            MAX(updated_at)      AS newest_update
+        FROM remote_inventory
+        GROUP BY warehouse
+    $$,
+    schedule     => '10m',
+    refresh_mode => 'FULL'
+);
+```
+
+After the first refresh:
+
+```sql
+SELECT * FROM inventory_dashboard;
+```
+
+```
+ warehouse | unique_products | total_units | oldest_update       | newest_update
+-----------+-----------------+-------------+---------------------+---------------------
+ east      |             142 |       23500 | 2026-03-14 08:00:00 | 2026-03-14 09:15:00
+ west      |              98 |       15200 | 2026-03-14 07:30:00 | 2026-03-14 09:10:00
+ central   |             215 |       41000 | 2026-03-14 06:00:00 | 2026-03-14 09:20:00
+```
+
+## Constraints and Caveats
+
+| Constraint | Details |
+|------------|---------|
+| **No trigger CDC** | Foreign tables don't support PostgreSQL row-level triggers. |
+| **No WAL CDC** | Foreign tables don't generate local WAL entries. |
+| **Network latency** | Each refresh cycle queries the remote database. Schedule accordingly. |
+| **Remote availability** | If the remote database is down, the refresh will fail (logged in `pgt_refresh_history`). The stream table retains its last successful data. |
+| **Authentication** | `CREATE USER MAPPING` credentials must remain valid. Use `.pgpass` or environment variables in production. |
+| **Snapshot storage** | Polling CDC creates a snapshot table sized proportionally to the remote table. Monitor disk usage. |
+
+## FAQ
+
+**Q: Why does my foreign table stream table only work in FULL mode?**
+
+Foreign tables cannot install row-level triggers (the mechanism pg_trickle uses
+for trigger-based CDC) and don't generate local WAL records (used by WAL-based
+CDC). FULL refresh works because it simply re-executes the remote query.
+Enable `pg_trickle.foreign_table_polling` if you need differential-style
+change detection.
+
+**Q: Can I mix foreign and local tables in the same defining query?**
+
+Yes. If your query joins a foreign table with a local table, pg_trickle uses
+trigger/WAL CDC for the local table and FULL-rescan or polling for the foreign
+table. The refresh mode must be FULL unless polling is enabled for the foreign
+table sources.
+
+**Q: What happens if the remote database is temporarily unavailable?**
+
+The refresh attempt fails, is logged in `pgt_refresh_history` with status
+`FAILED`, and the `consecutive_errors` counter increments. The stream table
+retains its last successful data. When the remote database recovers, the next
+scheduled refresh succeeds and the error counter resets.


### PR DESCRIPTION
Implements DOC-1 (ALL subquery docs), DOC-2 (window-in-expression docs), DOC-3 (foreign table tutorial) from the v0.6.0 roadmap. See commit message for details.