### PR TITLE
fix: suppress false-positive semgrep code-scanning alerts for DDL Spi::run calls

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1991,9 +1991,10 @@ fn rebuild_row_id_index(
     .unwrap_or(None);
 
     if let Some(idx_name) = existing {
-        Spi::run(&format!("DROP INDEX IF EXISTS {idx_name}")).map_err(|e| {
-            PgTrickleError::SpiError(format!("Failed to drop old row_id index: {e}"))
-        })?;
+        Spi::run(&format!("DROP INDEX IF EXISTS {idx_name}")) // nosemgrep: rust.spi.run.dynamic-format — DROP INDEX DDL cannot be parameterized; idx_name is obtained from pg_index via ::regclass::text.
+            .map_err(|e| {
+                PgTrickleError::SpiError(format!("Failed to drop old row_id index: {e}"))
+            })?;
     }
 
     // Rebuild with the new INCLUDE clause
@@ -2054,12 +2055,14 @@ fn migrate_aux_columns(
     // Transition: __pgt_count
     if !old_needs_pgt_count && new_storage_needs_pgt_count && !new_needs_dual_count {
         Spi::run(&format!(
+            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count BIGINT NOT NULL DEFAULT 0",
             quoted_table
         ))
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
     } else if old_needs_pgt_count && !new_storage_needs_pgt_count && !new_needs_dual_count {
         Spi::run(&format!(
+            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count",
             quoted_table
         ))
@@ -2069,11 +2072,13 @@ fn migrate_aux_columns(
     // Transition: __pgt_count_l / __pgt_count_r
     if !old_needs_dual_count && new_needs_dual_count {
         Spi::run(&format!(
+            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count_l BIGINT NOT NULL DEFAULT 0",
             quoted_table
         ))
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
         Spi::run(&format!(
+            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count_r BIGINT NOT NULL DEFAULT 0",
             quoted_table
         ))
@@ -2081,6 +2086,7 @@ fn migrate_aux_columns(
         // Drop __pgt_count if it was there and no longer needed
         if old_needs_pgt_count {
             Spi::run(&format!(
+                // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
                 "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count",
                 quoted_table
             ))
@@ -2088,11 +2094,13 @@ fn migrate_aux_columns(
         }
     } else if old_needs_dual_count && !new_needs_dual_count {
         Spi::run(&format!(
+            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count_l",
             quoted_table
         ))
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
         Spi::run(&format!(
+            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count_r",
             quoted_table
         ))
@@ -2100,6 +2108,7 @@ fn migrate_aux_columns(
         // Add __pgt_count if newly needed
         if new_storage_needs_pgt_count {
             Spi::run(&format!(
+                // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
                 "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count BIGINT NOT NULL DEFAULT 0",
                 quoted_table
             ))
@@ -4273,7 +4282,7 @@ fn execute_manual_full_refresh(
     // Suppress user triggers during TRUNCATE + INSERT to prevent
     // spurious trigger invocations with wrong semantics.
     if has_triggers {
-        Spi::run(&format!("ALTER TABLE {quoted_table} DISABLE TRIGGER USER"))
+        Spi::run(&format!("ALTER TABLE {quoted_table} DISABLE TRIGGER USER")) // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
     }
 

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -4869,6 +4869,7 @@ pub fn execute_differential_refresh(
             );
             if ao_suppress
                 && let Err(e) = Spi::run(&format!(
+                    // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; ao_quoted_table uses manual double-quote escaping.
                     "ALTER TABLE {} DISABLE TRIGGER USER",
                     ao_quoted_table
                 ))
@@ -4890,6 +4891,7 @@ pub fn execute_differential_refresh(
 
             if ao_suppress
                 && let Err(e) = Spi::run(&format!(
+                    // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; ao_quoted_table uses manual double-quote escaping.
                     "ALTER TABLE {} ENABLE TRIGGER USER",
                     ao_quoted_table
                 ))


### PR DESCRIPTION
## Summary

Closes all 12 open GitHub code-scanning alerts for `semgrep.rust.spi.run.dynamic-format`.

All flagged call sites are DDL statements (`ALTER TABLE … ADD/DROP COLUMN`, `ALTER TABLE … DISABLE/ENABLE TRIGGER USER`, `DROP INDEX IF EXISTS`) that **cannot be parameterized** in PostgreSQL — the SQL grammar does not allow placeholders for identifiers or DDL keywords.

Every identifier used in the dynamic SQL is properly escaped:
- Table names use `quote_identifier()` from pgrx.
- The `ao_quoted_table` in `refresh.rs` uses manual double-quote escaping (`schema.replace('"', "\"\"")`).
- The index name in the `DROP INDEX` case is obtained from `pg_index` via `::regclass::text`, which is a catalog-controlled value.

The fix adds `// nosemgrep: rust.spi.run.dynamic-format` inline suppressions with a brief justification comment at each site, matching the pattern already established elsewhere in the codebase (e.g. line 4389 of `src/api/mod.rs`).

## Changed files

| File | Lines changed | What |
|------|---------------|------|
| `src/api/mod.rs` | ~13 | nosemgrep on `DROP INDEX`, 8× `ALTER TABLE ADD/DROP COLUMN`, `DISABLE TRIGGER USER` |
| `src/refresh.rs` | ~2 | nosemgrep on `DISABLE TRIGGER USER` and `ENABLE TRIGGER USER` in append-only path |

## Security review

These suppressions are safe because:
1. DDL statements do not support `$1` placeholders — parameterization is not possible here.
2. All object names are double-quoted using PostgreSQL identifier quoting, preventing SQL injection via schema/table names containing special characters.
3. The `__pgt_count*` column names are internal constants, not user-supplied.
4. The index name comes from `pg_index` catalog, not from user input.

## Testing

- `just fmt && just lint` — passes with zero warnings.
- No logic change; this is a comment-only suppression.
