### PR TITLE
perf: add timing instrumentation to EC01B-2 TPC-H tests

### DIFF
--- a/tests/e2e_tpch_tests.rs
+++ b/tests/e2e_tpch_tests.rs
@@ -3106,7 +3106,6 @@ async fn ec01b_combined_delete_test(qname: &str, query_sql: &str) {
         }
         Err(e) => panic!("{qname} refresh error after combined delete: {e}"),
     }
-    let t = Instant::now();
 
     assert_tpch_invariant(&db, &st_name, query_sql, qname, 1)
         .await


### PR DESCRIPTION
Measure refresh latency for Q7/Q8/Q9 combined-delete cycles and stability cycles to track EC01B-1 per-leaf CTE performance impact on deep join trees.