### PR TITLE
fix: CI workflow failures — extract stability tests, fix CNPG job, increase timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v5
 
@@ -159,7 +159,7 @@ jobs:
   light-e2e-tests:
     name: Light E2E tests (${{ matrix.shard_name }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -685,65 +685,6 @@ jobs:
         run: |
           docker build -t pg_trickle-ext:ci \
             -f cnpg/Dockerfile.ext-build .
-
-  # ── G17-SOAK: Long-Running Stability Soak Test ───────────────────────
-
-  soak-test:
-    name: Stability soak test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    timeout-minutes: 30
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-
-      - name: Build E2E Docker image
-        run: ./tests/build_e2e_image.sh
-
-      - name: Run soak test (10 min)
-        run: SOAK_DURATION_SECS=600 ./scripts/run_e2e_tests.sh --test e2e_soak_tests --run-ignored all --no-capture
-        timeout-minutes: 20
-
-  # ── G17-MDB: Multi-Database Scheduler Isolation Test ──────────────────
-
-  mdb-test:
-    name: Multi-database isolation test
-    runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    timeout-minutes: 15
-    continue-on-error: true
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('Cargo.lock') }}
-
-      - name: Build E2E Docker image
-        run: ./tests/build_e2e_image.sh
-
-      - name: Run multi-database isolation test
-        run: ./scripts/run_e2e_tests.sh --test e2e_mdb_tests --run-ignored all --no-capture
 
       - name: Verify extension image layout
         run: |

--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -1,0 +1,59 @@
+# =============================================================================
+# Stability Tests — Long-running soak and multi-database isolation tests
+#
+# Separated from ci.yml because these are heavyweight, non-blocking stability
+# tests that don't gate PRs or merges.  They run daily and on manual dispatch.
+# =============================================================================
+name: Stability Tests
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Daily 03:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  NEXTEST_PROFILE: ci
+  PG_VERSION: "18"
+
+jobs:
+  # ── G17-SOAK: Long-Running Stability Soak Test ───────────────────────
+  soak-test:
+    name: Stability soak test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup pgrx environment
+        uses: ./.github/actions/setup-pgrx
+
+      - name: Build E2E Docker image
+        run: ./tests/build_e2e_image.sh
+
+      - name: Run soak test (10 min)
+        run: SOAK_DURATION_SECS=600 ./scripts/run_e2e_tests.sh --test e2e_soak_tests --run-ignored all --no-capture
+        timeout-minutes: 20
+
+  # ── G17-MDB: Multi-Database Scheduler Isolation Test ──────────────────
+  mdb-test:
+    name: Multi-database isolation test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup pgrx environment
+        uses: ./.github/actions/setup-pgrx
+
+      - name: Build E2E Docker image
+        run: ./tests/build_e2e_image.sh
+
+      - name: Run multi-database isolation test
+        run: ./scripts/run_e2e_tests.sh --test e2e_mdb_tests --run-ignored all --no-capture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,8 +188,11 @@ light-eligible; 10 files (~90 tests) require the full E2E image.
 | E2E bench — TPC-H FULL vs DIFF | ❌ | ❌ | Weekly (Sun) | ✅ |
 | dbt integration | ❌ | ❌ | ✅ | ✅ |
 | CNPG smoke test | ❌ | ❌ | ✅ | ✅ |
-| Soak test (G17-SOAK) | ❌ | ❌ | ✅ | ✅ |
-| Multi-database (G17-MDB) | ❌ | ❌ | ✅ | ✅ |
+| Soak test (G17-SOAK)¹ | ❌ | ❌ | ✅ | ✅ |
+| Multi-database (G17-MDB)¹ | ❌ | ❌ | ✅ | ✅ |
+
+¹ Soak and multi-database tests run in the separate `stability-tests.yml`
+workflow, not in ci.yml.
 
 > **Note:** Full E2E and TPC-H tests are **skipped on PRs** (the Docker build
 > is ~20 min). Light E2E tests run on every PR using `cargo pgrx package` +

