### PR TITLE
docs: add Step 0 GUC verification to stalled data flow diagnostic guide

### DIFF
--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -2421,6 +2421,41 @@ despite DML on the source tables -- follow this systematic diagnostic workflow.
 Each step narrows the problem from broad health checks down to specific root
 causes.
 
+**Step 0 -- Verify GUC configuration:**
+
+Misconfigured GUCs are a common and easy-to-miss cause of stalled or
+severely throttled data flow. Check all pg_trickle settings in one query:
+
+```sql
+SELECT name, setting, unit
+FROM pg_settings
+WHERE name LIKE 'pg_trickle.%'
+   OR name = 'max_worker_processes'
+ORDER BY name;
+```
+
+Key values to check:
+
+| GUC | Safe value | Problem if set to |
+|---|---|---|
+| `pg_trickle.enabled` | `on` | `off` -- stops all automatic refreshes |
+| `pg_trickle.tiered_scheduling` | `on` (fine) | `on` with all STs at `tier = 'frozen'` -- silently skips them |
+| `pg_trickle.max_consecutive_errors` | `3`-`10` | `1` -- one transient error suspends the ST permanently |
+| `pg_trickle.scheduler_interval_ms` | `100`-`1000` | Very high (e.g. `60000`) -- scheduler only wakes every 60 s |
+| `pg_trickle.event_driven_wake` | `on` | `off` -- falls back to poll-only; latency equals `scheduler_interval_ms` |
+| `pg_trickle.wake_debounce_ms` | `1`-`50` | Very high (e.g. `5000`) -- coalesces notifications for 5 s before acting |
+| `pg_trickle.auto_backoff` | `on` | Fine normally, but if refreshes take >95% of schedule it silently stretches intervals up to 8x |
+| `pg_trickle.default_schedule_seconds` | `1`-`60` | Very high -- isolated CALCULATED tables refresh very infrequently |
+| `max_worker_processes` | `>= 16` (typical) | Too low -- workers cannot be spawned; parallel mode silently stalls |
+
+Also check whether any stream tables are frozen:
+
+```sql
+SELECT pgt_name, refresh_tier
+FROM pgtrickle.pgt_stream_tables
+WHERE refresh_tier = 'frozen';
+```
+
 **Step 1 -- Quick health overview:**
 
 ```sql


### PR DESCRIPTION
## Summary

Extends the "How do I diagnose stalled data flow through stream tables?" guide in `docs/FAQ.md` with a new **Step 0 -- Verify GUC configuration** check, inserted before the existing Step 1.

Depends on #362.

## Motivation

Misconfigured GUCs are a frequent and easy-to-miss root cause of stalled or throttled refresh pipelines. Several GUCs that directly affect scheduler behaviour -- `pg_trickle.enabled`, `tiered_scheduling` with frozen tiers, `max_consecutive_errors = 1`, high `scheduler_interval_ms`, disabled `event_driven_wake`, high `wake_debounce_ms`, `auto_backoff` silently stretching intervals, and insufficient `max_worker_processes` -- are not surfaced by `health_check()` alone.

## Changes

- `docs/FAQ.md`: adds Step 0 to the stalled data flow diagnostic guide with:
  - A single query to dump all `pg_trickle.*` GUCs plus `max_worker_processes`
  - A reference table mapping each relevant GUC to safe values and the failure mode when misconfigured
  - A follow-up query to detect `tier = 'frozen'` stream tables

## Testing

Documentation-only change. No code changes.
