### PR TITLE
docs: add ST-to-ST change capture section to ARCHITECTURE.md

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -180,6 +180,26 @@ When `refresh_mode = 'IMMEDIATE'`, pg_trickle uses **statement-level AFTER trigg
 
 No change buffer tables, no scheduler involvement, and no WAL infrastructure is needed for IMMEDIATE mode. See [plans/sql/PLAN_TRANSACTIONAL_IVM.md](../plans/sql/PLAN_TRANSACTIONAL_IVM.md) for the design plan.
 
+#### ST-to-ST Change Capture (v0.11.0+)
+
+When a stream table's defining query references another stream table (rather than a base table), neither triggers nor WAL capture apply — the upstream source is itself maintained by pg_trickle. A dedicated **ST change buffer** mechanism enables downstream stream tables to refresh differentially even when their source is another stream table.
+
+```
+  Base Table  ──trigger/WAL──▶  changes_<oid>       (base-table buffer)
+  Stream Table A  ──refresh──▶  changes_pgt_<pgt_id>  (ST buffer for A's consumers)
+  Stream Table B  reads from    changes_pgt_<pgt_id>  (B depends on A)
+```
+
+**Buffer schema.** ST change buffers are named `pgtrickle_changes.changes_pgt_<pgt_id>` (using the internal `pgt_id` rather than the OID). Unlike base-table buffers, they store only `new_*` columns — no `old_*` columns — because ST deltas are expressed as INSERT/DELETE pairs, not UPDATE rows.
+
+**Delta capture — DIFFERENTIAL path.** When an upstream stream table refreshes in DIFFERENTIAL mode and has downstream consumers, the refresh engine captures the computed delta (the INSERT and DELETE rows applied to the upstream ST) into the ST change buffer via explicit DML. Downstream stream tables then read from this buffer exactly as they would read from a base-table change buffer.
+
+**Delta capture — FULL path.** When an upstream stream table refreshes in FULL mode (e.g., due to a mode downgrade or `full => true`), the engine takes a **pre-refresh snapshot**, executes the full refresh, then computes an `EXCEPT ALL` diff between the old and new contents. The resulting INSERT/DELETE pairs are written to the ST change buffer. This prevents FULL refreshes from cascading through the entire dependency chain — downstream STs always receive a minimal delta regardless of how the upstream was refreshed.
+
+**Frontier tracking.** ST source positions are tracked in the same frontier JSONB structure as base-table sources, using `pgt_<upstream_pgt_id>` as the key (e.g., `{"pgt_42": 157}`) rather than the OID-based keys used for base tables. The scheduler's `has_stream_table_source_changes()` function compares the downstream's last-consumed frontier position against the upstream buffer's current maximum LSN to decide whether a refresh is needed.
+
+**Lifecycle.** ST change buffers are created automatically when a stream table gains its first downstream consumer (`create_st_change_buffer_table()`), and dropped when the last downstream consumer is removed (`drop_st_change_buffer_table()`). On upgrade from pre-v0.11.0, existing ST-to-ST dependencies have their buffers auto-created on the first scheduler tick. Consumed rows are cleaned up by `cleanup_st_change_buffers_by_frontier()` after each successful downstream refresh.
+
 ### 4. DVM Engine (`src/dvm/`)
 
 The Differential View Maintenance engine is the core of the system. It transforms the defining SQL query into an executable operator tree that can compute deltas efficiently.
@@ -609,15 +629,20 @@ Runtime behavior is controlled by a growing set of GUC (Grand Unified Configurat
    │                                              │
    │ WAL mode: Logical Replication Slot           │
    │   wal_decoder bgworker → same buffer table   │
+   │                                              │
+   │ ST-to-ST: Refresh engine captures delta      │
+   │   → changes_pgt_<pgt_id> buffer table        │
    └─────────────────────────────────────────────┘
            │
            ▼
- Change Buffer Table (pgtrickle_changes.changes_<oid>)
-   Columns: change_id, lsn, xid, action (I/U/D), row_data (jsonb)
+ Change Buffer Table
+   Base tables:   pgtrickle_changes.changes_<oid>
+   ST sources:    pgtrickle_changes.changes_pgt_<pgt_id>
+   Columns: change_id, lsn, xid, action (I/D), row_data (jsonb)
            │
            ▼
  DVM Engine: generate delta SQL from operator tree
-   - Scan operator reads from change buffer
+   - Scan operator reads from changes_<oid> or changes_pgt_<id>
    - Filter/Project/Join transform the deltas
    - Aggregate recomputes affected groups
            │


### PR DESCRIPTION
## docs: Add ST-to-ST change capture section to ARCHITECTURE.md

The CDC section in ARCHITECTURE.md documented trigger-based and WAL-based capture paths in detail, but had no mention of the third CDC path introduced in v0.11.0: ST-to-ST change buffers.

### Changes

Added a new "ST-to-ST Change Capture (v0.11.0+)" subsection under CDC that documents:

- **Buffer schema**: `changes_pgt_<pgt_id>` naming, `new_*` columns only (no `old_*`), I/D pair format
- **DIFFERENTIAL path**: delta captured from refresh output into ST buffer
- **FULL path**: `EXCEPT ALL` pre/post diff prevents cascading FULL through the chain
- **Frontier tracking**: `pgt_<upstream_pgt_id>` keys in the JSONB frontier structure
- **Lifecycle**: auto-create on first downstream consumer, auto-drop on last removal, upgrade migration, cleanup via `cleanup_st_change_buffers_by_frontier()`

Also updated the end-to-end data flow diagram to show all three CDC paths (trigger, WAL, ST-to-ST) and the dual buffer naming scheme (`changes_<oid>` vs `changes_pgt_<pgt_id>`).
