### PR TITLE
docs: add PGXN installation section + promote release_status to stable

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -90,6 +90,46 @@ docker run --rm \
 
 ---
 
+## Installing from PGXN
+
+pg_trickle is published on the [PostgreSQL Extension Network (PGXN)](https://pgxn.org/dist/pg_trickle/).
+Installing via PGXN compiles the extension from source, so the Rust toolchain and pgrx are required.
+
+### 1. Install prerequisites
+
+```bash
+# Rust toolchain
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
+# pgrx build tool
+cargo install --locked cargo-pgrx --version 0.17.0
+cargo pgrx init --pg18 "$(pg_config --bindir)/pg_config"
+```
+
+### 2. Install the pgxn client
+
+```bash
+pip install pgxnclient
+```
+
+### 3. Install pg_trickle
+
+```bash
+pgxn install pg_trickle
+```
+
+To install a specific version:
+
+```bash
+pgxn install pg_trickle=0.9.0
+```
+
+> **Note:** After installation, follow the [PostgreSQL Configuration](#postgresql-configuration) and
+> [Extension Installation](#extension-installation) steps below.
+
+---
+
 ## Building from Source
 
 ### 1. Install Rust

--- a/META.json
+++ b/META.json
@@ -29,7 +29,7 @@
     }
   },
   "tags": ["ivm", "streaming", "materialized view", "cdc", "rust", "differential-dataflow"],
-  "release_status": "testing",
+  "release_status": "stable",
   "generated_by": "pg_trickle contributors",
   "meta-spec": {
     "version": "1.0.0",


### PR DESCRIPTION
## Summary

### INSTALL.md — new PGXN install section
Adds a dedicated **"Installing from PGXN"** section (inserted between the Docker dev section and "Building from Source") explaining:
- Prerequisites: Rust toolchain + pgrx 0.17.0
- Install the `pgxnclient` pip package
- `pgxn install pg_trickle` (with version-pinning example)

Previously the docs only covered GitHub Releases, CNPG, Docker dev, and building from source. PGXN was only mentioned in the release/publishing docs.

### META.json — release_status: testing → stable
At v0.9.0 with unit, integration, light E2E, full E2E, TPC-H, dbt, and CNPG CI coverage, the extension is mature enough to drop the `testing` label on PGXN. This affects how the package is displayed and ranked on pgxn.org.

## Checklist
- [x] No code changes, docs + metadata only
- [x] INSTALL.md still links correctly to PostgreSQL Configuration and Extension Installation sections