### PR TITLE
fix(ci): add scheduler_bench.rs stub to all Docker build stages

### DIFF
--- a/Dockerfile.ghcr
+++ b/Dockerfile.ghcr
@@ -78,6 +78,7 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '' > src/ivm.rs && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
+    echo 'fn main() {}' > benches/scheduler_bench.rs && \
     echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Pre-fetch dependencies. Docker caches this layer independently.

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -74,6 +74,7 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '' > src/ivm.rs && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
+    echo 'fn main() {}' > benches/scheduler_bench.rs && \
     echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Pre-fetch dependencies. Docker caches this layer independently.

--- a/cnpg/Dockerfile.ext-build
+++ b/cnpg/Dockerfile.ext-build
@@ -53,6 +53,7 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '' > src/ivm.rs && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
+    echo 'fn main() {}' > benches/scheduler_bench.rs && \
     echo 'fn main() {}' > pgtrickle-tui/src/main.rs && \
     cargo generate-lockfile && \
     cargo fetch

--- a/tests/Dockerfile.e2e
+++ b/tests/Dockerfile.e2e
@@ -44,6 +44,7 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo '' > src/ivm.rs && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
+    echo 'fn main() {}' > benches/scheduler_bench.rs && \
     echo 'fn main() {}' > pgtrickle-tui/src/main.rs
 
 # Pre-fetch all crates.  Cache mount keeps the registry between builds so


### PR DESCRIPTION
## Problem

All Docker-based CI jobs (E2E tests, DAG bench, dbt, CNPG smoke test) were
failing at the **"Build E2E Docker image"** step with:

```
error: failed to parse manifest at `/build/Cargo.toml`
```

Root cause: PR #495 added a new Criterion benchmark target to `Cargo.toml`:

```toml
[[bench]]
name = "scheduler_bench"
harness = false
```

All four Dockerfiles use a dependency-caching layer that creates minimal stub
files so `cargo fetch` can resolve crates without copying the full source tree.
That layer created stubs only for `refresh_bench.rs` and `diff_operators.rs`,
leaving `benches/scheduler_bench.rs` absent. Cargo validates that all declared
target source paths exist during manifest parsing, so it aborted with the
"failed to parse manifest" error before even downloading crates.

## Fix

Add `echo 'fn main() {}' > benches/scheduler_bench.rs` to the stub-creation
`RUN` step in all four Dockerfiles:

| File | Role |
|------|------|
| `tests/Dockerfile.e2e` | E2E / DAG bench / dbt CI jobs |
| `cnpg/Dockerfile.ext-build` | CNPG smoke test |
| `Dockerfile.ghcr` | GitHub Container Registry release image |
| `Dockerfile.hub` | Docker Hub release image |

## Testing

- `just fmt && just lint` pass with zero warnings.
- The fix is a purely additive one-liner in each Docker build stage; no logic
  or SQL changes are involved.
- CI will re-run the full matrix on this PR to confirm the Docker build
  succeeds.
