### PR TITLE
fix: eliminate scheduler race with manual ST-on-ST refreshes

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3671,6 +3671,42 @@ fn execute_manual_full_refresh(
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
     }
 
+    // ── Snapshot ST change buffer LSNs BEFORE TRUNCATE+INSERT ──────────
+    //
+    // Under READ COMMITTED, each SPI statement sees the latest committed
+    // data at statement start time.  If the frontier's ST-source LSNs are
+    // computed AFTER the INSERT, a concurrent upstream refresh might commit
+    // new change buffer rows between the INSERT and the MAX(lsn) query.
+    // The frontier would then advance past changes the INSERT never saw,
+    // causing subsequent manual refreshes to believe the data is current
+    // when it is actually stale.
+    //
+    // Capturing the LSNs before the INSERT ensures the frontier reflects
+    // at most the data that was visible to the INSERT.
+    let change_schema_for_snapshot =
+        crate::config::pg_trickle_change_buffer_schema().replace('"', "\"\"");
+    let st_source_lsn_snapshot: Vec<(i64, String)> =
+        crate::catalog::StDependency::get_for_st(st.pgt_id)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|dep| dep.source_type == "STREAM_TABLE")
+            .filter_map(|dep| {
+                let upstream_pgt_id = StreamTableMeta::pgt_id_for_relid(dep.source_relid)?;
+                if !crate::cdc::has_st_change_buffer(upstream_pgt_id, &change_schema_for_snapshot) {
+                    return None;
+                }
+                let lsn = Spi::get_one::<String>(&format!(
+                    "SELECT COALESCE(MAX(lsn)::text, pg_current_wal_lsn()::text) \
+             FROM \"{schema}\".changes_pgt_{id}",
+                    schema = change_schema_for_snapshot,
+                    id = upstream_pgt_id,
+                ))
+                .unwrap_or(None)
+                .unwrap_or_else(|| "0/0".to_string());
+                Some((upstream_pgt_id, lsn))
+            })
+            .collect();
+
     let truncate_sql = format!("TRUNCATE {quoted_table}");
     Spi::run(&truncate_sql).map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
 
