### PR TITLE
fix: lock search_path on CDC SECURITY DEFINER trigger functions

### DIFF
--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -191,7 +191,9 @@ pub fn create_change_trigger(
     // WAKE-1: PERFORM pg_notify wakes the scheduler immediately.
     let truncate_fn_sql = format!(
         "CREATE OR REPLACE FUNCTION {change_schema}.pg_trickle_cdc_truncate_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+         RETURNS trigger LANGUAGE plpgsql
+         SECURITY DEFINER
+         SET search_path = pg_catalog, pgtrickle, pgtrickle_changes, public AS $$
          BEGIN
              INSERT INTO {change_schema}.changes_{oid}
                  (lsn, action)
@@ -1448,7 +1450,9 @@ fn build_row_trigger_fn_sql(
     // how many rows are affected. Cost is negligible (~0.5 µs).
     format!(
         "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+         RETURNS trigger LANGUAGE plpgsql
+         SECURITY DEFINER
+         SET search_path = pg_catalog, pgtrickle, pgtrickle_changes, public AS $$
          BEGIN
              IF TG_OP = 'INSERT' THEN
                  INSERT INTO {cs}.changes_{oid}
@@ -1533,7 +1537,9 @@ fn build_stmt_trigger_fn_sql(
     // WAKE-1: PERFORM pg_notify wakes the scheduler immediately.
     let ins_fn = format!(
         "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_ins_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+         RETURNS trigger LANGUAGE plpgsql
+         SECURITY DEFINER
+         SET search_path = pg_catalog, pgtrickle, pgtrickle_changes, public AS $$
          BEGIN
              INSERT INTO {cs}.changes_{oid}
                  (lsn, action, pk_hash{ncn})
@@ -1553,7 +1559,9 @@ fn build_stmt_trigger_fn_sql(
         // Keyless table: no PK join possible — model UPDATE as DELETE+INSERT.
         format!(
             "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_upd_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+         RETURNS trigger LANGUAGE plpgsql
+         SECURITY DEFINER
+         SET search_path = pg_catalog, pgtrickle, pgtrickle_changes, public AS $$
          BEGIN
              INSERT INTO {cs}.changes_{oid}
                  (lsn, action, pk_hash{ocn})
@@ -1589,7 +1597,9 @@ fn build_stmt_trigger_fn_sql(
         let not_exists_join = build_pk_join_condition(pk_columns);
         format!(
             "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_upd_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+         RETURNS trigger LANGUAGE plpgsql
+         SECURITY DEFINER
+         SET search_path = pg_catalog, pgtrickle, pgtrickle_changes, public AS $$
          BEGIN
              INSERT INTO {cs}.changes_{oid}
                  (lsn, action, pk_hash{uccd}{ncn}{ocn})
@@ -1618,7 +1628,9 @@ fn build_stmt_trigger_fn_sql(
     // WAKE-1: PERFORM pg_notify wakes the scheduler immediately.
     let del_fn = format!(
         "CREATE OR REPLACE FUNCTION {cs}.pg_trickle_cdc_del_fn_{oid}()
-         RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+         RETURNS trigger LANGUAGE plpgsql
+         SECURITY DEFINER
+         SET search_path = pg_catalog, pgtrickle, pgtrickle_changes, public AS $$
          BEGIN
              INSERT INTO {cs}.changes_{oid}
                  (lsn, action, pk_hash{ocn})

--- a/tests/e2e_rls_tests.rs
+++ b/tests/e2e_rls_tests.rs
@@ -332,6 +332,54 @@ async fn test_ivm_trigger_functions_security_definer() {
     );
 }
 
+/// R4b: Verify that CDC trigger functions are SECURITY DEFINER with locked search_path.
+#[tokio::test]
+async fn test_cdc_trigger_functions_security_definer() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE rls_cdc_secdef_src (id INT PRIMARY KEY, val TEXT NOT NULL)")
+        .await;
+    db.execute("INSERT INTO rls_cdc_secdef_src VALUES (1, 'a')")
+        .await;
+
+    // DIFFERENTIAL mode creates the statement-level CDC triggers
+    db.create_st(
+        "rls_cdc_secdef_st",
+        "SELECT id, val FROM rls_cdc_secdef_src",
+        "1m",
+        "DIFFERENTIAL",
+    )
+    .await;
+
+    // All pg_trickle_cdc_* functions must be SECURITY DEFINER
+    let secdef_count: i64 = db
+        .query_scalar(
+            "SELECT count(*) FROM pg_proc \
+             WHERE proname LIKE 'pg_trickle_cdc_%' \
+             AND prosecdef = true",
+        )
+        .await;
+    assert!(
+        secdef_count > 0,
+        "CDC trigger functions should be SECURITY DEFINER (prosecdef = true), found {secdef_count}"
+    );
+
+    // All of them must also have a locked search_path
+    let without_search_path: i64 = db
+        .query_scalar(
+            "SELECT count(*) FROM pg_proc \
+             WHERE proname LIKE 'pg_trickle_cdc_%' \
+             AND prosecdef = true \
+             AND NOT (proconfig @> ARRAY['search_path=pg_catalog, pgtrickle, pgtrickle_changes, public'])",
+        )
+        .await;
+    assert_eq!(
+        without_search_path, 0,
+        "all CDC SECURITY DEFINER functions must have a locked search_path, \
+         found {without_search_path} without it"
+    );
+}
+
 // ══════════════════════════════════════════════════════════════════════
 // R10 — ENABLE/DISABLE RLS on source table triggers reinit
 // ══════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Follow-up to #378. The previous PR added `SECURITY DEFINER` to the CDC trigger functions but omitted `SET search_path`, which is required to fully harden `SECURITY DEFINER` functions against search_path hijacking attacks.

- Adds `SET search_path = pg_catalog, pgtrickle, pgtrickle_changes, public` to all six CDC trigger functions, matching the existing pattern used by the IVM trigger functions in `src/ivm.rs`
- Adds test **R4b** (`test_cdc_trigger_functions_security_definer`) to `e2e_rls_tests.rs` verifying both `prosecdef = true` and the locked search_path on all `pg_trickle_cdc_%` functions — closing the test coverage gap that let this go undetected

## Test plan

- [ ] `test_cdc_trigger_functions_security_definer` passes — verifies `prosecdef = true` and correct `proconfig` on all CDC trigger functions
- [ ] Existing RLS tests continue to pass

https://claude.ai/code/session_01P3vxpRnYaN4m6pYg8kFh33