### PR TITLE
docs(roadmap): add ST-to-ST differential refresh items to v0.11.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1995,6 +1995,28 @@ Deliver **one** of TS1 or TS2; whichever is completed first meets the exit crite
 
 > **External correctness gate subtotal: ~1–3 days**
 
+#### Differential ST-to-ST Refresh
+
+> **In plain terms:** When stream table B's defining query reads from stream
+> table A, pg_trickle currently forces a FULL refresh of B every time A
+> updates — re-executing B's entire query even when only a handful of rows
+> changed. This feature gives ST-to-ST dependencies the same CDC change
+> buffer that base tables already have, so B refreshes differentially (applying
+> only the delta). Crucially, even when A itself does a FULL refresh, a
+> pre/post snapshot diff is captured so B still receives a small I/D delta
+> rather than cascading FULL through the chain.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| ST-ST-1 | **Change buffer infrastructure.** Add `create_st_change_buffer_table()` / `drop_st_change_buffer_table()` in `cdc.rs`; lifecycle hooks in `api.rs` (create when a STREAM TABLE source is registered, drop when last consumer is removed); auto-create during extension upgrade for all existing ST-to-ST dependencies (idempotent). | 1 wk | [PLAN_ST_TO_ST.md §Phase 1](plans/sql/PLAN_ST_TO_ST.md) |
+| ST-ST-2 | **Delta capture — DIFFERENTIAL path.** In `execute_differential_refresh()`, use `MERGE … RETURNING` (PG 17+) to atomically apply the MERGE and insert delta rows into `changes_pgt_{id}` in a single round-trip. The explicit-DML path reads from the already-materialised `__pgt_delta_{id}` temp table. | 1–2 wk | [PLAN_ST_TO_ST.md §Phase 2](plans/sql/PLAN_ST_TO_ST.md) |
+| ST-ST-3 | **Delta capture — FULL path.** In `execute_full_refresh()`, snapshot the pre-refresh row set into a temp table, run the FULL refresh, then diff pre/post and write I/D pairs to `changes_pgt_{id}`. Downstream STs always receive a differential delta regardless of whether the upstream did FULL or DIFFERENTIAL. Cost is O(N) — accepted tradeoff that eliminates cascading FULL through deep ST chains. | 1 wk | [PLAN_ST_TO_ST.md §7](plans/sql/PLAN_ST_TO_ST.md) |
+| ST-ST-4 | **DVM scan operator for ST sources.** Extend `dvm/operators/scan.rs`: ST sources read from `changes_pgt_{id}` instead of `changes_{oid}`; introduce `pgt_`-prefixed LSN placeholder tokens; extend the frontier computation and placeholder resolver in `refresh.rs`. | 1–2 wk | [PLAN_ST_TO_ST.md §Phase 3](plans/sql/PLAN_ST_TO_ST.md) |
+| ST-ST-5 | **Scheduler integration.** Rewrite `has_stream_table_source_changes()` to check the ST buffer for rows beyond the frontier (mirrors `has_table_source_changes()`). Remove the `has_stream_table_changes → Full` override when upstream has a buffer; retain FULL + timestamp fallback when no buffer exists. | 0.5 wk | [PLAN_ST_TO_ST.md §Phase 4](plans/sql/PLAN_ST_TO_ST.md) |
+| ST-ST-6 | **Cleanup, lifecycle & tests.** Extend `drain_pending_cleanups()` for ST buffers; wire DDL lifecycle hooks in `hooks.rs` for schema changes. Unit tests for buffer lifecycle and DVM scan SQL; integration tests for the ST → ST DIFFERENTIAL chain; E2E tests for 3-level chain, DROP-middle-ST fallback, schema change buffer recreation, and min-frontier cleanup. | 1 wk | [PLAN_ST_TO_ST.md §Phase 5–6](plans/sql/PLAN_ST_TO_ST.md) |
+
+> **ST-to-ST differential subtotal: ~4.5–6.5 weeks**
+
 ### Stretch Goals (if capacity allows after Must-Ship)
 
 | Item | Description | Effort | Ref |
@@ -2004,7 +2026,7 @@ Deliver **one** of TS1 or TS2; whichever is completed first meets the exit crite
 
 > **Stretch subtotal: ~2–3 weeks (STRETCH-1) + 2–4 days (STRETCH-2 spike)**
 
