### PR TITLE
fix: add cascade parameter to drop_stream_table (STST-3)

### DIFF
--- a/pgtrickle-tui/src/test_db.rs
+++ b/pgtrickle-tui/src/test_db.rs
@@ -265,7 +265,7 @@ $$;
 
 -- ── drop_stream_table() ───────────────────────────────────────────────────
 -- Used by: drop
-CREATE OR REPLACE FUNCTION pgtrickle.drop_stream_table(name text)
+CREATE OR REPLACE FUNCTION pgtrickle.drop_stream_table(name text, cascade boolean DEFAULT true)
 RETURNS void LANGUAGE sql AS $$
     SELECT
 $$;

--- a/sql/archive/pg_trickle--0.15.0.sql
+++ b/sql/archive/pg_trickle--0.15.0.sql
@@ -941,7 +941,8 @@ AS 'MODULE_PATHNAME', 'slot_health_wrapper';
 -- src/api.rs:3203
 -- pg_trickle::api::drop_stream_table
 CREATE  FUNCTION pgtrickle."drop_stream_table"(
-	"name" TEXT /* &str */
+	"name" TEXT /* &str */,
+	"cascade" BOOL DEFAULT true /* bool */
 ) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */

--- a/sql/pg_trickle--0.14.0--0.15.0.sql
+++ b/sql/pg_trickle--0.14.0--0.15.0.sql
@@ -38,3 +38,14 @@
 --   Detects stuck watermarks and pauses downstream stream tables.
 --
 -- No catalog schema changes in this upgrade step.
+
+-- drop_stream_table: add cascade parameter (defaults to true)
+-- The old 1-arg overload is replaced by a 2-arg overload with a default.
+DROP FUNCTION IF EXISTS pgtrickle."drop_stream_table"(TEXT);
+CREATE FUNCTION pgtrickle."drop_stream_table"(
+    "name" TEXT /* &str */,
+    "cascade" BOOL DEFAULT true /* bool */
+) RETURNS void
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drop_stream_table_wrapper';

--- a/src/api.rs
+++ b/src/api.rs
@@ -3355,21 +3355,27 @@ fn alter_stream_table_impl(
 }
 
 /// Drop a stream table, removing the storage table and all catalog entries.
+///
+/// When `cascade` is `true` (the default) any downstream stream tables that
+/// depend on this one are automatically dropped first.  When `cascade` is
+/// `false` the function raises an error if any dependents exist, matching the
+/// behaviour of PostgreSQL's own `DROP TABLE … CASCADE | RESTRICT`.
 #[pg_extern(schema = "pgtrickle")]
-fn drop_stream_table(name: &str) {
-    let result = drop_stream_table_impl(name);
+fn drop_stream_table(name: &str, cascade: default!(bool, true)) {
+    let result = drop_stream_table_impl(name, cascade);
     if let Err(e) = result {
         raise_error_with_context(e);
     }
 }
 
-fn drop_stream_table_impl(name: &str) -> Result<(), PgTrickleError> {
+fn drop_stream_table_impl(name: &str, cascade: bool) -> Result<(), PgTrickleError> {
     let mut visited_pgt_ids = HashSet::new();
-    drop_stream_table_impl_inner(name, &mut visited_pgt_ids)
+    drop_stream_table_impl_inner(name, cascade, &mut visited_pgt_ids)
 }
 
 fn drop_stream_table_impl_inner(
     name: &str,
+    cascade: bool,
     visited_pgt_ids: &mut HashSet<i64>,
 ) -> Result<(), PgTrickleError> {
     let (schema, table_name) = parse_qualified_name(name)?;
@@ -3384,10 +3390,23 @@ fn drop_stream_table_impl_inner(
     // this ST's storage table.  We iterate by pgt_id to avoid re-querying
     // after each recursive drop changes the catalog.
     let downstream_ids = StDependency::get_downstream_pgt_ids(st.pgt_relid)?;
+    if !downstream_ids.is_empty() && !cascade {
+        let names: Vec<String> = downstream_ids
+            .iter()
+            .filter_map(|id| StreamTableMeta::get_by_id(*id).ok().flatten())
+            .map(|s| format!("{}.{}", s.pgt_schema, s.pgt_name))
+            .collect();
+        return Err(PgTrickleError::InvalidArgument(format!(
+            "stream table {}.{} has dependent stream tables: {}. Use cascade => true to drop them automatically.",
+            schema,
+            table_name,
+            names.join(", ")
+        )));
+    }
     for downstream_id in downstream_ids {
         if let Some(downstream_st) = StreamTableMeta::get_by_id(downstream_id)? {
             let qualified = format!("{}.{}", downstream_st.pgt_schema, downstream_st.pgt_name);
-            drop_stream_table_impl_inner(&qualified, visited_pgt_ids)?;
+            drop_stream_table_impl_inner(&qualified, cascade, visited_pgt_ids)?;
         }
     }
 


### PR DESCRIPTION
## Problem

CI E2E tests were failing with exit code 100:

```
thread 'test_drop_intermediate_st_in_cascade' panicked at tests/e2e/mod.rs:815:33:
SQL failed: error returned from database: function pgtrickle.drop_stream_table(unknown, cascade => boolean) does not exist
SQL: SELECT pgtrickle.drop_stream_table('stst3_drop_l2', cascade => true)
```

The STST-3 test `test_drop_intermediate_st_in_cascade` calls
`pgtrickle.drop_stream_table('name', cascade => true)` but the function only
accepted a single `name TEXT` argument.

## Fix

Add a `cascade BOOLEAN DEFAULT true` parameter to `drop_stream_table`:

- `cascade = true` (default): existing behaviour — downstream stream tables are
  dropped recursively before the target is removed.
- `cascade = false`: error if any dependent stream tables exist (matches
  PostgreSQL's own `DROP TABLE … RESTRICT` behaviour).

### Files changed

| File | Change |
|------|--------|
| `src/api.rs` | Add `cascade: default!(bool, true)` to `drop_stream_table`; implement non-cascade guard in `drop_stream_table_impl_inner` |
| `sql/archive/pg_trickle--0.15.0.sql` | Add `"cascade" BOOL DEFAULT true` to the archived function DDL |
| `sql/pg_trickle--0.14.0--0.15.0.sql` | DROP old 1-arg overload + CREATE new 2-arg overload (upgrade path) |
| `pgtrickle-tui/src/test_db.rs` | Update TUI test stub to match new signature |

## Testing

- Unit tests: 1687 passed ✅
- Upgrade completeness check: PASSED ✅
- E2E test `test_drop_intermediate_st_in_cascade` will pass once the full CI E2E suite runs with the rebuilt Docker image
