### PR TITLE
fix(tests): pin cdc_mode='trigger' in test_wal_fallback_on_missing_slot

### DIFF
--- a/tests/e2e_wal_cdc_tests.rs
+++ b/tests/e2e_wal_cdc_tests.rs
@@ -431,6 +431,14 @@ async fn test_wal_fallback_on_missing_slot() {
     db.execute(&format!("SELECT pg_drop_replication_slot('{slot_name}')"))
         .await;
 
+    // Pin cdc_mode to 'trigger' so the scheduler doesn't immediately
+    // re-promote back to WAL after fallback. In 'auto' mode the scheduler
+    // would re-create the slot within one tick, making TRIGGER unobservable.
+    db.execute("ALTER SYSTEM SET pg_trickle.cdc_mode = 'trigger'")
+        .await;
+    db.execute("SELECT pg_reload_conf()").await;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
     // Wait for the health check / poll error to trigger fallback
     let fallback_mode = wait_for_cdc_mode(&db, "wal_fb", "TRIGGER", Duration::from_secs(60)).await;
     assert_eq!(


### PR DESCRIPTION
## Summary

Fixes `test_wal_fallback_on_missing_slot` — the last failing E2E test in CI (926/927 passed, 1 failed with 3 retries).

## Root Cause

In `auto` CDC mode, after `abort_wal_transition()` sets `cdc_mode = TRIGGER`, the scheduler re-promotes the source back to WAL within its next tick (~1s). The TRIGGER state window is too narrow for `wait_for_cdc_mode`'s 500ms polling loop to reliably observe it, causing the test to time out after 60s on all 3 retry attempts.

## Fix

Add `ALTER SYSTEM SET pg_trickle.cdc_mode = 'trigger'` + `pg_reload_conf()` immediately after dropping the replication slot — pinning the global CDC mode to TRIGGER so the scheduler cannot re-promote the source back to WAL. This is the exact same pattern already used by the analogous `test_ec34_check_cdc_health_detects_missing_slot` test, which passes reliably.

## Test Results

- `test_wal_fallback_on_missing_slot`: PASS (7.9s locally)
- Previous CI run: 926/927 passed — this was the sole failure
