### PR TITLE
fix: retry CREATE DATABASE FROM TEMPLATE after terminating lingering backends

### DIFF
--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -195,6 +195,9 @@ async fn create_database(admin_connection_string: &str, db_name: &str) {
 /// pre-installed — no second `CREATE EXTENSION` run is needed.
 ///
 /// The template database must have zero active connections at call time.
+/// Background workers (e.g. the pg_trickle scheduler) may connect to the
+/// template after the extension is installed, so this function terminates
+/// any lingering backends and retries up to 10 times before giving up.
 #[cfg(not(feature = "light-e2e"))]
 async fn create_database_from_template(
     admin_connection_string: &str,
@@ -207,14 +210,37 @@ async fn create_database_from_template(
         .await
         .unwrap_or_else(|e| panic!("Failed to connect for CREATE DATABASE {db_name}: {e}"));
 
-    sqlx::query(&format!(
-        "CREATE DATABASE \"{db_name}\" TEMPLATE \"{template}\""
-    ))
-    .execute(&admin_pool)
-    .await
-    .unwrap_or_else(|e| panic!("Failed to CREATE DATABASE {db_name} from template: {e}"));
+    let create_sql = format!("CREATE DATABASE \"{db_name}\" TEMPLATE \"{template}\"");
+    let terminate_sql = format!(
+        "SELECT pg_terminate_backend(pid) \
+         FROM pg_stat_activity \
+         WHERE datname = '{template}' AND pid <> pg_backend_pid()"
+    );
 
-    admin_pool.close().await;
+    let mut last_err = None;
+    for attempt in 0u64..10 {
+        if attempt > 0 {
+            // Terminate any backends connected to the template DB
+            // (e.g. background workers that auto-connected after extension install).
+            let _ = sqlx::query(&terminate_sql).execute(&admin_pool).await;
+            tokio::time::sleep(std::time::Duration::from_millis(100 * attempt)).await;
+        }
+
+        match sqlx::query(&create_sql).execute(&admin_pool).await {
+            Ok(_) => {
+                admin_pool.close().await;
+                return;
+            }
+            Err(e) => {
+                last_err = Some(e);
+            }
+        }
+    }
+
+    panic!(
+        "Failed to CREATE DATABASE {db_name} from template after 10 attempts: {}",
+        last_err.unwrap()
+    );
 }
 
 /// Install pg_trickle once into a dedicated template database so that each


### PR DESCRIPTION
## Problem

CI run [#1220](https://github.com/grove/pg-trickle/actions/runs/23791546268) failed in three jobs:

- **E2E tests** -- test_auto_refresh_differential_mode
- **DAG bench (calc/throughput)** -- bench_latency_diamond_4_calc
- **DAG bench (parallel workers)** -- bench_latency_fanout_b2d5_par8

All failed with the same error:

```
source database "pgt_ext_template_<pid>" is being accessed by other users
```

The pg_trickle background worker (scheduler) connects to the template database after the extension is installed during create_extension_template(). When create_database_from_template() then tries to clone from it, PostgreSQL rejects the operation because the template has active connections.

(The fourth failure -- Light E2E 1/3 timeout -- was a CI infrastructure issue: setup-pgrx took 19 min, exceeding the 20 min job timeout.)

## Fix

create_database_from_template() now retries up to 10 times with exponential back-off (100ms, 200ms, ...). Before each retry, it terminates any backends connected to the template database via pg_terminate_backend().
