### PR TITLE
Document synergies between stratification and mutual recursion plans

### DIFF
--- a/plans/sql/PLAN_STRATIFICATION.md
+++ b/plans/sql/PLAN_STRATIFICATION.md
@@ -761,6 +761,11 @@ Phase 4 is technically independent of Phases 2 and 3 (it operates at the
 intra-CTE level, not the inter-table level) and could be done in
 parallel.
 
+**Shared foundation with PLAN_TRULY_MUTUALLY_RECURSIVE_CTES.md**: Phase 1
+(`classify_edge_monotonicity()`, `assign_strata()`) is also required by the
+mutual recursion plan's Approach B (diagnostic detection). These plans should
+share Phase 1 implementation. See Section 15 below.
+
 ---
 
 ## 9. Testing Strategy
@@ -1007,7 +1012,58 @@ infrastructure investment is worthwhile.
 
 ---
 
-## 14. References
+## 14. Related Plans and Synergies
+
+### PLAN_TRULY_MUTUALLY_RECURSIVE_CTES.md
+
+[PLAN_TRULY_MUTUALLY_RECURSIVE_CTES.md](PLAN_TRULY_MUTUALLY_RECURSIVE_CTES.md)
+designs support for mutually recursive query patterns via decomposition into
+circular stream tables. The two plans share infrastructure and are best
+developed together:
+
+**1. Phase 1 is shared infrastructure.**
+`classify_edge_monotonicity()` and `assign_strata()` (built in Stratification
+Phase 1) are also required by the mutual recursion plan's Approach B. They
+should be built once and used by both plans.
+
+**2. S-1 directly unblocks mutual recursion patterns with negation.**
+The most compelling real-world mutual recursion patterns (graph traversal
+with blocking edges, reachability with exclusions) involve `NOT EXISTS` on
+external base tables. Today these are rejected by the whole-tree monotonicity
+check. Stratification S-1 reclassifies these as safe because the
+non-monotone edge targets a lower-stratum source outside the cycle. Resolving
+S-1 removes a major friction point for users following the mutual recursion
+decomposition pattern.
+
+**3. S-2 makes mutual recursion convergence cheaper.**
+After the mutual recursion SCC converges, downstream consumers currently
+always run change detection. S-2 skips entire downstream strata when the
+upstream SCC produced no changes, reducing per-tick overhead.
+
+**4. S-3 speeds up inner CTEs inside decomposed stream tables.**
+Decomposed stream tables commonly contain `WITH RECURSIVE` CTEs with cycle
+elimination guards (`WHERE dst <> ALL(path)`). S-3 allows DRed instead of
+full recomputation for these, making each outer fixed-point iteration
+faster.
+
+**5. Stratum info enriches mutual recursion diagnostics.**
+With `pgt_stratum_status()` (built in Phase 5), users following the mutual
+recursion tutorial can immediately see the stratum assignment of their
+decomposed stream tables and downstream consumers.
+
+**Recommended sequencing**: Build Stratification Phase 1 first. Then
+Stratification Phases 2–4 and the mutual recursion plan's Approach B can
+proceed in parallel, sharing the Phase 1 foundation.
+
+### PLAN_CIRCULAR_REFERENCES.md
+
+Existing plan (fully implemented) for circular stream table dependencies.
+Provides the SCC detection, monotonicity validation, and fixed-point
+iteration that both this plan and the mutual recursion plan depend on.
+
+---
+
+## 15. References
 
 - Abiteboul, S., Hull, R., Vianu, V. (1995). Foundations of Databases,
   Chapter 15: Stratified Datalog.
@@ -1024,7 +1080,7 @@ infrastructure investment is worthwhile.
 
 ---
 
-## 15. Implementation Status
+## 16. Implementation Status
 
 | Phase | Description | Status |
 |-------|-------------|--------|

--- a/plans/sql/PLAN_TRULY_MUTUALLY_RECURSIVE_CTES.md
+++ b/plans/sql/PLAN_TRULY_MUTUALLY_RECURSIVE_CTES.md
@@ -1099,7 +1099,65 @@ result with existing infrastructure.
 
 ---
 
