### PR TITLE
fix: include ST change buffers in A-3-AO append-only heuristic checks

### DIFF
--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -3669,6 +3669,38 @@ pub fn execute_differential_refresh(
                     true
                 }
             }
+        })
+        // Also check ST (stream table) source change buffers.
+        // Without this, ST-on-ST cascades with empty catalog_source_oids
+        // would vacuously miss DELETE/UPDATE actions from the upstream ST.
+        || st_source_pgt_ids.iter().any(|&pgt_id| {
+            if !crate::cdc::has_st_change_buffer(pgt_id, &change_schema) {
+                return false;
+            }
+            let key = format!("pgt_{pgt_id}");
+            let prev_lsn = prev_frontier
+                .sources
+                .get(&key)
+                .map(|sv| sv.lsn.clone())
+                .unwrap_or_else(|| "0/0".to_string());
+            let new_lsn = new_frontier
+                .sources
+                .get(&key)
+                .map(|sv| sv.lsn.clone())
+                .unwrap_or_else(|| "0/0".to_string());
+            match Spi::get_one::<bool>(&format!(
+                "SELECT EXISTS(\
+                   SELECT 1 FROM \"{change_schema}\".changes_pgt_{pgt_id} \
+                   WHERE lsn > '{prev_lsn}'::pg_lsn \
+                   AND lsn <= '{new_lsn}'::pg_lsn \
+                   AND action IN ('D', 'U') \
+                   LIMIT 1\
+                 )",
+            )) {
+                Ok(Some(v)) => v,
+                Ok(None) => false,
+                Err(_) => true, // SPI failure: safe default
+            }
         });
 
         if has_non_insert {
@@ -3733,6 +3765,39 @@ pub fn execute_differential_refresh(
                 Ok(Some(v)) => v,
                 Ok(None) => false,
                 Err(_) => true, // SPI failure: safe default (skip heuristic)
+            }
+        })
+        // Also check ST source change buffers for DELETE/UPDATE actions.
+        // Without this, ST-on-ST cascades (catalog_source_oids is empty)
+        // would vacuously find no non-INSERT actions and incorrectly
+        // promote to append-only, causing duplicate rows.
+        || st_source_pgt_ids.iter().any(|&pgt_id| {
+            if !crate::cdc::has_st_change_buffer(pgt_id, &change_schema) {
+                return false;
+            }
+            let key = format!("pgt_{pgt_id}");
+            let prev_lsn = prev_frontier
+                .sources
+                .get(&key)
+                .map(|sv| sv.lsn.clone())
+                .unwrap_or_else(|| "0/0".to_string());
+            let new_lsn = new_frontier
+                .sources
+                .get(&key)
+                .map(|sv| sv.lsn.clone())
+                .unwrap_or_else(|| "0/0".to_string());
+            match Spi::get_one::<bool>(&format!(
+                "SELECT EXISTS(\
+                   SELECT 1 FROM \"{change_schema}\".changes_pgt_{pgt_id} \
+                   WHERE lsn > '{prev_lsn}'::pg_lsn \
+                   AND lsn <= '{new_lsn}'::pg_lsn \
+                   AND action IN ('D', 'U') \
+                   LIMIT 1\
+                 )",
+            )) {
+                Ok(Some(v)) => v,
+                Ok(None) => false,
+                Err(_) => true, // SPI failure: safe default
             }
         });
 


### PR DESCRIPTION
## Problem

The E2E test `test_st_on_st_uses_differential_not_full` fails consistently (3/3 retries) with:

```
assertion `left == right` failed: Expected grp 'a' doubled = 140, got 60
  left: 60
 right: 140
```

The downstream stream table produces duplicate rows instead of correctly updating
values during differential refresh.

## Root Cause

The A-3-AO append-only heuristic (introduced in v0.16.0) only checks
`catalog_source_oids` for DELETE/UPDATE actions when deciding whether to
promote a stream table to the append-only INSERT fast path. For ST-on-ST
cascades, `catalog_source_oids` is **empty** (upstream STs are tracked via
`st_source_pgt_ids` instead), so the check vacuously finds no non-INSERT
actions and incorrectly promotes the downstream ST to append-only mode.

The append-only path uses `INSERT ... WHERE __pgt_action = 'I'` which only
adds new rows without deleting old ones. When the upstream aggregate refresh
produces delete+insert delta pairs (e.g., group total 30→70), the downstream
keeps the old row (doubled=60) alongside the new row (doubled=140).

## Fix

Extend both the A-3a fallback check and A-3-AO auto-promotion check to also
scan `changes_pgt_{pgt_id}` buffers (upstream ST change buffers) for
DELETE/UPDATE actions, using the same LSN frontier range logic already used
by the `any_st_changes` detection earlier in the function.

## Testing

- `just fmt` — clean
- `just lint` — zero warnings
- `just test-unit` — 1700/1700 passed
- CI will validate E2E (`test_st_on_st_uses_differential_not_full`)

## CI Reference

Failing run: https://github.com/grove/pg-trickle/actions/runs/24009437006
