### PR TITLE
fix(sql): add missing DI-7 columns to 0.13.0 base install

### DIFF
--- a/sql/archive/pg_trickle--0.13.0.sql
+++ b/sql/archive/pg_trickle--0.13.0.sql
@@ -77,6 +77,8 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_stream_tables (
     blown_at        TIMESTAMPTZ,
     blow_reason     TEXT,
     st_partition_key TEXT,
+    max_differential_joins INT,
+    max_delta_fraction DOUBLE PRECISION,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
## Problem

CI run [#1192](https://github.com/grove/pg-trickle/actions/runs/23757857003) failed on all three Light E2E shards and the dbt getting-started example with:

```
column "max_differential_joins" does not exist
```

Light E2E shard 3/3 timed out at 20 minutes (pgrx cache miss caused a full recompile that consumed the budget before tests could start).

## Root Cause

Commit 25b82a7 (DI-7: scan-count-aware strategy selector) added `max_differential_joins` and `max_delta_fraction` columns to the upgrade script (`sql/pg_trickle--0.12.0--0.13.0.sql`) but omitted them from the base install `CREATE TABLE` in `sql/archive/pg_trickle--0.13.0.sql`.

Fresh installs (which Light E2E and dbt use) create the table without these columns, but `src/catalog.rs` references them in every INSERT and SELECT.

## Fix

Add the two missing columns to the 0.13.0 base install SQL, placed after `st_partition_key` and before `created_at` (matching the upgrade script order).

## Validation

- `scripts/check_upgrade_completeness.sh 0.12.0 0.13.0` passes (2 new columns detected and covered)
- `just fmt` and `just lint` pass (SQL-only change, no Rust modifications)
