### PR TITLE
fix: update test_diff_scan_keyless_max_aggregation to expect array_agg

### DIFF
--- a/src/dvm/operators/scan.rs
+++ b/src/dvm/operators/scan.rs
@@ -1384,9 +1384,10 @@ mod tests {
         let result = diff_scan(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // Should use MAX() to aggregate column values (identical rows
-        // have the same content, so MAX picks the correct value).
-        assert_sql_contains(&sql, "MAX(");
+        // Should use array_agg(col)[1] to pick a representative value
+        // for each content-hash group (works for all types, including
+        // jsonb which lacks a comparison operator needed by MAX).
+        assert_sql_contains(&sql, "array_agg(");
     }
 
     // ── P2-5 / WB-1: changed_cols VARBIT mask ──────────────────────


### PR DESCRIPTION
## Problem

PR #375 changed the keyless scan dedup strategy from `MAX(col)` to `array_agg(col)[1]` in `src/dvm/operators/scan.rs` but did not update the corresponding test assertion, causing `test_diff_scan_keyless_max_aggregation` to fail in CI on both Linux (amd64) and macOS (arm64).

## Fix

Update the test to assert `array_agg(` instead of `MAX(`, matching the new implementation.

## Testing

- All 1659 unit tests pass.
- `just lint` passes with zero warnings.
