### PR TITLE
fix: use base PK columns for EC-02 join correction row_id hash

### DIFF
--- a/src/dvm/operators/join.rs
+++ b/src/dvm/operators/join.rs
@@ -576,9 +576,19 @@ JOIN {delta_right} dr ON {cond}",
         let cond = rewrite_join_condition(condition, left, "dl", right, "dr");
         // delta_left is referenced in Part 1a/1b and correction; mark NOT MATERIALIZED.
         ctx.mark_cte_not_materialized(&left_result.cte_name);
-        let hash_correction =
-            "pgtrickle.pg_trickle_hash_multi(ARRAY[dl.__pgt_row_id::TEXT, dr.__pgt_row_id::TEXT])"
-                .to_string();
+
+        // Row ID for EC-02 correction rows: hash of both sides' PK columns,
+        // using the same canonical left-first, right-second order as
+        // Part 1 and Part 2 to ensure consistent row_ids.  Using
+        // dl.__pgt_row_id / dr.__pgt_row_id here would produce
+        // hash(hash(L), hash(R)) instead of hash(L_pk, R_pk), causing
+        // phantom row accumulation.
+        let mut hash_corr_args = left_key_exprs_dl.clone();
+        hash_corr_args.extend(right_key_exprs_dr.clone());
+        let hash_correction = format!(
+            "pgtrickle.pg_trickle_hash_multi(ARRAY[{}])",
+            hash_corr_args.join(", ")
+        );
         format!(
             "
 


### PR DESCRIPTION
## Problem

The **E2E coverage** job fails ([run #24239914595](https://github.com/grove/pg-trickle/actions/runs/24239914595)) with `test_inner_join_simultaneous_both_sides_update_large` producing 2010 rows instead of the expected 2000 — 10 phantom rows accumulate in the stream table.

### Root Cause

The **EC-02 correction term** in the inner join differential refresh computes `__pgt_row_id` using pre-hashed values from both delta CTEs:

```
hash(dl.__pgt_row_id, dr.__pgt_row_id) = hash(hash(L_pk), hash(R_pk))
```

Parts 1 and 2 use direct PK columns:

```
hash(L_pk, R_pk)
```

These are **not equal**, so the correction rows have different row_ids than the rows they are supposed to cancel, causing phantom row accumulation.

This is exactly the bug described in the CRITICAL comment at line 217 of `join.rs`:

> We use direct PK columns from both sides rather than mixing pre-computed `__pgt_row_id` with raw PK columns. Mixing them leads to `hash(hash(L), R)` vs `hash(L, hash(R))` which are NOT equal, causing phantom row accumulation...

The nested-join Part 3 correction (line 517) already uses the correct formula. The EC-02 correction was the only remaining path with the wrong hash.

## Fix

Replace `dl.__pgt_row_id::TEXT, dr.__pgt_row_id::TEXT` with `left_key_exprs_dl` + `right_key_exprs_dr` (base table PK column expressions), matching the pattern used by all other parts.

## Testing

- Unit tests: 1735 passed
- Lint/fmt: clean
- The failing test (`test_inner_join_simultaneous_both_sides_update_large`) targets exactly this scenario
