### PR TITLE
fix(upgrade): add missing refresh_tier column to 0.10.0→0.11.0 upgrade script

### DIFF
--- a/sql/pg_trickle--0.10.0--0.11.0.sql
+++ b/sql/pg_trickle--0.10.0--0.11.0.sql
@@ -35,6 +35,23 @@
 ALTER TABLE pgtrickle.pgt_stream_tables
     ADD COLUMN IF NOT EXISTS effective_refresh_mode TEXT;
 
+-- DAG perf: refresh_tier for hot/warm/cold/frozen scheduling tiers
+ALTER TABLE pgtrickle.pgt_stream_tables
+    ADD COLUMN IF NOT EXISTS refresh_tier TEXT NOT NULL DEFAULT 'hot';
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'pgt_stream_tables_refresh_tier_check'
+          AND conrelid = 'pgtrickle.pgt_stream_tables'::regclass
+    ) THEN
+        ALTER TABLE pgtrickle.pgt_stream_tables
+            ADD CONSTRAINT pgt_stream_tables_refresh_tier_check
+            CHECK (refresh_tier IN ('hot', 'warm', 'cold', 'frozen'));
+    END IF;
+END
+$$;
+
 -- FUSE-1: Fuse circuit breaker columns
 ALTER TABLE pgtrickle.pgt_stream_tables
     ADD COLUMN IF NOT EXISTS fuse_mode TEXT NOT NULL DEFAULT 'off';


### PR DESCRIPTION
## Problem

`just check-upgrade-all` fails:

```
━━━ Checking upgrade: 0.10.0 → 0.11.0 ━━━
Check 6: Column drift in existing tables
  ERROR: 1 new column(s) missing ADD COLUMN in upgrade script:
    - pgtrickle.pgt_stream_tables.refresh_tier
```

`refresh_tier` was added to `pgt_stream_tables` in the 0.11.0 DAG performance work (hot/warm/cold/frozen scheduling tiers) but was omitted from the upgrade script.

## Fix

Add `ADD COLUMN IF NOT EXISTS refresh_tier TEXT NOT NULL DEFAULT 'hot'` plus its CHECK constraint (idempotent DO block) to `sql/pg_trickle--0.10.0--0.11.0.sql`.

`just check-upgrade-all` passes after this change.