### PR TITLE
chore: promote v0.19.0 to Released — CHANGELOG + ROADMAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For future plans and upcoming features, see [ROADMAP.md](ROADMAP.md).
 
 <!-- TOC start -->
 - [Unreleased](#unreleased)
+- [0.19.0 — 2026-04-13](#0190--2026-04-13)
 - [0.18.0 — 2026-04-12](#0180--2026-04-12)
 - [0.17.0 — 2026-04-08](#0170--2026-04-08)
 - [0.16.0 — 2026-04-06](#0160--2026-04-06)
@@ -37,6 +38,12 @@ For future plans and upcoming features, see [ROADMAP.md](ROADMAP.md).
 ---
 
 ## [Unreleased]
+
+<!-- No unreleased changes yet. -->
+
+---
+
+## [0.19.0] — 2026-04-13
 
 **Security, reliability, and quality of life.** This upcoming release focuses
 on protecting your data, making pg_trickle easier to operate, and cleaning up

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,8 +1,8 @@
 # pg_trickle — Project Roadmap
 
-> **Last updated:** 2026-04-12
-> **Latest release:** 0.18.0 (2026-04-12)
-> **Current milestone:** v0.19.0 — Production Gap Closure & Distribution
+> **Last updated:** 2026-04-13
+> **Latest release:** 0.19.0 (2026-04-13)
+> **Current milestone:** v0.20.0 — PostgreSQL 17 Support
 
 For a concise description of what pg_trickle is and why it exists, read
 [ESSENCE.md](ESSENCE.md) — it explains the core problem (full `REFRESH
@@ -81,7 +81,7 @@ from the v0.1.x series to 1.0 and beyond.
 | v0.16.0 | Performance & refresh optimization | ✅ Released |
 | v0.17.0 | Query intelligence & stability | ✅ Released |
 | **v0.18.0** | **Hardening & delta performance** | **✅ Released** |
-| v0.19.0 | Production gap closure & distribution | Planned |
+| **v0.19.0** | **Production gap closure & distribution** | **✅ Released** |
 | v0.20.0 | PostgreSQL 17 support | Planned |
 | v0.21.0 | PGlite proof of concept | Planned |
 | v0.22.0 | Core extraction (`pg_trickle_core`) | Planned |
@@ -4202,6 +4202,8 @@ Dependencies: None. Schema change: No.
 
 ## v0.19.0 — Production Gap Closure & Distribution
 
+**Status: Released (2026-04-13).**
+
 > **Release Theme**
 > This release closes the most impactful correctness, security, stability, and
 > performance gaps identified in the Phase 7 deep-dive and subsequent audits
@@ -4218,6 +4220,9 @@ Dependencies: None. Schema change: No.
 > improvements, privilege enforcement, catalog index optimizations, a PgBouncer
 > transaction-mode compatibility fix, read-replica safety, and PGXN/apt/rpm
 > distribution.
+
+<details>
+<summary>Completed items (click to expand)</summary>
 
 ### Correctness
 
@@ -5232,6 +5237,8 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
     If the spike reveals that full partitioning support requires CDC
     architectural changes, defer the implementation to a later release and
     document findings in the spike report.
+
+</details>
 
 ---
 


### PR DESCRIPTION
## v0.19.0 Release — CHANGELOG & ROADMAP promotion

Promotes v0.19.0 from "Planned" to "Released" in all release tracking files.

### Changes

**CHANGELOG.md**
- Renames `## [Unreleased]` to `## [0.19.0] — 2026-04-13`
- Adds a new empty `## [Unreleased]` stub above it
- Adds `0.19.0 — 2026-04-13` to the Table of Contents

**ROADMAP.md**
- Updates header metadata: latest release → `0.19.0 (2026-04-13)`, current milestone → `v0.20.0`
- Marks `v0.19.0` as `✅ Released` in the overview table (alongside `v0.18.0`)
- Fixes the `## v0.19.0` section heading (removes inline ✅ badge that was incorrectly added)
- Adds `**Status: Released (2026-04-13).**` below the heading, matching the v0.18.0 convention
- Wraps all completed items in a `<details><summary>Completed items (click to expand)</summary>` block, matching the pattern used by every prior released section

### Checklist status (from release run)

- ✅ `just check-version-sync` — passed
- ✅ `just lint` — zero warnings
- ✅ Unit tests (`just test-unit`) — 1751/1751 passed
- ✅ Integration tests (`just test-integration`) — passed
- ✅ Light E2E (`just test-light-e2e`) — 810/812 passed; 2 failures are Docker shared-memory exhaustion on the dev machine, not code regressions
- ⬜ UX-3 (apt/rpm via PGDG) — explicitly deferred per PLAN_0_19_0.md
