### PR TITLE
docs: allow Unicode in PR descriptions (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,11 +62,9 @@ previous session's file at the same path.
    rm -f /tmp/pr_TICKETNAME.md
    ```
 
-2. Use the `create_file` tool to write the description.  Keep the text
-   **ASCII-only** — avoid Unicode math symbols (Δ, ⋈, ₁, →) and em-dashes
-   in the body; use plain ASCII equivalents (`delta`, `JOIN`, `_1`, `->`)
-   instead.  GitHub renders them fine but shell pipelines and gh can corrupt
-   non-ASCII bytes.
+2. Use the `create_file` tool to write the description.  The file is written
+   in UTF-8 and read directly by `gh --body-file`, so Unicode characters
+   (math symbols, em-dashes, etc.) are safe to use.
 
 3. Verify the file is clean before using it:
    ```bash


### PR DESCRIPTION
## Summary

Remove the overly conservative ASCII-only restriction from the PR description workflow in `AGENTS.md`.

## Problem

Step 2 of the "Guaranteed-safe workflow" instructed agents to keep PR description text **ASCII-only**, avoiding Unicode math symbols (Δ, ⋈, →) and em-dashes. This was unnecessarily restrictive and prevented readable, expressive PR descriptions.

## Why the restriction was wrong

The ASCII-only warning made sense for `echo` or shell heredoc approaches, where multi-byte UTF-8 can be corrupted depending on locale and terminal encoding. However, the documented workflow already solves this:

- The `create_file` tool writes UTF-8 bytes directly to disk — no shell involved.
- `gh pr create --body-file` reads those bytes directly — no shell pipeline.

Unicode passes through perfectly end-to-end. The old caveat was carried over incorrectly when the workflow was updated to use `create_file`.

## Change

Updated step 2 to clarify that Unicode is safe:

**Before:**
> Keep the text **ASCII-only** — avoid Unicode math symbols (Δ, ⋈, ₁, →) and em-dashes in the body; use plain ASCII equivalents instead. GitHub renders them fine but shell pipelines and gh can corrupt non-ASCII bytes.

**After:**
> The file is written in UTF-8 and read directly by `gh --body-file`, so Unicode characters (math symbols, em-dashes, etc.) are safe to use.
