### PR TITLE
roadmap: insert v0.19.0 PostgreSQL 17 support as PGlite prerequisite

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,10 +35,11 @@ coverage, all in plain language.
 - [v0.16.0 — Performance & Refresh Optimization](#v0160--performance--refresh-optimization)
 - [v0.17.0 — Query Intelligence & Stability](#v0170--query-intelligence--stability)
 - [v0.18.0 — Hardening & Delta Performance](#v0180--hardening--delta-performance)
-- [v0.19.0 — PGlite Proof of Concept](#v0190--pglite-proof-of-concept)
-- [v0.20.0 — Core Extraction (`pg_trickle_core`)](#v0200--core-extraction-pg_trickle_core)
-- [v0.21.0 — PGlite WASM Extension](#v0210--pglite-wasm-extension)
-- [v0.22.0 — PGlite Reactive Integration](#v0220--pglite-reactive-integration)
+- [v0.19.0 — PostgreSQL 17 Support](#v0190--postgresql-17-support)
+- [v0.20.0 — PGlite Proof of Concept](#v0200--pglite-proof-of-concept)
+- [v0.21.0 — Core Extraction (`pg_trickle_core`)](#v0210--core-extraction-pg_trickle_core)
+- [v0.22.0 — PGlite WASM Extension](#v0220--pglite-wasm-extension)
+- [v0.23.0 — PGlite Reactive Integration](#v0230--pglite-reactive-integration)
 - [v1.0.0 — Stable Release](#v100--stable-release)
 - [Post-1.0 — Scale, Ecosystem & Platform Expansion](#post-10--scale-ecosystem--platform-expansion)
 - [Effort Summary](#effort-summary)
@@ -79,10 +80,11 @@ from the v0.1.x series to 1.0 and beyond.
 | **v0.16.0** | **Performance & refresh optimization** | **✅ Released** |
 | **v0.17.0** | **Query intelligence & stability** | **✅ Released** |
 | v0.18.0 | Hardening & delta performance | Planned |
-| v0.19.0 | PGlite proof of concept | Planned |
-| v0.20.0 | Core extraction (`pg_trickle_core`) | Planned |
-| v0.21.0 | PGlite WASM extension | Planned |
-| v0.22.0 | PGlite reactive integration | Planned |
+| v0.19.0 | PostgreSQL 17 support | Planned |
+| v0.20.0 | PGlite proof of concept | Planned |
+| v0.21.0 | Core extraction (`pg_trickle_core`) | Planned |
+| v0.22.0 | PGlite WASM extension | Planned |
+| v0.23.0 | PGlite reactive integration | Planned |
 | v1.0.0 | Stable release (incl. PG 19 compatibility) | Planned |
 
 ---
@@ -3918,7 +3920,7 @@ Dependencies: PERF-1 (applies to the merged delta builder). Schema change: No.
 > bitmask (`old.col IS DISTINCT FROM new.col`) in the CDC trigger; store as
 > `int8` or `bit(n)` alongside the change row. Phase 1 only: bitmask
 > computation + storage. Phase 2 (delta-scan filtering using the bitmask)
-> deferred to v0.19.0. Provides the foundation for 50–90% delta volume
+> deferred to v0.20.0. Provides the foundation for 50–90% delta volume
 > reduction on wide-table UPDATE workloads.
 
 Gate behind `pg_trickle.columnar_tracking` GUC (default `off`).
@@ -4062,7 +4064,7 @@ Dependencies: None. Schema change: No.
 > to crash-test oracle only for v0.18.0: SQLancer in Docker, configured to
 > feed randomized SQL to the parser and DVM pipeline. Zero-panic guarantee —
 > any input that crashes the extension is a bug. Equivalence oracle
-> (DIFFERENTIAL ≡ FULL) and stateful DML fuzzing deferred to v0.19.0.
+> (DIFFERENTIAL ≡ FULL) and stateful DML fuzzing deferred to v0.20.0.
 
 Verify: 10K+ fuzzed queries with zero panics.
 Dependencies: None. Schema change: No.
@@ -4184,7 +4186,66 @@ Dependencies: None. Schema change: No.
 
 ---
 
-## v0.19.0 — PGlite Proof of Concept
+## v0.19.0 — PostgreSQL 17 Support
+
+> **Release Theme**
+> This release adds PostgreSQL 17 as a supported target alongside
+> PostgreSQL 18. PGlite is built on PostgreSQL 17, so this is a hard
+> prerequisite for the PGlite proof of concept (v0.20.0). The pgrx 0.17.x
+> framework already supports PG 17 — the work is enabling the feature flag,
+> adapting version-sensitive code paths, expanding the CI matrix, and
+> validating the full test suite against a PG 17 instance.
+
+### Cargo & Build System
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| PG17-1 | **Add `pg17` feature to `Cargo.toml`.** Define `pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]` feature. Keep `default = ["pg18"]`. | 1h | — |
+| PG17-2 | **Broaden `#[cfg]` guards in `src/dag.rs`.** Three `#[cfg(feature = "pg18")]` blocks must become `#[cfg(any(feature = "pg17", feature = "pg18"))]`. | 1–2h | — |
+| PG17-3 | **Guard `NodeTag` numeric assertions.** `src/dvm/parser/mod.rs` asserts specific `NodeTag` integer values (e.g., `T_GroupingSet = 107`) that shift between PG versions. Gate behind `#[cfg(feature = "pg18")]` or use per-version value tables. | 2–4h | — |
+| PG17-4 | **Audit `pg_sys::*` API surface.** Verify that every `pg_sys` call compiles and behaves correctly on PG 17 bindings. Focus on catalog struct field names, WAL decoder types, and any PG 18-only additions. | 4–8h | — |
+
+### CI & Infrastructure
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| PG17-5 | **CI matrix expansion.** Add PG 17 build + unit test job to `ci.yml`. Use `postgres:17` Docker image for integration and light E2E tests. | 4–8h | — |
+| PG17-6 | **`justfile` parameterisation.** Add `pg17` variants for build, test, and package recipes (e.g., `just build-pg17`, `just test-e2e-pg17`). | 2–4h | — |
+| PG17-7 | **`tests/Dockerfile.e2e` PG version parameter.** Accept a build arg for the base PostgreSQL image version so the same Dockerfile works for PG 17 and PG 18. | 2–4h | — |
+| PG17-8 | **Scripts parameterisation.** Update `run_unit_tests.sh`, `run_light_e2e_tests.sh`, `run_e2e_tests.sh` to accept a PG version argument instead of hardcoding `pg18`. | 2–4h | — |
+
+### Testing & Validation
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| PG17-9 | **Full E2E suite against PG 17.** Run the complete E2E test suite against a PG 17 instance. Fix any parser or catalog incompatibilities that surface. | 1–2d | — |
+| PG17-10 | **TPC-H validation on PG 17.** Run TPC-H benchmark queries on PG 17 to verify differential refresh correctness for complex queries. | 4–8h | — |
+| PG17-11 | **Upgrade path test.** Verify `ALTER EXTENSION pg_trickle UPDATE` from 0.18.0 to 0.19.0 works on both PG 17 and PG 18. | 2–4h | — |
+
+### Documentation
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| PG17-12 | **Update docs and README.** Change "PostgreSQL 18 extension" to "PostgreSQL 17/18 extension" in `README.md`, `INSTALL.md`, `src/lib.rs` doc comments, and `ARCHITECTURE.md`. | 1–2h | — |
+| PG17-13 | **Docker Hub image variants.** Publish images tagged with both PG versions (e.g., `:0.19.0-pg17`, `:0.19.0-pg18`). | 2–4h | — |
+
+> **v0.19.0 total: ~2–4 days**
+
+**Exit criteria:**
+- [ ] PG17-1: `cargo build --features pg17 --no-default-features` compiles cleanly
+- [ ] PG17-2/PG17-3: `cargo clippy --features pg17 --no-default-features` passes with zero warnings
+- [ ] PG17-4: No `pg_sys` compile errors on PG 17 bindings
+- [ ] PG17-5: CI runs unit + integration + light E2E tests on PG 17
+- [ ] PG17-9: Full E2E suite passes on PG 17 with zero failures
+- [ ] PG17-10: TPC-H differential refresh matches full refresh on PG 17
+- [ ] PG17-11: Extension upgrade path works on both PG 17 and PG 18
+- [ ] PG17-12: Documentation reflects PG 17/18 dual support
+- [ ] Extension upgrade path tested (`0.18.0 → 0.19.0`)
+- [ ] `just check-version-sync` passes
+
+---
+
+## v0.20.0 — PGlite Proof of Concept
 
 > **Release Theme**
 > This release validates whether PGlite users want real incremental view
@@ -4194,7 +4255,7 @@ Dependencies: None. Schema change: No.
 > simple patterns — single-table aggregates, two-table inner joins, and
 > filtered scans. It deliberately limits scope to 3–5 SQL patterns to
 > keep effort low while generating a concrete demand signal. If adoption
-> materialises, the full core extraction (v0.20.0) and WASM build (v0.21.0)
+> materialises, the full core extraction (v0.21.0) and WASM build (v0.22.0)
 > proceed. The main pg_trickle PostgreSQL extension ships no functional
 > changes in this release — only version bumps and upgrade migration
 > plumbing.
@@ -4418,7 +4479,7 @@ Dependencies: PGL-0-4. Schema change: No.
 
 > **In plain terms:** A clear table showing which SQL patterns are and are
 > not supported, what error you get for unsupported patterns, and when full
-> support is expected (v0.21.0). This prevents user frustration and sets
+> support is expected (v0.22.0). This prevents user frustration and sets
 > expectations.
 
 Verify: decision table in README and npm page lists all tested patterns with
@@ -4430,7 +4491,7 @@ Dependencies: None. Schema change: No.
 > **In plain terms:** Every error thrown by the plugin must include the
 > table name, the failing operation, and a one-sentence hint. Example:
 > `"LEFT JOIN is not supported in pglite-lite. Use @pgtrickle/pglite
-> (v0.21.0+) for full SQL support, or rewrite as INNER JOIN."`
+> (v0.22.0+) for full SQL support, or rewrite as INNER JOIN."`
 
 Verify: all error paths tested; every error message includes a remediation
 sentence.
@@ -4510,22 +4571,22 @@ Dependencies: PGL-0-4. Schema change: No.
 **TEST-5 — Extension upgrade path (0.18 to 0.19)**
 
 > **In plain terms:** The main pg_trickle PostgreSQL extension ships no
-> functional changes in v0.19.0, but the upgrade migration path must still
-> be tested. `ALTER EXTENSION pg_trickle UPDATE` from 0.18.0 to 0.19.0
+> functional changes in v0.20.0, but the upgrade migration path must still
+> be tested. `ALTER EXTENSION pg_trickle UPDATE` from 0.19.0 to 0.20.0
 > must leave existing stream tables intact.
 
 Verify: upgrade E2E test confirms all existing stream tables survive and
-refresh correctly after `0.18.0 -> 0.19.0` upgrade.
+refresh correctly after `0.19.0 -> 0.20.0` upgrade.
 Dependencies: None. Schema change: No (PG extension unchanged).
 
 ### Conflicts & Risks
 
 1. **Demand uncertainty is the primary risk.** This entire milestone is a bet
    that PGlite users want IVM beyond what pg_ivm provides. If Phase 0
-   generates no adoption signal, v0.20.0–v0.22.0 should be deprioritised and
+   generates no adoption signal, v0.21.0–v0.23.0 should be deprioritised and
    v1.0.0 proceeds without PGlite. Define a concrete adoption threshold
    (e.g., > 100 npm weekly downloads within 60 days of publication) as a
-   go/no-go gate for v0.20.0.
+   go/no-go gate for v0.21.0.
 
 2. **PGlite trigger infrastructure is unverified.** PGL-0-1 (trigger
    validation) is a hard prerequisite for everything else. If statement-level
@@ -4539,12 +4600,12 @@ Dependencies: None. Schema change: No (PG extension unchanged).
    Pin the minimum PGlite version in `package.json`.
 
 4. **No core Rust changes, but version bump required.** The main pg_trickle
-   extension needs a v0.19.0 version bump, upgrade migration SQL, and passing
+   extension needs a v0.20.0 version bump, upgrade migration SQL, and passing
    CI even though no functional code changes. This is low-risk but must not
    be forgotten.
 
 5. **ElectricSQL collaboration timing.** UX-5 (outreach) should happen
-   early — before v0.19.0 ships — to avoid building something ElectricSQL is
+   early — before v0.20.0 ships — to avoid building something ElectricSQL is
    already working on or would actively resist. If they signal interest in
    co-development, Phase 2 scope and timeline may shift.
 
@@ -4554,7 +4615,7 @@ Dependencies: None. Schema change: No (PG extension unchanged).
    compensate — consider porting the proptest approach to a JS property-
    testing library (e.g., fast-check).
 
-> **v0.19.0 total: ~2–3 weeks (PGlite plugin) + ~1–2 days (PG extension version bump)**
+> **v0.20.0 total: ~2–3 weeks (PGlite plugin) + ~1–2 days (PG extension version bump)**
 
 **Exit criteria:**
 - [ ] PGL-0-1: Statement-level triggers with transition tables confirmed working in PGlite
@@ -4576,12 +4637,12 @@ Dependencies: None. Schema change: No (PG extension unchanged).
 - [ ] UX-4: TypeScript type definitions ship with strict-mode compatibility
 - [ ] TEST-1: > 50 correctness test cases pass on PGlite latest
 - [ ] TEST-2: CI tests pass against PGlite N, N-1, N-2
-- [ ] TEST-5: Extension upgrade path tested (`0.18.0 -> 0.19.0`)
+- [ ] TEST-5: Extension upgrade path tested (`0.19.0 -> 0.20.0`)
 - [ ] `just check-version-sync` passes
 
 ---
 
-## v0.20.0 — Core Extraction (`pg_trickle_core`)
+## v0.21.0 — Core Extraction (`pg_trickle_core`)
 
 > **Release Theme**
 > This release surgically separates pg_trickle's "brain" — the DVM engine,
@@ -4590,7 +4651,7 @@ Dependencies: None. Schema change: No (PG extension unchanged).
 > The extraction touches ~51,000 lines of code across 30+ source files but
 > produces zero user-visible behavior change: every existing test must pass
 > unchanged. The payoff is threefold: the core crate compiles to WASM
-> (enabling the PGlite extension in v0.21.0), pure-logic unit tests run
+> (enabling the PGlite extension in v0.22.0), pure-logic unit tests run
 > without a PostgreSQL instance (10x faster CI), and the main extension
 > gains a cleaner internal architecture. Approximately 500 unsafe blocks in
 > the parser require an abstraction layer over raw `pg_sys` node traversal,
@@ -4731,13 +4792,13 @@ Dependencies: PGL-1-1. Schema change: No.
 
 **STAB-4 — Extension upgrade path (0.19 to 0.20)**
 
-> **In plain terms:** v0.20.0 makes no SQL-visible changes (same functions,
+> **In plain terms:** v0.21.0 makes no SQL-visible changes (same functions,
 > same catalog schema), but the upgrade migration must still be tested.
-> `ALTER EXTENSION pg_trickle UPDATE` from 0.19.0 to 0.20.0 must leave
+> `ALTER EXTENSION pg_trickle UPDATE` from 0.20.0 to 0.21.0 must leave
 > existing stream tables intact and refreshable.
 
 Verify: upgrade E2E test confirms stream tables survive and refresh
-correctly after `0.19.0 -> 0.20.0`.
+correctly after `0.20.0 -> 0.21.0`.
 Dependencies: None. Schema change: No.
 
 **STAB-5 — Feature-flag isolation for WASM target**
@@ -4814,7 +4875,7 @@ Dependencies: PGL-1-1. Schema change: No.
 
 **SCAL-2 — Core crate binary size for WASM budget**
 
-> **In plain terms:** v0.21.0 targets < 2 MB WASM bundle. Measure the
+> **In plain terms:** v0.22.0 targets < 2 MB WASM bundle. Measure the
 > compiled size of `pg_trickle_core` for the WASM target now so the budget
 > is known before Phase 2. If > 5 MB, investigate `wasm-opt` stripping and
 > feature-gating large operator modules.
@@ -4945,8 +5006,8 @@ Dependencies: PGL-1-1. Schema change: No.
    item. If the abstraction proves too leaky (e.g., too many pg_sys node
    types to wrap), consider leaving `rewrites.rs` and `sublinks.rs` in the
    extension crate and extracting only operators + DAG + types to the core
-   crate. This reduces v0.20.0 scope but still delivers the WASM-compilable
-   operator engine for v0.21.0.
+   crate. This reduces v0.21.0 scope but still delivers the WASM-compilable
+   operator engine for v0.22.0.
 
 2. **PERF-1 must be validated before merging.** Introducing a
    `trait DatabaseBackend` could add vtable dispatch overhead on the hot
@@ -4976,7 +5037,7 @@ Dependencies: PGL-1-1. Schema change: No.
    extraction order: types -> operators -> DAG -> diff -> rewrites ->
    sublinks.
 
-> **v0.20.0 total: ~3–4 weeks (extraction) + ~1–2 weeks (abstraction layer + testing)**
+> **v0.21.0 total: ~3–4 weeks (extraction) + ~1–2 weeks (abstraction layer + testing)**
 
 **Exit criteria:**
 - [ ] PGL-1-1: `pg_trickle_core` crate exists as a workspace member with zero pgrx dependencies
@@ -4993,7 +5054,7 @@ Dependencies: PGL-1-1. Schema change: No.
 - [ ] STAB-1: Zero `pg_sys::` references in `pg_trickle_core/src/`
 - [ ] STAB-2: `cargo build -p pg_trickle_core --no-default-features` passes in CI
 - [ ] STAB-3: `cargo pgrx package` and `cargo pgrx test` succeed with workspace layout
-- [ ] STAB-4: Extension upgrade path tested (`0.19.0 -> 0.20.0`)
+- [ ] STAB-4: Extension upgrade path tested (`0.20.0 -> 0.21.0`)
 - [ ] STAB-5: WASM target builds in CI
 - [ ] PERF-1: Criterion shows < 1% regression on `diff_operators` benchmark
 - [ ] PERF-2: Full benchmark suite passes with < 5% regression threshold
@@ -5008,12 +5069,12 @@ Dependencies: PGL-1-1. Schema change: No.
 
 ---
 
-## v0.21.0 — PGlite WASM Extension
+## v0.22.0 — PGlite WASM Extension
 
 > **Release Theme**
 > This release delivers the first working PGlite extension — the moment
 > pg_trickle's incremental view maintenance runs in the browser. By
-> wrapping `pg_trickle_core` (extracted in v0.20.0) in a thin C/FFI shim
+> wrapping `pg_trickle_core` (extracted in v0.21.0) in a thin C/FFI shim
 > and compiling to WASM via PGlite's Emscripten toolchain, we ship an npm
 > package (`@pgtrickle/pglite`) that gives PGlite users the full DVM
 > operator vocabulary — outer joins, window functions, subqueries,
@@ -5028,7 +5089,7 @@ Phase 2 for the full architecture.
 ### PGlite WASM Build (Phase 2)
 
 > **In plain terms:** This takes the `pg_trickle_core` crate extracted in
-> v0.20.0 and wraps it in a thin C shim that PGlite's Emscripten-based
+> v0.21.0 and wraps it in a thin C shim that PGlite's Emscripten-based
 > extension build system can compile to WASM. The result is a PGlite
 > extension package (`@pgtrickle/pglite`) that provides
 > `create_stream_table()`, `drop_stream_table()`, and `alter_stream_table()`
@@ -5159,12 +5220,12 @@ Dependencies: PGL-2-1, PGL-2-4. Schema change: No.
 
 **STAB-4 — Native extension upgrade path (0.20 → 0.21)**
 
-> **In plain terms:** v0.21.0 adds PGlite support but makes no SQL-visible
+> **In plain terms:** v0.22.0 adds PGlite support but makes no SQL-visible
 > changes to the native extension. The upgrade migration from 0.20.0 to
 > 0.21.0 must leave existing stream tables intact and refreshable.
 
 Verify: upgrade E2E test confirms stream tables survive and refresh
-correctly after `0.20.0 -> 0.21.0`.
+correctly after `0.21.0 -> 0.22.0`.
 Dependencies: None. Schema change: No.
 
 **STAB-5 — npm package version synchronization**
@@ -5445,7 +5506,7 @@ Dependencies: PGL-2-3, PERF-2. Schema change: No.
    Add it to the existing CI matrix as a separate job that only runs when
    `pg_trickle_pglite/` or `pg_trickle_core/` files are modified.
 
-> **v0.21.0 total: ~5–7 weeks (WASM build) + ~2–3 weeks (testing + polish)**
+> **v0.22.0 total: ~5–7 weeks (WASM build) + ~2–3 weeks (testing + polish)**
 
 **Exit criteria:**
 - [ ] PGL-2-1: C shim compiles and links against PGlite's WASM PostgreSQL headers
@@ -5461,7 +5522,7 @@ Dependencies: PGL-2-3, PERF-2. Schema change: No.
 - [ ] STAB-1: OOM stress test: PGlite survives with actionable error
 - [ ] STAB-2: Panic from invalid SQL returns SQL error, not WASM trap
 - [ ] STAB-3: Load/unload/reload lifecycle test: zero leaked allocations
-- [ ] STAB-4: Extension upgrade path tested (`0.20.0 -> 0.21.0`)
+- [ ] STAB-4: Extension upgrade path tested (`0.21.0 -> 0.22.0`)
 - [ ] PERF-1: WASM vs native benchmark report published (≤ 3× overhead)
 - [ ] PERF-2: WASM bundle ≤ 2 MB (CI gated)
 - [ ] PERF-3: Cold-start load time < 500 ms browser, < 200 ms Node.js
@@ -5477,7 +5538,7 @@ Dependencies: PGL-2-3, PERF-2. Schema change: No.
 
 ---
 
-## v0.22.0 — PGlite Reactive Integration
+## v0.23.0 — PGlite Reactive Integration
 
 > **Release Theme**
 > This release completes the PGlite story by bridging the gap between
@@ -5586,7 +5647,7 @@ Dependencies: PGL-3-1, PGL-3-2. Schema change: No.
 | STAB-1 | Memory leak prevention in long-lived hooks | M | P0 |
 | STAB-2 | Subscription cleanup on component unmount | S | P0 |
 | STAB-3 | Error boundary integration for hook failures | S | P0 |
-| STAB-4 | Native extension upgrade path (0.21 → 0.22) | S | P0 |
+| STAB-4 | Native extension upgrade path (0.22 → 0.23) | S | P0 |
 | STAB-5 | Framework version compatibility matrix | S | P1 |
 
 **STAB-1 — Memory leak prevention in long-lived hooks**
@@ -5628,16 +5689,16 @@ Verify: test dropping a stream table while `useStreamTable()` is active;
 assert error boundary catches the error with an actionable message.
 Dependencies: PGL-3-2, PGL-3-3. Schema change: No.
 
-**STAB-4 — Native extension upgrade path (0.21 → 0.22)**
+**STAB-4 — Native extension upgrade path (0.22 → 0.23)**
 
-> **In plain terms:** v0.22.0 adds reactive bindings at the TypeScript/npm
+> **In plain terms:** v0.23.0 adds reactive bindings at the TypeScript/npm
 > layer only. The native PostgreSQL extension and PGlite WASM extension
 > must continue to work unchanged. The upgrade migration from 0.21.0 to
 > 0.22.0 must leave existing stream tables and the `@pgtrickle/pglite`
 > WASM extension intact.
 
 Verify: upgrade E2E test confirms stream tables survive and refresh
-correctly after `0.21.0 -> 0.22.0`. TypeScript API backward compatibility
+correctly after `0.22.0 -> 0.23.0`. TypeScript API backward compatibility
 verified.
 Dependencies: None. Schema change: No.
 
@@ -5823,11 +5884,11 @@ Dependencies: PGL-3-4, PERF-1. Schema change: No.
 > `live.changes()` bridge emits the correct change events for INSERT,
 > UPDATE, and DELETE on the source table. Replay events into an
 > accumulator and assert it matches `SELECT * FROM stream_table`. This
-> extends v0.21.0 TEST-1 (operator E2E) by adding the reactive layer.
+> extends v0.22.0 TEST-1 (operator E2E) by adding the reactive layer.
 
 Verify: ≥ 69 tests (23 operators × 3 DML types). Accumulator matches
 `SELECT *` for every test case.
-Dependencies: PGL-3-1, v0.21.0 TEST-1. Schema change: No.
+Dependencies: PGL-3-1, v0.22.0 TEST-1. Schema change: No.
 
 **TEST-2 — React hook lifecycle tests**
 
@@ -5880,7 +5941,7 @@ Dependencies: STAB-1, PGL-3-2. Schema change: No.
    relatively new and its event format may change between PGlite releases.
    Pin the PGlite version and add an adapter layer so the bridge can
    accommodate event format changes without rewriting the React/Vue hooks.
-   If PGlite deprecates `live.changes()` before v0.22.0 ships, fall back
+   If PGlite deprecates `live.changes()` before v0.23.0 ships, fall back
    to `LISTEN/NOTIFY` with a custom channel.
 
 2. **CORR-2 (batch atomicity) and PERF-2 (single re-render) are coupled.**
@@ -5907,12 +5968,12 @@ Dependencies: STAB-1, PGL-3-2. Schema change: No.
    and scope it to documentation + a proof-of-concept, not production-grade
    support.
 
-6. **No native extension changes in v0.22.0.** This release is entirely
+6. **No native extension changes in v0.23.0.** This release is entirely
    in the TypeScript/npm layer. Any temptation to add native features
    (e.g., `LISTEN/NOTIFY` bridge, WebSocket push) should be deferred to
    post-1.0. Keep the scope tight: reactive bindings + examples + docs.
 
-> **v0.22.0 total: ~2–3 weeks (bridge + hooks) + ~1–2 weeks (examples + testing + polish)**
+> **v0.23.0 total: ~2–3 weeks (bridge + hooks) + ~1–2 weeks (examples + testing + polish)**
 
 **Exit criteria:**
 - [ ] PGL-3-1: Stream table changes appear in `live.changes()` event stream
@@ -5927,7 +5988,7 @@ Dependencies: STAB-1, PGL-3-2. Schema change: No.
 - [ ] STAB-1: 4-hour soak test: heap growth < 10%
 - [ ] STAB-2: 100 mount/unmount cycles: zero leaked subscriptions
 - [ ] STAB-3: Stream table dropped while hook active: error boundary catches
-- [ ] STAB-4: Extension upgrade path tested (`0.21.0 -> 0.22.0`)
+- [ ] STAB-4: Extension upgrade path tested (`0.22.0 -> 0.23.0`)
 - [ ] STAB-5: CI matrix passes for React 18, React 19, Vue 3.4+
 - [ ] PERF-1: INSERT-to-render latency < 50% of `live.incrementalQuery()` at 10K rows
 - [ ] PERF-2: Render count = 1 for bulk DML (1, 10, 100, 1000 rows)
@@ -5957,7 +6018,7 @@ forward-compatibility.
 > audits every internal `pg_sys::*` API call for breaking changes, adds
 > conditional compilation gates, and validates the WAL decoder against any
 > pgoutput format changes introduced in PG 19. Moved here from the
-> earlier v0.19.0 milestone because PG 19 beta availability is uncertain.
+> earlier v0.20.0 milestone because PG 19 beta availability is uncertain.
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
@@ -6149,10 +6210,11 @@ to keep the pre-1.0 milestones focused on performance and correctness.
 | v0.16.0 — Performance & Refresh Optimization | ~1–2wk MERGE alts + ~4–6wk aggregate fast-path + ~1–2wk append-only + ~2–3wk predicate pushdown + ~2–3wk template cache + ~2–3wk buffer compaction + ~3–6wk test coverage + ~1–2wk bench CI + ~2–3d auto-indexing + ~12–22h quick wins | — | |
 | v0.17.0 — Query Intelligence & Stability | ~2–3wk cost-based strategy + ~3–4wk columnar tracking + ~32–48h TIVM Phase 4 + ~1–2d ROWS FROM + ~2–3wk SQLancer + ~2–3wk incremental DAG + ~4–8h unsafe reduction + ~1–2wk api.rs mod + ~2–3d migration guide + ~3–5d runbook + ~2–3d playground + ~2–3d doc polish | — | |
 | v0.18.0 — Hardening & Delta Performance | ~70–100h | — | |
-| v0.19.0 — PGlite Proof of Concept | ~2–3wk (plugin) + ~1–2d (version bump) | — | |
-| v0.20.0 — Core Extraction (`pg_trickle_core`) | ~3–4wk (extraction) + ~1–2wk (abstraction + testing) | — | |
-| v0.21.0 — PGlite WASM Extension | ~5–7wk (WASM build) + ~2–3wk (testing + polish) | — | |
-| v0.22.0 — PGlite Reactive Integration | ~2–3wk (bridge + hooks) + ~1–2wk (examples + testing + polish) | — | |
+| v0.19.0 — PostgreSQL 17 Support | ~2–4d | — | |
+| v0.20.0 — PGlite Proof of Concept | ~2–3wk (plugin) + ~1–2d (version bump) | — | |
+| v0.21.0 — Core Extraction (`pg_trickle_core`) | ~3–4wk (extraction) + ~1–2wk (abstraction + testing) | — | |
+| v0.22.0 — PGlite WASM Extension | ~5–7wk (WASM build) + ~2–3wk (testing + polish) | — | |
+| v0.23.0 — PGlite Reactive Integration | ~2–3wk (bridge + hooks) + ~1–2wk (examples + testing + polish) | — | |
 | v1.0.0 — Stable release (incl. PG 19 compat) | ~36–66h | — | |
 | Post-1.0 (PG compat + Native DDL) | ~38–56h (PG 16–18) + ~13–21d (Native DDL) | — | |
 | Post-1.0 (ecosystem) | 88–134h | — | |


### PR DESCRIPTION
## Summary

Inserts a new **v0.19.0 — PostgreSQL 17 Support** milestone and renumbers the subsequent PGlite pipeline milestones.

PGlite runs on PostgreSQL 17. Without dual PG 17/18 support, the PGlite proof of concept cannot be validated against the correct PostgreSQL version. This milestone is a hard prerequisite for the entire PGlite track.

## New milestone: v0.19.0 — PostgreSQL 17 Support (~2-4 days)

- Add pg17 feature flag to Cargo.toml
- Broaden #[cfg(feature = "pg18")] guards in dag.rs and NodeTag assertions in parser/mod.rs
- Audit pg_sys::* API surface for PG 17 compatibility
- Add PG 17 job to CI matrix; parameterise justfile, scripts, and Dockerfile.e2e
- Full E2E + TPC-H suite against PG 17
- Update docs/README to reflect PG 17/18 dual support

## Renumbered milestones

| Before | After |
|--------|-------|
| v0.19.0 PGlite Proof of Concept | v0.20.0 |
| v0.20.0 Core Extraction | v0.21.0 |
| v0.21.0 PGlite WASM Extension| v0.21.0 PGlite WASM Extension| v0.21.0 PGlite WASM Exten.0| v0.21.0 PGliteferenc| v0.21.0 PGlite WASM Extension| v0.21.0 PGlite WASM Extension| v0.21.0 PGlite WASM Exten.0| v0.21.0 PGliteferenc| v8.0.
