### PR TITLE
fix: move nosemgrep comments to trailing position on SQL string lines

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2055,15 +2055,13 @@ fn migrate_aux_columns(
     // Transition: __pgt_count
     if !old_needs_pgt_count && new_storage_needs_pgt_count && !new_needs_dual_count {
         Spi::run(&format!(
-            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
-            "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count BIGINT NOT NULL DEFAULT 0",
+            "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count BIGINT NOT NULL DEFAULT 0", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             quoted_table
         ))
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
     } else if old_needs_pgt_count && !new_storage_needs_pgt_count && !new_needs_dual_count {
         Spi::run(&format!(
-            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
-            "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count",
+            "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             quoted_table
         ))
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
@@ -2072,44 +2070,38 @@ fn migrate_aux_columns(
     // Transition: __pgt_count_l / __pgt_count_r
     if !old_needs_dual_count && new_needs_dual_count {
         Spi::run(&format!(
-            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
-            "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count_l BIGINT NOT NULL DEFAULT 0",
+            "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count_l BIGINT NOT NULL DEFAULT 0", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             quoted_table
         ))
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
         Spi::run(&format!(
-            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
-            "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count_r BIGINT NOT NULL DEFAULT 0",
+            "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count_r BIGINT NOT NULL DEFAULT 0", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             quoted_table
         ))
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
         // Drop __pgt_count if it was there and no longer needed
         if old_needs_pgt_count {
             Spi::run(&format!(
-                // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
-                "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count",
+                "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
                 quoted_table
             ))
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
         }
     } else if old_needs_dual_count && !new_needs_dual_count {
         Spi::run(&format!(
-            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
-            "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count_l",
+            "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count_l", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             quoted_table
         ))
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
         Spi::run(&format!(
-            // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
-            "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count_r",
+            "ALTER TABLE {} DROP COLUMN IF EXISTS __pgt_count_r", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
             quoted_table
         ))
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
         // Add __pgt_count if newly needed
         if new_storage_needs_pgt_count {
             Spi::run(&format!(
-                // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
-                "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count BIGINT NOT NULL DEFAULT 0",
+                "ALTER TABLE {} ADD COLUMN IF NOT EXISTS __pgt_count BIGINT NOT NULL DEFAULT 0", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
                 quoted_table
             ))
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;

--- a/src/refresh.rs
+++ b/src/refresh.rs
@@ -4869,8 +4869,7 @@ pub fn execute_differential_refresh(
             );
             if ao_suppress
                 && let Err(e) = Spi::run(&format!(
-                    // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; ao_quoted_table uses manual double-quote escaping.
-                    "ALTER TABLE {} DISABLE TRIGGER USER",
+                    "ALTER TABLE {} DISABLE TRIGGER USER", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; ao_quoted_table uses manual double-quote escaping.
                     ao_quoted_table
                 ))
             {
@@ -4891,8 +4890,7 @@ pub fn execute_differential_refresh(
 
             if ao_suppress
                 && let Err(e) = Spi::run(&format!(
-                    // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; ao_quoted_table uses manual double-quote escaping.
-                    "ALTER TABLE {} ENABLE TRIGGER USER",
+                    "ALTER TABLE {} ENABLE TRIGGER USER", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; ao_quoted_table uses manual double-quote escaping.
                     ao_quoted_table
                 ))
             {


### PR DESCRIPTION
## Summary

Fixes the remaining 10 open code-scanning alerts from `semgrep.rust.spi.run.dynamic-format` that survived PR #486.

## Root cause

Semgrep suppression with `// nosemgrep` requires the comment to appear as a **trailing comment on the exact line number that semgrep flags**. In PR #486, the comments were placed as a standalone line *before* the SQL string literal inside the `format!()` arguments:

```rust
// Before (ineffective — comment is on a different line than what semgrep flags)
Spi::run(&format!(
    // nosemgrep: rust.spi.run.dynamic-format — ...
    "ALTER TABLE {} ADD COLUMN ...",
    quoted_table
))
```

Semgrep flags the line containing the string literal, not the `Spi::run` line, so the comment was one line too early.

## Fix

Move all 10 `// nosemgrep` comments to trailing position on the SQL string literal line:

```rust
// After (effective — comment is on the same line semgrep flags)
Spi::run(&format!(
    "ALTER TABLE {} ADD COLUMN ...", // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier.
    quoted_table
))
```

## Files changed

- `src/api/mod.rs` — 8 suppressions (ALTER TABLE ADD/DROP COLUMN for `__pgt_count*` transitions, DISABLE TRIGGER USER)
- `src/refresh.rs` — 2 suppressions (DISABLE/ENABLE TRIGGER USER in append-only path)

No logic changes whatsoever. `just fmt && just lint` passes with zero warnings.
