### PR TITLE
fix: use native ARM runner for GHCR multi-arch build, fix orphaned deps stage

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -8,9 +8,14 @@
 #   latest                    — moves to the most recent release
 #   pg18                      — floating alias for the latest 18.x build
 #
-# Multi-platform: linux/amd64 + linux/arm64 (via QEMU emulation for arm64).
+# Multi-platform: linux/amd64 + linux/arm64 using native runners (no QEMU).
+#   - amd64 builds on ubuntu-latest
+#   - arm64 builds on ubuntu-24.04-arm (native ARM runner)
 #
-# Smoke test runs on linux/amd64 only (no QEMU overhead).
+# Architecture:
+#   1. build (matrix) — compile & push single-platform images by digest
+#   2. smoke-test     — validate the amd64 image
+#   3. merge          — combine digests into a multi-arch manifest & push tags
 #
 # Triggers:
 #   - push tags v* (production releases)
@@ -41,20 +46,28 @@ permissions:
   packages: write
 
 jobs:
-  build-and-publish:
-    name: Build + publish (multi-arch)
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+  # ════════════════════════════════════════════════════════════════════════════
+  # Job 1: Build each platform natively and push by digest
+  # ════════════════════════════════════════════════════════════════════════════
+  build:
+    name: Build (${{ matrix.platform }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
 
     outputs:
-      image_tag: ${{ steps.meta.outputs.tags }}
-      version:   ${{ steps.version.outputs.version }}
-      amd64_tag: ${{ steps.amd64_tag.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v5
 
-      # ── Derive version ───────────────────────────────────────────────────
       - name: Derive version
         id: version
         run: |
@@ -67,31 +80,11 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Resolved version: ${VERSION}"
 
-      # ── Docker metadata (tags + labels) ──────────────────────────────────
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            # Immutable version + PG minor tag (e.g. 0.13.0-pg18.3)
-            type=raw,value=${{ steps.version.outputs.version }}-pg${{ env.PG_MINOR }}
-            # Floating pg18 alias — always points at the latest pg18.x build
-            type=raw,value=pg18
-            # latest — only on real version tags, not on dev/schedule runs
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-          labels: |
-            org.opencontainers.image.title=pg_trickle
-            org.opencontainers.image.description=PostgreSQL ${{ env.PG_MINOR }} with pg_trickle streaming tables and incremental view maintenance
-            org.opencontainers.image.vendor=grove
-            org.opencontainers.image.licenses=Apache-2.0
-            org.opencontainers.image.documentation=https://github.com/grove/pg-trickle/blob/main/docs/GETTING_STARTED.md
-
-      # ── Build infrastructure ─────────────────────────────────────────────
-      - name: Set up QEMU (arm64 emulation)
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -103,32 +96,68 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # ── Build amd64 only for smoke test ──────────────────────────────────
-      # We build amd64 first, load it locally for smoke testing, then push
-      # the full multi-arch manifest in the next step.  This avoids running
-      # the smoke test under slow QEMU arm64 emulation.
-      - name: Build amd64 image (for smoke test)
-        id: build_amd64
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile.ghcr
-          platforms: linux/amd64
-          push: false
-          load: true
-          tags: pg_trickle_smoke:latest
+          platforms: ${{ matrix.platform }}
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          outputs: type=image,"name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
 
-      # ── Smoke test (amd64) ────────────────────────────────────────────────
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # ════════════════════════════════════════════════════════════════════════════
+  # Job 2: Smoke-test the amd64 image
+  # ════════════════════════════════════════════════════════════════════════════
+  smoke-test:
+    name: Smoke test (amd64)
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Download amd64 digest
+        uses: actions/download-artifact@v4
+        with:
+          name: digest-amd64
+          path: ${{ runner.temp }}/digests
+
+      - name: Resolve digest
+        id: digest
+        run: |
+          DIGEST=$(ls "${{ runner.temp }}/digests" | head -1)
+          echo "sha=sha256:${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Start smoke container
         run: |
           docker run -d \
             --name pgtrickle-ghcr-smoke \
             -e POSTGRES_PASSWORD=smoke \
-            pg_trickle_smoke:latest
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.digest.outputs.sha }}"
 
           echo "Waiting for PostgreSQL to be ready..."
           for i in $(seq 1 30); do
@@ -198,21 +227,74 @@ jobs:
         if: always()
         run: docker rm -f pgtrickle-ghcr-smoke 2>/dev/null || true
 
-      # ── Push multi-arch manifest to GHCR ─────────────────────────────────
-      - name: Build and push multi-arch image
-        uses: docker/build-push-action@v7
+  # ════════════════════════════════════════════════════════════════════════════
+  # Job 3: Merge per-platform digests into a multi-arch manifest
+  # ════════════════════════════════════════════════════════════════════════════
+  merge:
+    name: Merge + publish manifest
+    needs: [build, smoke-test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Derive version
+        id: version
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+            VERSION="${VERSION}-dev"
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
         with:
-          context: .
-          file: Dockerfile.ghcr
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ steps.version.outputs.version }}
-          # Reuse the amd64 cache from the smoke-test build
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}-pg${{ env.PG_MINOR }}
+            type=raw,value=pg18
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=pg_trickle
+            org.opencontainers.image.description=PostgreSQL ${{ env.PG_MINOR }} with pg_trickle streaming tables and incremental view maintenance
+            org.opencontainers.image.vendor=grove
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.documentation=https://github.com/grove/pg-trickle/blob/main/docs/GETTING_STARTED.md
+
+      - name: Download all digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          TAGS=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          SOURCES=$(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+          # shellcheck disable=SC2086
+          docker buildx imagetools create $TAGS $SOURCES
+
+      - name: Inspect manifest
+        run: |
+          docker buildx imagetools inspect \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
 
       # ── Summary ──────────────────────────────────────────────────────────
       - name: Print summary

--- a/Dockerfile.ghcr
+++ b/Dockerfile.ghcr
@@ -59,15 +59,17 @@ RUN cargo install --locked cargo-pgrx --version 0.17.0
 # Initialise pgrx for PostgreSQL 18 using the system pg_config
 RUN cargo pgrx init --pg18 /usr/bin/pg_config
 
-# ── Stage 2: Compile dependencies (cached layer) ─────────────────────────────
+# ── Stage 2: Fetch dependencies (cached layer) ───────────────────────────────
+# Cargo.toml + Cargo.lock are copied first with stub source files so that
+# dependency fetching is cached independently of source changes.  The builder
+# stage extends this stage, inheriting the populated registry cache.
 FROM build-env AS build-deps
 
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
 
-# Minimal stubs so cargo can compile deps without the full source tree.
-# These stubs will be replaced in the build stage below.
+# Minimal stubs so cargo can resolve the dependency graph.
 RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
@@ -79,31 +81,21 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Pre-fetch dependencies. Docker caches this layer independently.
-# If only src/ changes on the next build, this layer is skipped, saving 10–15 min.
+# If only src/ changes on the next build, this layer is reused.
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     cargo fetch
 
 # ── Stage 3: Build the extension ─────────────────────────────────────────────
-FROM build-env AS builder
+# Extends build-deps so the fetched dependency cache is already warm.
+FROM build-deps AS builder
 
-WORKDIR /build
-
-# Copy source code and configuration
-COPY Cargo.toml Cargo.lock ./
-COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
+# Overwrite stubs with real source code.  Cargo.toml/Cargo.lock are already
+# present from build-deps and unchanged, so that layer stays cached.
 COPY src/ src/
 COPY pg_trickle.control ./
 
-# Create placeholder bench and workspace member files (required by Cargo.toml
-# but not needed for extension package)
-RUN mkdir -p benches pgtrickle-tui/src && \
-    echo 'fn main() {}' > benches/diff_operators.rs && \
-    echo 'fn main() {}' > benches/refresh_bench.rs && \
-    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
-
-# Compile the extension. Cargo will automatically use cached dependencies
-# from the build-deps stage's `cargo fetch` (stored in /root/.cargo).
+# Compile the extension.
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     cargo pgrx package --pg-config /usr/bin/pg_config && \

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -55,15 +55,17 @@ RUN cargo install --locked cargo-pgrx --version 0.17.0
 # Initialise pgrx for PostgreSQL 18 using the system pg_config
 RUN cargo pgrx init --pg18 /usr/bin/pg_config
 
-# ── Stage 2: Compile dependencies (cached layer) ────────────────────────────
+# ── Stage 2: Fetch dependencies (cached layer) ──────────────────────────────
+# Cargo.toml + Cargo.lock are copied first with stub source files so that
+# dependency fetching is cached independently of source changes.  The builder
+# stage extends this stage, inheriting the populated registry cache.
 FROM build-env AS build-deps
 
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
 
-# Minimal stubs so cargo can compile deps without the full source tree.
-# These stubs will be replaced in the build stage below.
+# Minimal stubs so cargo can resolve the dependency graph.
 RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
@@ -75,33 +77,21 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Pre-fetch dependencies. Docker caches this layer independently.
-# If only src/ changes on next build, this layer is skipped, saving 10–15 min.
-# This just warms the cargo cache; the actual compilation happens in the
-# builder stage against real source code.
+# If only src/ changes on the next build, this layer is reused.
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     cargo fetch
 
 # ── Stage 3: Build the extension ────────────────────────────────────────────
-FROM build-env AS builder
+# Extends build-deps so the fetched dependency cache is already warm.
+FROM build-deps AS builder
 
-WORKDIR /build
-
-# Copy source code and configuration
-COPY Cargo.toml Cargo.lock ./
-COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
+# Overwrite stubs with real source code.  Cargo.toml/Cargo.lock are already
+# present from build-deps and unchanged, so that layer stays cached.
 COPY src/ src/
 COPY pg_trickle.control ./
 
-# Create placeholder bench and workspace member files (required by Cargo.toml
-# but not needed for extension package)
-RUN mkdir -p benches pgtrickle-tui/src && \
-    echo 'fn main() {}' > benches/diff_operators.rs && \
-    echo 'fn main() {}' > benches/refresh_bench.rs && \
-    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
-
-# Compile the extension. Cargo will automatically use cached dependencies
-# from the build-deps stage's `cargo fetch` (stored in /root/.cargo).
+# Compile the extension.
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     cargo pgrx package --pg-config /usr/bin/pg_config && \


### PR DESCRIPTION
## Problem

The GHCR workflow timed out at 60 minutes on every run. The root cause is
that arm64 was compiled under **QEMU emulation** on an amd64 runner — Rust
compilation under QEMU is 5–10× slower and consistently blows the 60-minute
budget.

Failing run: https://github.com/grove/pg-trickle/actions/runs/23979430162

## Changes

### `ghcr.yml` — parallel native-runner builds

Rewrote the single monolithic job as three jobs following the [Docker
recommended pattern for multi-platform builds with GitHub
Actions](https://docs.docker.com/build/ci/github-actions/multi-platform/):

| Job | Runner | Timeout | Purpose |
|-----|--------|---------|---------|
| `build` (amd64) | `ubuntu-latest` | 45 min | Compile natively, push by digest |
| `build` (arm64) | `ubuntu-24.04-arm` | 45 min | Compile natively — no QEMU! |
| `smoke-test` | `ubuntu-latest` | 10 min | Validate the amd64 image |
| `merge` | `ubuntu-latest` | 10 min | Combine digests into multi-arch manifest |

Both arch builds run **in parallel** on their native runners. Each platform
gets its own GHA cache scope so cache hits don't stomp each other.

### `Dockerfile.ghcr` + `Dockerfile.hub` — fix orphaned `build-deps` stage

The `build-deps` stage did `cargo fetch` to warm the registry cache, but the
`builder` stage started from `FROM build-env AS builder`, not `FROM
build-deps`. This meant the fetch was dead code — the registry cache was never
inherited. Changed builder to extend `build-deps`, and removed the now-
redundant re-`COPY` of `Cargo.toml`/`Cargo.lock` (already present from
`build-deps`).

## Expected outcome

- Both platforms compile in ~25–35 min on native hardware (well within the
  45-minute per-job timeout)
- Total wall-clock time matches the slower of the two (parallel), not their sum
- Dependency cache layer is now actually effective on rebuilds
