### PR TITLE
fix: manual refresh honors needs_reinit; fix FDW server options

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -2377,6 +2377,17 @@ fn execute_manual_refresh(
             );
             (ins, del)
         })
+    } else if st.needs_reinit {
+        // When needs_reinit is set (e.g. by DDL hooks for ATTACH/DETACH
+        // PARTITION, or EC-16 function body change detection), force a
+        // FULL refresh regardless of the ST's refresh_mode.  This mirrors
+        // the scheduler's RefreshAction::Reinitialize path.
+        pgrx::info!(
+            "Stream table {}.{}: needs_reinit is set, performing FULL reinitialization",
+            schema,
+            table_name,
+        );
+        execute_manual_full_refresh(st, schema, table_name, source_oids).map(|_| (0i64, 0i64))
     } else {
         match st.refresh_mode {
             RefreshMode::Full => execute_manual_full_refresh(st, schema, table_name, source_oids)

--- a/tests/e2e_partition_tests.rs
+++ b/tests/e2e_partition_tests.rs
@@ -382,26 +382,19 @@ async fn test_foreign_table_full_refresh_works() {
     db.execute("CREATE EXTENSION IF NOT EXISTS postgres_fdw")
         .await;
 
-    let conn_info: String = db
+    // Build server options (host, port, dbname) — `user` is a USER MAPPING
+    // option, not a SERVER option in postgres_fdw.
+    let server_opts: String = db
         .query_scalar(
-            "SELECT format('host=%s port=%s dbname=%s user=%s',
+            "SELECT format('host ''%s'', port ''%s'', dbname ''%s''',
                 inet_server_addr()::text,
                 inet_server_port()::text,
-                current_database(),
-                current_user)",
+                current_database())",
         )
         .await;
 
     db.execute(&format!(
-        "CREATE SERVER IF NOT EXISTS loopback FOREIGN DATA WRAPPER postgres_fdw OPTIONS ({})",
-        conn_info
-            .split_whitespace()
-            .map(|kv| {
-                let (k, v) = kv.split_once('=').unwrap();
-                format!("{k} '{v}'")
-            })
-            .collect::<Vec<_>>()
-            .join(", ")
+        "CREATE SERVER IF NOT EXISTS loopback FOREIGN DATA WRAPPER postgres_fdw OPTIONS ({server_opts})",
     ))
     .await;
 


### PR DESCRIPTION
## Summary

Two bug fixes for e2e_partition_tests failures:

### 1. Manual refresh now honors `needs_reinit` flag

`execute_manual_refresh` did not check `st.needs_reinit`. When a DDL hook (e.g. ATTACH/DETACH PARTITION) set `needs_reinit = true` on a DIFFERENTIAL-mode stream table, a subsequent `refresh_stream_table()` call would run a differential refresh instead of a full reinitialization. The differential refresh found no change-buffer rows and returned (0,0), leaving the stream table with stale data.

Now `execute_manual_refresh` checks `needs_reinit` before dispatching and forces a FULL refresh when set, mirroring the scheduler's `RefreshAction::Reinitialize` path. The flag is cleared by `store_frontier_and_complete_refresh` after the FULL refresh succeeds.

**Fixes:** `test_partition_attach_triggers_reinit`

### 2. Fix postgres_fdw SERVER OPTIONS in f### 2. Fix poses### 2. Fix postgres_fdw SERVEs ### 2. Fix postgres_fdw SERVER OPTIONS in f### 2. Fix poses### 2. Fix postgrgr### 2. Fix postgresr`### 2. Fix postgres_fdw SERVER OPTIONS in f###as ### 2. Fix postgres_fdw SERVER OPTIONS in f### 2. Fixstatement.

**Fixes:** `test_foreign_table_full_refresh_works`

## Changed files

- `src/api.rs` — Add `needs_reinit` check in `execute_manual_refresh`
- `tests/e2e_partition_tests.rs` — Fix FDW server options construction