### PR TITLE
fix(ci): set max_worker_processes=128 in coverage Docker image

### DIFF
--- a/tests/Dockerfile.e2e-coverage
+++ b/tests/Dockerfile.e2e-coverage
@@ -126,10 +126,17 @@ RUN mkdir -p /coverage && chmod 777 /coverage
 # %p = PID, %m = binary signature hash — avoids collisions across processes.
 ENV LLVM_PROFILE_FILE="/coverage/pgs-%p-%m.profraw"
 
-# Configure shared_preload_libraries
+# Configure shared_preload_libraries and resource limits.
+# Mirror the settings from Dockerfile.e2e so bgworker tests work correctly.
 RUN echo "" >> /usr/share/postgresql/postgresql.conf.sample && \
     echo "# pg_trickle E2E coverage configuration" >> /usr/share/postgresql/postgresql.conf.sample && \
-    echo "shared_preload_libraries = 'pg_trickle'" >> /usr/share/postgresql/postgresql.conf.sample
+    echo "shared_preload_libraries = 'pg_trickle'" >> /usr/share/postgresql/postgresql.conf.sample && \
+    echo "wal_level = logical" >> /usr/share/postgresql/postgresql.conf.sample && \
+    echo "max_replication_slots = 10" >> /usr/share/postgresql/postgresql.conf.sample && \
+    echo "# Each test database spawns one pg_trickle scheduler BGW via the launcher." >> /usr/share/postgresql/postgresql.conf.sample && \
+    echo "# Default max_worker_processes=8 is too tight when many test databases run" >> /usr/share/postgresql/postgresql.conf.sample && \
+    echo "# concurrently (1 launcher + N scheduler workers + autovacuum workers)." >> /usr/share/postgresql/postgresql.conf.sample && \
+    echo "max_worker_processes = 128" >> /usr/share/postgresql/postgresql.conf.sample
 
 # Verify the extension files are in place
 RUN ls -la /usr/share/postgresql/18/extension/pg_trickle* && \


### PR DESCRIPTION
## Problem

The E2E coverage workflow (`coverage.yml`) fails on `test_scheduler_refreshes_multiple_healthy_sts` and `test_scheduler_writes_refresh_history` in `e2e_bgworker_tests.rs`:

```
pg_trickle scheduler did not appear in pg_stat_activity within 90 s.
Diagnostics: database=pgt_sched_e2e_26658_8, enabled=on,
  launcher_count=1, scheduler_count=6, total_bgworkers=0
```

See: https://github.com/grove/pg-trickle/actions/runs/24189835367/job/70603822067

## Root Cause

`Dockerfile.e2e-coverage` was missing the PostgreSQL resource-limit settings that `Dockerfile.e2e` sets:

- `max_worker_processes = 128` (default is 8)
- `wal_level = logical`
- `max_replication_slots = 10`

Each bgworker test creates its own database, and the launcher spawns a scheduler BGW per database. With the default `max_worker_processes=8`, the process limit is exhausted by the 8th/9th test, so the scheduler never appears for the later tests.

## Fix

Mirror the resource-limit settings from `Dockerfile.e2e` into `Dockerfile.e2e-coverage`.
