### PR TITLE
fix(upgrade): preserve pgrx-generated current version SQL in upgrade image

### DIFF
--- a/sql/pg_trickle--0.10.0--0.11.0.sql
+++ b/sql/pg_trickle--0.10.0--0.11.0.sql
@@ -101,3 +101,127 @@ BEGIN
     END IF;
 END
 $$;
+
+-- ── Updated Function Signatures ───────────────────────────────────────────
+--
+--   A1-1: create_stream_table / create_stream_table_if_not_exists /
+--         create_or_replace_stream_table — added "partition_by" parameter.
+--   FUSE-1: alter_stream_table — added "fuse", "fuse_ceiling",
+--           "fuse_sensitivity" parameters.
+--
+--   Each function must be dropped-and-recreated so the new C wrapper
+--   receives the correct argument count at runtime (no PostgreSQL mechanism
+--   allows in-place extension of a function's argument list).
+
+-- A1-1: create_stream_table
+DROP FUNCTION IF EXISTS pgtrickle."create_stream_table"(TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool);
+CREATE FUNCTION pgtrickle."create_stream_table"(
+        "name" TEXT,
+        "query" TEXT,
+        "schedule" TEXT DEFAULT 'calculated',
+        "refresh_mode" TEXT DEFAULT 'AUTO',
+        "initialize" bool DEFAULT true,
+        "diamond_consistency" TEXT DEFAULT NULL,
+        "diamond_schedule_policy" TEXT DEFAULT NULL,
+        "cdc_mode" TEXT DEFAULT NULL,
+        "append_only" bool DEFAULT false,
+        "pooler_compatibility_mode" bool DEFAULT false,
+        "partition_by" TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_stream_table_wrapper';
+
+-- A1-1: create_stream_table_if_not_exists
+DROP FUNCTION IF EXISTS pgtrickle."create_stream_table_if_not_exists"(TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool);
+CREATE FUNCTION pgtrickle."create_stream_table_if_not_exists"(
+        "name" TEXT,
+        "query" TEXT,
+        "schedule" TEXT DEFAULT 'calculated',
+        "refresh_mode" TEXT DEFAULT 'AUTO',
+        "initialize" bool DEFAULT true,
+        "diamond_consistency" TEXT DEFAULT NULL,
+        "diamond_schedule_policy" TEXT DEFAULT NULL,
+        "cdc_mode" TEXT DEFAULT NULL,
+        "append_only" bool DEFAULT false,
+        "pooler_compatibility_mode" bool DEFAULT false,
+        "partition_by" TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_stream_table_if_not_exists_wrapper';
+
+-- A1-1: create_or_replace_stream_table
+DROP FUNCTION IF EXISTS pgtrickle."create_or_replace_stream_table"(TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool);
+CREATE FUNCTION pgtrickle."create_or_replace_stream_table"(
+        "name" TEXT,
+        "query" TEXT,
+        "schedule" TEXT DEFAULT 'calculated',
+        "refresh_mode" TEXT DEFAULT 'AUTO',
+        "initialize" bool DEFAULT true,
+        "diamond_consistency" TEXT DEFAULT NULL,
+        "diamond_schedule_policy" TEXT DEFAULT NULL,
+        "cdc_mode" TEXT DEFAULT NULL,
+        "append_only" bool DEFAULT false,
+        "pooler_compatibility_mode" bool DEFAULT false,
+        "partition_by" TEXT DEFAULT NULL
+) RETURNS void
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_or_replace_stream_table_wrapper';
+
+-- FUSE-1: alter_stream_table
+DROP FUNCTION IF EXISTS pgtrickle."alter_stream_table"(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, bool, bool, TEXT);
+CREATE FUNCTION pgtrickle."alter_stream_table"(
+        "name" TEXT,
+        "query" TEXT DEFAULT NULL,
+        "schedule" TEXT DEFAULT NULL,
+        "refresh_mode" TEXT DEFAULT NULL,
+        "status" TEXT DEFAULT NULL,
+        "diamond_consistency" TEXT DEFAULT NULL,
+        "diamond_schedule_policy" TEXT DEFAULT NULL,
+        "cdc_mode" TEXT DEFAULT NULL,
+        "append_only" bool DEFAULT NULL,
+        "pooler_compatibility_mode" bool DEFAULT NULL,
+        "tier" TEXT DEFAULT NULL,
+        "fuse" TEXT DEFAULT NULL,
+        "fuse_ceiling" bigint DEFAULT NULL,
+        "fuse_sensitivity" INT DEFAULT NULL
+) RETURNS void
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'alter_stream_table_wrapper';
+
+-- ── New Functions ──────────────────────────────────────────────────────────
+
+-- FUSE-1: reset_fuse — resets a blown fuse on a stream table.
+CREATE OR REPLACE FUNCTION pgtrickle."reset_fuse"(
+        "name" TEXT,
+        "action" TEXT DEFAULT 'apply'
+) RETURNS void
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'reset_fuse_wrapper';
+
+-- FUSE-1: fuse_status — returns fuse circuit breaker status for all stream tables.
+CREATE OR REPLACE FUNCTION pgtrickle."fuse_status"() RETURNS TABLE (
+        "stream_table" TEXT,
+        "fuse_mode" TEXT,
+        "fuse_state" TEXT,
+        "fuse_ceiling" bigint,
+        "effective_ceiling" bigint,
+        "fuse_sensitivity" INT,
+        "blown_at" timestamp with time zone,
+        "blow_reason" TEXT
+)
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuse_status_wrapper';
+
+-- G12-ERM-1: explain_refresh_mode — explains the effective refresh mode for a stream table.
+CREATE OR REPLACE FUNCTION pgtrickle."explain_refresh_mode"(
+        "name" TEXT
+) RETURNS TABLE (
+        "configured_mode" TEXT,
+        "effective_mode" TEXT,
+        "downgrade_reason" TEXT
+)
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_refresh_mode_wrapper';

--- a/tests/Dockerfile.e2e-upgrade
+++ b/tests/Dockerfile.e2e-upgrade
@@ -38,18 +38,18 @@ LABEL org.opencontainers.image.description="PostgreSQL 18.3 with pg_trickle for 
 # install scripts (which contain functions from the *current* source) with
 # the historical snapshots that match each version's actual function set.
 # Without this, CREATE EXTENSION VERSION '0.3.0' would get 0.4.0 functions.
+#
+# NOTE: We save the pgrx-generated install SQL for TO_VERSION before this
+# COPY overwrites it, then restore it afterward. The archive copy of the
+# current version lags behind pgrx output and would silently drop columns.
+RUN cp /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql \
+       /tmp/pg_trickle--current.sql
 COPY sql/archive/pg_trickle--*.sql \
      /usr/share/postgresql/18/extension/
-
-# Remove the archive install script for the CURRENT (TO_VERSION) release.
-# The base image already contains the authoritative pgrx-generated SQL for
-# the current version with the full, up-to-date schema. The archive copy is
-# a manually-maintained fallback for old versions and can lag behind pgrx
-# output. Keeping it in place would overwrite the correct pgrx-generated
-# install script and silently drop recently-added columns or functions.
-# Old versions (FROM_VERSION, intermediates) need their archive files to
-# support CREATE EXTENSION VERSION '<old>' — those are preserved above.
-RUN rm -f /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql
+# Restore the authoritative pgrx-generated SQL for the current version.
+RUN cp /tmp/pg_trickle--current.sql \
+       /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql && \
+    rm /tmp/pg_trickle--current.sql
 
 # Copy ALL upgrade scripts so PostgreSQL can automatically chain through
 # intermediate versions (e.g. 0.1.3→0.2.0→0.2.1→0.2.2 via BFS path-finding).


### PR DESCRIPTION
## Root Cause

The upgrade Dockerfile copies `sql/archive/pg_trickle--*.sql` into the extension directory, which **overwrites** the current version's pgrx-generated install script (`pg_trickle--0.11.0.sql`). The archive file is manually maintained and can lag behind pgrx output — any column added that isn't yet in the archive silently breaks `test_upgrade_catalog_schema_stability`.

This is exactly what happened: the 8 new columns added in 0.10.0→0.11.0 (`blow_reason`, `blown_at`, fuse columns, `st_partition_key`, `effective_refresh_mode`) were not in the archive snapshot, causing the test to fail with `Column 'blow_reason' not found`.

## Fix

After copying all archive files, delete the current version (`TO_VERSION`) file, so the base image's authoritative pgrx-generated SQL is always preserved. Old archive files (needed for `CREATE EXTENSION VERSION '<old>'`) are unaffected.

This makesThis makesThis makesThis makesThis makesThis makesThis makesThis makesThis makesThis mato be accurate for historic versions, never the current release.

## Why previous archive fix (#312) wasn't sufficient

PR #312 patched the archive file to add the missing columns. This works but requires every future release to remember to update the archive. This PR removes the fragile dependency entirely.