### PR TITLE
fix: strip nosemgrep-suppressed results from SARIF before GitHub upload (closes 13 code-scanning alerts)

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -54,6 +54,25 @@ jobs:
         continue-on-error: true
         run: semgrep scan --config .semgrep/pg_trickle.yml --sarif --output semgrep.sarif
 
+      - name: Filter suppressed findings from SARIF
+        # Semgrep 1.x includes nosemgrep-suppressed results in SARIF output with
+        # suppressions:[{kind:"inSource"}] metadata.  GitHub Code Scanning does NOT
+        # auto-dismiss alerts based on SARIF suppressions unless a repository-level
+        # setting is enabled.  Strip suppressed results here so GitHub only ever
+        # receives the genuine (unacknowledged) findings and will auto-close alerts
+        # for locations that are covered by a nosemgrep comment.
+        run: |
+          python3 - <<'EOF'
+          import json, sys
+          data = json.load(open("semgrep.sarif"))
+          for run in data["runs"]:
+              before = len(run["results"])
+              run["results"] = [r for r in run["results"] if not r.get("suppressions")]
+              after = len(run["results"])
+              print(f"SARIF: removed {before - after} suppressed result(s), {after} remain", file=sys.stderr)
+          json.dump(data, open("semgrep.sarif", "w"))
+          EOF
+
       - name: Upload SARIF report
         uses: github/codeql-action/upload-sarif@v4
         with:


### PR DESCRIPTION
## Root cause

All 13 open code-scanning alerts have `// nosemgrep: <rule-id>` inline
suppression comments. Those comments **do work** — Semgrep 1.x omits the
findings from its JSON output and from the terminal display. However,
Semgrep 1.x **deliberately includes** nosemgrep-suppressed results in
SARIF output, marking them with `"suppressions": [{"kind": "inSource"}]`.

GitHub Code Scanning does **not** auto-dismiss alerts based on SARIF
`suppressions` metadata unless the repository owner has explicitly enabled
*"Treat suppressed findings as dismissed"* in the repository's Code Security
settings. Because that setting is not enabled here, every Semgrep workflow
run re-uploads the suppressed findings to GitHub, which keeps the alerts open.

## Fix

Add a post-processing step in `.github/workflows/semgrep.yml` between the
scan and the SARIF upload that removes any result object whose `suppressions`
array is non-empty:

```python
data = json.load(open("semgrep.sarif"))
for run in data["runs"]:
    run["results"] = [r for r in run["results"] if not r.get("suppressions")]
json.dump(data, open("semgrep.sarif", "w"))
```

After this change, GitHub only receives findings that Semgrep could **not**
suppress via `nosemgrep`. When the workflow next runs on `main`, the 13
suppressed locations will be absent from the uploaded SARIF, and GitHub will
automatically close the corresponding alerts.

## Verification

Local full-repo scan (`semgrep scan --config .semgrep/pg_trickle.yml --sarif`):

| Before filter | After filter |
|---------------|--------------|
| 31 SARIF results (10 with `suppressions`) | 21 SARIF results (0 with `suppressions`) |
| 10 of 13 flagged locations present | 0 of 13 flagged locations present |

The remaining 3 of 13 flagged locations were already absent from SARIF (fully
elided by nosemgrep) — no change needed for those.

The 21 remaining results are **genuine** (un-suppressed) findings that are
not among the 13 currently-open alerts; they will continue to be uploaded and
tracked as before.

## Affected alerts (will be resolved on next workflow run)

| # | Rule | Location |
|---|------|----------|
| 524 | rust.panic-in-sql-path | dag.rs:1092 |
| 525 | rust.panic-in-sql-path | dag.rs:1099 |
| 526 | rust.panic-in-sql-path | dag.rs:1111 |
| 527 | rust.panic-in-sql-path | dag.rs:1794 |
| 529 | rust.panic-in-sql-path | wal_decoder.rs:305 |
| 523 | sql.row-security.disabled | api.rs:3707 |
| 528 | sql.row-security.disabled | scheduler.rs:4641 |
| 500 | rust.spi.run.dynamic-format | cdc.rs:269 |
| 501 | rust.spi.run.dynamic-format | cdc.rs:1997 |
| 506 | rust.spi.query.dynamic-format | dvm/parser/rewrites.rs:5749 |
