### PR TITLE
fix(dvm): consistent join row_id hash + unified PH-D1 delete + block A-3-AO for joins

### DIFF
--- a/src/dvm/operators/join.rs
+++ b/src/dvm/operators/join.rs
@@ -215,26 +215,35 @@ pub fn diff_inner_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult,
         .concat()
         .join(", ");
 
-    // Row ID: hash of both child row IDs.
-    // For the delta side, we use __pgt_row_id from the delta CTE.
-    // For the base table side, we hash its PK/non-nullable columns
-    // instead of serializing the entire row with row_to_json().
+    // Row ID: hash of both sides' PK / non-nullable key columns.
     //
-    // S1 optimization: flatten into a single pg_trickle_hash_multi call with
-    // all key columns inline, avoiding nested hash calls.
-    // For nested join children, falls back to row_to_json for the snapshot side.
-    let right_key_exprs = build_base_table_key_exprs(right, "r");
-    let left_key_exprs = build_base_table_key_exprs(left, "l");
+    // CRITICAL: Part 1 and Part 2 MUST produce the SAME row_id for the
+    // same logical output row.  We use direct PK columns from both sides
+    // (always in left-first, right-second order) rather than mixing
+    // pre-computed __pgt_row_id with raw PK columns.  Mixing them leads
+    // to hash(hash(L), R) vs hash(L, hash(R)) which are NOT equal, causing
+    // phantom row accumulation in the stream table (UNIQUE_VIOLATION in the
+    // soak test).
+    //
+    // For Scan nodes: uses non-nullable (PK) columns directly.
+    // For nested join children: falls back to row_to_json for the snapshot
+    // side.
+    let right_key_exprs_r = build_base_table_key_exprs(right, "r");
+    let right_key_exprs_dr = build_base_table_key_exprs(right, "dr");
+    let left_key_exprs_l = build_base_table_key_exprs(left, "l");
+    let left_key_exprs_dl = build_base_table_key_exprs(left, "dl");
 
-    let mut hash1_args = vec!["dl.__pgt_row_id::TEXT".to_string()];
-    hash1_args.extend(right_key_exprs);
+    // Part 1: delta_left ⋈ base_right → hash(left_pks_from_dl, right_pks_from_r)
+    let mut hash1_args = left_key_exprs_dl.clone();
+    hash1_args.extend(right_key_exprs_r.clone());
     let hash_part1 = format!(
         "pgtrickle.pg_trickle_hash_multi(ARRAY[{}])",
         hash1_args.join(", ")
     );
 
-    let mut hash2_args = left_key_exprs;
-    hash2_args.push("dr.__pgt_row_id::TEXT".to_string());
+    // Part 2: base_left ⋈ delta_right → hash(left_pks_from_l, right_pks_from_dr)
+    let mut hash2_args = left_key_exprs_l.clone();
+    hash2_args.extend(right_key_exprs_dr.clone());
     let hash_part2 = format!(
         "pgtrickle.pg_trickle_hash_multi(ARRAY[{}])",
         hash2_args.join(", ")
@@ -502,13 +511,15 @@ pub fn diff_inner_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult,
             // delta CTEs.  Mark it NOT MATERIALIZED so PG inlines it.
             ctx.mark_cte_not_materialized(&left_result.cte_name);
 
-            // Row ID for correction rows: hash of both delta row IDs.
-            // For aggregate queries (Q03, Q10), the aggregate recomputes row_ids
-            // from GROUP BY columns, so the join-level row_id doesn't need to
-            // match Part 2's exactly.
-            let hash_correction =
-                "pgtrickle.pg_trickle_hash_multi(ARRAY[dl.__pgt_row_id::TEXT, dr.__pgt_row_id::TEXT])"
-                    .to_string();
+            // Row ID for correction rows: hash of both sides' PK columns,
+            // using the same canonical left-first, right-second order as
+            // Part 1 and Part 2 to ensure consistent row_ids.
+            let mut hash_corr_args = left_key_exprs_dl.clone();
+            hash_corr_args.extend(right_key_exprs_dr.clone());
+            let hash_correction = format!(
+                "pgtrickle.pg_trickle_hash_multi(ARRAY[{}])",
+                hash_corr_args.join(", ")
+            );
 
             format!(
                 "

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -2118,7 +2118,10 @@ fn build_trigger_insert_sql(
              WHERE d.__pgt_action = 'I'",
         )
     } else {
-        // Keyed: pre-delete + INSERT with ON CONFLICT DO NOTHING safety net
+        // Keyed: DISTINCT ON eliminates within-delta duplicates; ON CONFLICT
+        // is a safety net for any remaining row_id collisions with the ST.
+        // Callers that need guaranteed conflict-free inserts (PH-D1) should
+        // delete all matching row_ids from the ST before executing this.
         format!(
             "INSERT INTO {quoted_table} (__pgt_row_id, {user_col_list}) \
              SELECT DISTINCT ON (d.__pgt_row_id) d.__pgt_row_id, {d_user_col_list} \
@@ -3468,15 +3471,6 @@ pub fn execute_differential_refresh(
         )));
     }
 
