### PR TITLE
fix(dvm): skip EC-01 Part 1 split when L0 is available

### DIFF
--- a/src/dvm/operators/full_join.rs
+++ b/src/dvm/operators/full_join.rs
@@ -149,7 +149,16 @@ pub fn diff_full_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     // Same fix as inner_join / outer_join: when a left DELETE's old right
     // partner is simultaneously deleted, R₁ misses the match.
     // DI-11: Use same threshold as inner join for deep R₀ reconstruction.
-    let use_r0 = use_pre_change_snapshot(right, ctx.inside_semijoin, 4);
+    //
+    // When use_l0 is true (Part 2 uses L₀), the standard DBSP formula
+    // is already exact — no EC-01 split needed. See diff_inner_join
+    // for the full derivation.
+    let l0_available = use_pre_change_snapshot(left, ctx.inside_semijoin, 4);
+    let use_r0 = if l0_available {
+        false
+    } else {
+        use_pre_change_snapshot(right, ctx.inside_semijoin, 4)
+    };
 
     let r0_snapshot = if use_r0 {
         if is_join_child(right) {
@@ -472,12 +481,16 @@ mod tests {
         let result = diff_full_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // EC-01: Parts 1 and 3 are split when right child is simple (Scan)
-        assert_sql_contains(&sql, "Part 1a");
-        assert_sql_contains(&sql, "Part 1b");
+        // When L₀ is available (Scan children), Parts 1 and 3 are NOT
+        // split — standard formula is exact, no EC-01 needed.
+        // Parts 7a/7b (right anti-join transitions) are always present.
+        assert_sql_contains(&sql, "Part 1");
+        assert_sql_not_contains(&sql, "Part 1a");
+        assert_sql_not_contains(&sql, "Part 1b");
         assert_sql_contains(&sql, "Part 2");
-        assert_sql_contains(&sql, "Part 3a");
-        assert_sql_contains(&sql, "Part 3b");
+        assert_sql_contains(&sql, "Part 3");
+        assert_sql_not_contains(&sql, "Part 3a");
+        assert_sql_not_contains(&sql, "Part 3b");
         assert_sql_contains(&sql, "Part 4");
         assert_sql_contains(&sql, "Part 5");
         assert_sql_contains(&sql, "Part 6");
@@ -486,9 +499,9 @@ mod tests {
     }
 
     #[test]
-    fn test_ec01_full_join_r0_uses_except_all() {
-        // For Scan right children, Part 1b and Part 3b should use R₀ via
-        // EXCEPT ALL to find pre-change right partners.
+    fn test_ec01_full_join_no_r0_when_l0_available() {
+        // When L₀ is available (Scan children), R₀ is NOT used and
+        // Parts 1 and 3 are unsplit.
         let mut ctx = test_ctx();
         let left = scan(1, "a", "public", "a", &["id"]);
         let right = scan(2, "b", "public", "b", &["id", "name"]);
@@ -501,11 +514,11 @@ mod tests {
         let result = diff_full_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // R₀ uses DI-2 NOT EXISTS anti-join pattern
+        // L₀ uses NOT EXISTS anti-join (DI-2)
         assert_sql_contains(&sql, "NOT EXISTS");
-        // Part 1b and Part 3b present
-        assert_sql_contains(&sql, "Part 1b");
-        assert_sql_contains(&sql, "Part 3b");
+        // Parts 1 and 3 are NOT split
+        assert_sql_not_contains(&sql, "Part 1b");
+        assert_sql_not_contains(&sql, "Part 3b");
     }
 
     #[test]

--- a/src/dvm/operators/join.rs
+++ b/src/dvm/operators/join.rs
@@ -421,7 +421,33 @@ pub fn diff_inner_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult,
     //
     // The same child-type heuristics as use_l0 apply: Scan and simple
     // children use R₀; SemiJoin-containing deep chains fall back to R₁.
-    let use_r0 = use_pre_change_snapshot(right, ctx.inside_semijoin, DEEP_JOIN_L0_SCAN_THRESHOLD);
+    //
+    // IMPORTANT: When use_l0 is true (Part 2 uses L₀), the standard
+    // DBSP formula ΔL ⋈ R₁ + L₀ ⋈ ΔR is already mathematically exact:
+    //
+    //   ΔL ⋈ R₁ + L₀ ⋈ ΔR
+    //   = (L₁ - L₀) ⋈ R₁ + L₀ ⋈ (R₁ - R₀)
+    //   = L₁⋈R₁ - L₀⋈R₁ + L₀⋈R₁ - L₀⋈R₀
+    //   = J₁ - J₀  ✓
+    //
+    // Splitting Part 1 into 1a (ΔL_I ⋈ R₁) + 1b (ΔL_D ⋈ R₀) when L₀
+    // is already available introduces an uncorrected error of ΔL_D ⋈ ΔR.
+    // The EC-02 correction term cancels this within a single refresh, but
+    // under sustained load with keyless join stream tables (non-unique
+    // __pgt_row_id), the weight aggregation can fail to fully cancel the
+    // phantom rows across many concurrent-change cycles, causing monotonic
+    // row accumulation (G17-SOAK soak_join correctness violation).
+    //
+    // The EC-01 split is only needed when Part 2 uses L₁ (!use_l0),
+    // because in that case the standard formula has its own error term
+    // (ΔL ⋈ ΔR) and the EC-01 split halves the error to ΔL_I ⋈ ΔR
+    // (which Part 3 then corrects).
+    let use_r0 = if use_l0 {
+        // L₀ available → standard formula is exact → no split needed.
+        false
+    } else {
+        use_pre_change_snapshot(right, ctx.inside_semijoin, DEEP_JOIN_L0_SCAN_THRESHOLD)
+    };
 
     let right_part1_source = if use_r0 {
         if is_join_child(right) {
@@ -547,68 +573,11 @@ JOIN {delta_right} dr ON {cond}",
             // This may cause minor drift for very deep semi-join chains.
             String::new()
         }
-    } else if use_r0 && is_simple_child(left) {
-        // EC-02: simultaneous left-key + right-value changes (Scan ⋈ Scan).
-        //
-        // When Part 1 is split into 1a/1b (use_r0=true) AND Part 2 uses
-        // L₀ via EXCEPT ALL (use_l0=true, left is a simple Scan), the
-        // combined formula is:
-        //
-        //   Part 1a: ΔL_I ⋈ R₁  = ΔL_I ⋈ R₀ + ΔL_I ⋈ ΔR_I - ΔL_I ⋈ ΔR_D
-        //   Part 1b: ΔL_D ⋈ R₀
-        //   Part 2:  L₀ ⋈ ΔR_I - L₀ ⋈ ΔR_D
-        //
-        // Summing: ΔL ⋈ R₀ + L₀ ⋈ ΔR + ΔL_I ⋈ ΔR_I - ΔL_I ⋈ ΔR_D
-        //
-        // The correct formula requires: ΔL ⋈ R₀ + L₀ ⋈ ΔR + (ΔL_I - ΔL_D) ⋈ (ΔR_I - ΔR_D)
-        //
-        // Missing term: -ΔL_D ⋈ ΔR_I + ΔL_D ⋈ ΔR_D
-        //
-        // Fix: emit correction rows for each (dl WHERE action='D') ⋈ dr with
-        // flipped dr action, producing the missing -ΔL_D ⋈ ΔR_I + ΔL_D ⋈ ΔR_D.
-        //
-        // Example: d4_left.key 2→4, d4_right.val changes (key stays at 2)
-        //   ΔL = {D(id=3, key=2), I(id=3, key=4)}, ΔR = {D(id=7, key=2), I(id=7, key=2)}
-        //   Part 1b: D(lid=3, rid=7)
-        //   Part 2:  D(lid=3, rid=7) + I(lid=3, rid=7, new_rv)  ← spurious INSERT
-        //   Correction: I(lid=3, rid=7) + D(lid=3, rid=7, new_rv)
-        //   Net: D=−1−1+1=−1 ✓; I(new_rv)=+1−1=0 (cancelled) ✓
-        let cond = rewrite_join_condition(condition, left, "dl", right, "dr");
-        // delta_left is referenced in Part 1a/1b and correction; mark NOT MATERIALIZED.
-        ctx.mark_cte_not_materialized(&left_result.cte_name);
-
-        // Row ID for EC-02 correction rows: hash of both sides' PK columns,
-        // using the same canonical left-first, right-second order as
-        // Part 1 and Part 2 to ensure consistent row_ids.  Using
-        // dl.__pgt_row_id / dr.__pgt_row_id here would produce
-        // hash(hash(L), hash(R)) instead of hash(L_pk, R_pk), causing
-        // phantom row accumulation.
-        let mut hash_corr_args = left_key_exprs_dl.clone();
-        hash_corr_args.extend(right_key_exprs_dr.clone());
-        let hash_correction = format!(
-            "pgtrickle.pg_trickle_hash_multi(ARRAY[{}])",
-            hash_corr_args.join(", ")
-        );
-        format!(
-            "
-
-UNION ALL
-
--- Part 3: EC-02 correction — cancel -ΔL_D ⋈ ΔR_I and add ΔL_D ⋈ ΔR_D.
--- When Part 1 uses R₁ for inserts (1a) and R₀ for deletes (1b), the
--- cross-term ΔL_D ⋈ ΔR is double-counted. Flip dr actions to cancel.
-SELECT {hash_correction} AS __pgt_row_id,
-       CASE WHEN dr.__pgt_action = 'I' THEN 'D' ELSE 'I' END AS __pgt_action,
-       {all_cols_correction}
-FROM {delta_left} dl
-JOIN {delta_right} dr ON {cond}
-WHERE dl.__pgt_action = 'D'",
-            delta_left = left_result.cte_name,
-            delta_right = right_result.cte_name,
-        )
     } else {
-        // L₀ is used directly, Part 1 not split or left is nested join —
-        // no correction needed for this combination.
+        // L₀ is used directly — the standard formula is exact, no
+        // correction needed.  The former EC-02 correction for the EC-01
+        // split is no longer reachable here because use_r0 is now false
+        // whenever use_l0 is true.
         String::new()
     };
 
@@ -921,12 +890,14 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // EC-01: Part 1 is now split into 1a (inserts ⋈ R₁) + 1b (deletes ⋈ R₀)
-        assert_sql_contains(&sql, "Part 1a");
-        assert_sql_contains(&sql, "Part 1b");
+        // When L₀ is available (Scan ⋈ Scan), Part 1 is NOT split — standard
+        // formula is exact. Part 1 uses ΔL ⋈ R₁, Part 2 uses L₀ ⋈ ΔR.
+        assert_sql_contains(&sql, "Part 1");
         assert_sql_contains(&sql, "Part 2");
         assert_sql_contains(&sql, "pre-change_left");
-        assert_sql_contains(&sql, "pre-change_right R");
+        // R₀ is not used when L₀ is available (no EC-01 split).
+        assert_sql_not_contains(&sql, "Part 1a");
+        assert_sql_not_contains(&sql, "Part 1b");
     }
 
     #[test]
@@ -939,16 +910,15 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // Part 2 should use L₀ via NOT EXISTS anti-join (DI-2)
-        // Part 1b should use R₀ via NOT EXISTS anti-join (DI-2)
+        // Part 2 should use L₀ via NOT EXISTS anti-join (DI-2).
+        // R₀ is NOT used when L₀ is available (standard formula is exact).
         assert_sql_contains(&sql, "NOT EXISTS");
-        assert_sql_contains(&sql, "__pgt_action = 'I'");
         assert_sql_contains(&sql, "__pgt_action = 'D'");
-        // Both L₀ and R₀ should be present (at least two NOT EXISTS occurrences)
+        // Only L₀ needs NOT EXISTS (no R₀ split).
         let ne_count = sql.matches("NOT EXISTS").count();
         assert!(
-            ne_count >= 2,
-            "expected ≥2 NOT EXISTS (L₀ + R₀), got {ne_count}\n{sql}"
+            ne_count >= 1,
+            "expected ≥1 NOT EXISTS (L₀), got {ne_count}\n{sql}"
         );
     }
 
@@ -1172,8 +1142,8 @@ mod tests {
 
     #[test]
     fn test_diff_inner_join_scan_no_correction() {
-        // For Scan ⋈ Scan, EC-02 correction IS present (simultaneous change fix).
-        // The old "Correction for nested join" (L₁ path) should NOT appear.
+        // For Scan ⋈ Scan with L₀ available, NO correction is needed — the
+        // standard formula is exact. Neither EC-02 nor L₁ correction appears.
         let left = scan(1, "orders", "public", "o", &["id", "cust_id"]);
         let right = scan(2, "customers", "public", "c", &["id", "name"]);
         let cond = eq_cond("o", "cust_id", "c", "id");
@@ -1183,9 +1153,8 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // EC-02 correction is present for Scan ⋈ Scan (simultaneous-change fix).
-        assert_sql_contains(&sql, "EC-02 correction");
-        // L₁-based correction (for nested join children) should NOT appear.
+        // No correction terms — standard formula is exact when L₀ is used.
+        assert_sql_not_contains(&sql, "EC-02 correction");
         assert_sql_not_contains(&sql, "Correction for nested join");
     }
 
@@ -1479,9 +1448,9 @@ mod tests {
     // ── EC-01: R₀ via EXCEPT ALL tests ──────────────────────────────
 
     #[test]
-    fn test_ec01_simple_join_splits_part1() {
-        // Two simple Scan children → Part 1 split into 1a (inserts ⋈ R₁)
-        // and 1b (deletes ⋈ R₀ via EXCEPT ALL).
+    fn test_ec01_simple_join_no_split_when_l0_available() {
+        // Two simple Scan children → L₀ is available, so Part 1 is NOT
+        // split. The standard formula ΔL ⋈ R₁ + L₀ ⋈ ΔR is exact.
         let left = scan(1, "orders", "public", "o", &["id", "cust_id"]);
         let right = scan(2, "customers", "public", "c", &["id", "name"]);
         let cond = eq_cond("o", "cust_id", "c", "id");
@@ -1491,18 +1460,15 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // Part 1a: inserts → R₁ (current right)
-        assert_sql_contains(&sql, "Part 1a");
-        assert_sql_contains(&sql, "INSERTS JOIN current_right R");
+        // Part 1 is unsplit: ΔL ⋈ R₁ (no action filter)
+        assert_sql_contains(&sql, "Part 1");
+        assert_sql_not_contains(&sql, "Part 1a");
+        assert_sql_not_contains(&sql, "Part 1b");
+        assert_sql_not_contains(&sql, "EC-01 fix");
 
-        // Part 1b: deletes → R₀ (pre-change right via EXCEPT ALL)
-        assert_sql_contains(&sql, "Part 1b");
-        assert_sql_contains(&sql, "DELETES JOIN pre-change_right R");
-        assert_sql_contains(&sql, "EC-01 fix");
-
-        // Part 1a filters by action = 'I', Part 1b filters by action = 'D'
-        assert_sql_contains(&sql, "__pgt_action = 'I'");
-        assert_sql_contains(&sql, "__pgt_action = 'D'");
+        // Part 2 uses L₀
+        assert_sql_contains(&sql, "Part 2");
+        assert_sql_contains(&sql, "pre-change_left");
     }
 
     #[test]
@@ -1529,17 +1495,15 @@ mod tests {
     }
 
     #[test]
-    fn test_ec01_nested_right_child_3_scans_uses_r0() {
-        // EC01B-1: the ≤2-scan threshold was removed.  A right child with
-        // 3 scan nodes now uses the per-leaf CTE-based R₀ snapshot, so
-        // Part 1 IS split into 1a (inserts ⋈ R₁) and 1b (deletes ⋈ R₀).
+    fn test_ec01_nested_right_child_3_scans_no_split_when_l0() {
+        // Left child is a simple Scan → L₀ is available → Part 1 is NOT
+        // split at the outer join level. The standard formula is exact.
         let a = scan(1, "a", "public", "a", &["id"]);
         let b = scan(2, "b", "public", "b", &["id"]);
         let c = scan(3, "c", "public", "c", &["id"]);
         let right_inner = inner_join(eq_cond("b", "id", "c", "id"), b, c);
         let d = scan(4, "d", "public", "d", &["id"]);
         let right_deep = inner_join(eq_cond("b", "id", "d", "id"), right_inner, d);
-        // right has 3 scans → EC01B-1: use_r0 = true → Part 1 is split
         let tree = inner_join(eq_cond("a", "id", "b", "id"), a, right_deep);
 
         let mut ctx = test_ctx();
@@ -1548,15 +1512,16 @@ mod tests {
 
         let outer_cte_marker = format!("{} AS", result.cte_name);
         let outer_sql = sql.split(&outer_cte_marker).last().unwrap_or("");
-        // Per-leaf CTE R₀ → Part 1 is split
-        assert_sql_contains(outer_sql, "Part 1a");
-        assert_sql_contains(outer_sql, "Part 1b");
+        // L₀ available → no EC-01 split at the outer join
+        assert_sql_not_contains(outer_sql, "Part 1a");
+        assert_sql_not_contains(outer_sql, "Part 1b");
+        assert_sql_contains(outer_sql, "Part 1");
     }
 
     #[test]
-    fn test_ec01_nested_right_child_2_scans_uses_r0() {
-        // When right child is a nested join with ≤2 scan nodes and no
-        // SemiJoin, use_r0 is true → Part 1 is split.
+    fn test_ec01_nested_right_child_2_scans_no_split_when_l0() {
+        // Left child is a simple Scan → L₀ is available → Part 1 is NOT
+        // split even though the right child is a nested join.
         let a = scan(1, "a", "public", "a", &["id"]);
         let b = scan(2, "b", "public", "b", &["id"]);
         let c = scan(3, "c", "public", "c", &["id"]);
@@ -1567,9 +1532,9 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // Right has 2 scans → use_r0 = true → Part 1 split
-        assert_sql_contains(&sql, "Part 1a");
-        assert_sql_contains(&sql, "Part 1b");
+        // L₀ available → no EC-01 split
+        assert_sql_not_contains(&sql, "Part 1a");
+        assert_sql_not_contains(&sql, "Part 1b");
     }
 
     #[test]

--- a/src/dvm/operators/outer_join.rs
+++ b/src/dvm/operators/outer_join.rs
@@ -185,7 +185,16 @@ pub fn diff_left_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     //
     // R₀ = R_current EXCEPT ALL ΔR_inserts UNION ALL ΔR_deletes
     // DI-11: Use same threshold as inner join for deep R₀ reconstruction.
-    let use_r0 = use_pre_change_snapshot(right, ctx.inside_semijoin, 4);
+    //
+    // When use_l0 is true (Part 2 uses L₀), the standard DBSP formula
+    // is already exact — no EC-01 split needed. See diff_inner_join
+    // for the full derivation.
+    let l0_available = use_pre_change_snapshot(left, ctx.inside_semijoin, 4);
+    let use_r0 = if l0_available {
+        false
+    } else {
+        use_pre_change_snapshot(right, ctx.inside_semijoin, 4)
+    };
 
     // Build R₀ for Parts 1b/3b (includes all right_cols for JOIN/anti-join).
     // Separate from r_old_snapshot (used for Parts 4/5 NOT EXISTS only,
@@ -560,22 +569,25 @@ mod tests {
         let result = diff_left_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // EC-01: Parts 1 and 3 are split when right child is simple (Scan)
-        assert_sql_contains(&sql, "Part 1a");
-        assert_sql_contains(&sql, "Part 1b");
+        // When L₀ is available (Scan children), Part 1 and Part 3 are NOT
+        // split — standard formula is exact, no EC-01 needed.
+        assert_sql_contains(&sql, "Part 1");
+        assert_sql_not_contains(&sql, "Part 1a");
+        assert_sql_not_contains(&sql, "Part 1b");
         assert_sql_contains(&sql, "Part 2");
-        assert_sql_contains(&sql, "Part 3a");
-        assert_sql_contains(&sql, "Part 3b");
+        assert_sql_contains(&sql, "Part 3");
+        assert_sql_not_contains(&sql, "Part 3a");
+        assert_sql_not_contains(&sql, "Part 3b");
         assert_sql_contains(&sql, "Part 4");
         assert_sql_contains(&sql, "Part 5");
-        // EC-02: Part 6 corrects ΔL_D ⋈ ΔR double-counting
-        assert_sql_contains(&sql, "Part 6");
+        // EC-02 correction (Part 6) is NOT needed without EC-01 split.
+        assert_sql_not_contains(&sql, "Part 6");
     }
 
     #[test]
-    fn test_ec01_left_join_r0_uses_except_all() {
-        // For Scan right children, Part 1b and Part 3b should use R₀ via
-        // EXCEPT ALL to find pre-change right partners.
+    fn test_ec01_left_join_no_r0_when_l0_available() {
+        // When L₀ is available (Scan children), R₀ is NOT used — standard
+        // formula is exact. Parts 1 and 3 are unsplit.
         let mut ctx = test_ctx();
         let left = scan(1, "a", "public", "a", &["id", "bid"]);
         let right = scan(2, "b", "public", "b", &["id", "name"]);
@@ -584,12 +596,11 @@ mod tests {
         let result = diff_left_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // R₀ uses DI-2 NOT EXISTS anti-join pattern
+        // L₀ uses NOT EXISTS anti-join (DI-2)
         assert_sql_contains(&sql, "NOT EXISTS");
-        // Part 1b filters DELETEs only
-        assert_sql_contains(&sql, "Part 1b");
-        // Part 3b filters DELETEs only
-        assert_sql_contains(&sql, "Part 3b");
+        // Part 1 and Part 3 are NOT split
+        assert_sql_not_contains(&sql, "Part 1b");
+        assert_sql_not_contains(&sql, "Part 3b");
     }
 
     #[test]
@@ -768,10 +779,9 @@ mod tests {
     }
 
     #[test]
-    fn test_ec02_left_join_correction_for_scan_children() {
-        // When both left and right are Scan children (use_l0 && use_r0),
-        // EC-02 correction (Part 6) should be emitted to cancel ΔL_D ⋈ ΔR
-        // double-counting between Part 1b and Part 2.
+    fn test_ec02_left_join_no_correction_when_l0_available() {
+        // When L₀ is available (simple Scan children), the standard formula
+        // is exact and no EC-02 correction is needed.
         let mut ctx = test_ctx();
         let left = scan(1, "a", "public", "a", &["id", "key"]);
         let right = scan(2, "b", "public", "b", &["id", "val"]);
@@ -780,13 +790,7 @@ mod tests {
         let result = diff_left_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // EC-02 Part 6 should flip ΔR action
-        assert_sql_contains(&sql, "Part 6: EC-02 correction");
-        assert_sql_contains(
-            &sql,
-            "CASE WHEN dr.__pgt_action = 'I' THEN 'D' ELSE 'I' END",
-        );
-        // EC-02 only joins ΔL_D rows
-        assert_sql_contains(&sql, "dl.__pgt_action = 'D'");
+        // EC-02 Part 6 should NOT be present.
+        assert_sql_not_contains(&sql, "Part 6: EC-02 correction");
     }
 }


### PR DESCRIPTION
## Problem

The **stability soak test** (`soak_join`) fails with a correctness violation:
phantom rows accumulate monotonically, resulting in the stream table having
more rows than its defining query.

Example from CI run [#24255452889](https://github.com/grove/pg-trickle/actions/runs/24255452889):
```
CORRECTNESS VIOLATION: soak_join has 3742672 rows, query returns 3740897
```

The `soak_join` view joins `source_1` and `source_2` on `category`, but
`source_2`'s primary key (`id`) is **not** in the output columns. This makes
the right side "keyless" from pg_trickle's perspective.

## Root Cause

When L0 (the left pre-change snapshot) is available, the standard DBSP
join-delta formula is mathematically exact:

```
delta_J = delta_L join R1 + L0 join delta_R = J1 - J0
```

However, the **EC-01 optimisation** splits Part 1 into:
- **Part 1a:** delta_L_inserts join R1
- **Part 1b:** delta_L_deletes join R0

This split introduces an uncorrected error term `delta_L_D join delta_R` that
accumulates phantom rows over sustained workloads. The EC-02 correction
term was designed to cancel this per-refresh, but it fails under sustained
load with keyless joins (non-unique `__pgt_row_id`).

## Fix

Skip the EC-01 Part 1 split when `use_l0 = true` -- the unsplit formula is
already exact, so there is nothing to gain from the split and it introduces
the error.

Applied consistently across all three join operators:
- **Inner join** (`join.rs`): `use_r0 = false` when `use_l0 = true`
- **Left join** (`outer_join.rs`): same guard
- **Full join** (`full_join.rs`): same guard

Removed the now-dead EC-02 correction code path in inner join.

## Testing

- All **1,735 unit tests** pass (`just test-unit`)
- **11 unit tests** updated to reflect the new query plans
- `just fmt` and `just lint` clean (zero clippy warnings)
## Problem

The **stability soak test** (`soak_join`) fails with a correctness violation:
phantom rows accumulate monotonically, resulting in the stream table having
more rows than its defining query.

Example from CI run [#24255452889](https://github.com/grove/pg-trickle/actions/runs/24255452889):
```
CORRECTNESS VIOLATION: soak_join has 3742672 rows, query returns 3740897
```

The `soak_join` view joins `source_1` and `source_2` on `category`, but
`source_2`'s primary key (`id`) is **not** in the output columns. This makes
the right side "keyless" from pg_trickle's perspective.

## Root Cause

When `L₀` (the left pre-change snapshot) is available, the standard DBSP
join-delta formula is mathematically exact:

$$\Delta J = \Delta L \bowtie R_1 + L_0 \bowtie \Delta R = J_1 - J_0$$

However, the **EC-01 optimisation** splits Part 1 into:
- **Part 1a:** `ΔL_inserts ⋈ R₁`
- **Part 1b:** `ΔL_deletes ⋈ R₀`

This split introduces an uncorrected error term `ΔL_D This split introduces an uncorrec rows over sustained workloads. The EC-02 correction
term was designed to cancel this per-refresh, but it fails under sustained
load with keyless joins (non-unique `__pgt_row_id`).

## Fix

Skip the EC-01 Part Skip the EC-01 Part Skip the EC-01 Part Skip the EC-01 Part Skip the EC-01 Part Skip the g to gain from the split and it introduces
the error.

Applied consistently across all three join operators:
- **Inner join** (`join.rs`): `use_r0 = false` when `use_l0 = true`
- **Left join** (`outer_join.rs`): same guard
- **Full join** (`full_join.rs`): same guard

Removed the now-dead EC-02 cRemoveion code path in inner join.

## Testing

- All **1,735 unit tests** pass (`just tes- All **1,735 unit tests** pass (`just  refle- All **1,735 unit tests** pass (`just tes- All **1,735 unit tesclippy warnings)
