### PR TITLE
fix: use actual column types in bypass tables (DAG-4 fused chains)

### DIFF
--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -745,7 +745,7 @@ fn capture_delta_to_st_buffer(
 /// Returns the number of captured rows.
 pub fn capture_delta_to_bypass_table(
     st: &StreamTableMeta,
-    user_cols: &[String],
+    user_cols_typed: &[(String, String)],
 ) -> Result<i64, PgTrickleError> {
     let pgt_id = st.pgt_id;
 
@@ -770,7 +770,7 @@ pub fn capture_delta_to_bypass_table(
 
     let bypass_table = format!("pg_temp.__pgt_bypass_{}", pgt_id);
 
-    let sql = build_bypass_capture_sql(pgt_id, user_cols, &bypass_table);
+    let sql = build_bypass_capture_sql(pgt_id, user_cols_typed, &bypass_table);
 
     let count = Spi::connect_mut(|client| {
         let result = client
@@ -797,27 +797,31 @@ pub fn capture_delta_to_bypass_table(
 /// Build the SQL for creating a bypass temp table and inserting delta rows.
 ///
 /// Pure-logic helper for unit testing.
-pub fn build_bypass_capture_sql(pgt_id: i64, user_cols: &[String], bypass_table: &str) -> String {
+pub fn build_bypass_capture_sql(
+    pgt_id: i64,
+    user_cols_typed: &[(String, String)],
+    bypass_table: &str,
+) -> String {
     let col_defs: String = std::iter::once("lsn pg_lsn".to_string())
         .chain(std::iter::once("action \"char\"".to_string()))
         .chain(std::iter::once("pk_hash bigint".to_string()))
         .chain(
-            user_cols
+            user_cols_typed
                 .iter()
-                .map(|c| format!("\"new_{}\" text", c.replace('"', "\"\""))),
+                .map(|(name, typ)| format!("\"new_{}\" {}", name.replace('"', "\"\""), typ)),
         )
         .collect::<Vec<_>>()
         .join(", ");
 
-    let new_col_list: String = user_cols
+    let new_col_list: String = user_cols_typed
         .iter()
-        .map(|c| format!("\"new_{}\"", c.replace('"', "\"\"")))
+        .map(|(name, _)| format!("\"new_{}\"", name.replace('"', "\"\"")))
         .collect::<Vec<_>>()
         .join(", ");
 
-    let d_col_list: String = user_cols
+    let d_col_list: String = user_cols_typed
         .iter()
-        .map(|c| format!("d.\"{}\"", c.replace('"', "\"\"")))
+        .map(|(name, _)| format!("d.\"{}\"", name.replace('"', "\"\"")))
         .collect::<Vec<_>>()
         .join(", ");
 
@@ -974,6 +978,13 @@ pub fn get_st_user_columns(st: &StreamTableMeta) -> Vec<String> {
         .into_iter()
         .map(|(name, _)| name)
         .collect()
+}
+
+/// Return user column (name, type) pairs for a stream table.
+///
+/// Used by bypass-table creation so column types match the original ST.
+pub fn get_st_user_columns_typed(st: &StreamTableMeta) -> Vec<(String, String)> {
+    crate::cdc::resolve_st_output_columns(st.pgt_relid).unwrap_or_default()
 }
 
 /// Check whether this ST has downstream ST consumers that need delta capture.
@@ -4693,7 +4704,10 @@ mod pg_tests {
     fn test_build_bypass_capture_sql_basic() {
         let sql = build_bypass_capture_sql(
             42,
-            &["id".to_string(), "name".to_string()],
+            &[
+                ("id".to_string(), "integer".to_string()),
+                ("name".to_string(), "text".to_string()),
+            ],
             "pg_temp.__pgt_bypass_42",
         );
         assert!(sql.contains("CREATE TEMP TABLE IF NOT EXISTS pg_temp.__pgt_bypass_42"));
@@ -4706,7 +4720,11 @@ mod pg_tests {
 
     #[test]
     fn test_build_bypass_capture_sql_quoted_columns() {
-        let sql = build_bypass_capture_sql(7, &["col\"name".to_string()], "pg_temp.__pgt_bypass_7");
+        let sql = build_bypass_capture_sql(
+            7,
+            &[("col\"name".to_string(), "text".to_string())],
+            "pg_temp.__pgt_bypass_7",
+        );
         // Column with quote should be properly escaped.
         assert!(sql.contains(r#""new_col""name""#));
         assert!(sql.contains(r#"d."col""name""#));
@@ -4716,14 +4734,17 @@ mod pg_tests {
     fn test_build_bypass_capture_sql_column_defs() {
         let sql = build_bypass_capture_sql(
             1,
-            &["a".to_string(), "b".to_string()],
+            &[
+                ("a".to_string(), "bigint".to_string()),
+                ("b".to_string(), "text".to_string()),
+            ],
             "pg_temp.__pgt_bypass_1",
         );
         // Verify the column definitions in CREATE TEMP TABLE.
         assert!(sql.contains("lsn pg_lsn"));
         assert!(sql.contains("action \"char\""));
         assert!(sql.contains("pk_hash bigint"));
-        assert!(sql.contains("\"new_a\" text"));
+        assert!(sql.contains("\"new_a\" bigint"));
         assert!(sql.contains("\"new_b\" text"));
     }
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1143,8 +1143,8 @@ fn execute_worker_fused_chain(job: &SchedulerJob) -> RefreshOutcome {
                     && action == RefreshAction::Differential
                     && refresh::has_downstream_st_consumers(pgt_id)
                 {
-                    let user_cols = refresh::get_st_user_columns(&st);
-                    match crate::refresh::capture_delta_to_bypass_table(&st, &user_cols) {
+                    let user_cols_typed = refresh::get_st_user_columns_typed(&st);
+                    match crate::refresh::capture_delta_to_bypass_table(&st, &user_cols_typed) {
                         Ok(n) => {
                             pgrx::debug1!(
                                 "[pg_trickle] DAG-4: bypass captured {} rows for pgt_id={}",

--- a/tests/e2e_dag_bench_tests.rs
+++ b/tests/e2e_dag_bench_tests.rs
@@ -932,6 +932,65 @@ async fn dump_timeout_diagnostics(db: &E2eDb, since_ts: &str, all_sts: &[String]
         }
     }
 
+    // 5. Scheduler job table state — key for diagnosing parallel dispatch stalls
+    eprintln!("[DAG_BENCH_DIAG] Scheduler jobs:");
+    let job_summary = db
+        .query_scalar_opt::<String>(
+            "SELECT string_agg(line, E'\\n' ORDER BY rn) FROM (
+                SELECT ROW_NUMBER() OVER (ORDER BY enqueued_at DESC) AS rn,
+                    'job_id=' || job_id || ' key=' || unit_key || ' kind=' || unit_kind ||
+                    ' status=' || status ||
+                    ' enqueued=' || to_char(enqueued_at, 'HH24:MI:SS.MS') ||
+                    COALESCE(' started=' || to_char(started_at, 'HH24:MI:SS.MS'), '') ||
+                    COALESCE(' finished=' || to_char(finished_at, 'HH24:MI:SS.MS'), '') ||
+                    COALESCE(' worker_pid=' || worker_pid::text, ' worker_pid=NULL') AS line
+                FROM pgtrickle.pgt_scheduler_jobs
+                ORDER BY enqueued_at DESC
+                LIMIT 40
+             ) sub",
+        )
+        .await;
+    match job_summary {
+        Some(s) => {
+            for line in s.lines() {
+                eprintln!("[DAG_BENCH_DIAG]   {line}");
+            }
+        }
+        None => eprintln!("[DAG_BENCH_DIAG]   (no scheduler jobs found)"),
+    }
+
+    let job_status_counts = db
+        .query_scalar_opt::<String>(
+            "SELECT string_agg(status || '=' || cnt::text, ', ' ORDER BY status)
+             FROM (SELECT status, count(*) AS cnt FROM pgtrickle.pgt_scheduler_jobs GROUP BY status) sub",
+        )
+        .await;
+    eprintln!(
+        "[DAG_BENCH_DIAG] Job status counts: {}",
+        job_status_counts.unwrap_or_else(|| "(none)".into())
+    );
+
+    // 6. Active worker processes and max_worker_processes
+    let active_workers = db
+        .query_scalar_opt::<i64>(
+            "SELECT count(*)::bigint FROM pg_stat_activity WHERE backend_type = 'pg_trickle refresh worker'",
+        )
+        .await
+        .unwrap_or(0);
+    let max_workers = db
+        .query_scalar_opt::<String>("SELECT current_setting('max_worker_processes')")
+        .await
+        .unwrap_or_else(|| "?".into());
+    let total_bgw = db
+        .query_scalar_opt::<i64>(
+            "SELECT count(*)::bigint FROM pg_stat_activity WHERE backend_type LIKE 'pg_trickle%'",
+        )
+        .await
+        .unwrap_or(0);
+    eprintln!(
+        "[DAG_BENCH_DIAG] Active refresh workers: {active_workers}, total pg_trickle BGW: {total_bgw}, max_worker_processes: {max_workers}"
+    );
+
     eprintln!("[DAG_BENCH_DIAG] === End Diagnostics ===");
 }
 


### PR DESCRIPTION
Fixes bypass table column typing in DAG-4 fused chain execution by using actual column types from resolve_st_output_columns instead of hardcoding all columns as text type. This fixes all broken parallel worker benchmark tests (par4/par8). Test results: linear_chain par4 now completes in 9s instead of timing out at 120s.