--- a/tests/e2e_mixed_scheduling_tests.rs
+++ b/tests/e2e_mixed_scheduling_tests.rs
@@ -128,7 +128,10 @@ async fn refresh_for_mode(db: &E2eDb, st_name: &str, mode: ScheduleMode) {
 /// Wait for an entire chain of STs to be refreshed by the scheduler.
 ///
 /// For manual mode, refreshes each ST in order (topological).
-/// For scheduler modes, waits for the leaf ST to auto-refresh.
+/// For scheduler modes, waits for each ST in topological order to ensure
+/// changes propagate through the chain.  Waiting only for the leaf is racy:
+/// the scheduler might refresh the leaf with stale upstream data if the
+/// parent hasn't been refreshed yet in the current cycle.
 async fn refresh_chain_for_mode(db: &E2eDb, st_names: &[&str], mode: ScheduleMode) {
     match mode {
         ScheduleMode::Manual => {
@@ -137,17 +140,14 @@ async fn refresh_chain_for_mode(db: &E2eDb, st_names: &[&str], mode: ScheduleMod
             }
         }
         ScheduleMode::Serial | ScheduleMode::Parallel => {
-            // The scheduler handles topological ordering; just wait for the
-            // leaf to be refreshed.
-            if let Some(leaf) = st_names.last() {
+            // Wait for each ST in topological order so that downstream STs
+            // observe the refreshed upstream data.
+            for name in st_names {
                 let refreshed = db
-                    .wait_for_auto_refresh(leaf, Duration::from_secs(90))
+                    .wait_for_auto_refresh(name, Duration::from_secs(90))
                     .await;
                 if !refreshed {
-                    // Fallback: refresh the full chain manually
-                    for name in st_names {
-                        db.refresh_st_with_retry(name).await;
-                    }
+                    db.refresh_st_with_retry(name).await;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Fixes five failures from CI run #1307, and moves the stability tests (G17-SOAK and G17-MDB) out of `ci.yml` into their own dedicated workflow.

---

## Failures fixed

### 1. Soak test & MDB test — exit code 101 (`no such command: nextest`)

Both jobs used a manual Rust setup (`dtolnay/rust-toolchain` + `actions/cache@v4`) instead of the shared `.github/actions/setup-pgrx` composite action. `cargo-nextest` was never installed, so every run failed immediately.

**Fix:** Move both jobs to the new `stability-tests.yml` workflow which uses `setup-pgrx`, the same as every other job in the repo.

### 2. CNPG smoke test steps placed in the wrong job

The steps for verifying the extension image layout, building the composite image, deploying the CNPG cluster, and running the smoke test were accidentally placed inside the `mdb-test` job instead of `cnpg-smoke-test`.

**Fix:** Move the steps back into `cnpg-smoke-test` where they belong.

### 3. Integration tests — 15 min timeout

The `setup-pgrx` action occasionally takes 15+ min on a full cache miss (no warm Cargo/pgrx caches). The job was hitting the hard 15-minute limit and being cancelled before any tests ran.

**Fix:** Increase `integration-tests` timeout from 15 → 25 minutes.

### 4. Light E2E tests (shard 2/3) — 20 min timeout

Same root cause. `setup-pgrx` took ~19m40s and the job was cancelled before the test suite started.

**Fix:** Increase `light-e2e-tests` timeout from 20 → 30 minutes.

### 5. `test_mixed_sched_three_layer_chain_parallel` — exit code 100

`refresh_chain_for_mode` in the parallel/serial scheduler path waited only for the **leaf** ST to be refreshed by the scheduler, then asserted the leaf's contents matched its defining query. This was racy: the scheduler could have refreshed the leaf in an earlier cycle (before the upstream ST was up-to-date with the latest data change), causing the leaf to hold stale results at assertion time.

**Fix:** Wait for each ST in **topological order** (root → leaf) so every upstream ST is confirmed refreshed with the latest data before the downstream one is checked.

---

## New workflow: `stability-tests.yml`

Soak and multi-database isolation tests were never appropriate for `ci.yml`. They are:
- Non-blocking (`continue-on-error: true`)
- Heavyweight (10+ min runtime each)
- Not PR gates — they validate long-running stability, not correctness of a single change

The new `stability-tests.yml` runs on the same daily schedule and `workflow_dispatch` as before; the only change is they now get proper `setup-pgrx` infrastructure and live in their own workflow so CI run pages are less cluttered.

`AGENTS.md` updated to note the separate workflow with a footnote marker.
