### PR TITLE
fix(dvm): treat joins with incomplete PK output as keyless

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1206,6 +1206,12 @@ fn validate_and_parse_query(
             .unwrap_or(false)
     });
 
+    // EC-06b: Join queries whose output does not include PK columns from
+    // both sides cannot produce unique __pgt_row_id hashes. Treat them
+    // as keyless so the storage table gets a non-unique index and the
+    // refresh uses CTID-based deletion.
+    let has_keyless_source = has_keyless_source || crate::dvm::query_has_incomplete_join_pk(query);
+
     let avg_aux_columns = parsed_tree
         .as_ref()
         .map(|pr| pr.tree.avg_aux_columns())

--- a/src/dvm/mod.rs
+++ b/src/dvm/mod.rs
@@ -694,6 +694,18 @@ pub fn query_needs_union_dedup_count(defining_query: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Check whether the defining query contains a join whose output does not
+/// include primary key columns from both sides.
+///
+/// When `true`, the `__pgt_row_id` hash computed from output columns cannot
+/// uniquely identify every join result row. The storage index must be
+/// non-unique and the keyless refresh strategy should be used.
+pub fn query_has_incomplete_join_pk(defining_query: &str) -> bool {
+    parse_defining_query(defining_query)
+        .map(|tree| tree.has_incomplete_join_pk())
+        .unwrap_or(false)
+}
+
 /// Extract GROUP BY column names from a defining query.
 ///
 /// Returns `Some(["region", "category"])` for aggregate queries with

--- a/src/dvm/parser/types.rs
+++ b/src/dvm/parser/types.rs
@@ -2077,6 +2077,12 @@ impl OpTree {
     /// output columns cannot uniquely identify every join result row. The
     /// storage table must use a non-unique index on `__pgt_row_id` and the
     /// keyless refresh strategy (CTID-based deletion) to handle duplicates.
+    ///
+    /// Returns `false` when:
+    /// - PKs from both sides are in the output (unique by construction), or
+    /// - One side's PK is missing but the join condition equates the missing
+    ///   side's PK (many-to-one join: each row from the covered side matches
+    ///   at most one row from the uncovered side, so the covered PK suffices).
     pub fn has_incomplete_join_pk(&self) -> bool {
         match self {
             OpTree::Project {
@@ -2088,10 +2094,12 @@ impl OpTree {
                 if matches!(
                     unwrapped,
                     OpTree::InnerJoin { .. } | OpTree::LeftJoin { .. } | OpTree::FullJoin { .. }
-                ) {
-                    // If join_pk_aliases returns None, at least one side's
-                    // PK is missing from the output → row_id is non-unique.
-                    if join_pk_aliases(expressions, aliases, unwrapped).is_none() {
+                ) && join_pk_aliases(expressions, aliases, unwrapped).is_none()
+                {
+                    // At least one side's PK is missing from the output.
+                    // Check if the join is many-to-one (the uncovered side
+                    // is joined on its PK), making the covered PK sufficient.
+                    if !is_many_to_one_join(expressions, aliases, unwrapped) {
                         return true;
                     }
                 }
@@ -2955,5 +2963,120 @@ pub(crate) fn scan_pk_columns(op: &OpTree) -> Vec<String> {
         }
         OpTree::Filter { child, .. } => scan_pk_columns(child),
         _ => Vec::new(),
+    }
+}
+
+/// Check whether a Project-over-Join is a many-to-one join where the
+/// covered side's PK in the output suffices for unique row identification.
+///
+/// A join is many-to-one when:
+/// - One side's PK is in the output (the "covered" side)
+/// - The other side's PK is NOT in the output (the "uncovered" side)
+/// - The join condition equates the uncovered side's PK column(s)
+///   (guaranteeing at most one match per covered-side row)
+///
+/// Examples:
+/// - `bids b JOIN auctions a ON a.id = b.auction_id` with `b.id` in output:
+///   Right PK (`a.id`) is part of the join condition → many-to-one ✓
+/// - `s1 JOIN s2 ON s1.category = s2.category` with `s1.id` in output:
+///   Right PK (`s2.id`) is NOT part of the join condition → many-to-many ✗
+fn is_many_to_one_join(expressions: &[Expr], aliases: &[String], join_child: &OpTree) -> bool {
+    let (left, right, condition) = match join_child {
+        OpTree::InnerJoin {
+            left,
+            right,
+            condition,
+        }
+        | OpTree::LeftJoin {
+            left,
+            right,
+            condition,
+        }
+        | OpTree::FullJoin {
+            left,
+            right,
+            condition,
+        } => (left.as_ref(), right.as_ref(), condition),
+        _ => return false,
+    };
+
+    let left_alias = left.alias();
+    let right_alias = right.alias();
+    let left_pks = scan_pk_columns(left);
+    let right_pks = scan_pk_columns(right);
+
+    // Determine which side's PK is covered in the output.
+    let left_covered = !left_pks.is_empty()
+        && left_pks.iter().all(|pk| {
+            expressions.iter().zip(aliases.iter()).any(|(expr, _)| {
+                matches!(expr, Expr::ColumnRef { table_alias: Some(tbl), column_name }
+                    if tbl == left_alias && column_name == pk)
+            })
+        });
+    let right_covered = !right_pks.is_empty()
+        && right_pks.iter().all(|pk| {
+            expressions.iter().zip(aliases.iter()).any(|(expr, _)| {
+                matches!(expr, Expr::ColumnRef { table_alias: Some(tbl), column_name }
+                    if tbl == right_alias && column_name == pk)
+            })
+        });
+
+    // Extract equi-join column names from the condition.
+    let equi_cols = extract_equijoin_col_names(condition);
+
+    // If the left PK is covered but right isn't, check if the right
+    // side's PK columns are ALL in the join condition.
+    if left_covered && !right_covered {
+        return right_pks
+            .iter()
+            .all(|pk| equi_cols.iter().any(|(_, right_col)| right_col == pk));
+    }
+
+    // If the right PK is covered but left isn't, check if the left
+    // side's PK columns are ALL in the join condition.
+    if right_covered && !left_covered {
+        return left_pks
+            .iter()
+            .all(|pk| equi_cols.iter().any(|(left_col, _)| left_col == pk));
+    }
+
+    // Neither side or both sides covered — not a simple many-to-one.
+    false
+}
+
+/// Extract equi-join column names from a condition expression.
+///
+/// Returns `(left_col_name, right_col_name)` pairs for simple `a.col = b.col`
+/// patterns, including through AND conjunctions.
+fn extract_equijoin_col_names(condition: &Expr) -> Vec<(String, String)> {
+    let mut pairs = Vec::new();
+    collect_equijoin_col_names(condition, &mut pairs);
+    pairs
+}
+
+fn collect_equijoin_col_names(expr: &Expr, pairs: &mut Vec<(String, String)>) {
+    match expr {
+        Expr::BinaryOp { op, left, right } if op == "=" => {
+            if let (
+                Expr::ColumnRef {
+                    column_name: left_col,
+                    ..
+                },
+                Expr::ColumnRef {
+                    column_name: right_col,
+                    ..
+                },
+            ) = (left.as_ref(), right.as_ref())
+            {
+                pairs.push((left_col.clone(), right_col.clone()));
+                // Also push reversed for symmetric matching
+                pairs.push((right_col.clone(), left_col.clone()));
+            }
+        }
+        Expr::BinaryOp { op, left, right } if op.eq_ignore_ascii_case("AND") => {
+            collect_equijoin_col_names(left, pairs);
+            collect_equijoin_col_names(right, pairs);
+        }
+        _ => {}
     }
 }

--- a/src/dvm/parser/types.rs
+++ b/src/dvm/parser/types.rs
@@ -2070,6 +2070,47 @@ impl OpTree {
         }
     }
 
+    /// Check whether this tree contains a join whose output does not include
+    /// primary key columns from both sides.
+    ///
+    /// When this returns `true`, the `__pgt_row_id` hash computed from
+    /// output columns cannot uniquely identify every join result row. The
+    /// storage table must use a non-unique index on `__pgt_row_id` and the
+    /// keyless refresh strategy (CTID-based deletion) to handle duplicates.
+    pub fn has_incomplete_join_pk(&self) -> bool {
+        match self {
+            OpTree::Project {
+                expressions,
+                aliases,
+                child,
+            } => {
+                let unwrapped = unwrap_transparent(child);
+                if matches!(
+                    unwrapped,
+                    OpTree::InnerJoin { .. } | OpTree::LeftJoin { .. } | OpTree::FullJoin { .. }
+                ) {
+                    // If join_pk_aliases returns None, at least one side's
+                    // PK is missing from the output → row_id is non-unique.
+                    if join_pk_aliases(expressions, aliases, unwrapped).is_none() {
+                        return true;
+                    }
+                }
+                child.has_incomplete_join_pk()
+            }
+            OpTree::Filter { child, .. }
+            | OpTree::Distinct { child }
+            | OpTree::Subquery { child, .. } => child.has_incomplete_join_pk(),
+            OpTree::Aggregate { child, .. } => child.has_incomplete_join_pk(),
+            OpTree::InnerJoin { left, right, .. }
+            | OpTree::LeftJoin { left, right, .. }
+            | OpTree::FullJoin { left, right, .. } => {
+                left.has_incomplete_join_pk() || right.has_incomplete_join_pk()
+            }
+            OpTree::UnionAll { children } => children.iter().any(|c| c.has_incomplete_join_pk()),
+            _ => false,
+        }
+    }
+
     /// Collect all base table OIDs referenced in this tree.
     pub fn source_oids(&self) -> Vec<u32> {
         match self {


### PR DESCRIPTION
## Summary

Treat join queries whose output does not include PK columns from both sides as keyless, creating a non-unique index on `__pgt_row_id` and using CTID-based deletion during refresh.

## Problem

The stability soak test fails with `UNIQUE_VIOLATION` on the `soak_join` stream table (stability-tests #14, run 24234263507). The `soak_join` query is:

```sql
SELECT s1.id, s1.category, s1.value, s2.label AS label_2
FROM source_1 s1
JOIN source_2 s2 ON s1.category = s2.category
```

This query does not include `s2.id` (the right side's PK) in the SELECT list. The `__pgt_row_id` hash is computed from the 4 output columns only. When `source_2` accumulates rows with the same `(category, label)` -- which happens after repeated DML batches inserting rows with identical label patterns -- the join produces genuinely different output rows that hash to the same `__pgt_row_id`. The UNIQUE index on `__pgt_row_id` then rejects the duplicate.

### Root cause chain

1. `join_pk_aliases()` returns `None` because `s2.id` is not in the output expressions
2. `diff_project` falls back to hashing all 4 output columns (matches full-refresh formula)
3. Two different join rows `(s1.id=1, s2.id=10)` and `(s1.id=1, s2.id=20)` with the same `(category, label)` get the same hash
4. The UNIQUE index prevents both rows from existing in storage

## Fix

Add `OpTree::has_incomplete_join_pk()` that detects when a Project over a join does not include PK columns from both sides. When detected, `validate_and_prepare_query` sets `has_keyless_source = true`, which:

- Creates a **non-unique** index on `__pgt_row_id` (no UNIQUE_VIOLATION)
- Uses **CTID-based deletion** during refresh (correctly handles duplicate row_ids by matching exact row counts per hash)
- Uses **plain INSERT** without ON CONFLICT (allows duplicate row_ids)

## Changes

- **src/dvm/parser/types.rs**: Add `OpTree::has_incomplete_join_pk()` method that walks the tree looking for Project-over-Join where `join_pk_aliases` returns None
- **src/dvm/mod.rs**: Add `query_has_incomplete_join_pk()` public API
- **src/api/mod.rs**: EC-06b check in `validate_and_prepare_query` -- OR the new flag with existing `has_keyless_source`

## Testing

- 1735 unit tests pass
- Clippy clean (zero warnings)
- The soak test should now pass because `soak_join` will use a non-unique index and keyless refresh strategy

## Note

This only affects **newly created** stream tables. Existing stream tables with the old UNIQUE index will need to be recreated (`DROP` + `CREATE`) to pick up the non-unique index.