-> **v0.11.0 total: ~7–10 weeks (partitioning + isolation) + ~12h observability + ~14–21h default tuning + ~7–12h safety hardening + ~2–4 weeks should-ship (bitmask + fuse + external corpus) + ~1–2 days correctness quick-wins + ~2–3 days documentation**
+> **v0.11.0 total: ~7–10 weeks (partitioning + isolation) + ~12h observability + ~14–21h default tuning + ~7–12h safety hardening + ~2–4 weeks should-ship (bitmask + fuse + external corpus) + ~4.5–6.5 weeks ST-to-ST differential + ~1–2 days correctness quick-wins + ~2–3 days documentation**
 
 **Exit criteria:**
 - [ ] Declaratively partitioned stream tables accepted; partition key tracked in catalog *(or STRETCH-2 design spike complete with RFC)*
@@ -2028,6 +2050,7 @@ Deliver **one** of TS1 or TS2; whichever is completed first meets the exit crite
 - [ ] G13-EH: `UnsupportedOperator`, `CycleDetected`, `UpstreamSchemaChanged`, `QueryParseError` include `DETAIL` and `HINT` fields
 - [ ] G17-EC01B-NEG: Negative regression test documents ≥3-scan fall-back behavior; linked to v0.12.0 EC01B fix
 - [ ] G16-GS/SM/MQR/GUC: GETTING_STARTED restructured with progressive complexity; DVM_OPERATORS support matrix added; monitoring quick reference added; CONFIGURATION.md GUC matrix added
+- [ ] ST-ST-1–6: All ST-to-ST dependencies refresh differentially when upstream has a change buffer; FULL refreshes on an upstream ST produce a pre/post I/D diff so downstream STs never cascade FULL through the chain; auto-migration creates buffers for existing ST-to-ST dependencies on upgrade; 3-level E2E chain test passes
 - [ ] Extension upgrade path tested (`0.10.0 → 0.11.0`)
 
 ---

--- a/plans/sql/PLAN_ST_TO_ST.md
+++ b/plans/sql/PLAN_ST_TO_ST.md
@@ -2,6 +2,7 @@
 
 > **Status:** Proposed  
 > **Date:** 2026-03-25  
+> **Design Goal:** Maximum performance and differential propagation — FULL refreshes never cascade as FULL to downstream STs.  
 > **Related:** [PLAN_DAG_PERFORMANCE.md](../performance/PLAN_DAG_PERFORMANCE.md) ·
 > [ARCHITECTURE.md](../../docs/ARCHITECTURE.md) ·
 > [CONFIGURATION.md](../../docs/CONFIGURATION.md)
@@ -455,7 +456,13 @@ FULL refresh is the trickiest case. When an ST does a FULL refresh (truncate +
 rewrite), we still need to capture the **diff** between the old and new state
 so downstream STs can consume it differentially. Two approaches:
 
-### Option A: Pre/Post Diff (Recommended)
+### Chosen Approach: Pre/Post Diff
+
+**Decision:** Option A is implemented from day one. The design goal is that
+FULL refreshes on an upstream ST never force downstream STs to also do FULL.
+The ~2× FULL refresh cost is an accepted and bounded tradeoff: it is O(N)
+with the upstream table size, exactly the same complexity class as the FULL
+refresh itself, and it eliminates unbounded FULL cascading through deep chains.
 
 Before the FULL refresh, snapshot the current `__pgt_row_id` set. After the
 refresh, compare:
@@ -499,20 +506,8 @@ WHERE (pre.col1, pre.col2, ...) IS DISTINCT FROM (post.col1, post.col2, ...);
 **Cost:** Two table scans (pre-state + diff). For large STs this is
 meaningful overhead, but it's O(N) with the table size — the same as the
 FULL refresh itself. The constant factor roughly doubles the refresh time.
-
-### Option B: Skip FULL Capture (Simpler)
-
-When an ST does a FULL refresh, just **don't** write to the change buffer.
-Instead, clear the buffer and force downstream STs to FULL as well (the
-current behavior). This means FULL refreshes cascade as FULL through the
-chain, but DIFFERENTIAL refreshes cascade as DIFFERENTIAL.
-
-This is simpler to implement and still captures the majority of the benefit:
-in steady state, most refreshes are DIFFERENTIAL. FULL only happens during
-reinit, drift reset, or when the `refresh_mode = Full`.
-
-**Recommendation:** Start with Option B for the initial implementation, then
-add Option A as a follow-up when benchmarks show FULL cascading is a problem.
+This cost is accepted: a FULL refresh is already expensive, and protecting
+all downstream STs from a cascading FULL is worth the constant overhead.
 
 ---
 
@@ -564,14 +559,16 @@ interval already dominates at low $T_r$.
 
 ## 9. Migration & Compatibility
 