-## 13. References
+## 13. Related Plans and Synergies
+
+### PLAN_STRATIFICATION.md
+
+[PLAN_STRATIFICATION.md](PLAN_STRATIFICATION.md) designs explicit Datalog
+stratification for pg_trickle and has several concrete synergies with this
+plan. The two should be developed with shared infrastructure in mind:
+
+**1. Shared edge classification foundation.**
+Stratification Phase 1 builds `classify_edge_monotonicity()` — a function
+that classifies each dependency edge as monotone or non-monotone per source.
+The mutual recursion Approach B (diagnostic detection) needs the same
+analysis to determine which cross-CTE references are safe when generating
+rewrite suggestions. Building it once in Stratification Phase 1 avoids
+duplicating this logic.
+
+**2. S-1 unlocks richer decomposed patterns.**
+Stratification Feature S-1 (stratum-aware cycle validation) replaces the
+current whole-tree monotonicity check with per-edge classification. This
+directly unblocks decomposed mutual recursion patterns where individual
+stream tables use `NOT EXISTS` or `EXCEPT` against base tables outside the
+cycle. Today those patterns are rejected; with S-1 they are accepted because
+the non-monotone edge targets a lower-stratum source.
+
+Example from Section 3.4 of this plan (reach_red with `NOT EXISTS` on
+`blocked_edges`): currently rejected, allowed after S-1.
+
+**3. S-2 reduces waste during SCC convergence.**
+Decomposed mutual recursion creates a cyclic SCC plus downstream consumers.
+Stratification Feature S-2 (stratum-based scheduler skip) prevents those
+downstream consumers from running wasted refreshes while the SCC is still
+iterating to its fixed point.
+
+**4. S-3 speeds up the inner recursive CTEs.**
+Each decomposed stream table contains a `WITH RECURSIVE` CTE. If those CTEs
+use cycle elimination (`WHERE dst <> ALL(path)`) the current code falls back
+to full recomputation. Stratification Feature S-3 (stratified DRed) enables
+incremental DRed for exactly this pattern, making each outer fixed-point
+iteration faster.
+
+**5. Stratum info enriches rewrite suggestions.**
+With stratum assignment available (from Stratification Phase 1), the
+Approach B diagnostic can include concrete stratum information in its output:
+"Stream table A and B will form a cyclic SCC at stratum 0; downstream
+consumer C will be at stratum 1."
+
+**Recommended sequencing**: Build Stratification Phase 1 first, then
+implement Approach B of this plan and Stratification Phases 2–4 in parallel
+on top of the shared foundation.
+
+### PLAN_CIRCULAR_REFERENCES.md
+
+Existing plan for circular stream table dependencies — the core runtime
+mechanism (SCC detection, monotonicity validation, fixed-point iteration)
+that mutual recursion decomposition builds on.
+
+---
+
+## 14. References
 
 - Knaster-Tarski Fixed-Point Theorem: guarantees least fixed point for
   monotone functions over complete lattices.
@@ -1118,7 +1176,7 @@ result with existing infrastructure.
 
 ---
 
-## Implementation Status
+## 15. Implementation Status
 
 | Phase | Description | Status |
 |-------|-------------|--------|


### PR DESCRIPTION
## Summary

Adds cross-reference sections to both stratification and mutual recursion
plans, documenting how they share infrastructure and benefit each other.

## Changes

### PLAN_STRATIFICATION.md — new section 14

Explains the concrete synergies with PLAN_TRULY_MUTUALLY_RECURSIVE_CTES.md:

- Stratification Phase 1 (`classify_edge_monotonicity`, `assign_strata`) is
  shared infrastructure for both plans and should be built once
- Feature S-1 directly unblocks decomposed mutual recursion patterns that
  use `NOT EXISTS` or `EXCEPT` on external base tables (currently rejected
  by the whole-tree monotonicity check)
- Feature S-2 reduces wasted scheduler work during mutual recursion SCC
  convergence
- Feature S-3 speeds up the inner `WITH RECURSIVE` CTEs inside decomposed
  stream tables via stratified DRed
- Notes shared foundation in the Execution Order section

### PLAN_TRULY_MUTUALLY_RECURSIVE_CTES.md — new section 13

Explains the reciprocal dependencies on PLAN_STRATIFICATION.md and
recommends building Stratification Phase 1 first as the shared foundation
for both plans before proceeding with either plan's Approach B or Phases
2-4 in parallel.

## Recommended sequencing

Build Stratification Phase 1 (edge classification + stratum assignment)
first, then the mutual recursion plan's Approach B and Stratification
Phases 2-4 can proceed in parallel on top of that shared foundation.
