### PR TITLE
fix(upgrade): make TO_VERSION SQL save conditional in upgrade Dockerfile

### DIFF
--- a/tests/Dockerfile.e2e-upgrade
+++ b/tests/Dockerfile.e2e-upgrade
@@ -42,14 +42,19 @@ LABEL org.opencontainers.image.description="PostgreSQL 18.3 with pg_trickle for 
 # NOTE: We save the pgrx-generated install SQL for TO_VERSION before this
 # COPY overwrites it, then restore it afterward. The archive copy of the
 # current version lags behind pgrx output and would silently drop columns.
+# When TO_VERSION is an old release (e.g. upgrading 0.2.2→0.2.3 where the
+# base image has 0.11.0), the file won't exist — the archive provides it.
 RUN cp /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql \
-       /tmp/pg_trickle--current.sql
+       /tmp/pg_trickle--current.sql 2>/dev/null || true
 COPY sql/archive/pg_trickle--*.sql \
      /usr/share/postgresql/18/extension/
-# Restore the authoritative pgrx-generated SQL for the current version.
-RUN cp /tmp/pg_trickle--current.sql \
-       /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql && \
-    rm /tmp/pg_trickle--current.sql
+# Restore the authoritative pgrx-generated SQL for the current version only
+# if it was saved above (i.e. when TO_VERSION is the current release).
+RUN if [ -f /tmp/pg_trickle--current.sql ]; then \
+      cp /tmp/pg_trickle--current.sql \
+         /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql && \
+      rm /tmp/pg_trickle--current.sql; \
+    fi
 
 # Copy ALL upgrade scripts so PostgreSQL can automatically chain through
 # intermediate versions (e.g. 0.1.3→0.2.0→0.2.1→0.2.2 via BFS path-finding).


### PR DESCRIPTION
## Summary

Fixes `test_wal_fallback_on_missing_slot` — the last failing E2E test in CI (926/927 passed, 1 failed with 3 retries).

## Root Cause

In `auto` CDC mode, after `abort_wal_transition()` sets `cdc_mode = TRIGGER`, the scheduler re-promotes the source back to WAL within its next tick (~1s). The TRIGGER state window is too narrow for `wait_for_cdc_mode`'s 500ms polling loop to reliably observe it, causing the test to time out after 60s on all 3 retry attempts.

## Fix

Add `ALTER SYSTEM SET pg_trickle.cdc_mode = 'trigger'` + `pg_reload_conf()` immediately after dropping the replication slot — pinning the global CDC mode to TRIGGER so the scheduler cannot re-promote the source back to WAL. This is the exact same pattern already used by the analogous `test_ec34_check_cdc_health_detects_missing_slot` test, which passes reliably.

## Test Results

- `test_wal_fallback_on_missing_slot`: PASS (7.9s locally)
- Previous CI run: 926/927 passed — this was the sole failure