@@ -3780,26 +3816,12 @@ fn execute_manual_full_refresh(
     // scheduler's `prev_frontier.is_empty()` check doesn't trigger a
     // spurious FULL fallback on the first differential refresh.
     //
-    // ST-ST-7: Use MAX(lsn) from the actual change buffer rather than
-    // pg_current_wal_lsn(). This ensures the frontier records exactly
-    // the latest data point, preventing the next differential refresh
-    // from missing rows that sit AT the frontier LSN.
-    let change_schema = crate::config::pg_trickle_change_buffer_schema().replace('"', "\"\"");
-    for dep in crate::catalog::StDependency::get_for_st(st.pgt_id).unwrap_or_default() {
-        if dep.source_type == "STREAM_TABLE"
-            && let Some(upstream_pgt_id) = StreamTableMeta::pgt_id_for_relid(dep.source_relid)
-            && crate::cdc::has_st_change_buffer(upstream_pgt_id, &change_schema)
-        {
-            let lsn = Spi::get_one::<String>(&format!(
-                "SELECT COALESCE(MAX(lsn)::text, pg_current_wal_lsn()::text) \
-                 FROM \"{schema}\".changes_pgt_{id}",
-                schema = change_schema,
-                id = upstream_pgt_id,
-            ))
-            .unwrap_or(None)
-            .unwrap_or_else(|| "0/0".to_string());
-            frontier.set_st_source(upstream_pgt_id, lsn, data_ts.clone());
-        }
+    // Uses the pre-INSERT LSN snapshot captured above to avoid the TOCTOU
+    // race where concurrent upstream refreshes commit new change buffer
+    // rows between the INSERT and this point, advancing the frontier past
+    // data the INSERT never saw.
+    for (upstream_pgt_id, lsn) in &st_source_lsn_snapshot {
+        frontier.set_st_source(*upstream_pgt_id, lsn.clone(), data_ts.clone());
     }
 
     StreamTableMeta::store_frontier_and_complete_refresh(st.pgt_id, &frontier, 0)?;
@@ -3838,62 +3860,31 @@ fn execute_manual_differential_refresh(
     let prev_frontier = st.frontier.clone().unwrap_or_default();
 
     // For STs whose sources are all STREAM_TABLEs (frontier.sources is empty
-    // because there are no WAL change buffers to track), use upstream
-    // data_timestamp comparison.  Only run a FULL refresh (and bump
-    // data_timestamp) if an upstream has newer data.  If no upstream is newer,
-    // skip the refresh entirely to avoid spurious data_timestamp drift.
+    // because there are no WAL change buffers to track), always do a FULL
+    // refresh so the data is guaranteed correct. The background scheduler
+    // may have done a partial FULL refresh (some upstream STs not yet
+    // refreshed) which cannot be detected reliably by comparing timestamps
+    // or change buffer LSNs alone.
     if prev_frontier.is_empty() {
-        let any_upstream_newer = has_upstream_stream_table_changes(st.pgt_id)?;
-        if any_upstream_newer {
-            return execute_manual_full_refresh(st, schema, table_name, source_oids);
-        } else {
-            pgrx::info!(
-                "Stream table {}.{} refreshed (no-op: upstream unchanged)",
-                schema,
-                table_name,
-            );
-            return Ok(());
-        }
+        return execute_manual_full_refresh(st, schema, table_name, source_oids);
     }
 
     refresh::poll_foreign_table_sources_for_st(st)?;
 
-    // Mixed-dependency guard: if ANY upstream is a STREAM_TABLE, the DVM
-    // delta SQL will reference change buffers that don't exist for stream
-    // tables (they have no CDC triggers). Fall back to FULL refresh,
-    // consistent with how the scheduler handles these (scheduler.rs:1077).
+    // Mixed-dependency guard: if ANY upstream is a STREAM_TABLE, always do
+    // a FULL refresh.  The background scheduler may race with manual
+    // refreshes of upstream STs, producing a FULL refresh of this ST from
+    // partially-updated upstream data. Because the scheduler's frontier
+    // captures the latest change buffer LSN at the time of its refresh,
+    // there is no reliable after-the-fact signal to distinguish "scheduler
+    // correctly consumed all changes" from "scheduler read stale upstream
+    // data."  Unconditionally re-running the FULL refresh guarantees that
+    // the manual refresh always returns correct data.
     {
         let deps = StDependency::get_for_st(st.pgt_id).unwrap_or_default();
         let has_st_source = deps.iter().any(|dep| dep.source_type == "STREAM_TABLE");
         if has_st_source {
-            let any_st_upstream_newer = has_upstream_stream_table_changes(st.pgt_id)?;
-
-            // Check TABLE source change buffers for pending rows.
-            let change_schema =
-                crate::config::pg_trickle_change_buffer_schema().replace('"', "\"\"");
-            let any_table_changes = deps
-                .iter()
-                .filter(|dep| dep.source_type == "TABLE" || dep.source_type == "FOREIGN_TABLE")
-                .any(|dep| {
-                    Spi::get_one::<bool>(&format!(
-                        "SELECT EXISTS(SELECT 1 FROM \"{}\".changes_{} LIMIT 1)",
-                        change_schema,
-                        dep.source_relid.to_u32(),
-                    ))
-                    .unwrap_or(Some(false))
-                    .unwrap_or(false)
-                });
-
-            if any_st_upstream_newer || any_table_changes {
-                return execute_manual_full_refresh(st, schema, table_name, source_oids);
-            } else {
-                pgrx::info!(
-                    "Stream table {}.{} refreshed (no-op: upstream unchanged)",
-                    schema,
-                    table_name,
-                );
-                return Ok(());
-            }
+            return execute_manual_full_refresh(st, schema, table_name, source_oids);
         }
     }
 
@@ -3932,39 +3923,6 @@ fn execute_manual_differential_refresh(
         rows_deleted,
     );
     Ok(())
-}
-
-/// Check if any STREAM_TABLE upstream has a `data_timestamp` more recent than
-/// the given ST's own `data_timestamp`.
-///
-/// Mirrors the scheduler's `has_stream_table_source_changes()` — used by the
-/// manual refresh path to avoid bumping `data_timestamp` on no-op refreshes
-/// for calculated (ST-on-ST) stream tables.
-fn has_upstream_stream_table_changes(pgt_id: i64) -> Result<bool, PgTrickleError> {
-    let deps = StDependency::get_for_st(pgt_id)?;
-    for dep in deps {
-        if dep.source_type != "STREAM_TABLE" {
-            continue;
-        }
-        let upstream_newer = Spi::get_one::<bool>(&format!(
-            "SELECT EXISTS ( \
-               SELECT 1 \
-               FROM pgtrickle.pgt_stream_tables upstream \
-               JOIN pgtrickle.pgt_stream_tables us ON us.pgt_id = {pgt_id} \
-               WHERE upstream.pgt_relid = {relid}::oid \
-                 AND upstream.data_timestamp \
-                     > COALESCE(us.data_timestamp, '-infinity'::timestamptz) \
-             )",
-            relid = dep.source_relid.to_u32(),
-        ))
-        .map_err(|e| PgTrickleError::SpiError(e.to_string()))?
-        .unwrap_or(false);
-
-        if upstream_newer {
-            return Ok(true);
-        }
-    }
-    Ok(false)
 }
 
 /// Get source table OIDs for a stream table (used by manual refresh path).

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -4027,6 +4027,49 @@ fn refresh_single_st(
         return;
     }
 
+    // ST-on-ST safety: skip this ST if any upstream STREAM_TABLE source is
+    // currently being refreshed by another session.  When the scheduler does
+    // a FULL refresh of a downstream calculated ST, it reads the current
+    // state of all upstream STs.  If an upstream is mid-refresh (row locked
+    // by a manual `refresh_stream_table` call), the FULL refresh may read a
+    // mix of pre-/post-update upstream data, producing incorrect results
+    // that cannot be reliably detected and corrected afterwards.
+    //
+    // The check is cheap (one FOR SHARE SKIP LOCKED per upstream ST) and
+    // only affects STs with STREAM_TABLE dependencies.
+    {
+        let deps = crate::catalog::StDependency::get_for_st(pgt_id).unwrap_or_default();
+        let has_st_source = deps.iter().any(|dep| dep.source_type == "STREAM_TABLE");
+        if has_st_source {
+            let any_upstream_locked = deps
+                .iter()
+                .filter(|dep| dep.source_type == "STREAM_TABLE")
+                .any(|dep| {
+                    let upstream_pgt_id =
+                        crate::catalog::StreamTableMeta::pgt_id_for_relid(dep.source_relid);
+                    match upstream_pgt_id {
+                        Some(up_id) => Spi::get_one_with_args::<i64>(
+                            "SELECT pgt_id FROM pgtrickle.pgt_stream_tables \
+                                 WHERE pgt_id = $1 FOR SHARE SKIP LOCKED",
+                            &[up_id.into()],
+                        )
+                        .unwrap_or(None)
+                        .is_none(),
+                        None => false,
+                    }
+                });
+
+            if any_upstream_locked {
+                pgrx::debug1!(
+                    "[pg_trickle] skipping {}.{} — upstream ST is being refreshed by another session",
+                    st.pgt_schema,
+                    st.pgt_name,
+                );
+                return;
+            }
+        }
+    }
+
     // FUSE-5: Check fuse circuit breaker.
     if evaluate_fuse(&st) {
         log!(


### PR DESCRIPTION
## Problem

`test_fanout_then_converge` in `e2e_dag_topology_tests` was flaking in CI (~50% failure rate,
failing all 3 retries). The topology under test is:

```
foc_src -> foc_sum, foc_cnt, foc_max  (L1, schedule='1m')
                 -> foc_merged         (L2, schedule='calculated', 3-way JOIN)
```

After a DELETE, the test manually refreshes each L1 ST in turn, then refreshes L2. The assertion
was seeing impossible data like `total=30` (pre-delete sum) alongside `cnt=1` (post-delete count).

## Root Cause

The background scheduler races with manual test-driven refreshes. When the test commits
`refresh_st("foc_sum")`, the scheduler can start a new tick, refresh `foc_cnt` and `foc_max`
from CDC, then FULL-refresh `foc_merged` while `foc_sum` still holds stale data. The scheduler
then records the frontier at that point. Subsequent manual refreshes of `foc_merged` saw matching
LSNs and short-circuited as a no-op — leaving the incorrect data in place.

## Fixes

### 1. Unconditional FULL refresh for manual ST-on-ST refreshes (`src/api.rs`)

Removed the `has_upstream_stream_table_changes()` no-op guard from
`execute_manual_differential_refresh`. For any ST whose upstream is another ST, the manual refresh
path now always calls `execute_manual_full_refresh`, guaranteeing correct data regardless of
scheduler state.

Also removes the now-dead `has_upstream_stream_table_changes()` function (~90 lines).

### 2. Pre-INSERT LSN snapshot in `execute_manual_full_refresh` (`src/api.rs`)

Moved the change-buffer `MAX(lsn)` capture (used to populate the frontier) from **after** the
`TRUNCATE + INSERT` to **before** it. Under READ COMMITTED each SPI statement sees independently
committed data, so a concurrent upstream refresh committing new change-buffer rows between the
INSERT and the LSN query would advance the frontier past data the INSERT never saw. Capturing
the snapshot first closes this TOCTOU window.

### 3. Upstream lock check in `refresh_single_st` (`src/scheduler.rs`)

Before the scheduler refreshes a downstream ST that has `STREAM_TABLE` sources, it now checks
each upstream's catalog row with `FOR SHARE SKIP LOCKED`. If any upstream is locked by another
session (a manual `refresh_stream_table` call in progress), the downstream ST is skipped for
this tick — preventing a FULL refresh from reading a mix of stale and fresh upstream data.

The check is safe for same-session use: PostgreSQL allows a session to acquire `FOR SHARE` on a
row it already holds `FOR UPDATE` on, so the scheduler's own topological ordering within a tick
is unaffected.

## Testing

- **DAG topology suite** (`test_fanout_then_converge`, `test_deep_linear_5_layers`, 7 tests): 3 x 7/7 stable
- **Full E2E suite** (all `e2e_*` binaries, `--test-threads=4`): 0 failures
- **Unit tests** (1659): pass
- **`just fmt && just lint`**: zero warnings
