### PR TITLE
fix: add SECURITY DEFINER to CDC trigger functions

### DIFF
--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -191,7 +191,7 @@ pub fn create_change_trigger(
     // WAKE-1: PERFORM pg_notify wakes the scheduler immediately.
     let truncate_fn_sql = format!(
         "CREATE OR REPLACE FUNCTION {change_schema}.pg_trickle_cdc_truncate_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql AS $$
+         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
          BEGIN
              INSERT INTO {change_schema}.changes_{oid}
                  (lsn, action)
@@ -1448,7 +1448,7 @@ fn build_row_trigger_fn_sql(
     // how many rows are affected. Cost is negligible (~0.5 µs).
     format!(
         "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql AS $$
+         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
          BEGIN
              IF TG_OP = 'INSERT' THEN
                  INSERT INTO {cs}.changes_{oid}
@@ -1533,7 +1533,7 @@ fn build_stmt_trigger_fn_sql(
     // WAKE-1: PERFORM pg_notify wakes the scheduler immediately.
     let ins_fn = format!(
         "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_ins_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql AS $$
+         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
          BEGIN
              INSERT INTO {cs}.changes_{oid}
                  (lsn, action, pk_hash{ncn})
@@ -1553,7 +1553,7 @@ fn build_stmt_trigger_fn_sql(
         // Keyless table: no PK join possible — model UPDATE as DELETE+INSERT.
         format!(
             "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_upd_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql AS $$
+         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
          BEGIN
              INSERT INTO {cs}.changes_{oid}
                  (lsn, action, pk_hash{ocn})
@@ -1589,7 +1589,7 @@ fn build_stmt_trigger_fn_sql(
         let not_exists_join = build_pk_join_condition(pk_columns);
         format!(
             "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_upd_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql AS $$
+         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
          BEGIN
              INSERT INTO {cs}.changes_{oid}
                  (lsn, action, pk_hash{uccd}{ncn}{ocn})
@@ -1618,7 +1618,7 @@ fn build_stmt_trigger_fn_sql(
     // WAKE-1: PERFORM pg_notify wakes the scheduler immediately.
     let del_fn = format!(
         "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_del_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql AS $$
+         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
          BEGIN
              INSERT INTO {cs}.changes_{oid}
                  (lsn, action, pk_hash{ocn})


### PR DESCRIPTION
## Summary

- CDC trigger functions (`pg_trickle_cdc_fn`, `pg_trickle_cdc_truncate_fn`, `pg_trickle_cdc_ins_fn`, `pg_trickle_cdc_upd_fn` ×2, `pg_trickle_cdc_del_fn`) were missing `SECURITY DEFINER`
- Without it, they execute as the invoking user (whoever ran the DML on the source table), who typically has no INSERT privileges on the `pgtrickle_changes` schema
- This caused `permission denied for schema pgtrickle_changes` errors at runtime

## Test plan

- [ ] Create a stream table as a superuser
- [ ] Connect as a non-superuser with only privileges on the source table (no access to `pgtrickle_changes`)
- [ ] Run INSERT, UPDATE, DELETE, TRUNCATE on the source table — all should succeed without permission errors
- [ ] Verify change rows appear in `pgtrickle_changes.changes_<oid>`

https://claude.ai/code/session_01P3vxpRnYaN4m6pYg8kFh33