### PR TITLE
fix: add missing bulk_create to upgrade script

### DIFF
--- a/sql/archive/pg_trickle--0.15.0.sql
+++ b/sql/archive/pg_trickle--0.15.0.sql
@@ -267,6 +267,17 @@ AS 'MODULE_PATHNAME', 'bootstrap_gate_status_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
+-- src/api.rs:282
+-- pg_trickle::api::bulk_create
+CREATE  FUNCTION pgtrickle."bulk_create"(
+	"definitions" jsonb /* pgrx::datum::json::JsonB */
+) RETURNS jsonb /* pgrx::datum::json::JsonB */
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bulk_create_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
 -- src/api.rs:278
 -- pg_trickle::api::create_or_replace_stream_table
 CREATE  FUNCTION pgtrickle."create_or_replace_stream_table"(

--- a/sql/pg_trickle--0.14.0--0.15.0.sql
+++ b/sql/pg_trickle--0.14.0--0.15.0.sql
@@ -11,7 +11,7 @@
 --   changes needed for this release.
 --
 -- G15-BC: bulk_create(definitions JSONB)
---   Registered via pgrx #[pg_extern] (auto-registered on extension upgrade).
+--   New SQL-callable function — CREATE FUNCTION added below.
 --
 -- G8.1: Cross-session MERGE cache invalidation
 --   Already implemented via shared-memory CACHE_GENERATION counter.
@@ -49,3 +49,12 @@ CREATE FUNCTION pgtrickle."drop_stream_table"(
 STRICT
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'drop_stream_table_wrapper';
+
+-- G15-BC: bulk_create(definitions JSONB)
+-- New function added in 0.15.0 for batch stream table creation.
+CREATE FUNCTION pgtrickle."bulk_create"(
+    "definitions" jsonb /* pgrx::datum::json::JsonB */
+) RETURNS jsonb /* pgrx::datum::json::JsonB */
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bulk_create_wrapper';


### PR DESCRIPTION
## Summary

Fix upgrade E2E test failures from CI run #23971942387.

The `test_upgrade_chain_function_parity_with_fresh_install` test was failing for both `0.14.0 → 0.15.0` and `0.1.3 → 0.15.0` upgrade paths because:

- **Fresh install** had **64** functions in the `pgtrickle` schema
- **Upgraded install** had only **63** functions

### Root cause

The `bulk_create(jsonb)` function was added in v0.15.0 as a `#[pg_extern(schema = "pgtrickle")]` in `src/api.rs`. pgrx auto-generates its `CREATE FUNCTION` statement in the installed SQL, so fresh installs include it. However, it was missing from:

1. The **upgrade script** (`sql/pg_trickle--0.14.0--0.15.0.sql`) — no `CREATE FUNCTION` for `bulk_create`
2. The **archive SQL** (`sql/archive/pg_trickle--0.15.0.sql`) — not included in the manually maintained copy

### Changes

- Added `CREATE FUNCTION pgtrickle."bulk_create"(jsonb)` to the upgrade script
- Added the same function definition to the archive SQL
- Fixed the misleading comment that said `bulk_create` was "auto-registered on extension upgrade" (it's not — SQL functions require explicit `CREATE FUNCTION`)
