### PR TITLE
fix: reset ALTER SYSTEM settings at end of quota scheduler tests

### DIFF
--- a/tests/e2e_quota_tests.rs
+++ b/tests/e2e_quota_tests.rs
@@ -166,6 +166,12 @@ async fn test_per_database_worker_quota_does_not_starve_refreshes() {
         completed_b,
         "quota_st_b should refresh even with per_database_worker_quota=1"
     );
+
+    // Clean up cluster-wide ALTER SYSTEM settings so subsequent tests that
+    // use E2eDb::new() (which does NOT reset server configuration) see the
+    // correct defaults.
+    db.execute("ALTER SYSTEM RESET ALL").await;
+    db.reload_config_and_wait().await;
 }
 
 /// When quota is 0 (disabled) the scheduler behaves as before — all STs
@@ -209,6 +215,12 @@ async fn test_per_database_worker_quota_zero_disables_cap() {
         completed,
         "ST should refresh normally when per_database_worker_quota=0"
     );
+
+    // Clean up cluster-wide ALTER SYSTEM settings so subsequent tests that
+    // use E2eDb::new() (which does NOT reset server configuration) see the
+    // correct defaults.
+    db.execute("ALTER SYSTEM RESET ALL").await;
+    db.reload_config_and_wait().await;
 }
 
 // ── Helper ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The E2E coverage job fails on `test_per_database_worker_quota_guc_default` with:

```
assertion `left == right` failed: per_database_worker_quota default should be 0 (disabled)
  left: "1"
 right: "0"
```

**Run:** https://github.com/pg-trickle/pg_trickle/actions/runs/24255135330

## Root cause

The scheduler integration test `test_per_database_worker_quota_does_not_starve_refreshes`
executes `ALTER SYSTEM SET pg_trickle.per_database_worker_quota = 1` (plus other GUCs)
but never resets them. All E2E tests share the same Docker container (PostgreSQL cluster),
and tests run serially with `--test-threads=1` in alphabetical order:

1. `does_not_starve` sets `per_database_worker_quota = 1` via `ALTER SYSTEM`
2. `guc_default` uses `E2eDb::new()` (which does **not** call
   `reset_server_configuration()`) and expects the default `0`, but sees `1`

While `new_on_postgres_db()` resets `ALTER SYSTEM` at the **start** of each scheduler
test, the GUC smoke tests use `E2eDb::new()` which only creates a fresh database and
does not reset cluster-wide settings.

## Fix

Add `ALTER SYSTEM RESET ALL` + `pg_reload_conf()` at the end of both scheduler
integration tests (`does_not_starve` and `zero_disables_cap`) so they leave the
cluster in a clean state for any subsequent test.
