### PR TITLE
fix: use weight aggregation for non-deduplicated keyless join deltas

### DIFF
--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -2199,12 +2199,16 @@ pub fn prewarm_merge_cache(st: &StreamTableMeta) {
     // Build the USING clause — skip deduplication when the delta is already
     // deduplicated (G-M1 optimization for scan-chain queries).
     //
-    // EC-06: For keyless sources the delta is never deduplicated (multiple
-    // rows can share the same __pgt_row_id). Skip deduplication unconditionally.
-    //
     // B3-2: For non-deduplicated deltas, use weight aggregation instead of
     // DISTINCT ON.  Weight aggregation correctly handles diamond-flow queries
     // where multiple delta branches produce overlapping corrections.
+    //
+    // EC-06b: Join queries with incomplete PK output set has_keyless_source
+    // for storage safety (non-unique index), but their non-deduplicated join
+    // deltas still require weight aggregation for EC-02 correction cross-term
+    // cancellation.  Without weight agg, PostgreSQL MERGE's snapshot semantics
+    // prevent correction DELETEs from seeing rows inserted by earlier USING
+    // rows in the same statement, causing phantom row accumulation.
     //
     // A-2: When `has_key_changed` is available on a deduplicated delta, wrap
     // the USING clause with a filter that suppresses D-side rows for value-only
@@ -2217,10 +2221,6 @@ pub fn prewarm_merge_cache(st: &StreamTableMeta) {
              WHERE NOT (__d.__pgt_action = 'D' AND __d.__pgt_key_changed = FALSE))"
         )
     } else if delta_result.is_deduplicated {
-        format!("({delta_sql_template})")
-    } else if st.has_keyless_source {
-        // Keyless: do NOT collapse — duplicate row_ids are intentional
-        // (one per net insert/delete).
         format!("({delta_sql_template})")
     } else {
         build_weight_agg_using(&delta_sql_template, &user_col_list)
@@ -4500,16 +4500,17 @@ pub fn execute_differential_refresh(
         };
 
         // Build template USING clause — skip deduplication when deduplicated (G-M1)
-        // EC-06: For keyless sources, never collapse.
         // B3-2: Use weight aggregation instead of DISTINCT ON for correctness
         // on diamond-flow queries.
+        // EC-06b: Non-deduplicated keyless join deltas use weight agg for
+        // EC-02 correction cross-term cancellation (see prewarm_merge_cache).
         // A-2: Filter D-side value-only UPDATE rows when __pgt_key_changed is available.
-        let template_using = if (is_dedup || st.has_keyless_source) && has_key_changed {
+        let template_using = if is_dedup && has_key_changed {
             format!(
                 "(SELECT * FROM ({delta_sql_template}) __d \
                  WHERE NOT (__d.__pgt_action = 'D' AND __d.__pgt_key_changed = FALSE))"
             )
-        } else if is_dedup || st.has_keyless_source {
+        } else if is_dedup {
             format!("({delta_sql_template})")
         } else {
             build_weight_agg_using(&delta_sql_template, &user_col_list)


### PR DESCRIPTION
## Problem

The E2E coverage job fails in CI run [#24239914595](https://github.com/grove/pg-trickle/actions/runs/24239914595) with `test_inner_join_simultaneous_both_sides_update_large` producing 2010 rows instead of the expected 2000 (10 phantom rows).

## Root Cause

The EC-06b fix (#461, `bceea55`) correctly marks join queries with incomplete PK output as keyless (`has_keyless_source = true`) for storage safety (non-unique index on `__pgt_row_id`). However, this flag also caused the MERGE USING clause to skip **weight aggregation** for non-deduplicated join deltas.

Without weight aggregation, the **EC-02 correction mechanism** breaks:

1. **Part 2** of the join delta produces cross-term INSERT rows: `L_0[changed_left] JOIN delta_R[changed_right]`
2. **EC-02 correction** produces matching DELETE rows to cancel them
3. PostgreSQL MERGE uses **snapshot semantics** -- rows inserted by earlier USING rows are invisible to later rows' ON conditions
4. The EC-02 DELETE cannot see the Part 2 INSERT, so both execute independently
5. Result: 10 phantom cross-term rows (5 changed left x 1 matching changed right x 2 delta actions)

With weight aggregation, the cross-terms are netted at the SQL level (`GROUP BY __pgt_row_id, user_cols HAVING SUM(...) <> 0`), cancelling to net 0 **before** reaching the MERGE.

## Fix

Remove the `has_keyless_source` bypass for weight aggregation in both `prewarm_merge_cache` and `execute_differential_refresh`. By the time non-deduplicated deltas reach this branch, they are always join or aggregate deltas that benefit from weight aggregation for:

- EC-02 cross-term cancellation (simultaneous both-side join changes)
- Diamond-flow correction deduplication (B3-2)

Deduplicated deltas (scan-chain queries, including genuinely keyless sources) continue to bypass weight aggregation via the earlier `is_deduplicated` branches, preserving per-row multiplicity.

## Testing

- `test_inner_join_simultaneous_both_sides_update_large` -- previously FAILED, now passes
- All 6 join E2E tests pass
- All 16 cascade regression tests pass
- All 18 aggregate coverage tests pass
- All 11 coverage error tests pass
- 1735 unit tests pass
- `test_alter_query_data_correctness_with_dml_cycle` fails on `main` (pre-existing, unrelated)
