### PR TITLE
fix(scheduler): disable LISTEN in BGW to fix scheduler crash (WAKE-1)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -232,7 +232,12 @@ pub static PGS_IVM_RECURSIVE_MAX_DEPTH: GucSetting<i32> = GucSetting::<i32>::new
 /// Falls back to poll-based wake (using `scheduler_interval_ms`) when no
 /// notifications arrive. Disable if the NOTIFY overhead is measurable on
 /// extremely high-throughput write paths (> 100K DML/s).
-pub static PGS_EVENT_DRIVEN_WAKE: GucSetting<bool> = GucSetting::<bool>::new(true);
+// WAKE-1: PostgreSQL's LISTEN command is not allowed in background workers
+// (MyBackendType != B_BACKEND — see async.c:Async_Listen()). The scheduler is
+// always a background worker, so event-driven wake via LISTEN/NOTIFY cannot
+// function as designed. Default is off until a background-worker-compatible
+// wake mechanism is implemented (e.g., shared-memory latch signalling).
+pub static PGS_EVENT_DRIVEN_WAKE: GucSetting<bool> = GucSetting::<bool>::new(false);
 
 /// WAKE-1: Coalesce debounce interval in milliseconds.
 ///
@@ -839,11 +844,11 @@ pub fn register_gucs() {
     // WAKE-1: Event-driven scheduler wake GUCs.
     GucRegistry::define_bool_guc(
         c"pg_trickle.event_driven_wake",
-        c"Enable event-driven scheduler wake via LISTEN/NOTIFY (default on).",
-        c"When enabled, CDC triggers emit pg_notify('pgtrickle_wake') and the \
-           scheduler LISTENs on that channel, waking immediately instead of \
-           waiting for the poll interval. Reduces median latency ~34x for \
-           low-volume workloads. Disable for extreme write throughput (>100K DML/s).",
+        c"Enable event-driven scheduler wake via LISTEN/NOTIFY (default off; not yet functional in background workers).",
+        c"Reserved for future use. PostgreSQL LISTEN is not allowed in background \
+           worker processes (MyBackendType != B_BACKEND), so enabling this has no \
+           effect — the scheduler operates in polling-only mode regardless. \
+           CDC triggers still emit pg_notify('pgtrickle_wake') for future use.",
         &PGS_EVENT_DRIVEN_WAKE,
         GucContext::Suset,
         GucFlags::default(),

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1638,24 +1638,25 @@ pub extern "C-unwind" fn pg_trickle_scheduler_main(_arg: pg_sys::Datum) {
     }));
 
     // WAKE-1: Event-driven wake via LISTEN/NOTIFY.
-    // When enabled, the scheduler LISTENs on the 'pgtrickle_wake' channel.
-    // CDC triggers emit pg_notify('pgtrickle_wake', '') after writing to the
-    // change buffer.  PostgreSQL sets the scheduler's latch when a notification
-    // arrives (after the notifying transaction commits), causing wait_latch()
-    // to return immediately instead of sleeping for the full poll interval.
-    let event_driven = config::pg_trickle_event_driven_wake();
-    if event_driven {
-        BackgroundWorker::transaction(AssertUnwindSafe(|| {
-            if let Err(e) = Spi::run("LISTEN pgtrickle_wake") {
-                warning!(
-                    "pg_trickle scheduler: failed to LISTEN pgtrickle_wake: {}",
-                    e
-                );
-            }
-        }));
-        log!(
-            "pg_trickle scheduler: event-driven wake enabled (debounce={}ms)",
-            config::pg_trickle_wake_debounce_ms()
+    //
+    // PostgreSQL's LISTEN command is restricted to regular backends
+    // (MyBackendType == B_BACKEND). Background workers — which the scheduler
+    // always is — are rejected with "cannot execute LISTEN within a background
+    // process" (async.c:Async_Listen()). Attempting LISTEN causes an elog(ERROR)
+    // that escapes pgrx's catch_unwind and exits the process with exit code 1.
+    //
+    // Until a background-worker-compatible notification mechanism is implemented
+    // (e.g., direct latch signalling via shared memory), event_driven_wake is
+    // always forced to false here regardless of the GUC value. CDC triggers still
+    // emit pg_notify('pgtrickle_wake') for future use once this is re-enabled.
+    let event_driven = false;
+    if config::pg_trickle_event_driven_wake() {
+        // GUC is on but feature is not yet functional in BGWs — warn once at startup.
+        warning!(
+            "pg_trickle scheduler: event_driven_wake=on is not supported in background \
+             workers (PostgreSQL LISTEN is restricted to B_BACKEND processes). \
+             Operating in polling-only mode. Set pg_trickle.event_driven_wake=off \
+             to suppress this warning."
         );
     }
 


### PR DESCRIPTION
## Problem

All 9 `e2e_bgworker_tests` tests were failing with:

```
pg_trickle scheduler did not appear in pg_stat_activity within 90 s.
Diagnostics: launcher_count=1, scheduler_count=0, total_bgworkers=0
```

The scheduler was crashing immediately after spawn with:

```
ERROR:  cannot execute LISTEN within a background process
CONTEXT:  SQL statement "LISTEN pgtrickle_wake"
LOG:   background worker "pg_trickle scheduler" (PID 81) exited with exit code 1
```

Because dynamically spawned workers have `restart_time = None`, the launcher could not
respawn the crashed scheduler -- it waited the full 90-second timeout before giving up.

## Root Cause

The Phase 7 WAKE-1 feature (bc62023) set `event_driven_wake = true` by default and
added `LISTEN pgtrickle_wake` to the scheduler startup path. However, PostgreSQL
**forbids `LISTEN` in background worker processes**.

The restriction lives in `async.c:Async_Listen()`: only regular backends
(`MyBackendType == B_BACKEND`) may register for notifications. The scheduler is always
a background worker, so `LISTEN` triggers `elog(ERROR)` which escapes pgrx's
`catch_unwind` boundary and terminates the process immediately.

## Fix

**`src/scheduler.rs`** -- Remove the `LISTEN pgtrickle_wake` block. Force
`event_driven = false` unconditionally. Emit a one-time WARNING if the GUC is
manually set to `on`, explaining the limitation.

**`src/config.rs`** -- Change `PGS_EVENT_DRIVEN_WAKE` default from `true` to `false`.
Update the GUC description to document the BGW restriction.

CDC triggers still emit `pg_notify('pgtrickle_wake')` -- those run in regular backends
and are harmless. The plumbing is preserved for a future BGW-compatible mechanism
(e.g., shared-memory latch signalling).

## Test Results

Before fix: all 9 tests failed (3 retries each = 27 attempts).

After fix:

```
PASS [8.0s]  test_extension_loads_with_shared_preload
PASS [8.4s]  test_gucs_registered
PASS [8.7s]  test_auto_refresh_within_schedule
PASS [8.7s]  test_auto_refresh_differential_mode
PASS [8.8s]  test_auto_refresh_differential_with_cdc
PASS [9.0s]  test_scheduler_refreshes_multiple_healthy_sts
PASS [9.1s]  test_gucs_can_be_altered
PASS [9.9s]  test_auto_refresh_updates_catalog_metadata
PASS [9.9s]  test_scheduler_writes_refresh_history

Summary: 9 tests run: 9 passed, 0 skipped
```
