### PR TITLE
fix: abort orphaned transaction in parallel worker panic recovery (ERR-1d)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-retries = 0
+retries = 2
 
 [profile.ci]
 retries = 2

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -617,6 +617,17 @@ pub extern "C-unwind" fn pg_trickle_refresh_worker_main(_arg: pg_sys::Datum) {
                 error_msg,
             );
 
+            // ERR-1d fix: After a PG ERROR inside BackgroundWorker::transaction,
+            // the PostgreSQL transaction state is left in STARTED/ABORT state
+            // because CommitTransactionCommand was never called.  We must abort
+            // the orphaned transaction before starting a new one, otherwise
+            // StartTransactionCommand raises "unexpected state STARTED".
+            // SAFETY: AbortCurrentTransaction properly cleans up the aborted
+            // transaction and returns PostgreSQL to idle state.
+            unsafe {
+                pg_sys::AbortCurrentTransaction();
+            }
+
             // Determine if this is a retryable or permanent error.
             let is_retryable = crate::error::classify_spi_error_retryable(&error_msg);
 
@@ -4217,7 +4228,41 @@ fn refresh_single_st(
         }
         base_action
     };
-    let result = execute_scheduled_refresh(&st, action, tick_watermark, drift_counter);
+
+    // ERR-1e: Wrap the refresh in a subtransaction + catch_unwind so that
+    // PG ERRORs (which pgrx converts to panics via longjmp) don't abort
+    // the entire tick transaction.  On panic the subtransaction rolls back
+    // (undoing TRUNCATE + partial writes) and we set ERROR status in the
+    // still-valid outer transaction.
+    let subtxn = SubTransaction::begin();
+    let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+        execute_scheduled_refresh(&st, action, tick_watermark, drift_counter)
+    }));
+    let result = match result {
+        Ok(outcome) => {
+            subtxn.commit();
+            outcome
+        }
+        Err(panic_payload) => {
+            subtxn.rollback();
+            let error_msg = extract_panic_message(&panic_payload);
+            log!(
+                "pg_trickle: refresh panicked for {}.{}: {} — setting error state",
+                st.pgt_schema,
+                st.pgt_name,
+                error_msg,
+            );
+            let is_retryable = crate::error::classify_spi_error_retryable(&error_msg);
+            if !is_retryable {
+                let _ = StreamTableMeta::set_error_state(pgt_id, &error_msg);
+            }
+            if is_retryable {
+                RefreshOutcome::RetryableFailure
+            } else {
+                RefreshOutcome::PermanentFailure
+            }
+        }
+    };
 
     let retry = retry_states.entry(pgt_id).or_default();
     match result {

--- a/tests/e2e_error_state_tests.rs
+++ b/tests/e2e_error_state_tests.rs
@@ -95,10 +95,16 @@ async fn test_permanent_error_sets_error_status_and_alter_clears() {
     assert_eq!(db.count("public.err1e_st").await, 1);
 
     // ── Inject permanent error: drop the column ──
-    // Disable the block-source-DDL guard to allow the ALTER TABLE
+    // Wrap DML + DDL in a single transaction so the CDC change and schema
+    // change become visible atomically.  The DML triggers CDC so the
+    // scheduler detects upstream changes and attempts a FULL refresh,
+    // which fails because the defining query references the dropped column.
     db.execute_seq(&[
-        "SET pg_trickle.block_source_ddl = false",
+        "BEGIN",
+        "INSERT INTO err1e_src(id, val, extra) VALUES (2, 'trigger_dml', 'z')",
+        "SET LOCAL pg_trickle.block_source_ddl = false",
         "ALTER TABLE err1e_src DROP COLUMN extra",
+        "COMMIT",
     ])
     .await;
 
@@ -161,11 +167,8 @@ async fn test_permanent_error_sets_error_status_and_alter_clears() {
         .await;
 
     // ALTER to a valid query (without the dropped 'extra' column)
-    db.alter_st(
-        "err1e_st",
-        "defining_query => 'SELECT id, val FROM err1e_src'",
-    )
-    .await;
+    db.alter_st("err1e_st", "query => 'SELECT id, val FROM err1e_src'")
+        .await;
 
     // ── Verify status is back to ACTIVE ──
     let (status, _, _, _) = db.pgt_status("err1e_st").await;
@@ -217,10 +220,14 @@ async fn test_error_columns_visible_in_info_view() {
     // Wait for initial population
     assert_eq!(db.count("public.err1e_view_st").await, 1);
 
-    // Inject permanent error
+    // Inject permanent error — wrap DML + DDL in a transaction so CDC
+    // captures a change atomically with the schema break.
     db.execute_seq(&[
-        "SET pg_trickle.block_source_ddl = false",
+        "BEGIN",
+        "INSERT INTO err1e_view_src(id, val) VALUES (2, 'trigger_dml')",
+        "SET LOCAL pg_trickle.block_source_ddl = false",
         "ALTER TABLE err1e_view_src DROP COLUMN val",
+        "COMMIT",
     ])
     .await;
 
@@ -261,10 +268,14 @@ async fn test_refresh_rejects_error_status() {
     )
     .await;
 
-    // Inject permanent error
+    // Inject permanent error — wrap DML + DDL in a transaction so CDC
+    // captures a change atomically with the schema break.
     db.execute_seq(&[
-        "SET pg_trickle.block_source_ddl = false",
+        "BEGIN",
+        "INSERT INTO err1e_rej_src(id, val) VALUES (2, 'trigger_dml')",
+        "SET LOCAL pg_trickle.block_source_ddl = false",
         "ALTER TABLE err1e_rej_src DROP COLUMN val",
+        "COMMIT",
     ])
     .await;
 


### PR DESCRIPTION
## Summary

Fixes the error-state circuit breaker (ERR-1d/ERR-1e) so that permanent refresh errors (e.g., a dropped source column) properly set `ERROR` status on stream tables instead of crashing the worker in a retry loop.

## Root Cause

When a parallel refresh worker encountered a PG ERROR (e.g., `column "extra" does not exist`), the `catch_unwind` correctly caught the panic, but then calling `BackgroundWorker::transaction()` to set ERROR status failed with:

```
StartTransactionCommand: unexpected state STARTED
```

This caused the worker to crash, get reaped, and respawn indefinitely — never setting the ERROR status.

The PostgreSQL transaction state was left in STARTED/ABORT state after the panic because `CommitTransactionCommand` was never called on the aborted transaction.

## Changes

### `src/scheduler.rs`
1. **Parallel worker (ERR-1d)**: After `catch_unwind` catches a PG ERROR panic, call `AbortCurrentTransaction()` to properly clean up the orphaned transaction state before starting a fresh transaction to set ERROR status.
2. **Sequential path (ERR-1e)**: Wrap `execute_scheduled_refresh` in a `SubTransaction` + `catch_unwind` so PG ERRORs don't abort the entire scheduler tick transaction.

### `tests/e2e_error_state_tests.rs`
- Fix tests to inject DML inside the same transaction as the DDL column drop, so CDC captures a change that triggers the FULL refresh (which then hits the missing column error). Without DML, the scheduler sees no upstream changes and does NO_DATA refreshes indefinitely.
- Fix `alter_stream_table` parameter name: `defining_query` → `query`.

### `.config/nextest.toml`
- Set default profile `retries = 2` (matching CI profile) to handle transient Docker container startup failures locally.

## Testing

All 1143 E2E tests pass (3 flaky retried, 90 skipped as expected).
