### PR TITLE
fix: correct i32 type annotations for INT4 columns in circ_imm E2E tests (CIRC-IMM)

### DIFF
--- a/tests/e2e_circ_imm_tests.rs
+++ b/tests/e2e_circ_imm_tests.rs
@@ -154,12 +154,12 @@ async fn test_diamond_immediate_both_branches_update() {
         .await;
 
     // Both branches auto-refresh (IMMEDIATE)
-    let doubled: i64 = db
+    let doubled: i32 = db
         .query_scalar("SELECT doubled FROM circ_diamu_b WHERE id = 1")
         .await;
     assert_eq!(doubled, 1000, "B: 500*2=1000");
 
-    let shifted: i64 = db
+    let shifted: i32 = db
         .query_scalar("SELECT shifted FROM circ_diamu_c WHERE id = 1")
         .await;
     assert_eq!(shifted, 550, "C: 500+50=550");
@@ -669,7 +669,7 @@ async fn test_diamond_immediate_mixed_dml_sequence() {
         .await;
     assert_eq!(b_val_2, 999, "id=2 should have updated val=999");
 
-    let c_val_2: i64 = db
+    let c_val_2: i32 = db
         .query_scalar("SELECT c_val FROM circ_mix_d WHERE id = 2")
         .await;
     assert_eq!(c_val_2, 9990, "id=2 C branch: 999*10=9990");


### PR DESCRIPTION
## Problem

CI E2E tests failing with exit code 100 on commit `54ef2eb`:

```
thread 'test_diamond_immediate_both_branches_update' panicked at tests/e2e/mod.rs:926:33:
Scalar query failed: error occurred while decoding column 0: mismatched types;
Rust type `i64` (as SQL type `INT8`) is not compatible with SQL type `INT4`
SQL: SELECT doubled FROM circ_diamu_b WHERE id = 1

thread 'test_diamond_immediate_mixed_dml_sequence' panicked at tests/e2e/mod.rs:926:33:
Scalar query failed: error occurred while decoding column 0: mismatched types;
Rust type `i64` (as SQL type `INT8`) is not compatible with SQL type `INT4`
SQL: SELECT c_val FROM circ_mix_d WHERE id = 2
```

## Root cause

PostgreSQL integer arithmetic returns `INT4` by default:
- `val * 2` (`INT4 × INT4`) → `INT4`
- `val + 50` (`INT4 + INT4`) → `INT4`
- `val * 10` (`INT4 × INT4`) → `INT4`

The three `query_scalar` calls in the new CIRC-IMM tests annotated the results as `i64` (INT8), which sqlx rejects when the actual wire type is INT4.

## Fix

Change the three type annotations from `i64` to `i32` in `tests/e2e_circ_imm_tests.rs`:

| Test | Column | Expression | Type |
|------|--------|-----------|------|
| `test_diamond_immediate_both_branches_update` | `doubled` | `val * 2` | INT4 |
| `test_diamond_immediate_both_branches_update` | `shifted` | `val + 50` | INT4 |
| `test_diamond_immediate_mixed_dml_sequence` | `c_val` | `val * 10` | INT4 |

Both tests now pass locally.
