### PR TITLE
fix(release): make pgxn archive META.json verification robust

### DIFF
--- a/justfile
+++ b/justfile
@@ -412,10 +412,7 @@ pgxn-publish:
     git archive --format zip --prefix="pg_trickle-${VERSION}/" -o "$ARCHIVE" HEAD
     
     echo "Verifying archive contents..."
-    if ! unzip -l "$ARCHIVE" | grep -q "META.json"; then
-        echo "Error: META.json not found in the archive."
-        exit 1
-    fi
+    python3 scripts/verify_pgxn_archive.py "$ARCHIVE"
     
     if ! command -v pgxn >/dev/null 2>&1; then
         echo "Error: 'pgxn' command not found. Please install pgxn-utils."

--- a/scripts/verify_pgxn_archive.py
+++ b/scripts/verify_pgxn_archive.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Verify a PGXN zip archive contains required files."""
+
+from __future__ import annotations
+
+import sys
+import zipfile
+from pathlib import PurePosixPath
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: verify_pgxn_archive.py <archive.zip>", file=sys.stderr)
+        return 2
+
+    archive = sys.argv[1]
+
+    try:
+        with zipfile.ZipFile(archive) as zf:
+            names = zf.namelist()
+    except FileNotFoundError:
+        print(f"Error: archive not found: {archive}", file=sys.stderr)
+        return 1
+    except zipfile.BadZipFile:
+        print(f"Error: invalid zip archive: {archive}", file=sys.stderr)
+        return 1
+
+    # git archive adds a versioned prefix (e.g. pg_trickle-0.9.0/META.json).
+    has_meta = any(PurePosixPath(name).name == "META.json" for name in names)
+
+    if not has_meta:
+        print("Error: META.json not found in the archive.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- replace brittle `unzip -l | grep` META.json check in `just pgxn-publish`
- add `scripts/verify_pgxn_archive.py` for zip entry inspection
- keep archive prefix-aware META.json verification (e.g. `pg_trickle-<version>/META.json`)

## Why
The release workflow failed with a false negative: `META.json not found in the archive`.
The new verifier checks zip entries directly and is stable across CI environments.

## Validation
- just fmt
- just lint
- local smoke test: git archive + python verifier