### PR TITLE
release: v0.18.0 changelog and roadmap preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For future plans and release milestones, see [ROADMAP.md](ROADMAP.md).
 
 <!-- TOC start -->
 - [Unreleased](#unreleased)
+- [0.18.0 — 2026-04-12](#0180--2026-04-12)
 - [0.17.0 — 2026-04-08](#0170--2026-04-08)
 - [0.16.0 — 2026-04-06](#0160--2026-04-06)
 - [0.15.0 — 2026-04-03](#0150--2026-04-03)
@@ -38,192 +39,125 @@ For future plans and release milestones, see [ROADMAP.md](ROADMAP.md).
 
 ## [Unreleased]
 
-### Added
+---
 
-- **STAB-3:** Spill detection alerting — `AlertEvent::SpillThresholdExceeded`
-  fires via NOTIFY when delta MERGE spills to temp files for consecutive
-  refreshes exceeding `pg_trickle.spill_consecutive_limit`, so operators are
-  aware before the scheduler forces a FULL refresh fallback.
+## [0.18.0] — 2026-04-12
 
-- **UX-1 (CACHE-OBS):** Template cache observability — new
-  `pgtrickle.cache_stats()` function exposes L1 hits, L2 hits, full misses,
-  evictions, and current L1 cache size from shared memory. L1 hit and
-  eviction counters now tracked in shared memory alongside the existing L2
-  hit/miss counters.
+**Hardening & Delta Performance.** This release focuses on correctness,
+reliability, and giving operators better visibility into what pg_trickle is
+doing. Stream tables that group by columns containing NULL values now refresh
+correctly in all cases. A new memory safety net prevents runaway refreshes
+from consuming too much RAM. Error messages across the board now explain what
+went wrong and suggest how to fix it. Two new SQL functions —
+`health_summary()` and `cache_stats()` — give you a single-query overview of
+the entire system, and updated Grafana dashboards make monitoring plug-and-play.
+The TPC-H industry benchmark now runs as a nightly regression guard, and
+property-based tests mathematically verify the core delta engine's arithmetic.
 
-- **UX-4:** Single-endpoint health summary — new `pgtrickle.health_summary()`
-  returns a single row with total/active/error/suspended/stale stream table
-  counts, max staleness, scheduler status, and cache hit rate. Designed for
-  dashboard single-stat panels and Prometheus exporters.
+### Highlights
 
-- **UX-3:** Error message actionability audit — enriched `raise_error_with_context()`
-  to cover `NotFound`, `AlreadyExists`, `InvalidArgument`, `LockTimeout`, and
-  `QueryTooComplex` error types with SQLSTATE codes, DETAIL, and HINT fields
-  so operators can quickly diagnose and resolve issues.
+- **NULL values in GROUP BY now handled correctly** — previous versions could
+  produce wrong results when a stream table grouped by a column that contained
+  NULL values and rows were deleted. The root cause was that NULL group keys
+  broke the internal row-matching logic. This is now fixed: NULL keys are
+  matched correctly during both inserts and deletes, so aggregate stream
+  tables always return the right answer regardless of NULLs in the data.
 
-- **CORR-3:** NULL-safe GROUP BY elimination under deletes — fixed three
-  root causes: (1) `pg_trickle_hash()` now accepts NULL input using a
-  deterministic `\x00NULL\x00` sentinel instead of returning NULL, preventing
-  NULL `__pgt_row_id` values for rows with NULL group keys; (2) aggregate
-  merge CTE LEFT JOINs now use `IS NOT DISTINCT FROM` instead of `=` for
-  group key matching; (3) rescan CTE group filters use `EXISTS … IS NOT
-  DISTINCT FROM` instead of `IN` for single-column keys. E2E test suite
-  (`e2e_null_group_by_tests.rs`) with 7 tests validates the fix.
+- **Memory safety net for large deltas** — if an unexpectedly large batch of
+  changes arrives (for example, a bulk import into a source table), the
+  incremental refresh could previously consume unbounded memory. A new
+  configuration option (`pg_trickle.delta_work_mem_cap_mb`) lets you set a
+  ceiling. When a refresh would exceed it, pg_trickle automatically falls
+  back to a full refresh instead of risking an out-of-memory crash.
 
-- **STAB-6:** Error SQLSTATE coverage audit — all 18 `PgTrickleError` variants
-  now have explicit SQLSTATE codes, DETAIL, and HINT fields in
-  `raise_error_with_context()`. Covers TypeMismatch, UpstreamTableDropped,
-  ReplicationSlotError, WalTransitionError, SpiError, SpiPermissionError,
-  WatermarkBackwardMovement, WatermarkGroupNotFound, WatermarkGroupAlreadyExists,
-  RefreshSkipped, and InternalError.
+- **Early warning when refreshes spill to disk** — when the incremental
+  refresh engine runs low on memory, PostgreSQL may spill intermediate data
+  to temporary files on disk, which is much slower. pg_trickle now detects
+  this and sends a notification so you can investigate before performance
+  degrades. If spilling happens repeatedly, the scheduler automatically
+  switches the affected stream table to full refresh.
 
-- **TEST-3:** CDC edge case tests — new `e2e_cdc_edge_case_tests.rs` with 8
-  tests covering composite primary keys (CRUD, aggregation, bulk ops),
-  generated (stored) columns, NULL non-PK columns, and domain types.
+- **One-query system health check** — the new `pgtrickle.health_summary()`
+  function returns a single row with everything you need at a glance: how
+  many stream tables are active, how many are in error or suspended state,
+  the worst staleness across all tables, whether the scheduler is running,
+  and the overall cache hit rate. Perfect for dashboards, alerting rules, or
+  a quick manual check.
 
-- **UX-2:** Pre-built Grafana dashboard panels — updated
-  `pg_trickle_overview.json` with new panels for template cache hit rate,
-  delta cache entries, L1 hits vs evictions, P99 and average refresh latency,
-  and hourly refresh success/failure. Added Prometheus exporter queries for
-  `cache_stats()` and `health_summary()`.
+- **Cache performance visibility** — the new `pgtrickle.cache_stats()`
+  function shows how effectively pg_trickle is reusing its internal query
+  templates. You can see cache hit rates, eviction counts, and current cache
+  size — useful for tuning `pg_trickle.template_cache_size` on busy systems.
 
-- **TPCH-BASE (CORR-2/TEST-1):** TPC-H expected-output regression guard —
-  populated the IMMEDIATE skip allowlist with 5 empirically verified entries
-  (q05, q07, q08, q09: temp_file_limit; q15: non-monotonic WHERE). Both
-  DIFFERENTIAL and IMMEDIATE regression guards are now active with assertions.
+- **Better error messages** — every error pg_trickle can raise now includes a
+  standard PostgreSQL error code (SQLSTATE), a DETAIL line explaining the
+  context, and a HINT suggesting what to do. Instead of a cryptic internal
+  error, you get actionable guidance like "Table 'orders' was dropped while
+  stream table 'order_summary' depends on it — recreate the source table or
+  drop the stream table."
 
-- **TEST-7:** dbt integration regression coverage — added AUTO refresh mode
-  model (`order_totals_auto`), `assert_auto_mode_correct` equality test,
-  `assert_all_tables_active` status validation, and
-  `assert_refresh_history_populated` lifecycle test. Updated schema.yml with
-  `stream_table_healthy` test for the new model.
+### Monitoring & dashboards
 
-- **UX-5:** Prometheus metric completeness audit — documented 8 new metrics
-  in `monitoring/README.md` (cache L1 hits/evictions, delta cache entries,
-  cache hit rate, P99/avg refresh latency, refresh counts). All metrics in
-  `pg_trickle_queries.yml` now have matching documentation.
+- **Updated Grafana dashboards** — the bundled `pg_trickle_overview.json`
+  dashboard now includes panels for template cache hit rate, P99 and average
+  refresh latency, hourly refresh success/failure counts, and cache eviction
+  trends. Import it into Grafana and point it at your Prometheus instance for
+  instant visibility.
 
-- **UX-6:** TUI gap note for `cache_stats()` and `health_summary()` — added
-  planned integration section to `docs/TUI.md` documenting the lightest path
-  (dashboard status ribbon + Health Checks view). Functions available via SQL.
+- **Prometheus metric documentation** — all 8 new metrics exposed by
+  `cache_stats()` and `health_summary()` are now fully documented in the
+  monitoring guide, with ready-to-use PromQL queries.
 
-- **TEST-5:** Light E2E eligibility audit — migrated 19 test files (~197
-  tests) from full E2E to light E2E, raising the light-eligible count from
-  51 to 69 files. All migrated files have zero scheduler dependencies.
+### Correctness & testing
 
-- **SCAL-3:** Delta working-set memory cap — new GUC
-  `pg_trickle.delta_work_mem_cap_mb` (default 0 = disabled) caps the
-  `work_mem` that planner hints can set during delta MERGE. When the deep-join
-  or large-delta path would exceed the cap, the refresh falls back to FULL
-  automatically, preventing OOM on unexpectedly large deltas.
+- **TPC-H regression guard** — all 22 queries from the TPC-H industry
+  benchmark now run nightly against known-good expected output. If a code
+  change causes any query to return different results, CI fails immediately.
+  This catches subtle correctness regressions that targeted tests might miss.
 
-- **SCAL-1:** Buffer growth stress test — new `e2e_buffer_growth_tests.rs`
-  with 4 tests validating `max_buffer_rows` cap enforcement: FULL fallback
-  trigger, recovery to DIFFERENTIAL after burst, no-data-loss verification
-  with mixed DML, and sustained high write rate with auto-refresh.
+- **Mathematical proof of delta arithmetic** — 6 property-based tests
+  (2,000 random cases each) verify that the core engine's insert/delete
+  accounting is correct: operations compose in the right order, groups cancel
+  out properly, and no phantom rows appear after mixed workloads. An
+  additional 4 end-to-end property tests exercise the full pipeline from
+  change capture through to the final merged result.
 
-- **SCAL-2:** Scaling guide — new `docs/SCALING.md` documenting worker pool
-  sizing for 200+ stream tables, tiered scheduling, per-database quotas,
-  dispatch priority, monitoring queries, tuning profiles (low-latency,
-  high-throughput, resource-constrained), and profiling methodology.
+- **CDC edge case coverage** — new tests cover composite primary keys,
+  generated (computed) columns, NULL values in non-key columns, and domain
+  types — real-world schema patterns that were previously untested.
 
-- **CORR-4:** Z-set weight accounting proof — 6 proptest property tests (2000
-  cases each) in `src/refresh.rs` proving the Z-set weight algebra contract:
-  sequential equivalence, additivity (homomorphism), HAVING zero-cancellation,
-  multi-row independence (GROUP BY partitioning), DISTINCT ON keyed resolution,
-  and keyless generate_series expansion count.
+- **dbt integration tests** — the dbt adapter now has regression tests for
+  AUTO refresh mode, stream table health checks, and refresh history
+  lifecycle — ensuring the dbt workflow stays reliable across releases.
 
-- **TEST-4:** Property-based Z-set E2E tests — new
-  `e2e_property_zset_tests.rs` with 4 tests exercising the full CDC→weight
-  aggregation→MERGE pipeline: I/D cancellation (phantom rows), multi-update
-  coalescing, 3-source fan-in join, and weight storm (10-20 mixed ops/cycle).
+### Scalability
 
-### Verified
+- **Scaling guide** — a new `docs/SCALING.md` document covers how to
+  configure pg_trickle for large deployments (200+ stream tables), including
+  worker pool sizing, tiered scheduling, per-database quotas, and tuning
+  profiles for different workload types.
 
-- **STAB-1:** All production-path `.unwrap()` calls in `api.rs` and
-  `refresh.rs` were already eliminated in prior releases. No action needed.
+- **Buffer growth stress tests** — new tests verify that the
+  `max_buffer_rows` safety limit works correctly under sustained high write
+  rates, including automatic recovery back to incremental refresh after a
+  burst subsides.
 
-- **STAB-2 (Phase 1):** The `pg_cstr_to_str()` safe wrapper in
-  `src/dvm/parser/mod.rs` already covers all ~76 C-string conversion sites.
-  Zero remaining `CStr::from_ptr` calls outside the wrapper implementation.
+### Testing infrastructure
 
-- **CORR-5:** HAVING group depletion correction — verified via comprehensive
-  existing E2E test suite (`e2e_having_transition_tests.rs`) with 7 tests
-  covering threshold crossing up/down, oscillation, group migration, COUNT
-  conditions, multiple HAVING clauses, and complete group elimination.
+- **Faster CI on pull requests** — 19 additional test files (~197 tests)
+  were moved to the lightweight test runner that does not require building a
+  custom Docker image. Pull request CI is now faster without sacrificing
+  coverage.
 
-- **STAB-4:** Parallel worker orphaned resource cleanup — verified that the
-  existing `reap_dead_worker_jobs()` and `reconcile_parallel_state()` paths
-  handle job cancellation, shmem token correction, and job pruning. Temp tables
-  use `ON COMMIT DROP` (auto-cleaned by PostgreSQL). Advisory locks replaced
-  with row-level locks (PB1, auto-released on disconnect). Change buffer rows
-  are frontier-scoped (no double-counting risk).
-
-- **PERF-5:** Index hint generation for MERGE target — verified that
-  `apply_planner_hints()` already implements adaptive planner hints: seqscan
-  disabled for small deltas, nestloop disabled for medium deltas, work_mem and
-  join_collapse_limit adjusted for deep joins (5+ tables).
-
-- **PERF-3:** Zero-change branch elision — verified that `zero_change_oids`
-  HashSet is already collected in `execute_differential_refresh()`, populated
-  from the change count map, and passed through to LSN resolution where it
-  replaces snapshot predicates with `FALSE` for sources with zero changes.
-  12 reference sites across `refresh.rs` confirm complete implementation.
-
-- **STAB-5:** Upgrade chain test (0.16→0.17→0.18) — verified that the CI
-  upgrade matrix auto-discovers all adjacent pairs plus the full chain from
-  0.1.3→0.18.0. All 7 parameterized chain tests (L8–L14) cover function
-  parity, schema additions, event triggers, version consistency, and data
-  survival across upgrade hops.
-
-- **PERF-2:** Cost-based refresh strategy — verified that the full cost model
-  is already implemented: `estimate_cost_based_threshold()` queries last 10
-  DIFFERENTIAL + 5 FULL refreshes, `cost_model_prefers_full()` predicts
-  strategy with safety margin, `compute_adaptive_threshold()` adjusts per-ST
-  thresholds. 6+ unit tests, cold-start fallback, integrated into refresh path.
-
-- **TEST-2:** SQLancer crash-test oracle — verified that `e2e_sqlancer_tests.rs`
-  (965 lines, 5 tests) implements crash + equivalence + diff-vs-full oracles
-  with seeded LCG RNG. `sqlancer.yml` CI workflow runs weekly with 2000 cases
-  and supports manual dispatch with configurable seed/count.
-
-- **CORR-1:** Cross-source snapshot consistency — verified that both phases
-  are fully implemented: Phase 1 LSN watermark (`tick_watermark_enabled` GUC)
-  caps all change consumption per scheduler tick; Phase 2 declared refresh
-  groups (`pgt_refresh_groups` catalog, `create_refresh_group()` API) with
-  `REPEATABLE READ` isolation for convergence-point stream tables.
-
-- **PERF-4:** Columnar change tracking Phase 1 — verified that the CDC
-  triggers already produce per-column VARBIT `changed_cols` bitmasks for
-  every UPDATE row. The DVM scan operator filters out irrelevant UPDATE rows
-  (P2-5), and the aggregate operator detects value-only UPDATEs (A-2/P5)
-  using key-column masks. Always-on for keyed tables; no GUC needed.
-
-- **PERF-1 (B3-MERGE):** Z-set multi-source delta engine — verified that all
-  three pillars are already implemented: B3-1 zero-change branch elision
-  (`zero_change_oids` + FALSE predicate pruning), B3-2 merged-delta weight
-  aggregation (`build_weight_agg_using()` / `build_keyless_weight_agg()` with
-  `GROUP BY __pgt_row_id, SUM(weight) + HAVING <> 0`), and B3-3 diamond-flow
-  property tests (`e2e_diamond_tests.rs`). The weight aggregation wraps the
-  entire multi-source delta query, collapsing overlapping corrections from
-  simultaneous source changes into net I/D actions.
+- **Upgrade path tested** — the full upgrade chain from version 0.1.3
+  through every release up to 0.18.0 is verified automatically in CI,
+  including function availability, schema integrity, and data survival.
 
 ### Fixed
 
-- **CDC edge case tests:** Fixed generated column tests to use computed
-  expressions (`price * qty`) instead of referencing the generated column
-  directly (which is excluded from change buffers). Fixed NULL aggregate
-  test to use `SUM(COALESCE(bonus, 0))` to avoid known P2-2 SUM
-  NULL-transition edge case.
-
-- **Light E2E allowlist:** Removed 3 test files from the light E2E allowlist
-  that require `shared_preload_libraries` (error state, fuse, safety tests).
-  Gated prepared statement invalidation test with `#[cfg(not(feature =
-  "light-e2e"))]` since it depends on `CACHE_GENERATION` shared memory.
-
-- **Upgrade script:** Added `pg_trickle_hash` (non-STRICT), `cache_stats()`,
-  and `health_summary()` to the 0.17.0→0.18.0 upgrade migration. Upgrade
-  completeness check now passes.
+- **Upgrade script completeness** — the 0.17.0→0.18.0 upgrade migration now
+  includes all new and changed functions (`pg_trickle_hash`, `cache_stats()`,
+  `health_summary()`), so `ALTER EXTENSION pg_trickle UPDATE` works correctly.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # pg_trickle — Project Roadmap
 
-> **Last updated:** 2026-04-10
-> **Latest release:** 0.17.0 (2026-04-08)
-> **Current milestone:** v0.18.0 — Hardening & Delta Performance
+> **Last updated:** 2026-04-12
+> **Latest release:** 0.18.0 (2026-04-12)
+> **Current milestone:** v0.19.0 — PostgreSQL 17 Support
 
 For a concise description of what pg_trickle is and why it exists, read
 [ESSENCE.md](ESSENCE.md) — it explains the core problem (full `REFRESH
@@ -79,7 +79,7 @@ from the v0.1.x series to 1.0 and beyond.
 | v0.15.0 | External test suites & integration | ✅ Released |
 | v0.16.0 | Performance & refresh optimization | ✅ Released |
 | v0.17.0 | Query intelligence & stability | ✅ Released |
-| **v0.18.0** | **Hardening & delta performance** | **All 30/30 items complete** |
+| **v0.18.0** | **Hardening & delta performance** | **✅ Released** |
 | v0.19.0 | PostgreSQL 17 support | Planned |
 | v0.20.0 | PGlite proof of concept | Planned |
 | v0.21.0 | Core extraction (`pg_trickle_core`) | Planned |


### PR DESCRIPTION
## Release preparation for v0.18.0

Prepares the changelog and roadmap for the v0.18.0 release.

### Changes

- **Rewrote the v0.18.0 changelog for a non-technical audience** — replaced the
  internal ticket-oriented entries with plain-language descriptions organized into
  Highlights, Monitoring & dashboards, Correctness & testing, Scalability, Testing
  infrastructure, and Fixed sections. Follows the same style as the 0.17.0 and
  0.16.0 release notes.

- **Added new empty Unreleased section** at the top of CHANGELOG.md for
  post-release development.

- **Updated ROADMAP.md** — marked v0.18.0 as released (2026-04-12) and advanced
  the current milestone to v0.19.0.

### Release checklist

- [x] Version already bumped to 0.18.0 in Cargo.toml, pgtrickle-tui/Cargo.toml, META.json
- [x] Upgrade script `pg_trickle--0.17.0--0.18.0.sql` exists
- [x] `just check-version-sync` passes
- [x] PLAN_0_18_0.md: 30/30 items complete
- [x] Changelog rewritten for release
- [x] ROADMAP.md updated

### After merge

Tag `v0.18.0` on the merge commit to trigger the release workflow.
