### PR TITLE
fix(scheduler): remove LIMIT 1 from UNION ALL arms in has_table_source_changes (PERF-6 regression)

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -3942,17 +3942,13 @@ fn has_table_source_changes(st: &StreamTableMeta) -> bool {
     }
 
     // PERF-6: Build a single UNION ALL EXISTS query for all sources.
-    // Each arm is `SELECT 1 FROM <schema>.changes_<oid> LIMIT 1`.
-    // The outer EXISTS returns true if ANY source has pending rows.
+    // Note: LIMIT 1 is omitted from individual branches because
+    // `SELECT ... LIMIT 1 UNION ALL SELECT ...` is a syntax error in
+    // PostgreSQL (LIMIT binds at the top level, not per-branch).
+    // EXISTS already short-circuits on the first row found.
     let union_arms: Vec<String> = source_oids
         .iter()
-        .map(|oid| {
-            format!(
-                "SELECT 1 FROM {}.changes_{} LIMIT 1",
-                change_schema,
-                oid.to_u32(),
-            )
-        })
+        .map(|oid| format!("SELECT 1 FROM {}.changes_{}", change_schema, oid.to_u32(),))
         .collect();
     let batched_sql = format!("SELECT EXISTS({})", union_arms.join(" UNION ALL "));
 


### PR DESCRIPTION
## Summary

Fixes a regression introduced in PERF-6 (v0.19.0) that caused stream tables with multiple source tables to enter **ERROR state** immediately under the parallel scheduler.

## Root Cause

`has_table_source_changes()` was rewritten in PERF-6 to use a single batched `UNION ALL EXISTS` query. The implementation included `LIMIT 1` in each individual arm:

```sql
SELECT EXISTS(
  SELECT 1 FROM pgtrickle_changes.changes_12345 LIMIT 1
  UNION ALL
  SELECT 1 FROM pgtrickle_changes.changes_67890 LIMIT 1
)
```

`SELECT ... LIMIT 1 UNION ALL SELECT ...` is a **syntax error** in PostgreSQL — `LIMIT` binds to the outer query, not individual UNION arms. This is explicitly documented in the neighbouring `execute_differential_refresh()` function, which correctly avoided `LIMIT` in arms with the comment:

> "Note: LIMIT 1 is omitted from individual branches because `SELECT ... LIMIT 1 UNION ALL SELECT ...` is a syntax error in PostgreSQL (LIMIT binds at the top level, not per-branch)."

## Impact

**Serial scheduler**: The syntax error aborts the scheduler's `BackgroundWorker::transaction` silently each tick. `has_table_source_changes()` effectively always returns `false` for multi-source stream tables, so refreshes fall back to `NoData`. The affected serial E2E tests recovered via a 60-second manual-refresh fallback, masking the bug.

**Parallel scheduler**: The refresh worker runs inside its own `catch_unwind` boundary. The syntax error is caught, `classify_spi_error_retryable()` matches `"syntax error"` as non-retryable, and `set_error_state()` is called — putting any stream table with multiple source tables into **ERROR state on the very first scheduler tick**. This caused `test_mixed_sched_multiple_views_joined_parallel` to fail consistently.

## Fix

Remove `LIMIT 1` from the individual UNION ALL arms. `EXISTS` already short-circuits on the first row found, so `LIMIT` is unnecessary.

```sql
-- Before (broken):
SELECT EXISTS(
  SELECT 1 FROM schema.changes_A LIMIT 1
  UNION ALL
  SELECT 1 FROM schema.changes_B LIMIT 1
)

-- After (correct):
SELECT EXISTS(
  SELECT 1 FROM schema.changes_A
  UNION ALL
  SELECT 1 FROM schema.changes_B
)
```

## Test

```
test test_mixed_sched_multiple_views_joined_parallel ... ok

test result: ok. 1 passed; 0 failed
```
