### PR TITLE
fix(sql): remove duplicate columns from pgt_stream_tables DDL (v0.13.0 fresh install broken)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,8 +276,6 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_stream_tables (
     blown_at        TIMESTAMPTZ,
     blow_reason     TEXT,
     st_partition_key TEXT,
-    max_differential_joins INT,
-    max_delta_fraction DOUBLE PRECISION,
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -311,7 +309,7 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_refresh_history (
     start_time      TIMESTAMPTZ NOT NULL,
     end_time        TIMESTAMPTZ,
     action          TEXT NOT NULL
-                     CHECK (action IN ('NO_DATA', 'FULL', 'DIFFERENTIAL', 'DIFFERENTIAL', 'REINITIALIZE', 'SKIP')),
+                     CHECK (action IN ('NO_DATA', 'FULL', 'DIFFERENTIAL', 'REINITIALIZE', 'SKIP')),
     rows_inserted   BIGINT DEFAULT 0,
     rows_deleted    BIGINT DEFAULT 0,
     delta_row_count BIGINT DEFAULT 0,


### PR DESCRIPTION
## Problem

Fresh installs of v0.13.0 failed with:

```
ERROR: column "max_differential_joins" specified more than once
```

The `CREATE TABLE pgtrickle.pgt_stream_tables` statement in `src/lib.rs` contained
`max_differential_joins INT` and `max_delta_fraction DOUBLE PRECISION` twice — once
correctly as part of the DI-7 feature, and again below `st_partition_key` as a
leftover duplicate from the implementation.

This caused the extension SQL generated by `cargo pgrx package` to fail on any fresh
install, including all E2E and TPC-H tests.

## Fix

- Remove the duplicate `max_differential_joins INT` and `max_delta_fraction DOUBLE PRECISION`
  lines from `src/lib.rs`.
- Fix a duplicate `'DIFFERENTIAL'` entry in the `pgt_refresh_history` action CHECK
  constraint (same file).

## Testing

`just lint` passes. Re-running `just test-tpch` against the fixed image will confirm
the regression is resolved.
