### PR TITLE
fix(test): use 127.0.0.1 for postgres_fdw loopback in Docker

### DIFF
--- a/tests/e2e_partition_tests.rs
+++ b/tests/e2e_partition_tests.rs
@@ -382,19 +382,16 @@ async fn test_foreign_table_full_refresh_works() {
     db.execute("CREATE EXTENSION IF NOT EXISTS postgres_fdw")
         .await;
 
-    // Build server options (host, port, dbname) — `user` is a USER MAPPING
-    // option, not a SERVER option in postgres_fdw.
-    let server_opts: String = db
-        .query_scalar(
-            "SELECT format('host ''%s'', port ''%s'', dbname ''%s''',
-                inet_server_addr()::text,
-                inet_server_port()::text,
-                current_database())",
-        )
-        .await;
+    // Build server options — use 127.0.0.1 for loopback (inet_server_addr()
+    // returns the container's external IP which may not be reachable from
+    // within the same container).  `user` is a USER MAPPING option, not a
+    // SERVER option in postgres_fdw.
+    let port: String = db.query_scalar("SELECT inet_server_port()::text").await;
+    let dbname: String = db.query_scalar("SELECT current_database()").await;
 
     db.execute(&format!(
-        "CREATE SERVER IF NOT EXISTS loopback FOREIGN DATA WRAPPER postgres_fdw OPTIONS ({server_opts})",
+        "CREATE SERVER IF NOT EXISTS loopback FOREIGN DATA WRAPPER postgres_fdw \
+         OPTIONS (host '127.0.0.1', port '{port}', dbname '{dbname}')",
     ))
     .await;
 


### PR DESCRIPTION
The foreign table E2E test used `inet_server_addr()` to build the postgres_fdw server host, which returns the Docker container's external IP (e.g. `172.17.0.2`). This IP is not reachable for a same-server connection inside the container, causing `could not connect to server "loopback"`.

Fixed to use `127.0.0.1` instead.

**Fixes:** `test_foreign_table_full_refresh_works`