### PR TITLE
fix: Docker builds and CI jobs broken by pgtrickle-tui workspace member

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -710,10 +710,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
       - name: Build E2E Docker image
-        run: just build-e2e-image
+        run: ./tests/build_e2e_image.sh
 
       - name: Run soak test (10 min)
-        run: SOAK_DURATION_SECS=600 just test-soak
+        run: SOAK_DURATION_SECS=600 ./scripts/run_e2e_tests.sh --test e2e_soak_tests --run-ignored all --no-capture
         timeout-minutes: 20
 
   # ── G17-MDB: Multi-Database Scheduler Isolation Test ──────────────────
@@ -740,10 +740,10 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
 
       - name: Build E2E Docker image
-        run: just build-e2e-image
+        run: ./tests/build_e2e_image.sh
 
       - name: Run multi-database isolation test
-        run: just test-mdb
+        run: ./scripts/run_e2e_tests.sh --test e2e_mdb_tests --run-ignored all --no-capture
 
       - name: Verify extension image layout
         run: |

--- a/Dockerfile.ghcr
+++ b/Dockerfile.ghcr
@@ -64,17 +64,19 @@ FROM build-env AS build-deps
 
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
+COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
 
 # Minimal stubs so cargo can compile deps without the full source tree.
 # These stubs will be replaced in the build stage below.
-RUN mkdir -p src/bin src/dvm/operators benches && \
+RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
     echo '' > src/dvm/mod.rs && \
     echo '' > src/dvm/operators/mod.rs && \
     echo '' > src/ivm.rs && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
-    echo 'fn main() {}' > benches/diff_operators.rs
+    echo 'fn main() {}' > benches/diff_operators.rs && \
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Pre-fetch dependencies. Docker caches this layer independently.
 # If only src/ changes on the next build, this layer is skipped, saving 10–15 min.
@@ -89,14 +91,16 @@ WORKDIR /build
 
 # Copy source code and configuration
 COPY Cargo.toml Cargo.lock ./
+COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
 COPY src/ src/
 COPY pg_trickle.control ./
 
-# Create placeholder bench files (required by Cargo.toml but not needed for
-# extension package)
-RUN mkdir -p benches && \
+# Create placeholder bench and workspace member files (required by Cargo.toml
+# but not needed for extension package)
+RUN mkdir -p benches pgtrickle-tui/src && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
-    echo 'fn main() {}' > benches/refresh_bench.rs
+    echo 'fn main() {}' > benches/refresh_bench.rs && \
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Compile the extension. Cargo will automatically use cached dependencies
 # from the build-deps stage's `cargo fetch` (stored in /root/.cargo).

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -60,17 +60,19 @@ FROM build-env AS build-deps
 
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
+COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
 
 # Minimal stubs so cargo can compile deps without the full source tree.
 # These stubs will be replaced in the build stage below.
-RUN mkdir -p src/bin src/dvm/operators benches && \
+RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
     echo '' > src/dvm/mod.rs && \
     echo '' > src/dvm/operators/mod.rs && \
     echo '' > src/ivm.rs && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
-    echo 'fn main() {}' > benches/diff_operators.rs
+    echo 'fn main() {}' > benches/diff_operators.rs && \
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Pre-fetch dependencies. Docker caches this layer independently.
 # If only src/ changes on next build, this layer is skipped, saving 10–15 min.
@@ -87,14 +89,16 @@ WORKDIR /build
 
 # Copy source code and configuration
 COPY Cargo.toml Cargo.lock ./
+COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
 COPY src/ src/
 COPY pg_trickle.control ./
 
-# Create placeholder bench files (required by Cargo.toml but not needed for
-# extension package)
-RUN mkdir -p benches && \
+# Create placeholder bench and workspace member files (required by Cargo.toml
+# but not needed for extension package)
+RUN mkdir -p benches pgtrickle-tui/src && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
-    echo 'fn main() {}' > benches/refresh_bench.rs
+    echo 'fn main() {}' > benches/refresh_bench.rs && \
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Compile the extension. Cargo will automatically use cached dependencies
 # from the build-deps stage's `cargo fetch` (stored in /root/.cargo).

