### PR TITLE
fix(circular): fix 6 failing E2E circular tests

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1213,8 +1213,10 @@ fn alter_stream_table_query(
     let vq = validate_and_parse_query(&rewritten_query, &mut refresh_mode, false)?;
 
     // Cycle detection on the new dependency set (ALTER-aware: replaces
-    // the existing ST's edges rather than creating a sentinel node)
-    check_for_cycles_alter(st.pgt_id, &vq.source_relids)?;
+    // the existing ST's edges rather than creating a sentinel node).
+    // Pass the proposed query so monotonicity of the altered ST's new
+    // query is checked when it participates in a cycle.
+    check_for_cycles_alter(st.pgt_id, &vq.source_relids, &rewritten_query)?;
 
     // Get the current storage table columns (excluding internal __pgt_* columns)
     let old_columns = get_storage_table_columns(schema, table_name)?;
@@ -4463,6 +4465,32 @@ fn check_for_cycles(source_relids: &[(pg_sys::Oid, String)]) -> Result<(), PgTri
 /// `validate_and_parse_query` flow and its refresh mode is checked by
 /// the caller after creation.
 fn validate_cycle_allowed(cycle_nodes: &[String]) -> Result<(), PgTrickleError> {
+    validate_cycle_allowed_inner(cycle_nodes, None, None)
+}
+
+/// CYC-6: Variant of [`validate_cycle_allowed`] for the ALTER QUERY path.
+///
+/// Unlike `validate_cycle_allowed`, the ST being altered (`target_pgt_id`)
+/// already has a catalog entry, but its query is being replaced. The
+/// `proposed_query` is checked for monotonicity instead of the stored
+/// catalog entry so that non-monotone cycles are correctly rejected.
+fn validate_cycle_allowed_alter(
+    cycle_nodes: &[String],
+    target_pgt_id: i64,
+    proposed_query: &str,
+) -> Result<(), PgTrickleError> {
+    validate_cycle_allowed_inner(cycle_nodes, Some(target_pgt_id), Some(proposed_query))
+}
+
+/// Internal shared implementation for cycle-allowed checks.
+///
+/// `proposed_pgt_id` and `proposed_query` together override the defining
+/// query used for monotonicity checks of a specific ST (ALTER path).
+fn validate_cycle_allowed_inner(
+    cycle_nodes: &[String],
+    proposed_pgt_id: Option<i64>,
+    proposed_query: Option<&str>,
+) -> Result<(), PgTrickleError> {
     if !config::pg_trickle_allow_circular() {
         return Err(PgTrickleError::CycleDetected(cycle_nodes.to_vec()));
     }
@@ -4497,8 +4525,18 @@ fn validate_cycle_allowed(cycle_nodes: &[String]) -> Result<(), PgTrickleError> 
             )));
         }
 
+        // For the ALTER path: if this node is the one being altered,
+        // check the proposed (new) query for monotonicity instead of the
+        // stored defining_query — the stored query is the old one and
+        // would give a false pass.
+        let query_to_check = if proposed_pgt_id == Some(meta.pgt_id) {
+            proposed_query.unwrap_or(&meta.defining_query)
+        } else {
+            &meta.defining_query
+        };
+
         // All cycle members must have monotone queries
