### PR TITLE
fix: correct test_st_on_st_uses_differential_not_full flaky assertion

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3824,9 +3824,57 @@ fn execute_manual_full_refresh(
         frontier.set_st_source(*upstream_pgt_id, lsn.clone(), data_ts.clone());
     }
 
-    StreamTableMeta::store_frontier_and_complete_refresh(st.pgt_id, &frontier, 0)?;
+    // Detect no-op FULL refresh: check if any upstream ST source has a
+    // data_timestamp newer than ours.  If not, the TRUNCATE+INSERT above
+    // reproduced identical data, so we must NOT bump data_timestamp —
+    // otherwise downstream CALCULATED stream tables see a false "upstream
+    // changed" signal and their own data_timestamp drifts on every no-op
+    // cycle.
+    //
+    // This uses catalog data_timestamps (stable, not affected by change
+    // buffer cleanup) rather than frontier LSN comparisons (which become
+    // unreliable when buffer rows are consumed and MAX(lsn) falls back to
+    // pg_current_wal_lsn()).
+    let has_upstream_st_change = Spi::get_one::<bool>(&format!(
+        "SELECT EXISTS( \
+           SELECT 1 \
+           FROM pgtrickle.pgt_dependencies dep \
+           JOIN pgtrickle.pgt_stream_tables upstream \
+                ON upstream.pgt_relid = dep.source_relid \
+           WHERE dep.pgt_id = {pgt_id} \
+             AND dep.source_type = 'STREAM_TABLE' \
+             AND upstream.data_timestamp > COALESCE( \
+                   (SELECT data_timestamp \
+                    FROM pgtrickle.pgt_stream_tables \
+                    WHERE pgt_id = {pgt_id}), \
+                   '-infinity'::timestamptz) \
+         )",
+        pgt_id = st.pgt_id,
+    ))
+    .unwrap_or(Some(false))
+    .unwrap_or(false);
 
-    pgrx::info!("Stream table {}.{} refreshed (FULL)", schema, table_name);
+    // Also check WAL-based sources: if any slot position advanced
+    // beyond the previous frontier, data changed.
+    let prev_frontier = st.frontier.clone().unwrap_or_default();
+    let has_wal_change = slot_positions
+        .iter()
+        .any(|(oid, lsn)| prev_frontier.get_lsn(*oid) != *lsn);
+
+    if has_upstream_st_change || has_wal_change || prev_frontier.is_empty() {
+        StreamTableMeta::store_frontier_and_complete_refresh(st.pgt_id, &frontier, 0)?;
+        pgrx::info!("Stream table {}.{} refreshed (FULL)", schema, table_name);
+    } else {
+        // No upstream changes — store frontier but preserve data_timestamp.
+        StreamTableMeta::store_frontier(st.pgt_id, &frontier)?;
+        StreamTableMeta::update_after_no_data_refresh(st.pgt_id)?;
+        pgrx::info!(
+            "Stream table {}.{} refreshed (FULL, no-op — data_timestamp preserved)",
+            schema,
+            table_name
+        );
+    }
+
     Ok(())
 }
 

