### PR TITLE
fix: eliminate flaky scheduler races and ALTER SYSTEM GUC leaks in E2E tests

### DIFF
--- a/tests/e2e_dag_topology_tests.rs
+++ b/tests/e2e_dag_topology_tests.rs
@@ -12,6 +12,34 @@ use e2e::E2eDb;
 use e2e::property_support::{SeededRng, TraceConfig, TrackedIds, assert_st_query_invariants};
 
 // ═══════════════════════════════════════════════════════════════════════════
+// Scheduler Suppression
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Disable the background scheduler for the current test database.
+///
+/// Tests that perform manual refreshes in topological order can race with the
+/// scheduler, which may consume CDC changes out of order and produce stale
+/// results. This helper disables the scheduler per-database without affecting
+/// other parallel tests.
+async fn disable_scheduler(db: &E2eDb) {
+    db.execute(
+        "DO $$ BEGIN \
+           EXECUTE format('ALTER DATABASE %I SET pg_trickle.enabled = off', current_database()); \
+         END $$",
+    )
+    .await;
+    db.execute(
+        "SELECT pg_terminate_backend(pid) \
+         FROM pg_stat_activity \
+         WHERE datname = current_database() \
+           AND backend_type = 'pg_trickle scheduler' \
+           AND pid <> pg_backend_pid()",
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
 // Test 5.1 — Wide fan-out: 1 base → 4 leaf STs
 // ═══════════════════════════════════════════════════════════════════════════
 
@@ -123,6 +151,7 @@ async fn test_fanout_4_leaves() {
 #[tokio::test]
 async fn test_fanout_then_converge() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute(
         "CREATE TABLE foc_src (
@@ -217,6 +246,7 @@ async fn test_fanout_then_converge() {
 #[tokio::test]
 async fn test_deep_linear_5_layers() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute(
         "CREATE TABLE d5_src (
@@ -339,6 +369,7 @@ async fn test_deep_linear_5_layers() {
 #[tokio::test]
 async fn test_multi_source_diamond() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute(
         "CREATE TABLE msd_left (
@@ -650,6 +681,7 @@ async fn test_prop_deep_chain_small_trace() {
 
 async fn run_deep_chain_trace(seed: u64, config: &TraceConfig) {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
     let mut rng = SeededRng::new(seed);
     let mut ids = TrackedIds::new();
 

--- a/tests/e2e_stmt_cdc_tests.rs
+++ b/tests/e2e_stmt_cdc_tests.rs
@@ -14,6 +14,25 @@ mod e2e;
 
 use e2e::E2eDb;
 
+/// Disable the background scheduler for the current test database.
+async fn disable_scheduler(db: &E2eDb) {
+    db.execute(
+        "DO $$ BEGIN \
+           EXECUTE format('ALTER DATABASE %I SET pg_trickle.enabled = off', current_database()); \
+         END $$",
+    )
+    .await;
+    db.execute(
+        "SELECT pg_terminate_backend(pid) \
+         FROM pg_stat_activity \
+         WHERE datname = current_database() \
+           AND backend_type = 'pg_trickle scheduler' \
+           AND pid <> pg_backend_pid()",
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+}
+
 // ── Helper ────────────────────────────────────────────────────────────────
 
 /// Return the `tgtype & 1` value for the named trigger (0 = STATEMENT, 1 = ROW).
@@ -49,6 +68,7 @@ async fn trigger_old_table(db: &E2eDb, trigger_name: &str) -> String {
 #[tokio::test]
 async fn test_stmt_cdc_default_trigger_is_statement_level() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE stmt_type_src (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -124,6 +144,7 @@ async fn test_stmt_cdc_default_trigger_is_statement_level() {
 #[tokio::test]
 async fn test_stmt_cdc_bulk_insert_all_rows_captured() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE bulk_ins (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -171,6 +192,7 @@ async fn test_stmt_cdc_bulk_insert_all_rows_captured() {
 #[tokio::test]
 async fn test_stmt_cdc_bulk_update_keyed_table() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE bulk_upd (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -235,6 +257,7 @@ async fn test_stmt_cdc_bulk_update_keyed_table() {
 #[tokio::test]
 async fn test_stmt_cdc_bulk_delete_keyed_table() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE bulk_del (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -285,6 +308,7 @@ async fn test_stmt_cdc_bulk_delete_keyed_table() {
 #[tokio::test]
 async fn test_stmt_cdc_keyless_update_captured_as_delete_plus_insert() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     // Keyless table — no PRIMARY KEY.
     db.execute("CREATE TABLE keyless_upd (val TEXT)").await;
@@ -333,19 +357,17 @@ async fn test_stmt_cdc_keyless_update_captured_as_delete_plus_insert() {
 #[tokio::test]
 async fn test_stmt_cdc_row_mode_guc_creates_row_level_trigger() {
     let db = E2eDb::new().await.with_extension().await;
-
-    // Switch to row-level trigger mode globally.
-    db.alter_system_set_and_wait("pg_trickle.cdc_trigger_mode", "'row'", "row")
-        .await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE row_mode_src (id INT PRIMARY KEY, val TEXT)")
         .await;
-    db.create_st(
-        "row_mode_st",
-        "SELECT id, val FROM row_mode_src",
-        "1m",
-        "DIFFERENTIAL",
-    )
+
+    // Switch to row-level trigger mode for this session and create the ST
+    // on the same connection so the GUC is visible to create_stream_table.
+    db.execute_seq(&[
+        "SET pg_trickle.cdc_trigger_mode = 'row'",
+        "SELECT pgtrickle.create_stream_table('row_mode_st', $$SELECT id, val FROM row_mode_src$$, '1m', 'DIFFERENTIAL')",
+    ])
     .await;
 
     let source_oid = db.table_oid("row_mode_src").await;
@@ -373,16 +395,16 @@ async fn test_stmt_cdc_row_mode_guc_creates_row_level_trigger() {
     // DML still works correctly in row mode.
     db.execute("INSERT INTO row_mode_src VALUES (1, 'x'), (2, 'y')")
         .await;
-    db.refresh_st("row_mode_st").await;
+    db.execute_seq(&[
+        "SET pg_trickle.cdc_trigger_mode = 'row'",
+        "SELECT pgtrickle.refresh_stream_table('row_mode_st')",
+    ])
+    .await;
     assert_eq!(
         db.count("public.row_mode_st").await,
         2,
         "Row-level trigger should still capture DML correctly"
     );
-
-    // Restore the default so subsequent tests in the container are unaffected.
-    db.alter_system_reset_and_wait("pg_trickle.cdc_trigger_mode", "statement")
-        .await;
 }
 
 /// `pgtrickle.rebuild_cdc_triggers()` replaces an existing row-level trigger
@@ -392,19 +414,15 @@ async fn test_stmt_cdc_row_mode_guc_creates_row_level_trigger() {
 #[tokio::test]
 async fn test_stmt_cdc_rebuild_cdc_triggers_migrates_to_statement() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     // 1. Initially create the stream table with row-level triggers.
-    db.alter_system_set_and_wait("pg_trickle.cdc_trigger_mode", "'row'", "row")
-        .await;
-
     db.execute("CREATE TABLE rebuild_src (id INT PRIMARY KEY, val TEXT)")
         .await;
-    db.create_st(
-        "rebuild_st",
-        "SELECT id, val FROM rebuild_src",
-        "1m",
-        "DIFFERENTIAL",
-    )
+    db.execute_seq(&[
+        "SET pg_trickle.cdc_trigger_mode = 'row'",
+        "SELECT pgtrickle.create_stream_table('rebuild_st', 'SELECT id, val FROM rebuild_src', schedule := '1m', refresh_mode := 'DIFFERENTIAL')",
+    ])
     .await;
 
     let source_oid = db.table_oid("rebuild_src").await;
@@ -420,9 +438,11 @@ async fn test_stmt_cdc_rebuild_cdc_triggers_migrates_to_statement() {
     );
 
     // 2. Switch to statement mode and call rebuild_cdc_triggers().
-    db.alter_system_set_and_wait("pg_trickle.cdc_trigger_mode", "'statement'", "statement")
-        .await;
-    db.execute("SELECT pgtrickle.rebuild_cdc_triggers()").await;
+    db.execute_seq(&[
+        "SET pg_trickle.cdc_trigger_mode = 'statement'",
+        "SELECT pgtrickle.rebuild_cdc_triggers()",
+    ])
+    .await;
 
     // 3. Per-event statement-level triggers should now exist.
     assert_eq!(
@@ -465,6 +485,7 @@ async fn test_stmt_cdc_rebuild_cdc_triggers_migrates_to_statement() {
 #[tokio::test]
 async fn test_stmt_cdc_mixed_dml_in_transaction() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE mixed_dml (id INT PRIMARY KEY, val TEXT)")
         .await;

--- a/tests/e2e_user_trigger_tests.rs
+++ b/tests/e2e_user_trigger_tests.rs
@@ -10,6 +10,29 @@ mod e2e;
 
 use e2e::E2eDb;
 
+/// Disable the background scheduler for the current test database.
+///
+/// Trigger tests verify exact audit trail entries from manual refreshes.
+/// A concurrent scheduler refresh can consume CDC changes before the manual
+/// refresh, causing missing trigger invocations or extra trigger fires.
+async fn disable_scheduler(db: &E2eDb) {
+    db.execute(
+        "DO $$ BEGIN \
+           EXECUTE format('ALTER DATABASE %I SET pg_trickle.enabled = off', current_database()); \
+         END $$",
+    )
+    .await;
+    db.execute(
+        "SELECT pg_terminate_backend(pid) \
+         FROM pg_stat_activity \
+         WHERE datname = current_database() \
+           AND backend_type = 'pg_trickle scheduler' \
+           AND pid <> pg_backend_pid()",
+    )
+    .await;
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+}
+
 // ── Helper: create an audit trigger setup ──────────────────────────────
 //
 // Creates an audit log table and an AFTER trigger on the given stream table
@@ -65,6 +88,7 @@ fn audit_trigger_sql(st_name: &str) -> Vec<String> {
 #[tokio::test]
 async fn test_explicit_dml_insert() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     // Source table
     db.execute("CREATE TABLE src_ins (id INT PRIMARY KEY, val TEXT)")
@@ -129,6 +153,7 @@ async fn test_explicit_dml_insert() {
 #[tokio::test]
 async fn test_explicit_dml_update() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE src_upd (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -186,6 +211,7 @@ async fn test_explicit_dml_update() {
 #[tokio::test]
 async fn test_explicit_dml_delete() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE src_del (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -242,6 +268,7 @@ async fn test_explicit_dml_delete() {
 #[tokio::test]
 async fn test_explicit_dml_no_op_skip() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     // Use an aggregate ST so that source row changes may not change the aggregate.
     db.execute("CREATE TABLE src_agg (id INT PRIMARY KEY, grp TEXT, amount INT)")
@@ -327,6 +354,7 @@ async fn test_explicit_dml_no_op_skip() {
 #[tokio::test]
 async fn test_no_trigger_uses_merge() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE src_merge (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -358,6 +386,7 @@ async fn test_no_trigger_uses_merge() {
 #[tokio::test]
 async fn test_trigger_audit_trail() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE src_audit (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -415,6 +444,7 @@ async fn test_trigger_audit_trail() {
 #[tokio::test]
 async fn test_guc_off_suppresses_triggers() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE src_guc_off (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -437,14 +467,17 @@ async fn test_guc_off_suppresses_triggers() {
     }
     db.execute("TRUNCATE audit_log").await;
 
-    // Set GUC to 'off' globally — session-level SET is unreliable with
-    // connection pools (the refresh may run on a different connection).
-    db.alter_system_set_and_wait("pg_trickle.user_triggers", "'off'", "off")
-        .await;
-
-    // Modify source and refresh
+    // Modify source
     db.execute("INSERT INTO src_guc_off VALUES (2, 'b')").await;
-    db.refresh_st("st_guc_off").await;
+
+    // Set GUC to 'off' and refresh on the SAME connection so the
+    // session-level SET is visible to the refresh function.
+    // This avoids ALTER SYSTEM which is global and races with parallel tests.
+    db.execute_seq(&[
+        "SET pg_trickle.user_triggers = 'off'",
+        "SELECT pgtrickle.refresh_stream_table('st_guc_off')",
+    ])
+    .await;
 
     // ST should have the data
     let count: i64 = db.count("st_guc_off").await;
@@ -457,10 +490,6 @@ async fn test_guc_off_suppresses_triggers() {
         "Audit log should be empty when GUC is 'off', got {} entries",
         audit_count
     );
-
-    // Reset to default so other tests are not affected.
-    db.alter_system_reset_and_wait("pg_trickle.user_triggers", "auto")
-        .await;
 }
 
 // ── GUC: auto detects triggers ─────────────────────────────────────────
@@ -468,6 +497,7 @@ async fn test_guc_off_suppresses_triggers() {
 #[tokio::test]
 async fn test_guc_auto_detects_triggers() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE src_guc_auto (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -514,6 +544,7 @@ async fn test_guc_auto_detects_triggers() {
 #[tokio::test]
 async fn test_guc_on_alias_detects_triggers() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE src_guc_on (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -534,12 +565,14 @@ async fn test_guc_on_alias_detects_triggers() {
     }
     db.execute("TRUNCATE audit_log").await;
 
-    // Use ALTER SYSTEM SET so the value is visible across all pool connections.
-    db.alter_system_set_and_wait("pg_trickle.user_triggers", "'on'", "on")
-        .await;
-
+    // Set GUC to deprecated 'on' alias and refresh on the SAME connection.
+    // 'on' is treated as 'auto' — should still detect triggers.
     db.execute("INSERT INTO src_guc_on VALUES (2, 'b')").await;
-    db.refresh_st("st_guc_on").await;
+    db.execute_seq(&[
+        "SET pg_trickle.user_triggers = 'on'",
+        "SELECT pgtrickle.refresh_stream_table('st_guc_on')",
+    ])
+    .await;
 
     let insert_count: i64 = db
         .query_scalar("SELECT count(*) FROM audit_log WHERE op = 'INSERT'")
@@ -549,10 +582,6 @@ async fn test_guc_on_alias_detects_triggers() {
         "Deprecated 'on' alias should still detect trigger and fire it, got {} INSERT entries",
         insert_count
     );
-
-    // Reset to default so other tests are not affected.
-    db.alter_system_reset_and_wait("pg_trickle.user_triggers", "auto")
-        .await;
 }
 
 // ── FULL refresh suppresses row-level triggers ─────────────────────────
@@ -560,6 +589,7 @@ async fn test_guc_on_alias_detects_triggers() {
 #[tokio::test]
 async fn test_full_refresh_suppresses_triggers() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE src_full (id INT PRIMARY KEY, val TEXT)")
         .await;
@@ -598,6 +628,7 @@ async fn test_full_refresh_suppresses_triggers() {
 #[tokio::test]
 async fn test_before_trigger_modifies_new() {
     let db = E2eDb::new().await.with_extension().await;
+    disable_scheduler(&db).await;
 
     db.execute("CREATE TABLE src_before (id INT PRIMARY KEY, val TEXT)")
         .await;


### PR DESCRIPTION
## Summary

Fix flaky E2E tests in 3 test files by eliminating scheduler race conditions and `ALTER SYSTEM` GUC contamination between parallel tests.

## Changes

### `e2e_dag_topology_tests.rs`
- Added `disable_scheduler()` to `test_fanout_then_converge`, `test_deep_linear_5_layers`, `test_multi_source_diamond`, and `run_deep_chain_trace`
- Verified: 35/35 (5 runs × 7 tests)

### `e2e_user_trigger_tests.rs`
- Added `disable_scheduler()` to all 11 tests
- Converted `test_guc_off_suppresses_triggers` and `test_guc_on_alias_detects_triggers` from `ALTER SYSTEM SET` to session-level `SET` via `execute_seq`
- Verified: 55/55 (5 runs × 11 tests)

### `e2e_stmt_cdc_tests.rs`
- Added `disable_scheduler()` to all 8 tests
- Converted `test_stmt_cdc_row_mode_guc_creates_row_level_trigger` and `test_stmt_cdc_rebuild_cdc_triggers_migrates_to_statement` from `ALTER SYSTEM SET` to session-level `SET` via `execute_seq`
- Verified: 40/40 (5 runs × 8 tests)

## Root Causes

1. **Scheduler race**: Background scheduler worker consumes CDC trigger changes before manual `refresh_stream_table()` calls, causing assertions on empty stream tables to fail
2. **ALTER SYSTEM GUC leak**: `ALTER SYSTEM SET pg_trickle.cdc_trigger_mode = 'row'` (and similar for `user_triggers`) is server-wide and contaminates parallel tests running in other databases

## Fix Pattern

- **Scheduler**: Per-database `ALTER DATABASE SET pg_trickle.enabled = off` + `pg_terminate_backend` on the scheduler worker (no cross-test interference)
- **GUCs**: Session-level `SET` via `execute_seq` on the same pooled connection, replacing `ALTER SYSTEM SET` + `SELECT pg_reload_conf()`
