### PR TITLE
fix(refresh): remove spurious FULL fallback for non-recursive CTEs

### DIFF
--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -2672,21 +2672,15 @@ pub fn execute_differential_refresh(
         hasher.finish()
     };
 
-    let has_any_cte = dvm::query_has_cte(&st.defining_query)?;
     let has_recursive_cte = dvm::query_has_recursive_cte(&st.defining_query)?;
 
-    if has_any_cte {
-        pgrx::info!(
-            "[pg_trickle] CTE-backed differential refresh fallback: using FULL refresh for {}.{}",
-            schema,
-            name,
-        );
-        let result = execute_full_refresh(st);
-        if result.is_ok() {
-            post_full_refresh_cleanup(st);
-        }
-        return result;
-    }
+    // Non-recursive CTEs (WITH … AS (…)) are fully supported by the DVM
+    // engine: parse_defining_query_full() builds CteScan nodes and the
+    // diff engine processes them via diff_cte_scan().  There is no need for
+    // a FULL fallback here.  Recursive CTEs (WITH RECURSIVE) use a
+    // semi-naive / DRed strategy and bypass the MERGE template cache (they
+    // generate their delta SQL on every refresh instead of caching a
+    // template with LSN placeholders).
 
     let cached = if has_recursive_cte {
         None


### PR DESCRIPTION
## Problem

Non-recursive CTEs (`WITH base AS (SELECT ...) SELECT ... FROM base`) were falling back to FULL refresh at runtime, even though the DVM engine has full support for them.

The relevant code in `execute_differential_refresh`:

```rust
if has_any_cte {
    // fall back to FULL
    return execute_full_refresh(st);
}
```

This caused every query containing a `WITH` clause to silently use FULL refresh mode, defeating the purpose of setting `refresh_mode = 'DIFFERENTIAL'` or `'AUTO'`.

## Why this happened

Commit `1575213` added this fallback as a temporary safety measure while fixing 8 failing CTE E2E tests. The commit message said "until true incremental CTE delta propagation is implemented." The actual fix to the DVM operator layer landed in the same commit, but the FULL fallback was never removed.

## What the DVM engine actually supports

Non-recursive CTEs are fully handled:

- `parse_defining_query_full` builds `OpTree::CteScan` nodes and populates a `CteRegistry`
- `generate_delta_query` / `generate_delta_query_cached` pass the `CteRegistry` to `DiffContext` via `.with_cte_registry()`
- `diff_node` dispatches `CteScan` to `diff_cte_scan`, which differentiates the CTE body once and caches the delta for multi-reference CTEs

Recursive CTEs (`WITH RECURSIVE`) are a separate, legitimately different case — they use semi-naive / DRed evaluation and already correctly bypass the MERGE template cache.

## Fix

Remove the `has_any_cte` early-return and the `query_has_cte` call from `execute_differential_refresh`. Non-recursive CTEs now flow through the normal delta generation and MERGE pipeline, including the template cache.

Recursive CTEs are unaffected: `has_recursive_cte` still causes them to skip the template cache and generate fresh delta SQL each cycle.

## Testing

The existing light E2E suite (`tests/e2e_cte_tests.rs`) covers:
- `test_cte_differential_refresh_inserts`
- `test_cte_differential_refresh_updates`
- `test_cte_differential_refresh_deletes`
- `test_cte_differential_mixed_dml`
- `test_chained_ctes_differential_refresh`
- `test_cte_referenced_twice_differential`
- `test_cte_joined_with_base_table`
- `test_cte_single_row_source`
- `test_cte_differential_matches_full_results`

These all passed before (via FULL fallback) and should continue to pass — now using true differential refresh.
