### PR TITLE
fix: pass --baseline main to Criterion so regression check finds saved baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
           restore-keys: criterion-baseline-
 
       - name: Run benchmarks (create new/ data)
-        run: ./scripts/run_benchmarks.sh
+        run: ./scripts/run_benchmarks.sh -- --baseline main
         env:
           BENCH_QUICK: "1"
 

--- a/scripts/criterion_regression_check.py
+++ b/scripts/criterion_regression_check.py
@@ -44,7 +44,11 @@ def find_bench_pairs(criterion_dir: Path) -> list[tuple[str, float, float]]:
     results: list[tuple[str, float, float]] = []
 
     for new_file in sorted(criterion_dir.rglob("new/estimates.json")):
-        base_file = new_file.parent.parent / "base" / "estimates.json"
+        bench_dir = new_file.parent.parent
+        base_file = bench_dir / "base" / "estimates.json"
+        if not base_file.exists():
+            # Criterion --save-baseline <name> stores under <name>/ not base/
+            base_file = bench_dir / "main" / "estimates.json"
         if not base_file.exists():
             continue
 


### PR DESCRIPTION
## Problem

The benchmark regression check was always printing "No baseline/new pairs found — skipping regression check" even after the `criterion-baseline-main` cache existed.

**Root cause:** The `benchmarks` job saves the baseline via `--save-baseline main`, which stores data at `target/criterion/<group>/<bench>/main/estimates.json`. The `bench-regression` job ran benchmarks *without* `--baseline main`, so Criterion never loaded the saved baseline into `base/`. The regression script looked only for `base/estimates.json` and found nothing.

## Fix

1. **CI (`ci.yml`)**: Add `--baseline main` to the bench-regression step. Criterion uses this to copy `main/` into `base/` before running, so `new/` and `base/` both exist for comparison.

2. **Script (`criterion_regression_check.py`)**: Fall back to `main/estimates.json` when `base/estimates.json` is absent, so local runs with a `--save-baseline main` baseline also work.