-    pgrx::warning!(
-        "[pg_trickle] TRACE enter execute_differential_refresh for {schema}.{name} \
-         (pgt_id={}, is_append_only={}, has_keyless_source={}, relid={})",
-        st.pgt_id,
-        st.is_append_only,
-        st.has_keyless_source,
-        st.pgt_relid.to_u32(),
-    );
-
     // ── EC-16: Function-body change detection ────────────────────────
     // Check whether any user-defined function referenced in this ST's
     // defining query has had its source code changed via ALTER FUNCTION
@@ -3912,17 +3906,23 @@ pub fn execute_differential_refresh(
             .map(|entry| has_non_monotonic_cte(&entry.merge_sql_template))
             .unwrap_or(false) // no cache entry → allow promotion (A-3a guard catches it)
     });
+    // Also check whether the delta is deduplicated. Non-deduplicated
+    // deltas (joins, aggregates) can produce phantom row_id collisions
+    // across refresh cycles that the append-only INSERT path cannot
+    // safely handle — those need the PH-D1 DELETE+INSERT path.
+    let cached_is_deduplicated = MERGE_TEMPLATE_CACHE.with(|cache| {
+        cache
+            .borrow()
+            .get(&st.pgt_id)
+            .map(|entry| entry.is_deduplicated)
+            .unwrap_or(true) // no cache → assume dedup (safe: first cycle has no phantoms)
+    });
     if !is_append_only
         && !st.has_keyless_source
         && !cached_non_monotonic
