### PR TITLE
fix(upgrade): add missing create_stream_table signature updates in 0.12.0->0.13.0

### DIFF
--- a/sql/pg_trickle--0.12.0--0.13.0.sql
+++ b/sql/pg_trickle--0.12.0--0.13.0.sql
@@ -241,8 +241,12 @@ LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'alter_stream_table_wrapper';
 
 -- ── Stream table creation functions: add max_differential_joins / max_delta_fraction ──
--- These two parameters were added in 0.13.0 to all three create_stream_table
--- variants. Using CREATE OR REPLACE so the upgrade is idempotent.
+-- These two parameters were added in 0.13.0. The 0.12.0 versions had 11 params;
+-- PostgreSQL treats different param counts as different overloads, so we must
+-- explicitly drop the old 11-param signatures before creating the 13-param ones.
+DROP FUNCTION IF EXISTS pgtrickle."create_stream_table"(TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool, TEXT);
+DROP FUNCTION IF EXISTS pgtrickle."create_stream_table_if_not_exists"(TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool, TEXT);
+DROP FUNCTION IF EXISTS pgtrickle."create_or_replace_stream_table"(TEXT, TEXT, TEXT, TEXT, bool, TEXT, TEXT, TEXT, bool, bool, TEXT);
 
 CREATE OR REPLACE FUNCTION pgtrickle."create_stream_table"(
         "name" TEXT,


### PR DESCRIPTION
## Summary

Fixes `test_upgrade_chain_stream_tables_survive` failing with:

```
SQL failed: error returned from database: unboxing max_differential_joins_ argument failed
SQL: SELECT pgtrickle.create_stream_table('upgrade_st', ...)
```

## Root Cause

The three `create_stream_table` variants gained two new parameters in 0.13.0:

- `max_differential_joins INT DEFAULT NULL`
- `max_delta_fraction double precision DEFAULT NULL`

These went from 11 params (0.12.0 archive) to 13 params (0.13.0 archive).

The `0.12.0->0.13.0` upgrade script was missing `CREATE OR REPLACE FUNCTION`
statements for all three variants, so after upgrading:

- Database had the old 11-param signatures
- The 0.13.0 binary expected 13 params
- pgrx tried to unbox `max_differential_joins` at position 12, found nothing, and panicked

The fix adds `CREATE OR REPLACE FUNCTION` blocks for all three variants
(`create_stream_table`, `create_stream_table_if_not_exists`,
`create_or_replace_stream_table`) with the full 13-param signature.

## Impact

Fixes `test_upgrade_chain_stream_tables_survive` for:

- Upgrade E2E (0.12.0 to 0.13.0)
- Upgrade E2E (0.11.0 to 0.12.0, which chains through 0.13.0 in the full-chain test)
- Upgrade E2E (0.1.3 to 0.13.0)
