### PR TITLE
fix: rebuild __pgt_row_id index after compatible ALTER QUERY

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1724,6 +1724,69 @@ fn migrate_storage_table_compatible(
     Ok(())
 }
 
+/// Rebuild the `__pgt_row_id` index on a storage table.
+///
+/// The covering index created by `setup_storage_table` uses an INCLUDE clause
+/// referencing user columns.  When `migrate_storage_table_compatible` drops
+/// columns that appear in the INCLUDE list PostgreSQL silently drops the whole
+/// index, leaving no unique constraint for `ON CONFLICT (__pgt_row_id)` in
+/// differential refresh.  This function drops any surviving row-id index and
+/// recreates it with the correct INCLUDE clause for the *new* column set.
+fn rebuild_row_id_index(
+    schema: &str,
+    table_name: &str,
+    new_columns: &[ColumnDef],
+    has_keyless_source: bool,
+    is_partitioned: bool,
+) -> Result<(), PgTrickleError> {
+    let quoted_table = format!(
+        "{}.{}",
+        quote_identifier(schema),
+        quote_identifier(table_name),
+    );
+
+    // Drop any existing index on __pgt_row_id (may already be gone).
+    let existing: Option<String> = Spi::get_one_with_args(
+        "SELECT indexrelid::regclass::text FROM pg_index \
+         JOIN pg_attribute ON attrelid = indrelid AND attnum = ANY(indkey) \
+         WHERE indrelid = $1::regclass AND attname = '__pgt_row_id' \
+         LIMIT 1",
+        &[quoted_table.clone().into()],
+    )
+    .unwrap_or(None);
+
+    if let Some(idx_name) = existing {
+        Spi::run(&format!("DROP INDEX IF EXISTS {idx_name}")).map_err(|e| {
+            PgTrickleError::SpiError(format!("Failed to drop old row_id index: {e}"))
+        })?;
+    }
+
+    // Rebuild with the new INCLUDE clause
+    let auto_index = crate::config::pg_trickle_auto_index();
+    const COVERING_INDEX_MAX_COLUMNS: usize = 8;
+    let include_clause =
+        if auto_index && new_columns.len() <= COVERING_INDEX_MAX_COLUMNS && !new_columns.is_empty()
+        {
+            let include_cols: Vec<String> = new_columns
+                .iter()
+                .map(|c| quote_identifier(&c.name).to_string())
+                .collect();
+            format!(" INCLUDE ({})", include_cols.join(", "))
+        } else {
+            String::new()
+        };
+
+    let index_sql = if has_keyless_source || is_partitioned {
+        format!("CREATE INDEX ON {quoted_table} (__pgt_row_id){include_clause}",)
+    } else {
+        format!("CREATE UNIQUE INDEX ON {quoted_table} (__pgt_row_id){include_clause}",)
+    };
+    Spi::run(&index_sql)
+        .map_err(|e| PgTrickleError::SpiError(format!("Failed to recreate row_id index: {e}")))?;
+
+    Ok(())
+}
+
 /// Manage auxiliary columns (__pgt_count, __pgt_count_l/r, __pgt_aux_sum_*,
 /// __pgt_aux_count_*, __pgt_aux_sum2_*, __pgt_aux_sumx_*, __pgt_aux_nonnull_*)
 /// during ALTER QUERY when the query type or aggregate composition changes.
@@ -2054,6 +2117,18 @@ fn alter_stream_table_query(
         }
         SchemaChange::Compatible { added, removed } => {
             migrate_storage_table_compatible(schema, table_name, added, removed)?;
+            // Dropping columns may destroy the covering INCLUDE index on
+            // __pgt_row_id.  Rebuild it with the new column set so that
+            // ON CONFLICT (__pgt_row_id) in differential refresh still works.
+            if !removed.is_empty() {
+                rebuild_row_id_index(
+                    schema,
+                    table_name,
+                    &vq.columns,
+                    vq.has_keyless_source,
+                    st.st_partition_key.is_some(),
+                )?;
+            }
             st.pgt_relid
         }
         SchemaChange::Incompatible { reason } => {


### PR DESCRIPTION
## Problem

The E2E coverage job fails on `test_alter_query_data_correctness_with_dml_cycle` with:

```
error returned from database: there is no unique or exclusion constraint
matching the ON CONFLICT specification
SQL: SELECT pgtrickle.refresh_stream_table('aq_dml_st')
```

See [failed run](https://github.com/grove/pg-trickle/actions/runs/24234593132/job/70753919377).

## Root Cause

`setup_storage_table` creates a covering index on `__pgt_row_id` with an
`INCLUDE` clause referencing user columns (the AUTO-IDX-2 optimisation):

```sql
CREATE UNIQUE INDEX ON st (__pgt_row_id) INCLUDE (id, val)
```

When `ALTER STREAM TABLE ... SET (query => ...)` triggers a Compatible
schema change that removes columns (e.g. `id` and `val` are replaced by
`status` and `total_val`), `migrate_storage_table_compatible` runs
`ALTER TABLE DROP COLUMN` for each removed column. PostgreSQL silently
drops any index whose `INCLUDE` list references a dropped column, so the
unique constraint on `__pgt_row_id` disappears.

The subsequent differential refresh uses
`INSERT ... ON CONFLICT (__pgt_row_id) DO NOTHING`, which requires a
unique index on that column. With the index gone, PostgreSQL raises the
error above.

## Fix

Add `rebuild_row_id_index()` that:

1. Drops any surviving `__pgt_row_id` index (it may already be gone).
2. Recreates it with the correct `INCLUDE` clause for the new column
   set and the correct uniqueness (keyed vs keyless source, partitioned
   vs non-partitioned).

Called from the `SchemaChange::Compatible` path in
`alter_stream_table_query` whenever columns are removed.

## Testing

- `just fmt` and `just lint` pass with zero warnings.
- `just test-unit` passes (1735 tests).
- The fix targets the exact scenario in
  `test_alter_query_data_correctness_with_dml_cycle` (E2E) which will be
  validated by CI.
