### PR TITLE
fix(upgrade): correct 0.11.0->0.12.0 and 0.12.0->0.13.0 upgrade scripts

### DIFF
--- a/sql/pg_trickle--0.11.0--0.12.0.sql
+++ b/sql/pg_trickle--0.11.0--0.12.0.sql
@@ -1,15 +1,7 @@
 -- pg_trickle 0.11.0 -> 0.12.0 upgrade script
 --
--- Changes will be documented here as phases are implemented.
---
 -- Phase 1 (quick wins):
 --   PERF-3: tiered_scheduling GUC default changed to true. No DDL required.
---
--- Phase 2 (developer tooling):
---   DT-1: pgtrickle.explain_query_rewrite(query TEXT) SQL function.
---   DT-2: pgtrickle.diagnose_errors(name TEXT) SQL function.
---   DT-3: pgtrickle.list_auxiliary_columns(name TEXT) SQL function.
---   DT-4: pgtrickle.validate_query(query TEXT) SQL function.
 --
 -- Phase 5 (scalability foundations):
 --   A-2: Columnar change tracking -- per-column bitmask superset support.
@@ -17,6 +9,10 @@
 --        handled at runtime by alter_change_buffer_add_columns().
 --   D-4: Shared change buffers -- new pgt_shared_change_buffers catalog
 --        table; multi-frontier cleanup coordination.
+--
+-- Note: Developer tooling functions (DT-1 through DT-4) and the updated
+-- alter_stream_table signature were released in 0.13.0, not 0.12.0.
+-- They are handled by the 0.12.0→0.13.0 upgrade script.
 --
 -- ── Phase 0: Ensure 0.11.0 Functions Are Present ─────────────────────────────
 -- (These functions should have been in v0.11.0 and need to be carried forward)
