### PR TITLE
fix: use bare nosemgrep to reliably suppress 11 remaining code-scanning alerts

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -3704,8 +3704,7 @@ fn execute_manual_refresh(
     // always materializes the full result set regardless of who called
     // refresh_stream_table(). This mirrors REFRESH MATERIALIZED VIEW
     // semantics and prevents the "who refreshed it?" correctness hazard.
-    // nosemgrep: sql.row-security.disabled — intentional R3 bypass, mirrors REFRESH MATERIALIZED VIEW semantics.
-    Spi::run("SET LOCAL row_security = off")
+    Spi::run("SET LOCAL row_security = off") // nosemgrep — intentional R3 bypass, mirrors REFRESH MATERIALIZED VIEW semantics.
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
 
     // ERG-D: Determine the action label for history recording.
@@ -4038,7 +4037,7 @@ fn execute_manual_full_refresh(
     // Re-enable user triggers and emit NOTIFY so listeners know a FULL
     // refresh occurred.
     if has_triggers {
-        Spi::run(&format!("ALTER TABLE {quoted_table} ENABLE TRIGGER USER")) // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
+        Spi::run(&format!("ALTER TABLE {quoted_table} ENABLE TRIGGER USER")) // nosemgrep — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
 
         // PB2: Skip NOTIFY when pooler compatibility mode is enabled.

--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -266,7 +266,7 @@ pub fn drop_change_trigger(
             format!("pg_trickle_cdc_del_{}", oid_u32), // statement DELETE
             format!("pg_trickle_cdc_truncate_{}", oid_u32), // TRUNCATE (both modes)
         ] {
-            let _ = Spi::run(&format!("DROP TRIGGER IF EXISTS {trig} ON {table}")); // nosemgrep: rust.spi.run.dynamic-format — DDL cannot be parameterized; trig is an oid_u32 integer, table is a regclass-quoted identifier.
+            let _ = Spi::run(&format!("DROP TRIGGER IF EXISTS {trig} ON {table}")); // nosemgrep — DDL cannot be parameterized; trig is an oid_u32 integer, table is a regclass-quoted identifier.
         }
     }
 
@@ -1994,7 +1994,7 @@ pub fn rebuild_cdc_trigger(
         format!("pg_trickle_cdc_upd_{}", oid_u32),
         format!("pg_trickle_cdc_del_{}", oid_u32),
     ] {
-        let _ = Spi::run(&format!("DROP TRIGGER IF EXISTS {trig} ON {source_table}")); // nosemgrep: rust.spi.run.dynamic-format — DDL cannot be parameterized; trig is an oid_u32 integer, source_table is a regclass-quoted identifier.
+        let _ = Spi::run(&format!("DROP TRIGGER IF EXISTS {trig} ON {source_table}")); // nosemgrep — DDL cannot be parameterized; trig is an oid_u32 integer, source_table is a regclass-quoted identifier.
     }
 
     // 3. Create new trigger(s) matching the current mode.

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1089,14 +1089,14 @@ impl StDag {
                         result,
                     );
                     let w_lowlink = lowlinks[&w];
-                    let v_lowlink = lowlinks.get_mut(&v).unwrap(); // nosemgrep: rust.panic-in-sql-path -- SCC invariant: v is always in lowlinks
+                    let v_lowlink = lowlinks.get_mut(&v).unwrap(); // nosemgrep — SCC invariant: v is always in lowlinks
                     if w_lowlink < *v_lowlink {
                         *v_lowlink = w_lowlink;
                     }
                 } else if on_stack.contains(&w) {
                     // Successor w is on the stack → it's in the current SCC.
                     let w_index = indices[&w];
-                    let v_lowlink = lowlinks.get_mut(&v).unwrap(); // nosemgrep: rust.panic-in-sql-path -- SCC invariant: v is always in lowlinks
+                    let v_lowlink = lowlinks.get_mut(&v).unwrap(); // nosemgrep — SCC invariant: v is always in lowlinks
                     if w_index < *v_lowlink {
                         *v_lowlink = w_index;
                     }
@@ -1108,7 +1108,7 @@ impl StDag {
         if lowlinks[&v] == indices[&v] {
             let mut scc_nodes = Vec::new();
             loop {
-                let w = stack.pop().unwrap(); // nosemgrep: rust.panic-in-sql-path -- SCC loop invariant: stack is non-empty when root node found
+                let w = stack.pop().unwrap(); // nosemgrep — SCC loop invariant: stack is non-empty when root node found
                 on_stack.remove(&w);
                 scc_nodes.push(w);
                 if w == v {
@@ -1791,7 +1791,7 @@ impl ExecutionUnitDag {
         );
 
         // Collect external downstream edges of the LAST unit in the chain.
-        let last_id = *chain.last().unwrap(); // nosemgrep: rust.panic-in-sql-path -- chain is always non-empty by construction in build_execution_units
+        let last_id = *chain.last().unwrap(); // nosemgrep — chain is always non-empty by construction in build_execution_units
         let external_downstream: Vec<ExecutionUnitId> =
             self.edges.get(&last_id).cloned().unwrap_or_default();
 

--- a/src/dvm/parser/rewrites.rs
+++ b/src/dvm/parser/rewrites.rs
@@ -5746,7 +5746,7 @@ mod pg_tests {
     }
 
     fn regclass_oid(qualified_name: &str) -> u32 {
-        Spi::get_one::<i32>(&format!("SELECT '{}'::regclass::oid::int4", qualified_name)) // nosemgrep: rust.spi.query.dynamic-format \u2014 test-only helper; qualified_name is always a hard-coded literal in tests, never runtime user input
+        Spi::get_one::<i32>(&format!("SELECT '{}'::regclass::oid::int4", qualified_name)) // nosemgrep \u2014 test-only helper; qualified_name is always a hard-coded literal in tests, never runtime user input
             .expect("failed to look up relation oid")
             .expect("relation oid query returned NULL") as u32
     }

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -2460,7 +2460,7 @@ pub fn execute_full_refresh(st: &StreamTableMeta) -> Result<(i64, i64), PgTrickl
         // Drop any leftover pre-snapshot from a previous iteration
         // (e.g., SCC fixpoint loops where subtransaction commits don't
         // fire ON COMMIT DROP until the outer transaction commits).
-        let _ = Spi::run(&format!("DROP TABLE IF EXISTS __pgt_pre_{}", st.pgt_id)); // nosemgrep: rust.spi.run.dynamic-format — st.pgt_id is a plain i64, not user-supplied input.
+        let _ = Spi::run(&format!("DROP TABLE IF EXISTS __pgt_pre_{}", st.pgt_id)); // nosemgrep — st.pgt_id is a plain i64, not user-supplied input.
 
         let snapshot_sql = format!(
             "CREATE TEMP TABLE __pgt_pre_{pgt_id} ON COMMIT DROP AS \
@@ -4613,7 +4613,7 @@ pub fn execute_differential_refresh(
                 name.replace('"', "\"\""),
             );
 
-            let _ = Spi::run(&format!("DROP TABLE IF EXISTS __pgt_pre_{}", st.pgt_id)); // nosemgrep: rust.spi.run.dynamic-format — st.pgt_id is a plain i64, not user-supplied input.
+            let _ = Spi::run(&format!("DROP TABLE IF EXISTS __pgt_pre_{}", st.pgt_id)); // nosemgrep — st.pgt_id is a plain i64, not user-supplied input.
 
             let snapshot_sql = format!(
                 "CREATE TEMP TABLE __pgt_pre_{pgt_id} ON COMMIT DROP AS \

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -4638,8 +4638,7 @@ fn execute_scheduled_refresh(
     // runs as superuser, but this ensures the defining query always
     // materializes the full result set even if pg_trickle is installed
     // by a non-superuser role with BYPASSRLS.
-    // nosemgrep: sql.row-security.disabled — intentional R3 bypass, mirrors REFRESH MATERIALIZED VIEW semantics.
-    let _ = Spi::run("SET LOCAL row_security = off");
+    let _ = Spi::run("SET LOCAL row_security = off"); // nosemgrep — intentional R3 bypass, mirrors REFRESH MATERIALIZED VIEW semantics.
 
     // Execute the refresh
 

--- a/src/wal_decoder.rs
+++ b/src/wal_decoder.rs
@@ -302,7 +302,7 @@ fn create_replication_slot_internal(slot_name: &str) -> Result<String, PgTrickle
 
     let c_slot_name = CString::new(slot_name)
         .map_err(|e| PgTrickleError::ReplicationSlotError(format!("Invalid slot name: {}", e)))?;
-    let c_plugin = CString::new("test_decoding").unwrap(); // nosemgrep: rust.panic-in-sql-path -- literal has no NUL bytes; CString::new never fails here
+    let c_plugin = CString::new("test_decoding").unwrap(); // nosemgrep — literal has no NUL bytes; CString::new never fails here
 
     // SAFETY: Calling PostgreSQL C API functions for replication slot management.
     // These are the same functions called by pg_create_logical_replication_slot(),


### PR DESCRIPTION
## Summary

Follow-up to #407: fixes the 11 remaining code-scanning alerts that persisted after that PR was merged.

## Root cause

PR #407 used the rule-ID form `// nosemgrep: rust.spi.run.dynamic-format` etc. This did not suppress the alerts because:

- When semgrep scans with `--config .semgrep/pg_trickle.yml` (a local file), it prefixes each rule's `id:` with the config filename, so the real scan-time ID is `pg_trickle.rust.spi.run.dynamic-format`.
- The SARIF upload adds a further `semgrep.` namespace for GitHub Code Scanning, making the displayed ID `semgrep.rust.spi.run.dynamic-format`.
- Neither matches the literal string in the annotation.

Additionally, the two `sql.row-security.disabled` annotations were on the preceding comment line. Semgrep requires the `nosemgrep` comment to be **on the same line** as the matched expression.

## Fix

Replaced all `// nosemgrep: <rule-id>` with bare `// nosemgrep` (no rule ID). The bare form unconditionally suppresses all semgrep findings on that line, bypassing any namespace/prefix ambiguity. All affected lines were reviewed in PR #407 and confirmed to be intentional false positives (DDL that cannot be parameterized, OID-derived identifiers, SCC loop invariants, test-only helpers, etc.).

Also moved the two `sql.row-security.disabled` annotations inline onto the `Spi::run` call line.

## Affected locations

| File | Line | Reason |
|------|------|--------|
| `api.rs` | 3707 | `SET LOCAL row_security = off` — intentional R3 bypass |
| `api.rs` | 4040 | `ALTER TABLE ... ENABLE TRIGGER USER` — DDL, OID-derived name |
| `cdc.rs` | 269 | `DROP TRIGGER IF EXISTS` — DDL, integer OID + quoted identifier |
| `cdc.rs` | 1997 | `DROP TRIGGER IF EXISTS` — same |
| `dag.rs` | 1092, 1099 | `.unwrap()` — SCC lowlinks invariant |
| `dag.rs` | 1111 | `.unwrap()` — SCC stack non-empty invariant |
| `dag.rs` | 1794 | `.unwrap()` — chain non-empty by construction |
| `dvm/parser/rewrites.rs` | 5749 | `Spi::get_one` in test-only helper |
| `refresh.rs` | 2463, 4616 | `DROP TABLE IF EXISTS __pgt_pre_N` — `i64` pgt_id |
| `scheduler.rs` | 4641 | `SET LOCAL row_security = off` — intentional R3 bypass |
| `wal_decoder.rs` | 305 | `CString::new(literal).unwrap()` — literal has no NUL bytes |

## Testing

- `just fmt && just lint` — clean (0 warnings)
- `just test-unit` — 1688 tests, all passing
