### PR TITLE
ci: increase E2E coverage timeout from 75 to 120 minutes

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -80,12 +80,13 @@ jobs:
   # ── E2E coverage (Docker-based, weekly + manual) ──────────────────────
   # Runs the full E2E test suite against a coverage-instrumented Docker
   # image, extracts profraw files, merges with unit profdata, and uploads
-  # combined coverage. Expensive (~60 min), so scheduled weekly only.
+  # combined coverage. Expensive (~110 min with scheduling tests), so
+  # scheduled weekly only.
   e2e-coverage:
     name: E2E coverage
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
-    timeout-minutes: 75
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Problem

The E2E coverage job times out in CI run [#24249093218](https://github.com/grove/pg-trickle/actions/runs/24249093218) at the 75-minute limit, with e2e_mixed_scheduling_tests (30 tests) only completing 5 of 30 tests before cancellation.

## Root Cause

The e2e_mixed_scheduling_tests.rs file was added in #386 with 30 tests (10 scenarios x 3 scheduling modes). Each scheduler-mode test requires Docker container startup, scheduler configuration, and wait-for-auto-refresh polling. In coverage-instrumented builds these are significantly slower than normal E2E.

### Timing from run #24249093218

- 55 test files completed in ~54 minutes
- e2e_mixed_scheduling_tests ran 5/30 in ~9 minutes before timeout
- Extrapolated total: ~108 minutes

## Fix

Increase timeout-minutes from 75 to 120 in the e2e-coverage job. Updated the inline comment to reflect the actual runtime.