--- a/tests/e2e_cascade_regression_tests.rs
+++ b/tests/e2e_cascade_regression_tests.rs
@@ -895,15 +895,6 @@ async fn test_st_on_st_uses_differential_not_full() {
     db.refresh_st_with_retry("ssd_upstream").await;
     db.refresh_st_with_retry("ssd_downstream").await;
 
-    // Record how many COMPLETED refreshes the downstream had before the delta
-    let before_count: i64 = db
-        .query_scalar(
-            "SELECT count(*) FROM pgtrickle.pgt_refresh_history h
-             JOIN pgtrickle.pgt_stream_tables st ON st.pgt_id = h.pgt_id
-             WHERE st.pgt_name = 'ssd_downstream' AND h.status = 'COMPLETED'",
-        )
-        .await;
-
     // Enable fast scheduler
     configure_fast_scheduler(&db).await;
 
@@ -911,32 +902,46 @@ async fn test_st_on_st_uses_differential_not_full() {
     db.execute("INSERT INTO ssd_src (grp, val) VALUES ('a', 40), ('b', 50)")
         .await;
 
-    // Wait for the downstream ST to get a new COMPLETED refresh
+    // Wait for the downstream ST to reflect the new data.
+    //
+    // The scheduler may perform a spurious NO_DATA + DIFFERENTIAL cycle
+    // (triggered by the NS-8 last_refresh_at fallback) before the CDC
+    // changes from the INSERT are actually processed.  Waiting only for
+    // "a new COMPLETED refresh" can break too early on such a spurious
+    // cycle.  Instead, poll until the upstream data has been refreshed
+    // (SUM(total) reflects the new rows) AND the downstream has
+    // propagated it (SUM(doubled) = 2 × SUM(total)).
     let timeout = std::time::Duration::from_secs(60);
     let start = std::time::Instant::now();
     loop {
         if start.elapsed() > timeout {
             panic!(
-                "Timed out waiting for ssd_downstream to receive a scheduler-driven \
-                 refresh after delta INSERT"
+                "Timed out waiting for ssd_downstream to receive correct data \
+                 after delta INSERT (upstream may not have been refreshed)"
             );
         }
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
 
-        let current_count: i64 = db
-            .query_scalar(
-                "SELECT count(*) FROM pgtrickle.pgt_refresh_history h
-                 JOIN pgtrickle.pgt_stream_tables st ON st.pgt_id = h.pgt_id
-                 WHERE st.pgt_name = 'ssd_downstream' AND h.status = 'COMPLETED'",
-            )
+        // grp 'a': 10+20+40 = 70, grp 'b': 30+50 = 80 → total = 150
+        let upstream_total: i64 = db
+            .query_scalar("SELECT COALESCE(SUM(total), 0)::bigint FROM ssd_upstream")
             .await;
-        if current_count > before_count {
+        if upstream_total < 150 {
+            continue; // upstream not refreshed yet
+        }
+
+        // doubled total should be 300 (2 × 150)
+        let downstream_total: i64 = db
+            .query_scalar("SELECT COALESCE(SUM(doubled), 0)::bigint FROM ssd_downstream")
+            .await;
+        if downstream_total >= 300 {
             break;
         }
     }
 
-    // The downstream ST's most recent scheduler-driven refresh must be DIFFERENTIAL.
-    // If the force-FULL regression recurs, this will be 'FULL'.
+    // The downstream ST must have used at least one DIFFERENTIAL refresh
+    // (not FULL) to propagate the upstream changes. Check the most recent
+    // non-NO_DATA refresh — that's the one that carried the actual delta.
     let action: String = db
         .query_scalar(
             "SELECT h.action
@@ -944,6 +949,7 @@ async fn test_st_on_st_uses_differential_not_full() {
              JOIN pgtrickle.pgt_stream_tables st ON st.pgt_id = h.pgt_id
              WHERE st.pgt_name = 'ssd_downstream'
                AND h.status = 'COMPLETED'
+               AND h.action <> 'NO_DATA'
              ORDER BY h.refresh_id DESC
              LIMIT 1",
         )


### PR DESCRIPTION
## Problem

`test_st_on_st_uses_differential_not_full` was consistently failing with `doubled_a = 60` (stale) instead of `140` (expected).

## Root Cause

The test's wait loop broke out on the first new `COMPLETED` refresh of `ssd_downstream`, but the scheduler can perform a spurious NO_DATA + DIFFERENTIAL cycle (triggered by the NS-8 `last_refresh_at` fallback) before the CDC changes from the INSERT are actually processed by the upstream ST. The test was asserting against data from a refresh that ran before the delta propagated.

The scheduler DOES eventually propagate the correct data -- the wait condition was just too weak.

## Fixes

### 1. Data-driven wait loop (test fix)

Replace the refresh-count-based wait (`count(COMPLETED) > before_count`) with a data-driven wait that polls `SUM(total)` on `ssd_upstream` and `SUM(doubled)` on `ssd_downstream` until both reflect the post-INSERT values. Also filter the action assertion to exclude `NO_DATA` entries so it checks the refresh that actually carried the delta.

### 2. No-op data_timestamp preservation (`src/api.rs`)

After an unconditional FULL refresh of an ST-on-ST dependency, detect whether any upstream actually changed:
- For ST sources: compare upstream `data_timestamp` against our own
- For WAL sources: compare frontier LSN positions

If nothing changed, store the frontier but preserve `data_timestamp` to prevent spurious downstream cascade wakeups that would otherwise cause the NS-8 fallback to trigger unnecessary refreshes.

## Testing

- `test_st_on_st_uses_differential_not_full`: 3/3 stable (was 0/3 before)
- All 9 cascade regression tests: pass
- `just fmt && just lint`: clean
