### PR TITLE
fix: skip append-only fast path for STs with downstream consumers

### DIFF
--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -3749,7 +3749,11 @@ pub fn execute_differential_refresh(
             .map(|entry| has_non_monotonic_cte(&entry.merge_sql_template))
             .unwrap_or(false) // no cache entry → allow promotion (A-3a guard catches it)
     });
-    if !is_append_only && !st.has_keyless_source && !cached_non_monotonic {
+    if !is_append_only
+        && !st.has_keyless_source
+        && !cached_non_monotonic
+        && !has_downstream_st_consumers(st.pgt_id)
+    {
         let has_non_insert = catalog_source_oids.iter().any(|oid| {
             let prev_lsn = prev_frontier.get_lsn(*oid);
             let new_lsn = new_frontier.get_lsn(*oid);
@@ -4589,7 +4593,12 @@ pub fn execute_differential_refresh(
     // produce delta DELETEs or UPDATEs that the bare INSERT path cannot
     // handle. When detected, clear the incorrectly set catalog flag so
     // subsequent refreshes skip the heuristic check overhead.
-    if is_append_only {
+    //
+    // STs with downstream ST consumers must skip this path: the fast
+    // path returns early before capture_delta_to_st_buffer() runs,
+    // so downstream STs would never see change buffer rows and their
+    // data_timestamp would never advance — breaking ST-on-ST cascades.
+    if is_append_only && !has_downstream_st_consumers(st.pgt_id) {
         if has_non_monotonic_cte(&resolved.merge_sql) {
             pgrx::debug1!(
                 "[pg_trickle] A-3a: skipping append-only for {}.{} — \


### PR DESCRIPTION
## Problem

Four E2E tests in `e2e_dag_autorefresh_tests` were timing out consistently in CI (run [#24019721659](https://github.com/grove/pg-trickle/actions/runs/24019721659)):

- `test_autorefresh_3_layer_cascade` — `ar3_l3 should auto-refresh after base mutation`
- `test_autorefresh_calculated_schedule` — `arc_l2 (CALCULATED) should auto-refresh when upstream L1 changes`
- `test_autorefresh_staggered_schedules` — `ars_l3 should eventually auto-refresh after base mutation`
- `test_prop_autorefresh_no_spurious_changes` — `INVARIANT VIOLATED at cycle 3 … ST rows: 8, Query rows: 9`

All four tests share the same pattern: a 3-layer ST-on-ST cascade where the leaf ST never refreshed after a base-table mutation.

## Root Cause

The **A-3a append-only INSERT fast path** introduced in v0.16.0 (#406) contains an early `return Ok((rows_inserted, 0))` that exits `execute_differential_refresh()` before `capture_delta_to_st_buffer()` runs.

For an ST that has downstream ST consumers (e.g. L1 in a `base → L1 → L2 → L3` chain), this means:

1. L1 gets auto-promoted to append-only via the A-3-AO heuristic (all-INSERT batch, no non-monotonic CTEs).
2. On the next cycle, L1 uses the append-only INSERT fast path and returns early.
3. `capture_delta_to_st_buffer()` is **never called** — L1's change buffer stays empty.
4. L2's `has_stream_table_source_changes()` returns `false` → L2 sees `NoData` → `data_timestamp` never advances.
5. L3 waits for L2 to advance, which never happens.

The property test additionally saw a missing-row invariant violation because the cascade stopped propagating INSERTs mid-chain.

## Fix

Two guards added to `src/refresh.rs`:

**1. A-3a execution** — skip the append-only fast path when the ST has downstream consumers, falling through to the explicit DML / MERGE path that calls `capture_delta_to_st_buffer()`:

```rust
// Before
if is_append_only {

// After
if is_append_only && !has_downstream_st_consumers(st.pgt_id) {
```

**2. A-3-AO heuristic promotion** — don't auto-promote STs with downstream consumers to append-only, avoiding promotion + immediate reversion overhead on every cycle:

```rust
// Before
if !is_append_only && !st.has_keyless_source && !cached_non_monotonic {

// After
if !is_append_only
    && !st.has_keyless_source
    && !cached_non_monotonic
    && !has_downstream_st_consumers(st.pgt_id)
{
```

`has_downstream_st_consumers()` is already called a few lines later for `use_explicit_dml`, so the extra call hits the same cached catalog query path.

## Testing

- `just fmt` + `just lint` — clean (0 warnings)
- `just test-unit` — 1700 tests pass
- The four failing E2E tests exercise exactly this code path