+        && cached_is_deduplicated
         && !has_downstream_st_consumers(st.pgt_id)
     {
-        pgrx::warning!(
-            "[pg_trickle] TRACE A-3-AO guard ENTERED for {schema}.{name} \
-             (pgt_id={}, cached_non_monotonic={})",
-            st.pgt_id,
-            cached_non_monotonic,
-        );
         let has_non_insert = catalog_source_oids.iter().any(|oid| {
             let prev_lsn = prev_frontier.get_lsn(*oid);
             let new_lsn = new_frontier.get_lsn(*oid);
@@ -3975,11 +3975,6 @@ pub fn execute_differential_refresh(
         });
 
         if !has_non_insert {
-            pgrx::warning!(
-                "[pg_trickle] TRACE A-3-AO PROMOTING {schema}.{name} to append-only \
-                 (pgt_id={}, batch is INSERT-only)",
-                st.pgt_id,
-            );
             pgrx::debug1!(
                 "[pg_trickle] A-3-AO: heuristic append-only promotion for {}.{} — \
                  current batch is INSERT-only",
@@ -4747,19 +4742,20 @@ pub fn execute_differential_refresh(
     // data_timestamp would never advance — breaking ST-on-ST cascades.
     if is_append_only && !has_downstream_st_consumers(st.pgt_id) {
         let non_monotonic = has_non_monotonic_cte(&resolved.merge_sql);
-        pgrx::warning!(
-            "[pg_trickle] TRACE A-3a append-only EXECUTING for {schema}.{name} \
-             (pgt_id={}, non_monotonic={}, is_deduplicated={}, merge_sql_len={})",
-            st.pgt_id,
-            non_monotonic,
-            resolved.is_deduplicated,
-            resolved.merge_sql.len(),
-        );
-        let _ = std::fs::write(
-            format!("/tmp/pgt_ao_{}.txt", st.pgt_id),
-            format!("APPEND-ONLY for {}.{}", schema, name),
-        );
-        if non_monotonic {
+        // Non-deduplicated deltas (joins, aggregates) must NOT use the
+        // append-only fast path: even with ON CONFLICT DO NOTHING, the
+        // delta can produce rows that collide with existing ST rows from
+        // prior cycles. Revert the catalog flag and fall through to the
+        // normal PH-D1/MERGE path.
+        if !resolved.is_deduplicated {
+            pgrx::debug1!(
+                "[pg_trickle] A-3a: skipping append-only for {}.{} — \
+                 non-deduplicated delta (join/aggregate)",
+                schema,
+                name,
+            );
+            let _ = StreamTableMeta::update_append_only(st.pgt_id, false);
+        } else if non_monotonic {
             pgrx::debug1!(
                 "[pg_trickle] A-3a: skipping append-only for {}.{} — \
                  non-monotonic query operators detected",
@@ -4775,12 +4771,6 @@ pub fn execute_differential_refresh(
             //   MERGE INTO "schema"."table" AS st USING (...delta...) AS d ON ...
             // We extract the delta subquery and wrap it in INSERT INTO.
             let insert_sql = build_append_only_insert_sql(schema, name, &resolved.merge_sql);
-
-            pgrx::warning!(
-                "[pg_trickle] TRACE A-3a INSERT SQL for {schema}.{name} (pgt_id={}): {}",
-                st.pgt_id,
-                &insert_sql[..insert_sql.len().min(500)],
-            );
 
             // A-3a: If user_triggers = 'off' and the ST has user triggers,
             // suppress them around the INSERT (same as the normal MERGE path).
@@ -5079,34 +5069,10 @@ pub fn execute_differential_refresh(
         && st.st_partition_key.is_none()
         && !has_pgt_placeholders;
 
-    pgrx::warning!(
-        "[pg_trickle] TRACE strategy selection for {schema}.{name} (pgt_id={}): \
-         use_delete_insert={}, use_agg_fast_path={}, use_explicit_dml={}, \
-         use_prepared={}, is_deduplicated={}, has_keyless={}",
-        st.pgt_id,
-        use_delete_insert,
-        use_agg_fast_path,
-        use_explicit_dml,
-        use_prepared,
-        resolved.is_deduplicated,
-        st.has_keyless_source,
-    );
-
     let (merge_count, strategy_label) = if let Some(result) = hash_merge_result {
         // A1-3b: HASH per-partition MERGE already executed above.
-        let _ = std::fs::write(
-            format!("/tmp/pgt_strat_{}.txt", st.pgt_id),
-            "HASH-MERGE-RESULT",
-        );
         result
     } else if use_delete_insert {
-        let _ = std::fs::write(
-            format!("/tmp/pgt_strat_{}.txt", st.pgt_id),
-            format!(
-                "PH-D1-ENTER use_di={} dedup={} keyless={}",
-                use_delete_insert, resolved.is_deduplicated, st.has_keyless_source
-            ),
-        );
         // ── PH-D1: DELETE+INSERT path ───────────────────────────────
         // For small deltas against large tables, separate DELETE + INSERT
         // avoids the MERGE join cost. The delta is materialized into a
@@ -5128,65 +5094,55 @@ pub fn execute_differential_refresh(
         Spi::run(&materialize_sql).map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
         let t_mat = t_mat_start.elapsed();
 
-        // Diagnostic: check delta for duplicate row_ids and ST conflicts
-        {
-            let dup_count = Spi::get_one::<i64>(&format!(
-                "SELECT COUNT(*) FROM (\
-                    SELECT __pgt_row_id FROM __pgt_delta_{pgt_id} \
-                    WHERE __pgt_action = 'I' \
-                    GROUP BY __pgt_row_id HAVING COUNT(*) > 1\
-                ) x",
-                pgt_id = st.pgt_id,
-            ))
-            .unwrap_or(Some(0))
-            .unwrap_or(0);
-            let conflict_count = Spi::get_one::<i64>(&format!(
-                "SELECT COUNT(*) FROM __pgt_delta_{pgt_id} d \
-                 JOIN \"{sch}\".\"{tbl}\" st ON st.__pgt_row_id = d.__pgt_row_id \
-                 WHERE d.__pgt_action = 'I'",
-                pgt_id = st.pgt_id,
-                sch = schema.replace('"', "\"\""),
-                tbl = name.replace('"', "\"\""),
-            ))
-            .unwrap_or(Some(0))
-            .unwrap_or(0);
-            let total_i = Spi::get_one::<i64>(&format!(
-                "SELECT COUNT(*) FROM __pgt_delta_{} WHERE __pgt_action = 'I'",
-                st.pgt_id,
-            ))
-            .unwrap_or(Some(0))
-            .unwrap_or(0);
-            let _ = std::fs::write(
-                format!("/tmp/pgt_delta_diag_{}.txt", st.pgt_id),
-                format!(
-                    "PH-D1 delta for {}.{}: total_I={}, dup_rowids={}, st_conflicts={}",
-                    schema, name, total_i, dup_count, conflict_count,
-                ),
-            );
-        }
-
-        // Step 1: DELETE rows marked for removal
+        // Step 1: DELETE rows touched by the delta.
+        //
+        // For keyed sources, delete ALL rows whose __pgt_row_id appears
+        // anywhere in the delta (both 'D' and 'I' actions).  This is
+        // critical for join deltas: an UPDATE on a source row produces
+        // both a 'D' (old values) and an 'I' (new values) with the same
+        // __pgt_row_id. Deleting all matching row_ids up-front guarantees
+        // the subsequent INSERT never hits a UNIQUE_VIOLATION, eliminating
+        // the fragile ON CONFLICT + pre-delete approach.
+        //
+        // For keyless sources, only delete rows matching 'D' actions
+        // (the __pgt_row_id index is non-unique, so no conflict risk).
         let t_del_start = Instant::now();
-        let _ = std::fs::write(format!("/tmp/pgt_step_{}.txt", st.pgt_id), "STEP-1-DELETE");
-        let del_count = Spi::connect_mut(|client| {
-            let result = client
-                .update(&resolved.trigger_delete_sql, None, &[])
-                .map_err(|e| PgTrickleError::SpiError(format!("[PH-D1-DELETE] {}", e)))?;
-            Ok::<usize, PgTrickleError>(result.len())
-        })?;
+        let del_count = if !st.has_keyless_source {
+            let quoted_table = format!(
+                "\"{}\".\"{}\"",
+                schema.replace('"', "\"\""),
+                name.replace('"', "\"\""),
+            );
+            let unified_del_sql = format!(
+                "DELETE FROM {quoted_table} WHERE __pgt_row_id IN (\
+                     SELECT __pgt_row_id FROM __pgt_delta_{pgt_id}\
+                 )",
+                pgt_id = st.pgt_id,
+            );
+            Spi::connect_mut(|client| {
+                let result = client
+                    .update(&unified_del_sql, None, &[])
+                    .map_err(|e| PgTrickleError::SpiError(format!("[PH-D1-DELETE] {}", e)))?;
+                Ok::<usize, PgTrickleError>(result.len())
+            })?
+        } else {
+            Spi::connect_mut(|client| {
+                let result = client
+                    .update(&resolved.trigger_delete_sql, None, &[])
+                    .map_err(|e| PgTrickleError::SpiError(format!("[PH-D1-DELETE] {}", e)))?;
+                Ok::<usize, PgTrickleError>(result.len())
+            })?
+        };
         let t_del = t_del_start.elapsed();
 
         // Step 2: UPDATE existing rows where values changed.
-        // For keyed sources using pre-delete + INSERT, the UPDATE is
-        // unnecessary: the pre-delete removes all ST rows matching delta
-        // 'I' row_ids, and the INSERT re-inserts them with updated values.
-        // This also avoids a UNIQUE_VIOLATION that can occur during the
-        // UPDATE FROM join when the delta has overlapping row_ids from
-        // join Part 1/Part 2.
+        // For keyed sources, the unified DELETE in step 1 already removed
+        // all rows matching delta row_ids (both 'D' and 'I'), so the
+        // UPDATE step is unnecessary — the INSERT will re-create them
+        // with updated values.
         let t_upd_start = Instant::now();
         let upd_count = if st.has_keyless_source {
             // Keyless sources still need the UPDATE step
-            let _ = std::fs::write(format!("/tmp/pgt_step_{}.txt", st.pgt_id), "STEP-2-UPDATE");
             Spi::connect_mut(|client| {
                 let result = client
                     .update(&resolved.trigger_update_sql, None, &[])
@@ -5194,66 +5150,22 @@ pub fn execute_differential_refresh(
                 Ok::<usize, PgTrickleError>(result.len())
             })?
         } else {
-            // Keyed sources: skip UPDATE, pre-delete + INSERT handles it
+            // Keyed sources: skip UPDATE, unified DELETE + INSERT handles it
             0
         };
         let t_upd = t_upd_start.elapsed();
 
         // Step 3: INSERT genuinely new rows.
-        // For keyed sources, pre-delete any ST rows whose __pgt_row_id
-        // appears in the delta as 'I', then INSERT.  This handles phantom
-        // rows from Part 1/Part 2 hash mismatches in join deltas where
-        // the same logical row gets different __pgt_row_id values across
-        // refresh cycles.  The pre-delete + INSERT runs in a single SPI
-        // connection to ensure command-counter visibility.
+        // For keyed sources, all conflicting row_ids were removed in step 1,
+        // so no ON CONFLICT clause is needed. DISTINCT ON in the INSERT SQL
+        // (from build_trigger_insert_sql) handles within-delta duplicates.
         let t_ins_start = Instant::now();
-        // Strategy marker: survives longjmp — write FULL SQL for diagnosis
-        let _ = std::fs::write(
-            format!("/tmp/pgt_insert_sql_{}.txt", st.pgt_id),
-            &resolved.trigger_insert_sql,
-        );
-        let _ = std::fs::write(
-            format!("/tmp/pgt_strat_{}.txt", st.pgt_id),
-            format!(
-                "PH-D1-INSERT keyless={} sql_len={}",
-                st.has_keyless_source,
-                resolved.trigger_insert_sql.len()
-            ),
-        );
-        let ins_count = if !st.has_keyless_source {
-            // Keyed sources: pre-delete conflicting rows, then INSERT.
-            let quoted_table = format!(
-                "\"{}\".\"{}\"",
-                schema.replace('"', "\"\""),
-                name.replace('"', "\"\""),
-            );
-            let pre_del_sql = format!(
-                "DELETE FROM {quoted_table} WHERE __pgt_row_id IN (\
-                     SELECT __pgt_row_id FROM __pgt_delta_{pgt_id} WHERE __pgt_action = 'I'\
-                 )",
-                pgt_id = st.pgt_id,
-            );
-            // Use Spi::run for both pre-delete and insert to avoid potential
-            // pgrx SPI wrapper issues with ON CONFLICT.
-            Spi::run(&pre_del_sql)
-                .map_err(|e| PgTrickleError::SpiError(format!("[PH-D1-PRE-DEL] {}", e)))?;
-            // Count pre-deleted rows (approximate — run returns no count)
-            let _ = std::fs::write(
-                format!("/tmp/pgt_predel_{}.txt", st.pgt_id),
-                "pre_deleted=via_spi_run",
-            );
-            Spi::run(&resolved.trigger_insert_sql)
+        let ins_count = Spi::connect_mut(|client| {
+            let result = client
+                .update(&resolved.trigger_insert_sql, None, &[])
                 .map_err(|e| PgTrickleError::SpiError(format!("[PH-D1-INSERT] {}", e)))?;
-            // Row count not available from Spi::run; use 0 as placeholder.
-            0_usize
-        } else {
-            Spi::connect_mut(|client| {
-                let result = client
-                    .update(&resolved.trigger_insert_sql, None, &[])
-                    .map_err(|e| PgTrickleError::SpiError(format!("[PH-D1-INSERT] {}", e)))?;
-                Ok::<usize, PgTrickleError>(result.len())
-            })?
-        };
+            Ok::<usize, PgTrickleError>(result.len())
+        })?;
         let t_ins = t_ins_start.elapsed();
 
         pgrx::info!(
@@ -5272,7 +5184,6 @@ pub fn execute_differential_refresh(
 
         (del_count + upd_count + ins_count, "delete_insert")
     } else if use_agg_fast_path {
-        let _ = std::fs::write(format!("/tmp/pgt_strat_{}.txt", st.pgt_id), "AGG-FAST-PATH");
         // ── B-1: Aggregate fast-path ────────────────────────────────
         // For all-algebraic aggregate queries, use explicit DML
         // (DELETE+UPDATE+INSERT) to avoid the MERGE hash-join cost.
@@ -5336,7 +5247,7 @@ pub fn execute_differential_refresh(
 
         (del_count + upd_count + ins_count, "agg_fast_path")
     } else if use_explicit_dml {
-        let _ = std::fs::write(format!("/tmp/pgt_strat_{}.txt", st.pgt_id), "EXPLICIT-DML"); // ── User-trigger path: explicit DML ─────────────────────────
+        // ── User-trigger path: explicit DML ─────────────────────────
         // Decompose the MERGE into DELETE + UPDATE + INSERT so that
         // user-defined triggers fire with correct TG_OP / OLD / NEW.
 
@@ -5532,57 +5443,20 @@ pub fn execute_differential_refresh(
         let params = build_execute_params(&resolved.source_oids, prev_frontier, new_frontier);
         let execute_sql = format!("EXECUTE {stmt_name}({params})");
 
-        let parameterized_sql_for_debug = resolved.parameterized_merge_sql.clone();
-        let _ = std::fs::write(
-            format!("/tmp/pgt_strat_{}.txt", st.pgt_id),
-            format!(
-                "MERGE-PREPARED sql={}",
-                &resolved.merge_sql[..resolved.merge_sql.len().min(500)]
-            ),
-        );
         let n = Spi::connect_mut(|client| {
             let result = client
                 .update(&execute_sql, None, &[])
                 .map_err(|e| PgTrickleError::SpiError(format!("[MERGE-PREPARED] {}", e)))?;
             Ok::<usize, PgTrickleError>(result.len())
-        })
-        .inspect_err(|_e| {
-            let path = format!("/tmp/pgt_debug_exec_{}.sql", st.pgt_id);
-            let content =
-                format!("-- EXECUTE: {execute_sql}\n-- Template:\n{parameterized_sql_for_debug}");
-            let _ = std::fs::write(&path, &content);
-            pgrx::warning!(
-                "[pg_trickle] EXECUTE failed for pgt_id={}, SQL dumped to {}",
-                st.pgt_id,
-                path
-            );
         })?;
         (n, "merge_prepared")
     } else {
         // ── MERGE path (default for small deltas) ───────────────────
-        let merge_sql_for_debug = resolved.merge_sql.clone();
-        let _ = std::fs::write(
-            format!("/tmp/pgt_strat_{}.txt", st.pgt_id),
-            format!(
-                "MERGE sql_prefix={}",
-                &resolved.merge_sql[..resolved.merge_sql.len().min(200)]
-            ),
-        );
         let n = Spi::connect_mut(|client| {
             let result = client
                 .update(&resolved.merge_sql, None, &[])
                 .map_err(|e| PgTrickleError::SpiError(format!("[MERGE] {}", e)))?;
             Ok::<usize, PgTrickleError>(result.len())
-        })
-        .inspect_err(|_e| {
-            // Dump failing SQL to /tmp for debugging
-            let path = format!("/tmp/pgt_debug_merge_{}.sql", st.pgt_id);
-            let _ = std::fs::write(&path, &merge_sql_for_debug);
-            pgrx::warning!(
-                "[pg_trickle] MERGE failed for pgt_id={}, SQL dumped to {}",
-                st.pgt_id,
-                path
-            );
         })?;
         (n, "merge")
     };

--- a/tests/e2e_soak_tests.rs
+++ b/tests/e2e_soak_tests.rs
@@ -373,16 +373,6 @@ async fn test_soak_stability() {
 
     let db = E2eDb::new().await.with_extension().await;
 
-    // Enable verbose error logging for diagnostics
-    db.execute("ALTER SYSTEM SET log_min_messages = 'warning'")
-        .await;
-    db.execute("ALTER SYSTEM SET log_error_verbosity = 'verbose'")
-        .await;
-    // Force ALL refreshes to use MERGE (disable PH-D1) to isolate the error source
-    db.execute("ALTER SYSTEM SET pg_trickle.merge_strategy = 'merge'")
-        .await;
-    db.execute("SELECT pg_reload_conf()").await;
-
     // ── Setup ──────────────────────────────────────────────────────────
     println!("  Setting up source tables and stream tables...");
     create_source_tables(&db, n_sources).await;
@@ -456,80 +446,6 @@ async fn test_soak_stability() {
             // Check error states
             if let Err(e) = check_no_error_states(&db).await {
                 println!("FAIL — {e}");
-                // Query catalog for detailed error info + pgt_id
-                let err_detail: Vec<(i64, String, String)> = sqlx::query_as(
-                    "SELECT pgt_id, pgt_name::text, last_error_message \
-                     FROM pgtrickle.pgt_stream_tables \
-                     WHERE status = 'ERROR' AND last_error_message IS NOT NULL",
-                )
-                .fetch_all(&db.pool)
-                .await
-                .unwrap_or_default();
-                for (pgt_id, name, _msg) in &err_detail {
-                    // Read strategy marker file written by the extension
-                    let strat: Option<String> = sqlx::query_scalar(&format!(
-                        "SELECT pg_read_file('/tmp/pgt_strat_{}.txt', true)",
-                        pgt_id
-                    ))
-                    .fetch_one(&db.pool)
-                    .await
-                    .ok()
-                    .flatten();
-                    println!(
-                        "  STRATEGY for {} (pgt_id={}): {}",
-                        name,
-                        pgt_id,
-                        strat.as_deref().unwrap_or("(none)")
-                    );
-                    // Read delta diagnostic
-                    let diag: Option<String> = sqlx::query_scalar(&format!(
-                        "SELECT pg_read_file('/tmp/pgt_delta_diag_{}.txt', true)",
-                        pgt_id
-                    ))
-                    .fetch_one(&db.pool)
-                    .await
-                    .ok()
-                    .flatten();
-                    if let Some(d) = &diag {
-                        println!("  DELTA DIAG: {}", d);
-                    }
-                    // Read pre-delete count
-                    let predel: Option<String> = sqlx::query_scalar(&format!(
-                        "SELECT pg_read_file('/tmp/pgt_predel_{}.txt', true)",
-                        pgt_id
-                    ))
-                    .fetch_one(&db.pool)
-                    .await
-                    .ok()
-                    .flatten();
-                    if let Some(p) = &predel {
-                        println!("  PRE-DELETE: {}", p);
-                    }
-                    // Read step marker
-                    let step: Option<String> = sqlx::query_scalar(&format!(
-                        "SELECT pg_read_file('/tmp/pgt_step_{}.txt', true)",
-                        pgt_id
-                    ))
-                    .fetch_one(&db.pool)
-                    .await
-                    .ok()
-                    .flatten();
-                    if let Some(s) = &step {
-                        println!("  LAST STEP: {}", s);
-                    }
-                    // Read the full INSERT SQL
-                    let insert_sql: Option<String> = sqlx::query_scalar(&format!(
-                        "SELECT pg_read_file('/tmp/pgt_insert_sql_{}.txt', true)",
-                        pgt_id
-                    ))
-                    .fetch_one(&db.pool)
-                    .await
-                    .ok()
-                    .flatten();
-                    if let Some(sql) = &insert_sql {
-                        println!("  INSERT SQL: {}", sql);
-                    }
-                }
                 health_check_failures.push(format!("[{elapsed}s] {e}"));
             } else {
                 print!("states OK, ");


### PR DESCRIPTION
## Summary

Fix the root cause of the `soak_join` UNIQUE_VIOLATION in the G17-SOAK stability test: asymmetric `__pgt_row_id` hash computation between Part 1 and Part 2 of join deltas. Also hardens the PH-D1 DELETE+INSERT path and blocks append-only promotion for non-deduplicated (join/aggregate) deltas.

## Root Cause

Part 1 and Part 2 of inner join deltas used **asymmetric hash expressions** for `__pgt_row_id`:
- Part 1 (delta_left join base_right): `hash(dl.__pgt_row_id, r.pk_cols...)`
- Part 2 (base_left join delta_right): `hash(l.pk_cols..., dr.__pgt_row_id)`

Since `hash(A, B) != hash(B, A)`, the same logical join row got different row_ids depending on which source side produced the delta. Phantom rows accumulated in the stream table across refresh cycles, eventually triggering UNIQUE_VIOLATION when a new delta tried to insert a row_id that already existed from a prior cycle's Part 1/Part 2 mismatch.

## Changes

### `src/dvm/operators/join.rs`
- Use **direct PK columns from both sides** in canonical left-first, right-second order for Part 1, Part 2, and Part 3 (correction term) hashes
- All three parts now produce identical `__pgt_row_id` values for the same logical output row
- Replaced `dl.__pgt_row_id::TEXT` / `dr.__pgt_row_id::TEXT` with `build_base_table_key_exprs(left/right, "dl"/"dr")` for consistency

### `src/refresh.rs`
- **PH-D1 unified DELETE**: For keyed sources, delete ALL rows whose `__pgt_row_id` appears anywhere in the delta (both D and I actions), not just D actions. This eliminates the fragile pre-delete + ON CONFLICT approach
- **Block A-3-AO promotion** for non-deduplicated deltas: joins/aggregates should never be promoted to append-only mode (phantom row collisions cannot be handled by bare INSERT)
- **Block A-3a execution** for non-deduplicated deltas: if a join ST was previously promoted to append-only, revert the flag and fall through to PH-D1/MERGE
- Remove diagnostic `/tmp/pgt_*` file writes and `pgrx::warning!` TRACE messages from PR #455
- Remove debug `.inspect_err()` handlers that dumped SQL to `/tmp`

### `tests/e2e_soak_tests.rs`
- Remove debug overrides (`merge_strategy = 'merge'`, `log_error_verbosity = 'verbose'`)
- Remove `/tmp/pgt_*` marker file reads from the soak diagnostic handler
- Net reduction of 84 lines of temporary debugging code

## Testing

- `just test-unit`: 1735 tests pass
- `just lint`: zero warnings
- `e2e_join_tests`: all 6 tests pass (including `test_inner_join_simultaneous_both_sides_update_large`)
- `e2e_append_only_tests`: all 10 tests pass
- Manual 50-cycle stress test with concurrent updates on both join sides: passes (PH-D1 path confirmed via logs)
- Soak test (`e2e_soak_tests`): still reproduces under scheduler-driven refresh; the hash fix addresses the root cause but the scheduler path may have additional timing-sensitive behavior (to be investigated separately)
