### PR TITLE
fix(dvm): revert L0-skip-EC-01 optimization that caused FULL JOIN phantom rows

### DIFF
--- a/src/dvm/operators/full_join.rs
+++ b/src/dvm/operators/full_join.rs
@@ -149,16 +149,7 @@ pub fn diff_full_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     // Same fix as inner_join / outer_join: when a left DELETE's old right
     // partner is simultaneously deleted, R₁ misses the match.
     // DI-11: Use same threshold as inner join for deep R₀ reconstruction.
-    //
-    // When use_l0 is true (Part 2 uses L₀), the standard DBSP formula
-    // is already exact — no EC-01 split needed. See diff_inner_join
-    // for the full derivation.
-    let l0_available = use_pre_change_snapshot(left, ctx.inside_semijoin, 4);
-    let use_r0 = if l0_available {
-        false
-    } else {
-        use_pre_change_snapshot(right, ctx.inside_semijoin, 4)
-    };
+    let use_r0 = use_pre_change_snapshot(right, ctx.inside_semijoin, 4);
 
     let r0_snapshot = if use_r0 {
         if is_join_child(right) {
@@ -481,16 +472,12 @@ mod tests {
         let result = diff_full_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // When L₀ is available (Scan children), Parts 1 and 3 are NOT
-        // split — standard formula is exact, no EC-01 needed.
-        // Parts 7a/7b (right anti-join transitions) are always present.
-        assert_sql_contains(&sql, "Part 1");
-        assert_sql_not_contains(&sql, "Part 1a");
-        assert_sql_not_contains(&sql, "Part 1b");
+        // EC-01: Parts 1 and 3 are split when right child is simple (Scan)
+        assert_sql_contains(&sql, "Part 1a");
+        assert_sql_contains(&sql, "Part 1b");
         assert_sql_contains(&sql, "Part 2");
-        assert_sql_contains(&sql, "Part 3");
-        assert_sql_not_contains(&sql, "Part 3a");
-        assert_sql_not_contains(&sql, "Part 3b");
+        assert_sql_contains(&sql, "Part 3a");
+        assert_sql_contains(&sql, "Part 3b");
         assert_sql_contains(&sql, "Part 4");
         assert_sql_contains(&sql, "Part 5");
         assert_sql_contains(&sql, "Part 6");
@@ -499,9 +486,9 @@ mod tests {
     }
 
     #[test]
-    fn test_ec01_full_join_no_r0_when_l0_available() {
-        // When L₀ is available (Scan children), R₀ is NOT used and
-        // Parts 1 and 3 are unsplit.
+    fn test_ec01_full_join_r0_uses_except_all() {
+        // For Scan right children, Part 1b and Part 3b should use R₀ via
+        // EXCEPT ALL to find pre-change right partners.
         let mut ctx = test_ctx();
         let left = scan(1, "a", "public", "a", &["id"]);
         let right = scan(2, "b", "public", "b", &["id", "name"]);
@@ -514,11 +501,11 @@ mod tests {
         let result = diff_full_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // L₀ uses NOT EXISTS anti-join (DI-2)
+        // R₀ uses DI-2 NOT EXISTS anti-join pattern
         assert_sql_contains(&sql, "NOT EXISTS");
-        // Parts 1 and 3 are NOT split
-        assert_sql_not_contains(&sql, "Part 1b");
-        assert_sql_not_contains(&sql, "Part 3b");
+        // Part 1b and Part 3b present
+        assert_sql_contains(&sql, "Part 1b");
+        assert_sql_contains(&sql, "Part 3b");
     }
 
     #[test]

--- a/src/dvm/operators/join.rs
+++ b/src/dvm/operators/join.rs
@@ -421,33 +421,7 @@ pub fn diff_inner_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult,
     //
     // The same child-type heuristics as use_l0 apply: Scan and simple
     // children use R₀; SemiJoin-containing deep chains fall back to R₁.
-    //
-    // IMPORTANT: When use_l0 is true (Part 2 uses L₀), the standard
-    // DBSP formula ΔL ⋈ R₁ + L₀ ⋈ ΔR is already mathematically exact:
-    //
-    //   ΔL ⋈ R₁ + L₀ ⋈ ΔR
-    //   = (L₁ - L₀) ⋈ R₁ + L₀ ⋈ (R₁ - R₀)
-    //   = L₁⋈R₁ - L₀⋈R₁ + L₀⋈R₁ - L₀⋈R₀
-    //   = J₁ - J₀  ✓
-    //
-    // Splitting Part 1 into 1a (ΔL_I ⋈ R₁) + 1b (ΔL_D ⋈ R₀) when L₀
-    // is already available introduces an uncorrected error of ΔL_D ⋈ ΔR.
-    // The EC-02 correction term cancels this within a single refresh, but
-    // under sustained load with keyless join stream tables (non-unique
-    // __pgt_row_id), the weight aggregation can fail to fully cancel the
-    // phantom rows across many concurrent-change cycles, causing monotonic
-    // row accumulation (G17-SOAK soak_join correctness violation).
-    //
-    // The EC-01 split is only needed when Part 2 uses L₁ (!use_l0),
-    // because in that case the standard formula has its own error term
-    // (ΔL ⋈ ΔR) and the EC-01 split halves the error to ΔL_I ⋈ ΔR
-    // (which Part 3 then corrects).
-    let use_r0 = if use_l0 {
-        // L₀ available → standard formula is exact → no split needed.
-        false
-    } else {
-        use_pre_change_snapshot(right, ctx.inside_semijoin, DEEP_JOIN_L0_SCAN_THRESHOLD)
-    };
+    let use_r0 = use_pre_change_snapshot(right, ctx.inside_semijoin, DEEP_JOIN_L0_SCAN_THRESHOLD);
 
     let right_part1_source = if use_r0 {
         if is_join_child(right) {
@@ -573,11 +547,68 @@ JOIN {delta_right} dr ON {cond}",
             // This may cause minor drift for very deep semi-join chains.
             String::new()
         }
+    } else if use_r0 && is_simple_child(left) {
+        // EC-02: simultaneous left-key + right-value changes (Scan ⋈ Scan).
+        //
+        // When Part 1 is split into 1a/1b (use_r0=true) AND Part 2 uses
+        // L₀ via EXCEPT ALL (use_l0=true, left is a simple Scan), the
+        // combined formula is:
+        //
+        //   Part 1a: ΔL_I ⋈ R₁  = ΔL_I ⋈ R₀ + ΔL_I ⋈ ΔR_I - ΔL_I ⋈ ΔR_D
+        //   Part 1b: ΔL_D ⋈ R₀
+        //   Part 2:  L₀ ⋈ ΔR_I - L₀ ⋈ ΔR_D
+        //
+        // Summing: ΔL ⋈ R₀ + L₀ ⋈ ΔR + ΔL_I ⋈ ΔR_I - ΔL_I ⋈ ΔR_D
+        //
+        // The correct formula requires: ΔL ⋈ R₀ + L₀ ⋈ ΔR + (ΔL_I - ΔL_D) ⋈ (ΔR_I - ΔR_D)
+        //
+        // Missing term: -ΔL_D ⋈ ΔR_I + ΔL_D ⋈ ΔR_D
+        //
+        // Fix: emit correction rows for each (dl WHERE action='D') ⋈ dr with
+        // flipped dr action, producing the missing -ΔL_D ⋈ ΔR_I + ΔL_D ⋈ ΔR_D.
+        //
+        // Example: d4_left.key 2→4, d4_right.val changes (key stays at 2)
+        //   ΔL = {D(id=3, key=2), I(id=3, key=4)}, ΔR = {D(id=7, key=2), I(id=7, key=2)}
+        //   Part 1b: D(lid=3, rid=7)
+        //   Part 2:  D(lid=3, rid=7) + I(lid=3, rid=7, new_rv)  ← spurious INSERT
+        //   Correction: I(lid=3, rid=7) + D(lid=3, rid=7, new_rv)
+        //   Net: D=−1−1+1=−1 ✓; I(new_rv)=+1−1=0 (cancelled) ✓
+        let cond = rewrite_join_condition(condition, left, "dl", right, "dr");
+        // delta_left is referenced in Part 1a/1b and correction; mark NOT MATERIALIZED.
+        ctx.mark_cte_not_materialized(&left_result.cte_name);
+
+        // Row ID for EC-02 correction rows: hash of both sides' PK columns,
+        // using the same canonical left-first, right-second order as
+        // Part 1 and Part 2 to ensure consistent row_ids.  Using
+        // dl.__pgt_row_id / dr.__pgt_row_id here would produce
+        // hash(hash(L), hash(R)) instead of hash(L_pk, R_pk), causing
+        // phantom row accumulation.
+        let mut hash_corr_args = left_key_exprs_dl.clone();
+        hash_corr_args.extend(right_key_exprs_dr.clone());
+        let hash_correction = format!(
+            "pgtrickle.pg_trickle_hash_multi(ARRAY[{}])",
+            hash_corr_args.join(", ")
+        );
+        format!(
+            "
+
+UNION ALL
+
+-- Part 3: EC-02 correction — cancel -ΔL_D ⋈ ΔR_I and add ΔL_D ⋈ ΔR_D.
+-- When Part 1 uses R₁ for inserts (1a) and R₀ for deletes (1b), the
+-- cross-term ΔL_D ⋈ ΔR is double-counted. Flip dr actions to cancel.
+SELECT {hash_correction} AS __pgt_row_id,
+       CASE WHEN dr.__pgt_action = 'I' THEN 'D' ELSE 'I' END AS __pgt_action,
+       {all_cols_correction}
+FROM {delta_left} dl
+JOIN {delta_right} dr ON {cond}
+WHERE dl.__pgt_action = 'D'",
+            delta_left = left_result.cte_name,
+            delta_right = right_result.cte_name,
+        )
     } else {
-        // L₀ is used directly — the standard formula is exact, no
-        // correction needed.  The former EC-02 correction for the EC-01
-        // split is no longer reachable here because use_r0 is now false
-        // whenever use_l0 is true.
+        // L₀ is used directly, Part 1 not split or left is nested join —
+        // no correction needed for this combination.
         String::new()
     };
 
@@ -890,14 +921,12 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // When L₀ is available (Scan ⋈ Scan), Part 1 is NOT split — standard
-        // formula is exact. Part 1 uses ΔL ⋈ R₁, Part 2 uses L₀ ⋈ ΔR.
-        assert_sql_contains(&sql, "Part 1");
+        // EC-01: Part 1 is now split into 1a (inserts ⋈ R₁) + 1b (deletes ⋈ R₀)
+        assert_sql_contains(&sql, "Part 1a");
+        assert_sql_contains(&sql, "Part 1b");
         assert_sql_contains(&sql, "Part 2");
         assert_sql_contains(&sql, "pre-change_left");
-        // R₀ is not used when L₀ is available (no EC-01 split).
-        assert_sql_not_contains(&sql, "Part 1a");
-        assert_sql_not_contains(&sql, "Part 1b");
+        assert_sql_contains(&sql, "pre-change_right R");
     }
 
     #[test]
@@ -910,15 +939,16 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // Part 2 should use L₀ via NOT EXISTS anti-join (DI-2).
-        // R₀ is NOT used when L₀ is available (standard formula is exact).
+        // Part 2 should use L₀ via NOT EXISTS anti-join (DI-2)
+        // Part 1b should use R₀ via NOT EXISTS anti-join (DI-2)
         assert_sql_contains(&sql, "NOT EXISTS");
+        assert_sql_contains(&sql, "__pgt_action = 'I'");
         assert_sql_contains(&sql, "__pgt_action = 'D'");
-        // Only L₀ needs NOT EXISTS (no R₀ split).
+        // Both L₀ and R₀ should be present (at least two NOT EXISTS occurrences)
         let ne_count = sql.matches("NOT EXISTS").count();
         assert!(
-            ne_count >= 1,
-            "expected ≥1 NOT EXISTS (L₀), got {ne_count}\n{sql}"
+            ne_count >= 2,
+            "expected ≥2 NOT EXISTS (L₀ + R₀), got {ne_count}\n{sql}"
         );
     }
 
@@ -1142,8 +1172,8 @@ mod tests {
 
     #[test]
     fn test_diff_inner_join_scan_no_correction() {
-        // For Scan ⋈ Scan with L₀ available, NO correction is needed — the
-        // standard formula is exact. Neither EC-02 nor L₁ correction appears.
+        // For Scan ⋈ Scan, EC-02 correction IS present (simultaneous change fix).
+        // The old "Correction for nested join" (L₁ path) should NOT appear.
         let left = scan(1, "orders", "public", "o", &["id", "cust_id"]);
         let right = scan(2, "customers", "public", "c", &["id", "name"]);
         let cond = eq_cond("o", "cust_id", "c", "id");
@@ -1153,8 +1183,9 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // No correction terms — standard formula is exact when L₀ is used.
-        assert_sql_not_contains(&sql, "EC-02 correction");
+        // EC-02 correction is present for Scan ⋈ Scan (simultaneous-change fix).
+        assert_sql_contains(&sql, "EC-02 correction");
+        // L₁-based correction (for nested join children) should NOT appear.
         assert_sql_not_contains(&sql, "Correction for nested join");
     }
 
@@ -1448,9 +1479,9 @@ mod tests {
     // ── EC-01: R₀ via EXCEPT ALL tests ──────────────────────────────
 
     #[test]
-    fn test_ec01_simple_join_no_split_when_l0_available() {
-        // Two simple Scan children → L₀ is available, so Part 1 is NOT
-        // split. The standard formula ΔL ⋈ R₁ + L₀ ⋈ ΔR is exact.
+    fn test_ec01_simple_join_splits_part1() {
+        // Two simple Scan children → Part 1 split into 1a (inserts ⋈ R₁)
+        // and 1b (deletes ⋈ R₀ via EXCEPT ALL).
         let left = scan(1, "orders", "public", "o", &["id", "cust_id"]);
         let right = scan(2, "customers", "public", "c", &["id", "name"]);
         let cond = eq_cond("o", "cust_id", "c", "id");
@@ -1460,15 +1491,18 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // Part 1 is unsplit: ΔL ⋈ R₁ (no action filter)
-        assert_sql_contains(&sql, "Part 1");
-        assert_sql_not_contains(&sql, "Part 1a");
-        assert_sql_not_contains(&sql, "Part 1b");
-        assert_sql_not_contains(&sql, "EC-01 fix");
+        // Part 1a: inserts → R₁ (current right)
+        assert_sql_contains(&sql, "Part 1a");
+        assert_sql_contains(&sql, "INSERTS JOIN current_right R");
 
-        // Part 2 uses L₀
-        assert_sql_contains(&sql, "Part 2");
-        assert_sql_contains(&sql, "pre-change_left");
+        // Part 1b: deletes → R₀ (pre-change right via EXCEPT ALL)
+        assert_sql_contains(&sql, "Part 1b");
+        assert_sql_contains(&sql, "DELETES JOIN pre-change_right R");
+        assert_sql_contains(&sql, "EC-01 fix");
+
+        // Part 1a filters by action = 'I', Part 1b filters by action = 'D'
+        assert_sql_contains(&sql, "__pgt_action = 'I'");
+        assert_sql_contains(&sql, "__pgt_action = 'D'");
     }
 
     #[test]
@@ -1495,15 +1529,17 @@ mod tests {
     }
 
     #[test]
-    fn test_ec01_nested_right_child_3_scans_no_split_when_l0() {
-        // Left child is a simple Scan → L₀ is available → Part 1 is NOT
-        // split at the outer join level. The standard formula is exact.
+    fn test_ec01_nested_right_child_3_scans_uses_r0() {
+        // EC01B-1: the ≤2-scan threshold was removed.  A right child with
+        // 3 scan nodes now uses the per-leaf CTE-based R₀ snapshot, so
+        // Part 1 IS split into 1a (inserts ⋈ R₁) and 1b (deletes ⋈ R₀).
         let a = scan(1, "a", "public", "a", &["id"]);
         let b = scan(2, "b", "public", "b", &["id"]);
         let c = scan(3, "c", "public", "c", &["id"]);
         let right_inner = inner_join(eq_cond("b", "id", "c", "id"), b, c);
         let d = scan(4, "d", "public", "d", &["id"]);
         let right_deep = inner_join(eq_cond("b", "id", "d", "id"), right_inner, d);
+        // right has 3 scans → EC01B-1: use_r0 = true → Part 1 is split
         let tree = inner_join(eq_cond("a", "id", "b", "id"), a, right_deep);
 
         let mut ctx = test_ctx();
@@ -1512,16 +1548,15 @@ mod tests {
 
         let outer_cte_marker = format!("{} AS", result.cte_name);
         let outer_sql = sql.split(&outer_cte_marker).last().unwrap_or("");
-        // L₀ available → no EC-01 split at the outer join
-        assert_sql_not_contains(outer_sql, "Part 1a");
-        assert_sql_not_contains(outer_sql, "Part 1b");
-        assert_sql_contains(outer_sql, "Part 1");
+        // Per-leaf CTE R₀ → Part 1 is split
+        assert_sql_contains(outer_sql, "Part 1a");
+        assert_sql_contains(outer_sql, "Part 1b");
     }
 
     #[test]
-    fn test_ec01_nested_right_child_2_scans_no_split_when_l0() {
-        // Left child is a simple Scan → L₀ is available → Part 1 is NOT
-        // split even though the right child is a nested join.
+    fn test_ec01_nested_right_child_2_scans_uses_r0() {
+        // When right child is a nested join with ≤2 scan nodes and no
+        // SemiJoin, use_r0 is true → Part 1 is split.
         let a = scan(1, "a", "public", "a", &["id"]);
         let b = scan(2, "b", "public", "b", &["id"]);
         let c = scan(3, "c", "public", "c", &["id"]);
@@ -1532,9 +1567,9 @@ mod tests {
         let result = diff_inner_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // L₀ available → no EC-01 split
-        assert_sql_not_contains(&sql, "Part 1a");
-        assert_sql_not_contains(&sql, "Part 1b");
+        // Right has 2 scans → use_r0 = true → Part 1 split
+        assert_sql_contains(&sql, "Part 1a");
+        assert_sql_contains(&sql, "Part 1b");
     }
 
     #[test]

--- a/src/dvm/operators/outer_join.rs
+++ b/src/dvm/operators/outer_join.rs
@@ -185,16 +185,7 @@ pub fn diff_left_join(ctx: &mut DiffContext, op: &OpTree) -> Result<DiffResult, 
     //
     // R₀ = R_current EXCEPT ALL ΔR_inserts UNION ALL ΔR_deletes
     // DI-11: Use same threshold as inner join for deep R₀ reconstruction.
-    //
-    // When use_l0 is true (Part 2 uses L₀), the standard DBSP formula
-    // is already exact — no EC-01 split needed. See diff_inner_join
-    // for the full derivation.
-    let l0_available = use_pre_change_snapshot(left, ctx.inside_semijoin, 4);
-    let use_r0 = if l0_available {
-        false
-    } else {
-        use_pre_change_snapshot(right, ctx.inside_semijoin, 4)
-    };
+    let use_r0 = use_pre_change_snapshot(right, ctx.inside_semijoin, 4);
 
     // Build R₀ for Parts 1b/3b (includes all right_cols for JOIN/anti-join).
     // Separate from r_old_snapshot (used for Parts 4/5 NOT EXISTS only,
@@ -569,25 +560,22 @@ mod tests {
         let result = diff_left_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // When L₀ is available (Scan children), Part 1 and Part 3 are NOT
-        // split — standard formula is exact, no EC-01 needed.
-        assert_sql_contains(&sql, "Part 1");
-        assert_sql_not_contains(&sql, "Part 1a");
-        assert_sql_not_contains(&sql, "Part 1b");
+        // EC-01: Parts 1 and 3 are split when right child is simple (Scan)
+        assert_sql_contains(&sql, "Part 1a");
+        assert_sql_contains(&sql, "Part 1b");
         assert_sql_contains(&sql, "Part 2");
-        assert_sql_contains(&sql, "Part 3");
-        assert_sql_not_contains(&sql, "Part 3a");
-        assert_sql_not_contains(&sql, "Part 3b");
+        assert_sql_contains(&sql, "Part 3a");
+        assert_sql_contains(&sql, "Part 3b");
         assert_sql_contains(&sql, "Part 4");
         assert_sql_contains(&sql, "Part 5");
-        // EC-02 correction (Part 6) is NOT needed without EC-01 split.
-        assert_sql_not_contains(&sql, "Part 6");
+        // EC-02: Part 6 corrects ΔL_D ⋈ ΔR double-counting
+        assert_sql_contains(&sql, "Part 6");
     }
 
     #[test]
-    fn test_ec01_left_join_no_r0_when_l0_available() {
-        // When L₀ is available (Scan children), R₀ is NOT used — standard
-        // formula is exact. Parts 1 and 3 are unsplit.
+    fn test_ec01_left_join_r0_uses_except_all() {
+        // For Scan right children, Part 1b and Part 3b should use R₀ via
+        // EXCEPT ALL to find pre-change right partners.
         let mut ctx = test_ctx();
         let left = scan(1, "a", "public", "a", &["id", "bid"]);
         let right = scan(2, "b", "public", "b", &["id", "name"]);
@@ -596,11 +584,12 @@ mod tests {
         let result = diff_left_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // L₀ uses NOT EXISTS anti-join (DI-2)
+        // R₀ uses DI-2 NOT EXISTS anti-join pattern
         assert_sql_contains(&sql, "NOT EXISTS");
-        // Part 1 and Part 3 are NOT split
-        assert_sql_not_contains(&sql, "Part 1b");
-        assert_sql_not_contains(&sql, "Part 3b");
+        // Part 1b filters DELETEs only
+        assert_sql_contains(&sql, "Part 1b");
+        // Part 3b filters DELETEs only
+        assert_sql_contains(&sql, "Part 3b");
     }
 
     #[test]
@@ -779,9 +768,10 @@ mod tests {
     }
 
     #[test]
-    fn test_ec02_left_join_no_correction_when_l0_available() {
-        // When L₀ is available (simple Scan children), the standard formula
-        // is exact and no EC-02 correction is needed.
+    fn test_ec02_left_join_correction_for_scan_children() {
+        // When both left and right are Scan children (use_l0 && use_r0),
+        // EC-02 correction (Part 6) should be emitted to cancel ΔL_D ⋈ ΔR
+        // double-counting between Part 1b and Part 2.
         let mut ctx = test_ctx();
         let left = scan(1, "a", "public", "a", &["id", "key"]);
         let right = scan(2, "b", "public", "b", &["id", "val"]);
@@ -790,7 +780,13 @@ mod tests {
         let result = diff_left_join(&mut ctx, &tree).unwrap();
         let sql = ctx.build_with_query(&result.cte_name);
 
-        // EC-02 Part 6 should NOT be present.
-        assert_sql_not_contains(&sql, "Part 6: EC-02 correction");
+        // EC-02 Part 6 should flip ΔR action
+        assert_sql_contains(&sql, "Part 6: EC-02 correction");
+        assert_sql_contains(
+            &sql,
+            "CASE WHEN dr.__pgt_action = 'I' THEN 'D' ELSE 'I' END",
+        );
+        // EC-02 only joins ΔL_D rows
+        assert_sql_contains(&sql, "dl.__pgt_action = 'D'");
     }
 }


### PR DESCRIPTION
## Summary

Reverts commit a80b474 (PR #470) which introduced an optimization to skip the
EC-01 Part 1 split when L0 (pre-change left snapshot) was available. The
optimization was based on the theoretical DBSP formula being exact when L0
is used, but it causes correctness issues in practice.

## Problem

CI run #1538 (manual dispatch on main) revealed two E2E failures:

### 1. test_diff_full_equivalence_full_join (Full E2E - consistent failure)

The FULL JOIN differential refresh produces a phantom row after simultaneous
changes on both join sides. The stream table has 4 rows while the defining
query returns 3.

Root cause: Without the EC-01 split, Part 1 uses unsplit DL JOIN R1 which
retains stale join matches from simultaneously changed rows. Without EC-02
correction terms, phantom rows are never cancelled.

### 2. test_consecutive_errors_tracked_and_reset (Light E2E - flaky)

This test passed on the push-triggered CI for the same commit but failed on
the manual dispatch. It appears to be a pre-existing flaky test unrelated to
PR #470 and is not addressed in this PR.

## Fix

Restore the original EC-01 split plus EC-02 correction for all three join
operators:

- Inner join (join.rs): Restore use_r0 without the L0 gate, restore EC-02
  correction term
- Left join (outer_join.rs): Restore use_r0 without the L0 gate
- Full join (full_join.rs): Restore use_r0 without the L0 gate

## Testing

- All 1735 unit tests pass
- Lint (clippy + fmt) passes with zero warnings
- Full CI validation recommended before merge (manual dispatch)
