### PR TITLE
fix: disable scheduler in multi-cycle DAG tests to eliminate flakiness

### DIFF
--- a/tests/e2e_multi_cycle_dag_tests.rs
+++ b/tests/e2e_multi_cycle_dag_tests.rs
@@ -19,6 +19,42 @@ mod e2e;
 use e2e::E2eDb;
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Scheduler Suppression
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Disable the background scheduler for the current test database.
+///
+/// These tests perform manual refreshes in strict topological order. A
+/// concurrent scheduler tick can consume CDC changes out of order, causing
+/// stale data and flaky assertions. We suppress the scheduler by:
+///
+/// 1. Setting `pg_trickle.enabled = off` at the database level so any
+///    new scheduler connection to this DB will see it disabled.
+/// 2. Terminating any scheduler worker backend that already connected.
+///
+/// This is per-database and does not affect other tests' databases.
+async fn disable_scheduler(db: &E2eDb) {
+    // Set database-level GUC so any reconnecting scheduler sees it.
+    db.execute(
+        "DO $$ BEGIN \
+           EXECUTE format('ALTER DATABASE %I SET pg_trickle.enabled = off', current_database()); \
+         END $$",
+    )
+    .await;
+    // Terminate existing scheduler workers connected to this database.
+    db.execute(
+        "SELECT pg_terminate_backend(pid) \
+         FROM pg_stat_activity \
+         WHERE datname = current_database() \
+           AND backend_type = 'pg_trickle scheduler' \
+           AND pid <> pg_backend_pid()",
+    )
+    .await;
+    // Brief pause to let the worker exit.
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Shared Setup Helpers
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -31,6 +67,10 @@ use e2e::E2eDb;
 ///           → mc_l3 (filter: doubled > 30)
 /// ```
 async fn setup_3_layer_pipeline(db: &E2eDb) {
+    // Suppress the background scheduler for this database — these tests
+    // perform manual refreshes in strict topological order.
+    disable_scheduler(db).await;
+
     db.execute(
         "CREATE TABLE mc_src (
             id  SERIAL PRIMARY KEY,
@@ -125,6 +165,10 @@ async fn assert_pipeline_correct(db: &E2eDb) {
 ///       └──→ dm_l2 (JOIN l1a + l1b on grp)
 /// ```
 async fn setup_diamond_pipeline(db: &E2eDb) {
+    // Suppress the background scheduler for this database — these tests
+    // perform manual refreshes in strict topological order.
+    disable_scheduler(db).await;
+
     db.execute(
         "CREATE TABLE dm_src (
             id  SERIAL PRIMARY KEY,


### PR DESCRIPTION
## Summary

Fix flaky `e2e_multi_cycle_dag_tests` by disabling the background scheduler per-database before creating stream tables.

## Problem

All 6 tests in `e2e_multi_cycle_dag_tests` were flaky when running in parallel (~50% failure rate). The tests perform manual refreshes in strict topological order, but the per-database background scheduler runs concurrently and can:

1. Consume CDC changes from `mc_src` before the test's manual `refresh_st_with_retry("mc_l1")` call
2. Leave the manual refresh with no new CDC data to process (effectively a no-op)
3. Result in stale aggregate data at L1, which cascades to L2/L3

Typical error: ST shows `total=40, cnt=6` while the ground-truth query returns `total=45, cnt=7` (exactly one cycle behind).

## Fix

Added a `disable_scheduler()` helper that suppresses the scheduler for the current test database only (does not affect other parallel tests):

1. `ALTER DATABASE ... SET pg_trickle.enabled = off` so any reconnecting scheduler worker sees the disabled flag
2. `pg_terminate_backend()` to kill any existing scheduler worker for this DB
3. Brief 100ms pause to let the worker exit

Called at the start of both `setup_3_layer_pipeline()` and `setup_diamond_pipeline()`, before any stream tables are created.

## Verification

- 30/30 parallel runs pass (previously ~50% failure rate)
- Cascade regression tests (9/9) unaffected
- `just fmt && just lint` clean
