### PR TITLE
fix(upgrade): save/restore current-release SQL via control file, not TO_VERSION

### DIFF
--- a/tests/Dockerfile.e2e-upgrade
+++ b/tests/Dockerfile.e2e-upgrade
@@ -39,22 +39,27 @@ LABEL org.opencontainers.image.description="PostgreSQL 18.3 with pg_trickle for 
 # the historical snapshots that match each version's actual function set.
 # Without this, CREATE EXTENSION VERSION '0.3.0' would get 0.4.0 functions.
 #
-# NOTE: We save the pgrx-generated install SQL for TO_VERSION before this
-# COPY overwrites it, then restore it afterward. The archive copy of the
-# current version lags behind pgrx output and would silently drop columns.
-# When TO_VERSION is an old release (e.g. upgrading 0.2.2→0.2.3 where the
-# base image has 0.11.0), the file won't exist — the archive provides it.
-RUN cp /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql \
-       /tmp/pg_trickle--current.sql 2>/dev/null || true
+# The archive COPY also overwrites the *current* release's SQL (e.g.
+# pg_trickle--0.11.0.sql) with a stale snapshot. That snapshot may be missing
+# columns or function signatures added after the archive was cut, causing
+# "unboxing ... argument failed" errors at runtime. We must always preserve
+# the pgrx-generated SQL for the current default_version — regardless of
+# whether TO_VERSION matches the current release or is a historic version.
+#
+# Strategy: read default_version from the control file, save that file before
+# the COPY, restore it after.
+RUN current_ver=$(sed -n "s/^default_version = '\\(.*\\)'$/\\1/p" \
+        /usr/share/postgresql/18/extension/pg_trickle.control) && \
+    cp "/usr/share/postgresql/18/extension/pg_trickle--${current_ver}.sql" \
+       /tmp/pg_trickle--current-release.sql
 COPY sql/archive/pg_trickle--*.sql \
      /usr/share/postgresql/18/extension/
-# Restore the authoritative pgrx-generated SQL for the current version only
-# if it was saved above (i.e. when TO_VERSION is the current release).
-RUN if [ -f /tmp/pg_trickle--current.sql ]; then \
-      cp /tmp/pg_trickle--current.sql \
-         /usr/share/postgresql/18/extension/pg_trickle--${TO_VERSION}.sql && \
-      rm /tmp/pg_trickle--current.sql; \
-    fi
+# Restore the authoritative pgrx-generated SQL for the current release.
+RUN current_ver=$(sed -n "s/^default_version = '\\(.*\\)'$/\\1/p" \
+        /usr/share/postgresql/18/extension/pg_trickle.control) && \
+    cp /tmp/pg_trickle--current-release.sql \
+       "/usr/share/postgresql/18/extension/pg_trickle--${current_ver}.sql" && \
+    rm /tmp/pg_trickle--current-release.sql
 
 # Copy ALL upgrade scripts so PostgreSQL can automatically chain through
 # intermediate versions (e.g. 0.1.3→0.2.0→0.2.1→0.2.2 via BFS path-finding).


### PR DESCRIPTION
## Problem

After #315, upgrade jobs for **historic pairs** (e.g. `0.5.0 → 0.6.0`) still fail with:

```
unboxing partition_by_ argument failed
SQL: SELECT pgtrickle.create_stream_table('lr_st', ...)
```

**Root cause:** #315 protected `pg_trickle--${TO_VERSION}.sql` — but for historic pairs like `0.5.0 → 0.6.0`, `TO_VERSION = 0.6.0` doesn't exist in the base image. The save was silently skipped, so the archive `COPY` still overwrote `pg_trickle--0.11.0.sql` with the stale archive snapshot. That snapshot lacks `partition_by` in `create_stream_table`. When `E2eDb::with_extension()` calls `CREATE EXTENSION` (picking up `default_version = '0.11.0'`), it installs the old schema and all calls to `create_stream_table` fail.

## Fix

Instead of keying off `TO_VERSION`, read `default_version` from `pg_trickle.control` to find the authoritative SQL file and unconditionally save/restore it:

```dockerfile
RUN current_ver=$(sed -n "s/^default_version = '\(.*\)'$/\1/p" \
                                          /p         .co                                          /p         .co                                
                                           
COPY sql/archive/pg_trickle--*.sql \
     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq     /usr/share/post  esq upgrade tests pass.
