### PR TITLE
ci: remove stale Microsoft APT sources before apt-get update

### DIFF
--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -85,6 +85,10 @@ runs:
       if: runner.os == 'Linux' && inputs.pg-install-mode == 'system'
       shell: bash
       run: |
+        # Remove Microsoft APT sources that intermittently return 403 on
+        # GitHub-hosted ubuntu-latest runners, causing apt-get update to fail.
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                   /etc/apt/sources.list.d/azure-cli.list
         sudo apt-get update -qq
         sudo apt-get install -y -qq curl ca-certificates gnupg lsb-release >/dev/null
 
@@ -108,6 +112,10 @@ runs:
       if: runner.os == 'Linux' && inputs.pg-install-mode == 'download'
       shell: bash
       run: |
+        # Remove Microsoft APT sources that intermittently return 403 on
+        # GitHub-hosted ubuntu-latest runners, causing apt-get update to fail.
+        sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                   /etc/apt/sources.list.d/azure-cli.list
         sudo apt-get update -qq
         sudo apt-get install -y -qq \
           bison \


### PR DESCRIPTION
## Summary

Remove stale Microsoft APT repository sources before running apt-get update
in the setup-pgrx composite action, fixing an intermittent CI failure unrelated
to the extension code.

## Problem

The stability soak test run
[#24248990395](https://github.com/grove/pg-trickle/actions/runs/24248990395)
failed at the Setup pgrx environment step of the Multi-database isolation
test job with:

    E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease
       403  Forbidden [IP: 13.107.213.41 443]
    E: The repository ... azure-cli noble InRelease is no longer signed.
    E: Failed to fetch https://packages.microsoft.com/ubuntu/24.04/prod/dists/noble/InRelease
       403  Forbidden [IP: 13.107.213.41 443]
    Process completed with exit code 100.

GitHub-hosted ubuntu-latest runners come pre-configured with Microsoft APT
sources (azure-cli.list, microsoft-prod.list) that intermittently return 403
when apt-get update fetches their indices.

## Fix

Remove the two Microsoft source-list files before the first apt-get update
call in both the system and download PostgreSQL install modes of
.github/actions/setup-pgrx/action.yml.

The extension has no dependency on Azure CLI or any other Microsoft-distributed
package, so removing those sources has no effect on the build.

## Testing

- The fix eliminates the root cause of run #24248990395
- No code changes: only CI infrastructure
