### PR TITLE
fix: resolve semgrep CI failure

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -48,6 +48,10 @@ jobs:
         run: python -m pip install --upgrade semgrep
 
       - name: Run Semgrep ruleset
+        # Advisory-only: upload findings as SARIF but do not block CI.
+        # Semgrep exits with code 2 when blocking findings exist; continue-on-error
+        # prevents that from failing the job while still uploading the SARIF report.
+        continue-on-error: true
         run: semgrep scan --config .semgrep/pg_trickle.yml --sarif --output semgrep.sarif
 
       - name: Upload SARIF report

--- a/.semgrep/pg_trickle.yml
+++ b/.semgrep/pg_trickle.yml
@@ -40,12 +40,12 @@ rules:
       and intercept calls made by the privileged function.
     paths:
       include:
-        - src/**
-        - sql/**
+        - /src/**
+        - /sql/**
       exclude:
         - "**/*.md"
-        - plans/**
-        - docs/**
+        - /plans/**
+        - /docs/**
     pattern-regex: SECURITY\s+DEFINER
 
   # ── Phase 2: Extension-specific privilege-context rules ─────────────────────
@@ -62,12 +62,12 @@ rules:
       via the extension API.
     paths:
       include:
-        - src/**
-        - sql/**
+        - /src/**
+        - /sql/**
       exclude:
         - "**/*.md"
-        - plans/**
-        - docs/**
+        - /plans/**
+        - /docs/**
     pattern-regex: 'SET\s+LOCAL\s+row_security\s*=\s*off'
 
   - id: sql.set-role.present
@@ -82,12 +82,12 @@ rules:
       the one you intend.
     paths:
       include:
-        - src/**
-        - sql/**
+        - /src/**
+        - /sql/**
       exclude:
         - "**/*.md"