--- a/cnpg/Dockerfile.ext-build
+++ b/cnpg/Dockerfile.ext-build
@@ -43,8 +43,9 @@ RUN cargo pgrx init --pg18 /usr/bin/pg_config
 # ── Dependency caching layer ────────────────────────────────────────────────
 WORKDIR /build
 COPY Cargo.toml ./
+COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
 
-RUN mkdir -p src/bin src/dvm/operators benches && \
+RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
     echo '' > src/dvm/mod.rs && \
@@ -52,6 +53,7 @@ RUN mkdir -p src/bin src/dvm/operators benches && \
     echo '' > src/ivm.rs && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs && \
     cargo generate-lockfile && \
     cargo fetch
 

--- a/tests/Dockerfile.e2e
+++ b/tests/Dockerfile.e2e
@@ -33,16 +33,18 @@ FROM ${BUILDER_IMAGE} AS builder
 # Copy manifests + lockfile so dep downloads are cached separately from source.
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
+COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
 
 # Create minimal stubs so cargo can resolve the workspace without real source.
-RUN mkdir -p src/bin src/dvm/operators benches && \
+RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
     echo '' > src/dvm/mod.rs && \
     echo '' > src/dvm/operators/mod.rs && \
     echo '' > src/ivm.rs && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
-    echo 'fn main() {}' > benches/diff_operators.rs
+    echo 'fn main() {}' > benches/diff_operators.rs && \
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Pre-fetch all crates.  Cache mount keeps the registry between builds so
 # this becomes a no-op when Cargo.lock hasn't changed.

--- a/tests/Dockerfile.e2e-coverage
+++ b/tests/Dockerfile.e2e-coverage
@@ -53,15 +53,17 @@ RUN cargo pgrx init --pg18 /usr/bin/pg_config
 # ── Dependency caching layer ────────────────────────────────────────────────
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
+COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
 
-RUN mkdir -p src/bin src/dvm/operators benches && \
+RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
     echo '' > src/dvm/mod.rs && \
     echo '' > src/dvm/operators/mod.rs && \
     echo '' > src/ivm.rs && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
-    echo 'fn main() {}' > benches/diff_operators.rs
+    echo 'fn main() {}' > benches/diff_operators.rs && \
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \


### PR DESCRIPTION
## Problem

CI run [#1304](https://github.com/grove/pg-trickle/actions/runs/23909860397) has widespread failures across 8+ jobs. All stem from two root causes:

### 1. Docker builds fail: missing `pgtrickle-tui` workspace member

After `pgtrickle-tui` was added as a workspace member in `Cargo.toml`, all Dockerfiles that copy `Cargo.toml` and run `cargo fetch` or `cargo generate-lockfile` fail with:

```
error: failed to load manifest for workspace member `/build/pgtrickle-tui`
  failed to read `/build/pgtrickle-tui/Cargo.toml`
  No such file or directory (os error 2)
```

**Affected jobs:** E2E tests, DAG bench (calc/throughput), DAG bench (parallel workers), dbt integration, dbt getting-started example, CNPG smoke test, Stability soak test, Multi-database isolation test.

### 2. Soak test & multi-db test: `just` not installed

These two CI jobs call `just build-e2e-image` and `just test-soak`/`just test-mdb` but never install `just`, causing `exit code 127` (command not found).

## Fix

### Docker builds
Add `COPY pgtrickle-tui/Cargo.toml` and a stub `pgtrickle-tui/src/main.rs` to all 5 Dockerfiles that resolve the Cargo workspace:
- `tests/Dockerfile.e2e`
- `tests/Dockerfile.e2e-coverage`
- `cnpg/Dockerfile.ext-build`
- `Dockerfile.ghcr`
- `Dockerfile.hub`

The TUI binary isn't needed in any of these images — only its `Cargo.toml` is required for workspace resolution.

### CI workflow
Replace `just` commands with direct script invocations (matching the justfile definitions) in the `soak-test` and `mdb-test` jobs. No other CI jobs use `just`.
