### PR TITLE
fix(ci): prevent 40-min Setup pgrx hang from oversized stale target cache

### DIFF
--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -48,10 +48,12 @@ runs:
       uses: actions/cache@v5
       with:
         path: target
-        key: v2-cargo-build-pgrx0.17-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS || 'unknown' }}-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          v2-cargo-build-pgrx0.17-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS || 'unknown' }}-
-          v2-cargo-build-pgrx0.17-${{ runner.os }}-${{ runner.arch }}-
+        # v3: drop restore-keys fallback. Restoring a stale oversized cache
+        # from a different branch/commit (via the fallback prefix match) was
+        # causing 40+ minute hangs because the target/ dir reaches 30 GB+.
+        # On a cache miss we now compile fresh (15-20 min) rather than
+        # spending longer downloading an irrelevant stale cache.
+        key: v3-cargo-build-pgrx0.17-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS || 'unknown' }}-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Cache cargo-pgrx binary
       id: cache-cargo-pgrx


### PR DESCRIPTION
The target/ dir grows to 30 GB+ (18 GB debug/deps from 90 E2E test binaries). The restore-keys fallback was matching a large stale cache from another branch, causing 40+ min hangs. Fix: bump to v3 key + drop restore-keys so cache miss triggers a fresh compile instead.