### PR TITLE
fix(upgrade): save/restore current-release SQL via control file, not TO_VERSION

### DIFF
--- a/tests/Dockerfile.e2e-upgrade
+++ b/tests/Dockerfile.e2e-upgrade
@@ -39,22 +39,27 @@ LABEL org.opencontainers.image.description="PostgreSQL 18.3 with pg_trickle for 
 # the historical snapshots that match each version's actual function set.
 # Without this, CREATE EXTENSION VERSION '0.3.0' would get 0.4.0 functions.
 #
-# NOTE: We save the pgrx-generated install SQL for TO_VERSION before this
-# COPY overwrites it, then restore it afterward. The archive copy of the
-# current version lags behind pgrx output and would silently drop columns.
-# When TO_VERSION is an old release (e.g. upgrading 0.2.2→0.2.3 where the
-# base image has 0.11.0), the file won't exist — the archive provides it.
-RUN cp /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql \
-       /tmp/pg_trickle--current.sql 2>/dev/null || true
+# The archive COPY also overwrites the *current* release's SQL (e.g.
+# pg_trickle--0.11.0.sql) with a stale snapshot. That snapshot may be missing
+# columns or function signatures added after the archive was cut, causing
+# "unboxing ... argument failed" errors at runtime. We must always preserve
+# the pgrx-generated SQL for the current default_version — regardless of
+# whether TO_VERSION matches the current release or is a historic version.
+#
+# Strategy: read default_version from the control file, save that file before
+# the COPY, restore it after.
+RUN current_ver=$(sed -n "s/^default_version = '\\(.*\\)'$/\\1/p" \
+        /usr/share/postgresql/18/extension/pg_trickle.control) && \
+    cp "/usr/share/postgresql/18/extension/pg_trickle--${current_ver}.sql" \
+       /tmp/pg_trickle--current-release.sql
 COPY sql/archive/pg_trickle--*.sql \
      /usr/share/postgresql/18/extension/
-# Restore the authoritative pgrx-generated SQL for the current version only
-# if it was saved above (i.e. when TO_VERSION is the current release).
-RUN if [ -f /tmp/pg_trickle--current.sql ]; then \
-      cp /tmp/pg_trickle--current.sql \
-         /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql && \
-      rm /tmp/pg_trickle--current.sql; \
-    fi
+# Restore the authoritative pgrx-generated SQL for the current release.
+RUN current_ver=$(sed -n "s/^default_version = '\\(.*\\)'$/\\1/p" \
+        /usr/share/postgresql/18/extension/pg_trickle.control) && \
+    cp /tmp/pg_trickle--current-release.sql \
+       "/usr/share/postgresql/18/extension/pg_trickle--${current_ver}.sql" && \
+    rm /tmp/pg_trickle--current-release.sql
 
 # Copy ALL upgrade scripts so PostgreSQL can automatically chain through
 # intermediate versions (e.g. 0.1.3→0.2.0→0.2.1→0.2.2 via BFS path-finding).


### PR DESCRIPTION
## Problem

After #315, upgrade jobs for **historic pairs** (e.g. `0.5.0 → 0.6.0`) still fail with:

```
unboxing partition_by_ argument failed
SQL: SELECT pgtrickle.create_stream_table('lr_st', ...)
```

**Root cause:** #315 fixed the case where `TO_VERSION` equals the current release (0.11.0 → saves/restores that file). But for historic pairs like `0.5.0 → 0.6.0`, `TO_VERSION = 0.6.0` which doesn't exist in the base image — the save is silently skipped. The archive `COPY` then overwrites `pg_trickle--0.11.0.sql` with the stale archive snapshot. That snapshot is missing `partition_by` in `create_stream_table`. When `E2eDb::with_extension()` calls `CREATE EXTENSION` (with no version, picks up `default_version = '0.11.0'`), it installs the old schema. Any call to `create_stream_table` then fails because the binary expects the new 5-arg signature but PostgreSQL dispatches the old 4-arg one.

## Fix

Instead of keying off `TO_VERSION` (which only matches the currenInstead of keying off `TO_VERSION` (whm `pg_trickle.Instead of keying off `TO_VERSION` (which only matches the currenInstead of keying off `it befoInstead of keying off `TO_VERSION` (wCOPY`:

```dockerfile
RUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUersRUN current_ver=$(sed -n "s/^defaultRUernt_ver}.sql" && \
    rm /tmp/pg_trickle--current-release.sql
```

This works for **all** upgrade pairs:
- Historic pairs (`0.5.0 → 0.6.0`): saves `0.11.0` SQL, archive o- Hisite- Historic pairs (`0.5.0 → 0.6.0`): saves `0.11.0` SQL, archive o- Hisite- Historic pairs (`0.5.0 → 0.6.0`): saves `0.11.0` SQL, archive o- Hisite- Historic pairs (`0.5.0 → 0.6.0`): saves `0.11.0` SQL, archive o- Hisite- Historic pairs (`0.5.0 →  3 - Historic pequire `PGS_UPGRADE_TO` to match the binary version).
