### PR TITLE
fix: use curl to upload directly to PGXN Manager API

### DIFF
--- a/.github/workflows/pgxn.yml
+++ b/.github/workflows/pgxn.yml
@@ -20,14 +20,6 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-
-      - name: Install pgxn_utils
-        run: gem install pgxn_utils --no-document
-
       - name: Package and upload to PGXN
         run: just pgxn-publish
         env:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -30,7 +30,7 @@ under **Settings → Secrets and variables → Actions → New repository secret
 
 | Secret | Used by | Description |
 |--------|---------|-------------|
-| `PGXN_USERNAME` | `pgxn.yml` | Your PGXN account username. The workflow maps this to `PGXN_USER` for the `pgxn-utils release` command when publishing source archives to the [PostgreSQL Extension Network](https://pgxn.org/). Register at [pgxn.org](https://pgxn.org/). |
+| `PGXN_USERNAME` | `pgxn.yml` | Your PGXN account username. Used to authenticate the `curl` upload to [PGXN Manager](https://manager.pgxn.org/) when publishing source archives to the [PostgreSQL Extension Network](https://pgxn.org/). Register at [pgxn.org](https://pgxn.org/). |
 | `PGXN_PASSWORD` | `pgxn.yml` | Password for the PGXN account above. Never hardcode this — it must be stored as a secret so it is never exposed in logs or committed to the repository. |
 | `CODECOV_TOKEN` | `coverage.yml` | Upload token for [Codecov](https://codecov.io/). Used to publish unit and E2E coverage reports. Obtain it from the Codecov dashboard after linking the repository. The workflow degrades gracefully (`fail_ci_if_error: false`) if absent. |
 | `BENCHER_API_TOKEN` | `benchmarks.yml` | API token for [Bencher](https://bencher.dev/), the continuous benchmarking platform. Used to track Criterion benchmark results on `main` and detect regressions on pull requests. The benchmark steps are **skipped entirely** when this secret is absent, so CI still passes without it. Create a project at bencher.dev and copy the token from the project settings. |
@@ -315,7 +315,7 @@ If the workflow created a draft or partial Release before failing:
 | Build failure | Compilation error in release profile | Fix on `main`, re-tag (Option B) |
 | Docker push failed | Missing permissions | Verify `packages: write` is in the workflow and `GITHUB_TOKEN` has GHCR access, then re-run (Option A) |
 | Smoke test failed | Extension doesn't load in PostgreSQL | Fix the issue, re-tag (Option B) |
-| PGXN upload failed | Missing `PGXN_USERNAME` / `PGXN_PASSWORD` secrets, `pgxn_utils` installation failure, or `META.json` version not updated | Add the secrets in repository settings, ensure the workflow can install `pgxn_utils`, verify `META.json` version matches the tag, and re-run the `pgxn.yml` workflow from the Actions tab |
+| PGXN upload failed | Missing `PGXN_USERNAME` / `PGXN_PASSWORD` secrets, or `META.json` version not updated | Add the secrets in repository settings; verify `META.json` version matches the tag; re-run the `pgxn.yml` workflow from the Actions tab |
 | Rate limited | GitHub API or GHCR throttling | Wait a few minutes, then re-run (Option A) |
 
 ### Yanking a release

--- a/justfile
+++ b/justfile
@@ -414,22 +414,25 @@ pgxn-publish:
     echo "Verifying archive contents..."
     python3 scripts/verify_pgxn_archive.py "$ARCHIVE"
     
-    if ! command -v pgxn-utils >/dev/null 2>&1; then
-        echo "Error: 'pgxn-utils' command not found. Please install pgxn_utils."
-        exit 1
-    fi
-
-    # pgxn_utils expects PGXN_USER; keep PGXN_USERNAME compatibility for CI secrets.
-    export PGXN_USER="${PGXN_USER:-${PGXN_USERNAME:-}}"
-    if [ -z "${PGXN_USER:-}" ] || [ -z "${PGXN_PASSWORD:-}" ]; then
+    if [ -z "${PGXN_USERNAME:-}" ] || [ -z "${PGXN_PASSWORD:-}" ]; then
         echo "Error: missing PGXN credentials."
-        echo "Set PGXN_USER (or PGXN_USERNAME) and PGXN_PASSWORD."
+        echo "Set PGXN_USERNAME and PGXN_PASSWORD environment variables."
         exit 1
     fi
     
     echo "Uploading to PGXN..."
-    pgxn-utils release "$ARCHIVE"
-    echo "Successfully uploaded pg_trickle-$VERSION to PGXN!"
+    HTTP_STATUS=$(curl --silent --output /tmp/pgxn_response.txt --write-out "%{http_code}" \
+        -F "archive=@$ARCHIVE" \
+        -u "${PGXN_USERNAME}:${PGXN_PASSWORD}" \
+        "https://manager.pgxn.org/upload")
+    
+    if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
+        echo "Successfully uploaded pg_trickle-$VERSION to PGXN! (HTTP $HTTP_STATUS)"
+    else
+        echo "Error: PGXN upload failed with HTTP $HTTP_STATUS"
+        cat /tmp/pgxn_response.txt
+        exit 1
+    fi
 
 # ── Docker ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

The `pgxn_utils` Ruby gem (last released 2021) depends on `json 1.6.8`, whose C extension fails to compile against Ruby 3.3 (`rb_cFixnum` removed, `rb_str_new` macro arity change). This makes the previous `pgxn-utils release` approach unworkable in CI.

Before that, the workflow used `pgxnclient` which does not have an `upload` subcommand at all.

## Solution

Replace **all** third-party CLI dependencies with a direct `curl` POST to `https://manager.pgxn.org/upload` using HTTP basic auth from the existing `PGXN_USERNAME`/`PGXN_PASSWORD` secrets. This is the same API endpoint that both `pgxn-utils` and PGXN Manager's web UI use under the hood.

### Changes
- **justfile**: replace `pgxn-utils release` with `curl -F archive=@$ARCHIVE -u ...`
- **pgxn.yml**: remove Ruby setup and gem install steps - **pgxn.yml**: remove Ruby setup and gem install steps - **pgxn.yml**: remove Ruby setup and gem iab- **pgxn.yml**: remove Ruby setup and gem install steps - **pgxn.s