### PR TITLE
ci: increase E2E coverage timeout from 45 to 75 minutes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,12 +80,12 @@ jobs:
   # ── E2E coverage (Docker-based, weekly + manual) ──────────────────────
   # Runs the full E2E test suite against a coverage-instrumented Docker
   # image, extracts profraw files, merges with unit profdata, and uploads
-  # combined coverage. Expensive (~30 min), so scheduled weekly only.
+  # combined coverage. Expensive (~60 min), so scheduled weekly only.
   e2e-coverage:
     name: E2E coverage
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Problem

The **E2E coverage** job in the Coverage workflow was cancelled mid-run
([run #24231553967](https://github.com/grove/pg-trickle/actions/runs/24231553967))
because the coverage-instrumented test suite now exceeds the 45-minute timeout.
All 11 tests that completed in the final test file (`e2e_differential_gaps_tests`)
were passing — the job was simply too slow under `cargo-llvm-cov` instrumentation.

## Fix

Increase `timeout-minutes` for the `e2e-coverage` job from **45** to **75** minutes
to provide sufficient headroom. Updated the comment to reflect the new expected
runtime (~60 min).
