### PR TITLE
ci: free up disk space before E2E tests target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,17 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     timeout-minutes: 90
     steps:
+      - name: Free up disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          docker system prune -af
+          df -h
+
       - uses: actions/checkout@v5
 
       - name: Setup pgrx environment


### PR DESCRIPTION
Clears runner disk space by purging dotnet, android, and large boost/ghc directories since the ~60 E2E artifact builds exhaust the standard GitHub Actions Linux runner disk capacity.