### PR TITLE
fix(upgrade): add missing 0.11.0 columns to archive SQL snapshot

### DIFF
--- a/sql/archive/pg_trickle--0.11.0.sql
+++ b/sql/archive/pg_trickle--0.11.0.sql
@@ -67,6 +67,16 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_stream_tables (
     pooler_compatibility_mode BOOLEAN NOT NULL DEFAULT FALSE,
     refresh_tier    TEXT NOT NULL DEFAULT 'hot'
                      CHECK (refresh_tier IN ('hot', 'warm', 'cold', 'frozen')),
+    effective_refresh_mode TEXT,
+    fuse_mode       TEXT NOT NULL DEFAULT 'off'
+                     CHECK (fuse_mode IN ('off', 'on', 'auto')),
+    fuse_state      TEXT NOT NULL DEFAULT 'armed'
+                     CHECK (fuse_state IN ('armed', 'blown', 'disabled')),
+    fuse_ceiling    BIGINT,
+    fuse_sensitivity INT,
+    blown_at        TIMESTAMPTZ,
+    blow_reason     TEXT,
+    st_partition_key TEXT,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
Fixes test_upgrade_catalog_schema_stability on the 0.1.3→0.11.0 upgrade path.

The sql/archive/pg_trickle--0.11.0.sql snapshot was stale (identical to 0.10.0), missing 8 columns added in the 0.10.0→0.11.0 upgrade script: effective_refresh_mode, fuse_mode, fuse_state, fuse_ceiling, fuse_sensitivity, blown_at, blow_reason, st_partition_key.

Added all 8 columns with correct types and CHECK constraints. Column count now matches the 41 entries expected by the test.