### PR TITLE
test(staleness): improve coverage for pg_stat_stream_tables and NULL last_refresh_at

### DIFF
--- a/tests/catalog_tests.rs
+++ b/tests/catalog_tests.rs
@@ -368,7 +368,7 @@ async fn test_staleness_uses_last_refresh_at_not_data_timestamp() {
         )
         .await;
     assert!(
-        staleness_secs < 300.0,
+        staleness_secs < 120.0,
         "staleness ({staleness_secs:.1}s) should reflect last_refresh_at (~60s ago), \
          not data_timestamp (~7200s ago)"
     );
@@ -432,6 +432,165 @@ async fn test_stale_null_without_schedule() {
     assert!(
         stale.is_none(),
         "stale should be NULL for a stream table without a schedule"
+    );
+}
+
+#[tokio::test]
+async fn test_stale_null_when_last_refresh_at_is_null() {
+    // A scheduled table that has never been refreshed (last_refresh_at IS NULL)
+    // should have stale = NULL, not false. stream_tables_info computes
+    // EXTRACT(EPOCH FROM (now() - NULL)) which is NULL, so the comparison
+    // evaluates to NULL — correctly indicating "unknown" rather than "not stale".
+    let db = TestDb::with_catalog().await;
+
+    db.execute("CREATE TABLE never_refreshed (id INT)").await;
+    let oid: i32 = db
+        .query_scalar("SELECT 'never_refreshed'::regclass::oid::int")
+        .await;
+
+    db.execute(&format!(
+        "INSERT INTO pgtrickle.pgt_stream_tables \
+         (pgt_relid, pgt_name, pgt_schema, defining_query, schedule, \
+          refresh_mode, status, is_populated) \
+         VALUES ({}, 'never_st', 'public', 'SELECT * FROM never_refreshed', \
+                 '5m', 'FULL', 'INITIALIZING', false)",
+        oid
+    ))
+    .await;
+
+    let stale: Option<bool> = db
+        .query_scalar_opt(
+            "SELECT stale FROM pgtrickle.stream_tables_info WHERE pgt_name = 'never_st'",
+        )
+        .await;
+    assert!(
+        stale.is_none(),
+        "stale should be NULL for a scheduled table that has never been refreshed \
+         (last_refresh_at IS NULL)"
+    );
+
+    let staleness: Option<f64> = db
+        .query_scalar_opt(
+            "SELECT EXTRACT(EPOCH FROM staleness) \
+             FROM pgtrickle.stream_tables_info WHERE pgt_name = 'never_st'",
+        )
+        .await;
+    assert!(
+        staleness.is_none(),
+        "staleness should be NULL when last_refresh_at is NULL"
+    );
+}
+
+// ── pg_stat_stream_tables View ────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_pg_stat_stream_tables_stale_true_when_overdue() {
+    let db = TestDb::with_catalog().await;
+
+    db.execute("CREATE TABLE pgstat_stale_src (id INT)").await;
+    let oid: i32 = db
+        .query_scalar("SELECT 'pgstat_stale_src'::regclass::oid::int")
+        .await;
+
+    db.execute(&format!(
+        "INSERT INTO pgtrickle.pgt_stream_tables \
+         (pgt_relid, pgt_name, pgt_schema, defining_query, schedule, \
+          refresh_mode, status, is_populated, last_refresh_at) \
+         VALUES ({}, 'pgstat_stale_st', 'public', 'SELECT * FROM pgstat_stale_src', \
+                 '5m', 'FULL', 'ACTIVE', true, now() - interval '10 minutes')",
+        oid
+    ))
+    .await;
+
+    let stale: bool = db
+        .query_scalar(
+            "SELECT stale FROM pgtrickle.pg_stat_stream_tables \
+             WHERE pgt_name = 'pgstat_stale_st'",
+        )
+        .await;
+    assert!(
+        stale,
+        "pg_stat_stream_tables.stale should be true when last_refresh_at exceeds schedule"
+    );
+}
+
+#[tokio::test]
+async fn test_pg_stat_stream_tables_nodata_not_stale() {
+    // Regression: old data_timestamp + recent last_refresh_at must not be stale
+    // in pg_stat_stream_tables (same fix as stream_tables_info).
+    let db = TestDb::with_catalog().await;
+
+    db.execute("CREATE TABLE pgstat_nodata_src (id INT)").await;
+    let oid: i32 = db
+        .query_scalar("SELECT 'pgstat_nodata_src'::regclass::oid::int")
+        .await;
+
+    db.execute(&format!(
+        "INSERT INTO pgtrickle.pgt_stream_tables \
+         (pgt_relid, pgt_name, pgt_schema, defining_query, schedule, \
+          refresh_mode, status, is_populated, data_timestamp, last_refresh_at) \
+         VALUES ({}, 'pgstat_nodata_st', 'public', 'SELECT * FROM pgstat_nodata_src', \
+                 '5m', 'FULL', 'ACTIVE', true, \
+                 now() - interval '2 hours', now() - interval '1 minute')",
+        oid
+    ))
+    .await;
+
+    let stale: bool = db
+        .query_scalar(
+            "SELECT stale FROM pgtrickle.pg_stat_stream_tables \
+             WHERE pgt_name = 'pgstat_nodata_st'",
+        )
+        .await;
+    assert!(
+        !stale,
+        "pg_stat_stream_tables.stale should be false when last_refresh_at is recent, \
+         even if data_timestamp is hours old (NO_DATA pass scenario)"
+    );
+
+    let staleness_secs: f64 = db
+        .query_scalar(
+            "SELECT EXTRACT(EPOCH FROM staleness) \
+             FROM pgtrickle.pg_stat_stream_tables WHERE pgt_name = 'pgstat_nodata_st'",
+        )
+        .await;
+    assert!(
+        staleness_secs < 120.0,
+        "pg_stat_stream_tables.staleness ({staleness_secs:.1}s) should reflect \
+         last_refresh_at (~60s ago), not data_timestamp (~7200s ago)"
+    );
+}
+
+#[tokio::test]
+async fn test_pg_stat_stream_tables_stale_null_when_never_refreshed() {
+    // last_refresh_at IS NULL (explicit guard in pg_stat_stream_tables CASE WHEN)
+    // should yield stale = NULL, not false.
+    let db = TestDb::with_catalog().await;
+
+    db.execute("CREATE TABLE pgstat_null_src (id INT)").await;
+    let oid: i32 = db
+        .query_scalar("SELECT 'pgstat_null_src'::regclass::oid::int")
+        .await;
+
+    db.execute(&format!(
+        "INSERT INTO pgtrickle.pgt_stream_tables \
+         (pgt_relid, pgt_name, pgt_schema, defining_query, schedule, \
+          refresh_mode, status, is_populated) \
+         VALUES ({}, 'pgstat_null_st', 'public', 'SELECT * FROM pgstat_null_src', \
+                 '5m', 'FULL', 'INITIALIZING', false)",
+        oid
+    ))
+    .await;
+
+    let stale: Option<bool> = db
+        .query_scalar_opt(
+            "SELECT stale FROM pgtrickle.pg_stat_stream_tables \
+             WHERE pgt_name = 'pgstat_null_st'",
+        )
+        .await;
+    assert!(
+        stale.is_none(),
+        "pg_stat_stream_tables.stale should be NULL when last_refresh_at has never been set"
     );
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -142,6 +142,55 @@ SELECT st.*,
        END AS stale
 FROM pgtrickle.pgt_stream_tables st;
 
+CREATE OR REPLACE VIEW pgtrickle.pg_stat_stream_tables AS
+SELECT
+    st.pgt_id,
+    st.pgt_schema,
+    st.pgt_name,
+    st.status,
+    st.refresh_mode,
+    st.is_populated,
+    st.data_timestamp,
+    st.schedule,
+    now() - st.last_refresh_at AS staleness,
+    CASE WHEN st.schedule IS NOT NULL AND st.last_refresh_at IS NOT NULL
+              AND st.schedule !~ '[\s@]'
+         THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
+              pgtrickle.parse_duration_seconds(st.schedule)
+         ELSE NULL::boolean
+    END AS stale,
+    st.consecutive_errors,
+    st.needs_reinit,
+    st.last_refresh_at,
+    COALESCE(stats.total_refreshes, 0) AS total_refreshes,
+    COALESCE(stats.successful_refreshes, 0) AS successful_refreshes,
+    COALESCE(stats.failed_refreshes, 0) AS failed_refreshes,
+    COALESCE(stats.total_rows_inserted, 0) AS total_rows_inserted,
+    COALESCE(stats.total_rows_deleted, 0) AS total_rows_deleted,
+    stats.avg_duration_ms,
+    stats.last_action,
+    stats.last_status
+FROM pgtrickle.pgt_stream_tables st
+LEFT JOIN LATERAL (
+    SELECT
+        count(*)::bigint AS total_refreshes,
+        count(*) FILTER (WHERE h.status = 'COMPLETED')::bigint AS successful_refreshes,
+        count(*) FILTER (WHERE h.status = 'FAILED')::bigint AS failed_refreshes,
+        COALESCE(sum(h.rows_inserted), 0)::bigint AS total_rows_inserted,
+        COALESCE(sum(h.rows_deleted), 0)::bigint AS total_rows_deleted,
+        CASE WHEN count(*) FILTER (WHERE h.end_time IS NOT NULL) > 0
+             THEN avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000)
+                  FILTER (WHERE h.end_time IS NOT NULL)
+             ELSE NULL
+        END::float8 AS avg_duration_ms,
+        (SELECT h2.action FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_action,
+        (SELECT h2.status FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_status
+    FROM pgtrickle.pgt_refresh_history h
+    WHERE h.pgt_id = st.pgt_id
+) stats ON true;
+
 CREATE OR REPLACE VIEW pgtrickle.quick_health AS
 SELECT
     (SELECT count(*) FROM pgtrickle.pgt_stream_tables)::bigint

--- a/tests/e2e_monitoring_tests.rs
+++ b/tests/e2e_monitoring_tests.rs
@@ -255,7 +255,7 @@ async fn test_staleness_reflects_last_refresh_at_after_refresh() {
         )
         .await;
     assert!(
-        staleness_secs < 10.0,
+        staleness_secs < 30.0,
         "staleness ({staleness_secs:.2}s) should be near-zero after refresh \
          (based on last_refresh_at, not the old data_timestamp)"
     );
@@ -318,5 +318,100 @@ async fn test_no_data_refresh_does_not_cause_false_stale() {
     assert_eq!(
         stale_count, 0,
         "quick_health.stale_tables should be 0 when last_refresh_at is recent"
+    );
+}
+
+#[tokio::test]
+async fn test_pg_stat_stream_tables_nodata_not_stale() {
+    // Verifies the same NO_DATA fix applies to pg_stat_stream_tables.stale,
+    // which uses an explicit `last_refresh_at IS NOT NULL` guard in its CASE WHEN.
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE mon_pgstat_nd (id INT PRIMARY KEY)")
+        .await;
+    db.execute("INSERT INTO mon_pgstat_nd VALUES (1)").await;
+
+    db.create_st(
+        "mon_pgstat_nd_st",
+        "SELECT id FROM mon_pgstat_nd",
+        "5m",
+        "FULL",
+    )
+    .await;
+
+    // Simulate a NO_DATA pass: data is 2 hours old, scheduler ran 30 seconds ago
+    db.execute(
+        "UPDATE pgtrickle.pgt_stream_tables \
+         SET data_timestamp  = now() - interval '2 hours', \
+             last_refresh_at = now() - interval '30 seconds' \
+         WHERE pgt_name = 'mon_pgstat_nd_st'",
+    )
+    .await;
+
+    let stale: bool = db
+        .query_scalar(
+            "SELECT COALESCE(stale, false) FROM pgtrickle.pg_stat_stream_tables \
+             WHERE pgt_name = 'mon_pgstat_nd_st'",
+        )
+        .await;
+    assert!(
+        !stale,
+        "pg_stat_stream_tables.stale should be false when last_refresh_at is recent, \
+         even with old data_timestamp"
+    );
+
+    let staleness_secs: f64 = db
+        .query_scalar(
+            "SELECT EXTRACT(EPOCH FROM staleness) \
+             FROM pgtrickle.pg_stat_stream_tables WHERE pgt_name = 'mon_pgstat_nd_st'",
+        )
+        .await;
+    assert!(
+        staleness_secs < 300.0,
+        "pg_stat_stream_tables.staleness ({staleness_secs:.1}s) should reflect \
+         last_refresh_at (~30s ago), not data_timestamp (~7200s ago)"
+    );
+}
+
+#[tokio::test]
+async fn test_pg_stat_stream_tables_stale_null_when_never_refreshed() {
+    // An ST that was just created and has never been refreshed should have
+    // pg_stat_stream_tables.stale = NULL (not false), because
+    // last_refresh_at IS NULL and the explicit NULL guard fires.
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE mon_pgstat_null (id INT PRIMARY KEY)")
+        .await;
+    db.execute("INSERT INTO mon_pgstat_null VALUES (1)").await;
+
+    // Create without triggering an initial refresh — use with_extension
+    // which does not auto-refresh, so last_refresh_at starts as NULL.
+    db.execute(
+        "SELECT pgtrickle.create_stream_table('mon_pgstat_null_st', \
+         'SELECT id FROM mon_pgstat_null', '5m', 'FULL', false)",
+    )
+    .await;
+
+    // Confirm last_refresh_at is NULL before any refresh
+    let last_refresh_at_is_null: bool = db
+        .query_scalar(
+            "SELECT last_refresh_at IS NULL FROM pgtrickle.pgt_stream_tables \
+             WHERE pgt_name = 'mon_pgstat_null_st'",
+        )
+        .await;
+    assert!(
+        last_refresh_at_is_null,
+        "last_refresh_at should be NULL before first refresh"
+    );
+
+    let stale: Option<bool> = db
+        .query_scalar_opt(
+            "SELECT stale FROM pgtrickle.pg_stat_stream_tables \
+             WHERE pgt_name = 'mon_pgstat_null_st'",
+        )
+        .await;
+    assert!(
+        stale.is_none(),
+        "pg_stat_stream_tables.stale should be NULL when last_refresh_at has never been set"
     );
 }


### PR DESCRIPTION
## What and why

Follow-up to #382, addressing gaps in the initial test suite.

### Gaps closed

**`pg_stat_stream_tables` had no staleness tests** despite having the same `last_refresh_at` fix applied. A regression there would go undetected.

**`last_refresh_at IS NULL` was untested** — a scheduled table that has never been refreshed should report `stale = NULL` (unknown), not `false`. Both views handle this differently (`stream_tables_info` via NULL arithmetic, `pg_stat_stream_tables` via an explicit `IS NOT NULL` guard) and neither case was covered.

### Changes

**`tests/common/mod.rs`**
- Add `pg_stat_stream_tables` view to `CATALOG_DDL`

**`tests/catalog_tests.rs`**
- `test_stale_null_when_last_refresh_at_is_null` — both `stale` and `staleness` are NULL in `stream_tables_info` when `last_refresh_at` is unset
- `test_pg_stat_stream_tables_stale_true_when_overdue` — basic stale=true case
- `test_pg_stat_stream_tables_nodata_not_stale` — NO_DATA regression: old `data_timestamp`, recent `last_refresh_at` → `stale=false`
- `test_pg_stat_stream_tables_stale_null_when_never_refreshed` — explicit NULL guard case
- Tighten staleness interval bound from `< 300s` to `< 120s`

**`tests/e2e_monitoring_tests.rs`**
- `test_pg_stat_stream_tables_nodata_not_stale` — e2e NO_DATA regression for `pg_stat_stream_tables`
- `test_pg_stat_stream_tables_stale_null_when_never_refreshed` — e2e NULL guard using `create_stream_table(..., false)` to skip initial refresh
- Widen post-refresh staleness assertion from `< 10s` to `< 30s` to reduce flakiness