-        - plans/**
-        - docs/**
+        - /plans/**
+        - /docs/**
     pattern-regex: '(SET\s+ROLE\b|RESET\s+ROLE\b)'
 
   - id: rust.panic-in-sql-path
@@ -106,23 +106,26 @@ rules:
           - pattern: $X.unwrap()
           - pattern: $X.expect($MSG)
           - pattern: panic!(...)
-      # Exclude unit test functions — panics in #[test] / #[pg_test] bodies are
-      # expected and do not run inside the PostgreSQL backend process.
+      # Exclude test code — panics in test bodies are expected and do not run
+      # inside the PostgreSQL backend process.
+      #
+      # IMPORTANT: Semgrep's Rust AST does not support matching attribute annotations
+      # (#[test], #[cfg(test)]) combined with fn/mod declarations in pattern-not-inside.
+      # The reliable approach is to match the *named* test module bodies directly.
+      # All test modules in this codebase use the well-known names `tests` or `pg_tests`.
       - pattern-not-inside: |
-          #[test]
-          fn $FN($$$) {
+          mod tests {
             ...
           }
       - pattern-not-inside: |
-          #[pg_test]
-          fn $FN($$$) {
+          mod pg_tests {
             ...
           }
     paths:
       include:
-        - src/**
+        - /src/**
       exclude:
         # DVM engine is internal computation; not a direct SQL entry point.
-        - src/dvm/**
+        - /src/dvm/**
         # Standalone CLI binary — not loaded into the PostgreSQL process
-        - src/bin/**
+        - /src/bin/**

--- a/src/api.rs
+++ b/src/api.rs
@@ -4348,8 +4348,7 @@ fn pgt_status() -> TableIterator<
                 None,
                 &[],
             )
-            .map_err(|e| pgrx::error!("st_list: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("st_list: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         for row in result {
@@ -4404,8 +4403,7 @@ fn pgt_scc_status() -> TableIterator<
                 None,
                 &[],
             )
-            .map_err(|e| pgrx::error!("pgt_scc_status: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("pgt_scc_status: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         for row in result {
@@ -4483,8 +4481,7 @@ fn explain_refresh_mode_impl(name: &str) -> Vec<(String, Option<String>, Option<
                 None,
                 &[schema.as_str().into(), table_name.as_str().into()],
             )
-            .map_err(|e| pgrx::error!("explain_refresh_mode: SPI error: {e}"))
-            .expect("unreachable after error!")
+            .unwrap_or_else(|e| pgrx::error!("explain_refresh_mode: SPI error: {e}"))
             .first()
             .get_two::<String, String>()
             .unwrap_or((None, None))
@@ -5195,8 +5192,7 @@ fn bootstrap_gate_status_fn() -> TableIterator<
                 None,
                 &[],
             )
-            .map_err(|e| pgrx::error!("bootstrap_gate_status: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("bootstrap_gate_status: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         for row in result {

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1089,14 +1089,14 @@ impl StDag {
                         result,
                     );
                     let w_lowlink = lowlinks[&w];
-                    let v_lowlink = lowlinks.get_mut(&v).unwrap();
+                    let v_lowlink = lowlinks.get_mut(&v).unwrap(); // nosemgrep: semgrep.rust.panic-in-sql-path -- SCC invariant: v is always in lowlinks
                     if w_lowlink < *v_lowlink {
                         *v_lowlink = w_lowlink;
                     }
                 } else if on_stack.contains(&w) {
                     // Successor w is on the stack → it's in the current SCC.
                     let w_index = indices[&w];
-                    let v_lowlink = lowlinks.get_mut(&v).unwrap();
+                    let v_lowlink = lowlinks.get_mut(&v).unwrap(); // nosemgrep: semgrep.rust.panic-in-sql-path -- SCC invariant: v is always in lowlinks
                     if w_index < *v_lowlink {
                         *v_lowlink = w_index;
                     }
@@ -1108,7 +1108,7 @@ impl StDag {
         if lowlinks[&v] == indices[&v] {
             let mut scc_nodes = Vec::new();
             loop {
-                let w = stack.pop().unwrap();
+                let w = stack.pop().unwrap(); // nosemgrep: semgrep.rust.panic-in-sql-path -- SCC loop invariant: stack is non-empty when root node found
                 on_stack.remove(&w);
                 scc_nodes.push(w);
                 if w == v {
@@ -1791,7 +1791,7 @@ impl ExecutionUnitDag {
         );
 
         // Collect external downstream edges of the LAST unit in the chain.
-        let last_id = *chain.last().unwrap();
+        let last_id = *chain.last().unwrap(); // nosemgrep: semgrep.rust.panic-in-sql-path -- chain is always non-empty by construction in build_execution_units
         let external_downstream: Vec<ExecutionUnitId> =
             self.edges.get(&last_id).cloned().unwrap_or_default();
 

--- a/src/dvm/parser/rewrites.rs
+++ b/src/dvm/parser/rewrites.rs
@@ -5746,9 +5746,7 @@ mod pg_tests {
     }
 
     fn regclass_oid(qualified_name: &str) -> u32 {
-        // nosemgrep: semgrep.rust.spi.query.dynamic-format \u2014 test-only helper; qualified_name is
-        // always a hard-coded literal in tests, never runtime user input.
-        Spi::get_one::<i32>(&format!("SELECT '{}'::regclass::oid::int4", qualified_name))
+        Spi::get_one::<i32>(&format!("SELECT '{}'::regclass::oid::int4", qualified_name)) // nosemgrep: semgrep.rust.spi.query.dynamic-format \u2014 test-only helper; qualified_name is always a hard-coded literal in tests, never runtime user input
             .expect("failed to look up relation oid")
             .expect("relation oid query returned NULL") as u32
     }

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -240,8 +240,7 @@ fn collect_slot_health_rows() -> Vec<(String, i64, bool, i64, String)> {
                 None,
                 &[],
             )
-            .map_err(|e| pgrx::error!("slot_health: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("slot_health: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         for row in result {
@@ -481,8 +480,7 @@ fn st_refresh_stats() -> TableIterator<
                 None,
                 &[],
             )
-            .map_err(|e| pgrx::error!("st_refresh_stats: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("st_refresh_stats: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         for row in result {
@@ -594,8 +592,7 @@ fn get_refresh_history(
                 None,
                 &[schema.into(), table_name.into(), max_rows.into()],
             )
-            .map_err(|e| pgrx::error!("get_refresh_history: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("get_refresh_history: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         let epoch_zero = TimestampWithTimeZone::try_from(0i64).unwrap_or_else(|_| {
@@ -1498,8 +1495,7 @@ fn change_buffer_sizes() -> TableIterator<
                 None,
                 &[],
             )
-            .map_err(|e| pgrx::error!("change_buffer_sizes: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("change_buffer_sizes: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         for row in result {
@@ -1571,8 +1567,7 @@ fn list_sources(
                 None,
                 &[schema.into(), table_name.into()],
             )
-            .map_err(|e| pgrx::error!("list_sources: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("list_sources: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         for row in result {
@@ -1632,8 +1627,7 @@ fn dependency_tree() -> TableIterator<
                 None,
                 &[],
             )
-            .map_err(|e| pgrx::error!("dependency_tree: failed to load stream tables: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("dependency_tree: failed to load stream tables: {e}"));
 
         let mut m = std::collections::HashMap::new();
         for row in result {
@@ -1685,8 +1679,7 @@ fn dependency_tree() -> TableIterator<
                 None,
                 &[],
             )
-            .map_err(|e| pgrx::error!("dependency_tree: failed to load dependencies: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("dependency_tree: failed to load dependencies: {e}"));
 
         for row in result {
             let consumer = row.get::<String>(1).unwrap_or(None).unwrap_or_default();
@@ -2198,8 +2191,7 @@ fn refresh_timeline(
                 None,
                 &[max_rows.into()],
             )
-            .map_err(|e| pgrx::error!("refresh_timeline: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("refresh_timeline: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         for row in result {
@@ -2281,8 +2273,7 @@ fn trigger_inventory() -> TableIterator<
                 None,
                 &[],
             )
-            .map_err(|e| pgrx::error!("trigger_inventory: SPI select failed: {e}"))
-            .expect("unreachable after error!()");
+            .unwrap_or_else(|e| pgrx::error!("trigger_inventory: SPI select failed: {e}"));
 
         let mut out = Vec::new();
         for row in result {

--- a/src/wal_decoder.rs
+++ b/src/wal_decoder.rs
@@ -302,7 +302,7 @@ fn create_replication_slot_internal(slot_name: &str) -> Result<String, PgTrickle
 
     let c_slot_name = CString::new(slot_name)
         .map_err(|e| PgTrickleError::ReplicationSlotError(format!("Invalid slot name: {}", e)))?;
-    let c_plugin = CString::new("test_decoding").unwrap();
+    let c_plugin = CString::new("test_decoding").unwrap(); // nosemgrep: semgrep.rust.panic-in-sql-path -- literal has no NUL bytes; CString::new never fails here
 
     // SAFETY: Calling PostgreSQL C API functions for replication slot management.
     // These are the same functions called by pg_create_logical_replication_slot(),


### PR DESCRIPTION
## Problem

The Semgrep CI job ([run #23977494493](https://github.com/grove/pg-trickle/actions/runs/23977494493)) failed with exit code 2. Three root causes were found.

## Root causes and fixes

### 1. Workflow: missing `continue-on-error: true`

The workflow comment said "advisory-only: findings should not fail CI yet", but `continue-on-error: true` was never added to the step. Semgrep exits with code 2 whenever blocking findings exist, so every scan failed.

**Fix:** add `continue-on-error: true` to the *Run Semgrep ruleset* step.

### 2. Rule `rust.panic-in-sql-path` was silently broken

Two bugs in the rule definition:

- **`$$$` is invalid in `pattern-not-inside`** for function parameter lists. `$$$` is the call-site spread metavariable; the correct form for function parameters is `$...ARGS`. This caused a Rust parse error and the rule was silently skipped entirely.
- **Attribute + declaration patterns don't work** in semgrep's Rust AST. Patterns like `#[test]\nfn $FN(...) { ... }` in `pattern-not-inside` never matched because semgrep does not link attribute annotations to their `fn`/`mod` node. The reliable alternative is to match the named module body (`mod tests { ... }`, `mod pg_tests { ... }`).
- **Path glob anchoring warnings** for all `paths:` entries — changed `src/**` → `/src/**` etc. to be explicit about root-relative matching and silence forward-compat warnings.

### 3. Genuine panic findings in SQL-reachable code

Once the rule parsed correctly, 18 real findings surfaced in production paths.

| Location | Fix |
|---|---|
| `src/api.rs` (4 sites), `src/monitor.rs` (9 sites) | Rewrote `.map_err(pgrx::error!(...)).expect("unreachable after error!()")` as `.unwrap_or_else(|e| pgrx::error!(...))` — eliminates the panic path entirely |
| `src/dag.rs` (4 sites) | Added `// nosemgrep` annotation with invariant justification (Tarjan SCC algorithm guarantees) |
| `src/wal_decoder.rs` (1 site) | Added `// nosemgrep` annotation — `CString::new("test_decoding")` uses a compile-time literal with no NUL bytes |
| `src/dvm/parser/rewrites.rs` | Moved `nosemgrep` comment to the triggering line (semgrep requires same-line suppression) |

## Result

- 0 rule parse errors
- 0 panic findings
- 55 advisory findings remain (`spi.run.dynamic-format`, `sql.security-definer.present`, `spi.query.dynamic-format`) — pre-existing, intentional patterns
