### PR TITLE
fix(upgrade): update 0.10.0 archive SQL with refresh_tier column and tier parameter

### DIFF
--- a/sql/archive/pg_trickle--0.10.0.sql
+++ b/sql/archive/pg_trickle--0.10.0.sql
@@ -65,6 +65,8 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_stream_tables (
     scc_id          INT,
     last_fixpoint_iterations INT,
     pooler_compatibility_mode BOOLEAN NOT NULL DEFAULT FALSE,
+    refresh_tier    TEXT NOT NULL DEFAULT 'hot'
+                     CHECK (refresh_tier IN ('hot', 'warm', 'cold', 'frozen')),
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -332,7 +334,8 @@ SELECT
      FROM pgtrickle.pgt_dependencies d
      WHERE d.pgt_id = st.pgt_id AND d.source_type = 'TABLE') AS cdc_modes,
     st.scc_id,
-    st.last_fixpoint_iterations
+    st.last_fixpoint_iterations,
+    st.refresh_tier
 FROM pgtrickle.pgt_stream_tables st
 LEFT JOIN LATERAL (
     SELECT
@@ -560,7 +563,8 @@ CREATE  FUNCTION pgtrickle."alter_stream_table"(
 	"diamond_schedule_policy" TEXT DEFAULT NULL, /* core::option::Option<&str> */
 	"cdc_mode" TEXT DEFAULT NULL, /* core::option::Option<&str> */
 	"append_only" bool DEFAULT NULL, /* core::option::Option<bool> */
-	"pooler_compatibility_mode" bool DEFAULT NULL /* core::option::Option<bool> */
+	"pooler_compatibility_mode" bool DEFAULT NULL, /* core::option::Option<bool> */
+	"tier" TEXT DEFAULT NULL /* core::option::Option<&str> */
 ) RETURNS void
 
 LANGUAGE c /* Rust */


### PR DESCRIPTION
## Problem

All upgrade E2E jobs were failing with two errors:
- `test_upgrade_catalog_schema_stability` (L1): `Column 'refresh_tier' with type containing 'text' not found in catalog`
- `test_upgrade_drop_recreate_roundtrip` (L3): `column "refresh_tier" does not exist`

## Root Cause

`sql/archive/pg_trickle--0.10.0.sql` was snapshotted before `refresh_tier` was added to `pgt_stream_tables` (G-7: tiered scheduling feature). The upgrade Dockerfile copies all archive SQL files **over** the pgrx-generated install scripts:

```dockerfile
COPY sql/archive/pg_trickle--*.sql /usr/share/postgresql/18/extension/
```

So `CREATE EXTENSION pg_trickle` on the upgrade image installed the stale archive schema (missing `refresh_tier`). Since the compiled .so reads `COALESCE(refresh_tier, 'hot')` in every catalog SELECT, this fails immedSo `CREATE EXTENSION pg_trickle` on the upgrade image installed the stale archive schema (missing `refresh_tier`). Since the compiled .so reads `COALESCE(refresh_tier,e--So `CREATE EXTENSION pg_trickle` on the upgrade1.So `CREATE EXTENSION pg_trickle` on the upgrade image installed the stale archive schema (missing `refresh_tier`). Sinc` to `pg_stat_stream_tables` view  
3. Added `tier TEXT DEFAULT NULL` parameter to `alter_stream_table` function signature