-- **Existing STs are unaffected.** Change buffers are only created when
-  downstream STs are added. Existing ST-to-ST dependencies continue to use
-  FULL until the buffer is created.
-- **Opt-out:** A future GUC (`pg_trickle.st_change_buffers = on|off`) can
-  disable buffer creation for deployments that prefer FULL simplicity.
-- **Upgrade path:** On extension upgrade, no automatic buffer creation. Users
-  run `ALTER STREAM TABLE ... REFRESH MODE DIFFERENTIAL` or we detect the
-  opportunity during the next DAG rebuild.
+- **Always-on.** ST change buffers are created unconditionally whenever a
+  stream table is used as a source by another stream table. There is no
+  opt-out GUC — the feature is always active. Deployments that want FULL
+  propagation can set `refresh_mode = Full` on downstream STs explicitly.
+- **Upgrade path:** On extension upgrade, automatically scan `pgt_dependencies`
+  for all existing `source_type = 'STREAM_TABLE'` rows and create the missing
+  `changes_pgt_{id}` buffers. Existing ST-to-ST dependencies immediately gain
+  differential propagation without any user action. The upgrade step runs
+  inside the extension update transaction and is idempotent (uses
+  `CREATE TABLE IF NOT EXISTS`).
 
 ---
 
@@ -581,8 +578,9 @@ interval already dominates at low $T_r$.
 |------|------------|
 | Buffer tables increase catalog bloat | Only created for STs with downstream dependents; dropped when last consumer is removed |
 | Large deltas cause buffer table bloat | Cleanup runs at min-frontier; buffer_partitioning GUC enables partition-based cleanup |
-| `pg_current_wal_lsn()` not advancing on read-only workloads | Use a synthetic monotonic counter (e.g., `pg_current_xact_id()`) as fallback; or accept the existing WAL-based model |
-| FULL refresh capture (Option A) doubles the FULL cost | Start with Option B (skip capture on FULL, cascade FULL). Add Option A later based on demand |
+| `pg_current_wal_lsn()` not advancing on read-only workloads | **Dismissed.** The INSERT into `changes_pgt_{id}` is itself a WAL write, which always advances `pg_current_wal_lsn()`. A valid LSN is always available at capture time. |
+| Pre/post diff doubles the FULL refresh time | **Accepted tradeoff.** The cost is O(N) — same complexity class as the FULL refresh itself. It eliminates unbounded FULL cascading through downstream chains. |
+| No opt-out for ST change buffers | By design: always-on maximises differential propagation. Downstream STs can still be set to `refresh_mode = Full` individually if needed. |
 | DVM scan template cache invalidation | Existing `get_delta_sql_template()` cache must be invalidated when a source switches from TABLE to STREAM_TABLE source type (this shouldn't happen in practice) |
 | Schema changes on upstream ST | Handled by dropping/recreating the buffer; downstream STs already handle source schema changes via `needs_reinit` |
 


### PR DESCRIPTION
## Summary

Two related documentation updates:

1. **`plans/sql/PLAN_ST_TO_ST.md`** — Apply "maximum performance and differential" design decisions:
   - **Section 7:** Replace "Option A (Recommended) / Option B (Simpler)" with a single "Chosen Approach: Pre/Post Diff". FULL refreshes on upstream STs always produce a pre/post I/D delta so downstream STs never cascade FULL. The ~2× FULL refresh cost is explicitly accepted as a bounded, O(N) tradeoff.
   - **Section 9:** Always-on (no opt-out GUC). Auto-migrate existing ST-to-ST dependencies during extension upgrade using `CREATE TABLE IF NOT EXISTS`.
   - **Section 10:** Dismiss the `pg_current_wal_lsn()` risk (the buffer INSERT itself is a WAL write). Replace the "FULL capture doubles cost" risk row with an "Accepted tradeoff" entry. Add a "No opt-out by design" row.

2. **`ROADMAP.md`** — Add ST-to-ST differential refresh as a should-ship addition to v0.11.0:
   - 6 new items: ST-ST-1 (buffer infrastructure + auto-migration on upgrade), ST-ST-2 (DIFFERENTIAL delta capture via `MERGE ... RETURNING`), ST-ST-3 (FULL refresh pre/post diff capture), ST-ST-4 (DVM scan operator for ST sources), ST-ST-5 (scheduler integration), ST-ST-6 (cleanup, lifecycle, tests)
   - New exit criterion for ST-ST-1–6
   - Updated v0.11.0 effort total to include ~4.5–6.5 weeks for ST-to-ST differential

## Related

- Plan: [plans/sql/PLAN_ST_TO_ST.md](plans/sql/PLAN_ST_TO_ST.md)
- Earlier PRs: #274 (initial ST-to-ST plan), #275 (fix MERGE RETURNING)