-        match crate::dvm::parse_defining_query_full(&meta.defining_query) {
+        match crate::dvm::parse_defining_query_full(query_to_check) {
             Ok(pr) => crate::dvm::check_monotonicity(&pr.tree)?,
             Err(e) => {
                 return Err(PgTrickleError::InvalidArgument(format!(
@@ -4518,9 +4556,15 @@ fn validate_cycle_allowed(cycle_nodes: &[String]) -> Result<(), PgTrickleError> 
 /// this function re-uses the existing ST's node in the DAG and replaces its
 /// incoming edges with the proposed new source dependencies. This correctly
 /// detects cycles like A → B → A that a sentinel node would miss.
+///
+/// `proposed_query` is the new defining query being applied to `pgt_id`.
+/// It is passed to the cycle validation so the monotonicity of the altered
+/// ST's new query is checked — not the old stored query — when it would
+/// participate in a cycle.
 fn check_for_cycles_alter(
     pgt_id: i64,
     source_relids: &[(pg_sys::Oid, String)],
+    proposed_query: &str,
 ) -> Result<(), PgTrickleError> {
     if source_relids.is_empty() {
         return Ok(());
@@ -4558,7 +4602,9 @@ fn check_for_cycles_alter(
 
     match dag.detect_cycles() {
         Ok(()) => Ok(()),
-        Err(PgTrickleError::CycleDetected(nodes)) => validate_cycle_allowed(&nodes),
+        Err(PgTrickleError::CycleDetected(nodes)) => {
+            validate_cycle_allowed_alter(&nodes, pgt_id, proposed_query)
+        }
         Err(e) => Err(e),
     }
 }

--- a/tests/e2e_circular_tests.rs
+++ b/tests/e2e_circular_tests.rs
@@ -97,27 +97,40 @@ async fn test_circular_monotone_cycle_converges() {
     db.execute("INSERT INTO cyc_edges VALUES (1,2), (2,3), (3,4)")
         .await;
 
-    // cyc_reach_a: direct edges plus paths through cyc_reach_b
+    // Create both STs with non-cyclic initial queries to avoid forward-reference
+    // validation failures, then ALTER them into a cycle.
     db.execute(
         "SELECT pgtrickle.create_stream_table('cyc_reach_a', \
-         $$SELECT DISTINCT e.src, e.dst FROM cyc_edges e \
-           UNION ALL \
-           SELECT DISTINCT e.src, rb.dst \
-           FROM cyc_edges e \
-           INNER JOIN cyc_reach_b rb ON e.dst = rb.src$$, \
+         $$SELECT DISTINCT e.src, e.dst FROM cyc_edges e$$, \
+         '1s', 'DIFFERENTIAL', false)",
+    )
+    .await;
+    db.execute(
+        "SELECT pgtrickle.create_stream_table('cyc_reach_b', \
+         $$SELECT DISTINCT e.src, e.dst FROM cyc_edges e$$, \
          '1s', 'DIFFERENTIAL', false)",
     )
     .await;
 
-    // cyc_reach_b: direct edges plus paths through cyc_reach_a
+    // cyc_reach_a: direct edges plus paths through cyc_reach_b
     db.execute(
-        "SELECT pgtrickle.create_stream_table('cyc_reach_b', \
-         $$SELECT DISTINCT e.src, e.dst FROM cyc_edges e \
+        "SELECT pgtrickle.alter_stream_table('cyc_reach_a', \
+         query => $$SELECT DISTINCT e.src, e.dst FROM cyc_edges e \
+           UNION ALL \
+           SELECT DISTINCT e.src, rb.dst \
+           FROM cyc_edges e \
+           INNER JOIN cyc_reach_b rb ON e.dst = rb.src$$)",
+    )
+    .await;
+
+    // cyc_reach_b: direct edges plus paths through cyc_reach_a (forms the cycle)
+    db.execute(
+        "SELECT pgtrickle.alter_stream_table('cyc_reach_b', \
+         query => $$SELECT DISTINCT e.src, e.dst FROM cyc_edges e \
            UNION ALL \
            SELECT DISTINCT ra.src, e.dst \
            FROM cyc_reach_a ra \
-           INNER JOIN cyc_edges e ON ra.dst = e.src$$, \
-         '1s', 'DIFFERENTIAL', false)",
+           INNER JOIN cyc_edges e ON ra.dst = e.src$$)",
     )
     .await;
 
@@ -319,21 +332,35 @@ async fn test_circular_convergence_records_iterations() {
     db.execute("INSERT INTO cyc_conv_src VALUES (1, 10), (2, 20)")
         .await;
 
-    // Simple cycle: A references B, B references A (both monotone passthrough)
+    // Create both STs with non-cyclic initial queries to avoid forward-reference
+    // validation failures, then ALTER them into a cycle.
     db.execute(
         "SELECT pgtrickle.create_stream_table('cyc_conv_a', \
-         $$SELECT id, val FROM cyc_conv_src \
-           UNION ALL \
-           SELECT DISTINCT b.id, b.val FROM cyc_conv_b b$$, \
+         $$SELECT id, val FROM cyc_conv_src$$, \
          '1s', 'DIFFERENTIAL', false)",
     )
     .await;
     db.execute(
         "SELECT pgtrickle.create_stream_table('cyc_conv_b', \
-         $$SELECT id, val FROM cyc_conv_src \
-           UNION ALL \
-           SELECT DISTINCT a.id, a.val FROM cyc_conv_a a$$, \
+         $$SELECT id, val FROM cyc_conv_src$$, \
          '1s', 'DIFFERENTIAL', false)",
+    )
+    .await;
+
+    // Simple cycle: A references B
+    db.execute(
+        "SELECT pgtrickle.alter_stream_table('cyc_conv_a', \
+         query => $$SELECT id, val FROM cyc_conv_src \
+           UNION ALL \
+           SELECT DISTINCT b.id, b.val FROM cyc_conv_b b$$)",
+    )
+    .await;
+    // B references A (completes the cycle)
+    db.execute(
+        "SELECT pgtrickle.alter_stream_table('cyc_conv_b', \
+         query => $$SELECT id, val FROM cyc_conv_src \
+           UNION ALL \
+           SELECT DISTINCT a.id, a.val FROM cyc_conv_a a$$)",
     )
     .await;
 
@@ -399,25 +426,38 @@ async fn test_circular_nonconvergence_error_status() {
     db.execute("INSERT INTO cyc_nc_edges VALUES (1,2), (2,3), (3,1)")
         .await;
 
-    // Transitive closure cycle (needs multiple iterations for 3-node graph)
+    // Create both STs with non-cyclic initial queries to avoid forward-reference
+    // validation failures, then ALTER them into a cycle.
     db.execute(
         "SELECT pgtrickle.create_stream_table('cyc_nc_a', \
-         $$SELECT DISTINCT e.src, e.dst FROM cyc_nc_edges e \
-           UNION ALL \
-           SELECT DISTINCT e.src, b.dst \
-           FROM cyc_nc_edges e \
-           INNER JOIN cyc_nc_b b ON e.dst = b.src$$, \
+         $$SELECT DISTINCT e.src, e.dst FROM cyc_nc_edges e$$, \
          '1s', 'DIFFERENTIAL', false)",
     )
     .await;
     db.execute(
         "SELECT pgtrickle.create_stream_table('cyc_nc_b', \
-         $$SELECT DISTINCT e.src, e.dst FROM cyc_nc_edges e \
+         $$SELECT DISTINCT e.src, e.dst FROM cyc_nc_edges e$$, \
+         '1s', 'DIFFERENTIAL', false)",
+    )
+    .await;
+
+    // Transitive closure cycle (needs multiple iterations for 3-node graph)
+    db.execute(
+        "SELECT pgtrickle.alter_stream_table('cyc_nc_a', \
+         query => $$SELECT DISTINCT e.src, e.dst FROM cyc_nc_edges e \
+           UNION ALL \
+           SELECT DISTINCT e.src, b.dst \
+           FROM cyc_nc_edges e \
+           INNER JOIN cyc_nc_b b ON e.dst = b.src$$)",
+    )
+    .await;
+    db.execute(
+        "SELECT pgtrickle.alter_stream_table('cyc_nc_b', \
+         query => $$SELECT DISTINCT e.src, e.dst FROM cyc_nc_edges e \
            UNION ALL \
            SELECT DISTINCT a.src, e.dst \
            FROM cyc_nc_a a \
-           INNER JOIN cyc_nc_edges e ON a.dst = e.src$$, \
-         '1s', 'DIFFERENTIAL', false)",
+           INNER JOIN cyc_nc_edges e ON a.dst = e.src$$)",
     )
     .await;
 
@@ -456,21 +496,35 @@ async fn test_circular_drop_member_clears_scc_id() {
         .await;
     db.execute("INSERT INTO cyc_drop_src VALUES (1, 10)").await;
 
-    // Create two STs forming a cycle
+    // Create two STs with non-cyclic initial queries to avoid forward-reference
+    // validation failures, then ALTER them into a cycle.
     db.execute(
         "SELECT pgtrickle.create_stream_table('cyc_drop_a', \
-         $$SELECT id, val FROM cyc_drop_src \
-           UNION ALL \
-           SELECT DISTINCT b.id, b.val FROM cyc_drop_b b$$, \
+         $$SELECT id, val FROM cyc_drop_src$$, \
          '1m', 'DIFFERENTIAL', false)",
     )
     .await;
     db.execute(
         "SELECT pgtrickle.create_stream_table('cyc_drop_b', \
-         $$SELECT id, val FROM cyc_drop_src \
-           UNION ALL \
-           SELECT DISTINCT a.id, a.val FROM cyc_drop_a a$$, \
+         $$SELECT id, val FROM cyc_drop_src$$, \
          '1m', 'DIFFERENTIAL', false)",
+    )
+    .await;
+
+    // ALTER A to reference B
+    db.execute(
+        "SELECT pgtrickle.alter_stream_table('cyc_drop_a', \
+         query => $$SELECT id, val FROM cyc_drop_src \
+           UNION ALL \
+           SELECT DISTINCT b.id, b.val FROM cyc_drop_b b$$)",
+    )
+    .await;
+    // ALTER B to reference A (completes the cycle)
+    db.execute(
+        "SELECT pgtrickle.alter_stream_table('cyc_drop_b', \
+         query => $$SELECT id, val FROM cyc_drop_src \
+           UNION ALL \
+           SELECT DISTINCT a.id, a.val FROM cyc_drop_a a$$)",
     )
     .await;
 
@@ -513,7 +567,9 @@ async fn test_circular_drop_member_clears_scc_id() {
 #[tokio::test]
 async fn test_circular_default_rejects_cycles() {
     let db = E2eDb::new().await.with_extension().await;
-    // Default: allow_circular = false (do NOT set it)
+    // Explicitly enforce the default to prevent GUC pollution from other tests
+    // that may have set allow_circular=true via ALTER SYSTEM.
+    db.execute("SET pg_trickle.allow_circular = false").await;
 
     db.execute("CREATE TABLE cyc_def_src (id INT PRIMARY KEY, val INT NOT NULL)")
         .await;


### PR DESCRIPTION
Fixes all 6 failing tests in e2e_circular_tests.rs via three fixes: (1) rewrite tests 1/3/4/5 to use CREATE+ALTER pattern instead of forward references; (2) check proposed query monotonicity in check_for_cycles_alter ALTER path; (3) add explicit SET allow_circular=false guard in test 6 against GUC pollution from shared container.