@@ -111,77 +107,4 @@ CREATE OR REPLACE FUNCTION pgtrickle."create_or_replace_stream_table"(
 LANGUAGE c
 AS 'MODULE_PATHNAME', 'create_or_replace_stream_table_wrapper';
 
--- ── Phase 2: Developer Diagnostic Functions ───────────────────────────────
-
--- DT-1: explain_query_rewrite — walk a query through every DVM rewrite pass.
-CREATE OR REPLACE FUNCTION pgtrickle."explain_query_rewrite"(
-        "query" TEXT
-) RETURNS TABLE (
-        "pass_name" TEXT,
-        "changed" bool,
-        "sql_after" TEXT
-)
-STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_query_rewrite_wrapper';
-
--- DT-2: diagnose_errors — last 5 FAILED refresh events with classification.
-CREATE OR REPLACE FUNCTION pgtrickle."diagnose_errors"(
-        "name" TEXT
-) RETURNS TABLE (
-        "event_time" timestamp with time zone,
-        "error_type" TEXT,
-        "error_message" TEXT,
-        "remediation" TEXT
-)
-STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'diagnose_errors_wrapper';
-
--- DT-3: list_auxiliary_columns — __pgt_* columns on a stream table's storage.
-CREATE OR REPLACE FUNCTION pgtrickle."list_auxiliary_columns"(
-        "name" TEXT
-) RETURNS TABLE (
-        "column_name" TEXT,
-        "data_type" TEXT,
-        "purpose" TEXT
-)
-STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_auxiliary_columns_wrapper';
-
--- DT-4: validate_query — parse and validate without creating a stream table.
-CREATE OR REPLACE FUNCTION pgtrickle."validate_query"(
-        "query" TEXT
-) RETURNS TABLE (
-        "check_name" TEXT,
-        "result" TEXT,
-        "severity" TEXT
-)
-STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'validate_query_wrapper';
-
--- ── A1-1c: ALTER partition_by support ─────────────────────────────────────
--- Add partition_by parameter to alter_stream_table.
-DROP FUNCTION IF EXISTS pgtrickle."alter_stream_table"(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, bool, bool, TEXT, TEXT, bigint, INT);
-CREATE FUNCTION pgtrickle."alter_stream_table"(
-        "name" TEXT,
-        "query" TEXT DEFAULT NULL,
-        "schedule" TEXT DEFAULT NULL,
-        "refresh_mode" TEXT DEFAULT NULL,
-        "status" TEXT DEFAULT NULL,
-        "diamond_consistency" TEXT DEFAULT NULL,
-        "diamond_schedule_policy" TEXT DEFAULT NULL,
-        "cdc_mode" TEXT DEFAULT NULL,
-        "append_only" bool DEFAULT NULL,
-        "pooler_compatibility_mode" bool DEFAULT NULL,
-        "tier" TEXT DEFAULT NULL,
-        "fuse" TEXT DEFAULT NULL,
-        "fuse_ceiling" bigint DEFAULT NULL,
-        "fuse_sensitivity" INT DEFAULT NULL,
-        "partition_by" TEXT DEFAULT NULL
-) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'alter_stream_table_wrapper';
 

--- a/sql/pg_trickle--0.12.0--0.13.0.sql
+++ b/sql/pg_trickle--0.12.0--0.13.0.sql
@@ -211,10 +211,13 @@ LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'dedup_stats_fn_wrapper';
 
 -- ── A1-1c: ALTER partition_by support ─────────────────────────────────────
--- Drop the old signature and recreate with the partition_by parameter.
--- This is idempotent: if the user already has the new signature from
--- the 0.11.0→0.12.0 upgrade path, DROP IF EXISTS + CREATE is safe.
+-- Drop all historical overloads and recreate with the full 0.13.0 signature.
+-- The 0.12.0 archive has an 11-param version; older upgrade paths may have
+-- left a 14-param or 15-param overload. All are replaced by the 17-param
+-- signature that includes max_differential_joins and max_delta_fraction.
+DROP FUNCTION IF EXISTS pgtrickle."alter_stream_table"(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, bool, bool, TEXT);
 DROP FUNCTION IF EXISTS pgtrickle."alter_stream_table"(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, bool, bool, TEXT, TEXT, bigint, INT);
+DROP FUNCTION IF EXISTS pgtrickle."alter_stream_table"(TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, TEXT, bool, bool, TEXT, TEXT, bigint, INT, TEXT);
 CREATE FUNCTION pgtrickle."alter_stream_table"(
         "name" TEXT,
         "query" TEXT DEFAULT NULL,
@@ -230,7 +233,9 @@ CREATE FUNCTION pgtrickle."alter_stream_table"(
         "fuse" TEXT DEFAULT NULL,
         "fuse_ceiling" bigint DEFAULT NULL,
         "fuse_sensitivity" INT DEFAULT NULL,
-        "partition_by" TEXT DEFAULT NULL
+        "partition_by" TEXT DEFAULT NULL,
+        "max_differential_joins" INT DEFAULT NULL,
+        "max_delta_fraction" double precision DEFAULT NULL
 ) RETURNS void
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'alter_stream_table_wrapper';


### PR DESCRIPTION
## Summary

Fixes three bugs in the SQL upgrade scripts that caused three upgrade E2E tests
to fail (`test_upgrade_chain_function_parity_with_fresh_install`):

- Upgrade E2E (0.11.0 to 0.12.0)
- Upgrade E2E (0.12.0 to 0.13.0)
- Upgrade E2E (0.1.3 to 0.13.0)

## Root Cause

The upgrade E2E test L13 installs the old version from archive, upgrades, then
counts `pgtrickle.*` functions and compares against a fresh install of the
target version. A mismatch means the upgrade script added or left behind
functions that don't match the archived release.

### Bug 1 -- 0.11.0->0.12.0: DT functions don't belong here

The upgrade script added `explain_query_rewrite`, `diagnose_errors`,
`list_auxiliary_columns`, and `validate_query` (Phase 2 / DT-1 through DT-4).
However, the 0.12.0 archive has the exact same 52 functions as 0.11.0 --
these functions were only released in 0.13.0.

Fix: Remove Phase 2 from the 0.11.0 to 0.12.0 script.

### Bug 2 -- 0.11.0->0.12.0: alter_stream_table drop/recreate doesn't belong

The script dropped a 14-param `alter_stream_table` overload (which never
existed in any archive) and created a 15-param version. Both the 0.11.0 and
0.12.0 archives carry the 11-param signature; `alter_stream_table` was not
changed between these versions.

Fix: Remove the A1-1c section from the 0.11.0 to 0.12.0 script entirely.

### Bug 3 -- 0.12.0->0.13.0: wrong DROP target and missing params in CREATE

The 0.12.0 archive has an 11-param `alter_stream_table` but the script:

- Dropped a 14-param overload (never existed), leaving the 11-param alive and
  creating a duplicate overload alongside the newly created function.
- Created a 15-param version, missing `max_differential_joins` and
  `max_delta_fraction` that are present in the 0.13.0 archive (17 params).

Fix:
- Drop the 11-param (archive 0.12.0), 14-param (historical no-op), and
  15-param (residual from old buggy 0.11.0 to 0.12.0 chains) overloads.
- Create the correct 17-param version matching the 0.13.0 binary.

## Verification

After these fixes, the function-count math for each test:

| Upgrade path | Start | Net change | Expected end | Archive target |
|---|---|---|---|---|
| 0.11.0 to 0.12.0 | 52 | 0 (OR REPLACE only) | 52 | 52 |
| 0.12.0 to 0.13.0 | 52 | -1 drop 11-param, +1 new 17-param, +7 DT/profiling | 59 | 59 |
| 0.1.3 to 0.13.0 | chain | same as above at the final step | 59 | 59 |

Fixes: https://github.com/grove/pg-trickle/actions/runs/23807977222
