### PR TITLE
fix(tests): fix four E2E test failures — ownership race, circular drop, composite version, FK cascade

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -311,7 +311,8 @@ CREATE INDEX IF NOT EXISTS idx_deps_pgt_id ON pgtrickle.pgt_dependencies (pgt_id
 -- Refresh history / audit log
 CREATE TABLE IF NOT EXISTS pgtrickle.pgt_refresh_history (
     refresh_id      BIGSERIAL PRIMARY KEY,
-    pgt_id           BIGINT NOT NULL,
+    pgt_id           BIGINT NOT NULL
+                     REFERENCES pgtrickle.pgt_stream_tables(pgt_id) ON DELETE CASCADE,
     data_timestamp  TIMESTAMPTZ NOT NULL,
     start_time      TIMESTAMPTZ NOT NULL,
     end_time        TIMESTAMPTZ,

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -839,6 +839,37 @@ impl E2eDb {
         }
     }
 
+    /// Execute `setup_sql` on a connection, then try `target_sql` and return its
+    /// result, then run `teardown_sql` unconditionally.  All three statements use
+    /// the **same** connection so session state (e.g. `SET ROLE`) is preserved.
+    ///
+    /// Use this instead of multi-statement strings passed to `try_execute`,
+    /// which sqlx rejects with "cannot insert multiple commands into a prepared
+    /// statement".
+    pub async fn try_execute_with_role(
+        &self,
+        setup_sql: &str,
+        target_sql: &str,
+        teardown_sql: &str,
+    ) -> Result<(), sqlx::Error> {
+        let mut conn = self
+            .pool
+            .acquire()
+            .await
+            .expect("Failed to acquire DB connection for try_execute_with_role");
+        sqlx::query(setup_sql)
+            .execute(&mut *conn)
+            .await
+            .unwrap_or_else(|e| panic!("setup SQL failed: {}\nSQL: {}", e, setup_sql));
+        let result = sqlx::query(target_sql)
+            .execute(&mut *conn)
+            .await
+            .map(|_| ());
+        // Always reset, even if target failed.
+        let _ = sqlx::query(teardown_sql).execute(&mut *conn).await;
+        result
+    }
+
     /// Reload PostgreSQL configuration and wait briefly for SIGHUP settings to apply.
     pub async fn reload_config_and_wait(&self) {
         self.execute("SELECT pg_reload_conf()").await;

--- a/tests/e2e_ownership_tests.rs
+++ b/tests/e2e_ownership_tests.rs
@@ -16,16 +16,18 @@ use e2e::E2eDb;
 
 /// Helper: create the two test roles and a source table owned by sec1_owner.
 async fn setup_ownership_test(db: &E2eDb) {
-    // Create roles
+    // Create roles — use EXCEPTION to handle the race where parallel tests try
+    // to create the same cluster-level role simultaneously.  IF NOT EXISTS inside
+    // a DO block is not atomic; we catch both duplicate_object (42710, role
+    // already exists) and unique_violation (23505, concurrent INSERT race).
     db.execute(
-        "DO $$ BEGIN \
-           IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'sec1_owner') THEN \
-             CREATE ROLE sec1_owner LOGIN; \
-           END IF; \
-           IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'sec1_other') THEN \
-             CREATE ROLE sec1_other LOGIN; \
-           END IF; \
-         END $$",
+        "DO $$ BEGIN CREATE ROLE sec1_owner LOGIN; \
+         EXCEPTION WHEN duplicate_object OR unique_violation THEN NULL; END $$",
+    )
+    .await;
+    db.execute(
+        "DO $$ BEGIN CREATE ROLE sec1_other LOGIN; \
+         EXCEPTION WHEN duplicate_object OR unique_violation THEN NULL; END $$",
     )
     .await;
 
@@ -57,12 +59,14 @@ async fn test_ownership_nonowner_drop_denied() {
     let db = E2eDb::new().await.with_extension().await;
     setup_ownership_test(&db).await;
 
-    // Attempt to drop as sec1_other (non-owner, non-superuser)
+    // Attempt to drop as sec1_other (non-owner, non-superuser).
+    // Use try_execute_with_role to run SET ROLE / target / RESET ROLE on the
+    // same connection (sqlx rejects multi-statement prepared statements).
     let result = db
-        .try_execute(
-            "SET ROLE sec1_other; \
-             SELECT pgtrickle.drop_stream_table('sec1_st'); \
-             RESET ROLE;",
+        .try_execute_with_role(
+            "SET ROLE sec1_other",
+            "SELECT pgtrickle.drop_stream_table('sec1_st')",
+            "RESET ROLE",
         )
         .await;
 
@@ -83,12 +87,13 @@ async fn test_ownership_nonowner_alter_denied() {
     let db = E2eDb::new().await.with_extension().await;
     setup_ownership_test(&db).await;
 
-    // Attempt to alter as sec1_other (non-owner, non-superuser)
+    // Attempt to alter as sec1_other (non-owner, non-superuser).
+    // Use try_execute_with_role to avoid multi-statement prepared-statement error.
     let result = db
-        .try_execute(
-            "SET ROLE sec1_other; \
-             SELECT pgtrickle.alter_stream_table('sec1_st', schedule => '30s'); \
-             RESET ROLE;",
+        .try_execute_with_role(
+            "SET ROLE sec1_other",
+            "SELECT pgtrickle.alter_stream_table('sec1_st', schedule => '30s')",
+            "RESET ROLE",
         )
         .await;
 

--- a/tests/e2e_property_circular_tests.rs
+++ b/tests/e2e_property_circular_tests.rs
@@ -417,6 +417,14 @@ async fn run_break_cycle_trace(seed: u64) {
         .await;
     db.execute("SELECT pg_reload_conf()").await;
     tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Break the cycle: the survivor still references drop_name, so ALTER it
+    // to remove that back-reference before we attempt the drop.
+    db.execute(&format!(
+        "SELECT pgtrickle.alter_stream_table('{survivor_name}', \
+         query => $$SELECT id, val FROM prop_brk_src$$)",
+    ))
+    .await;
     db.drop_st(drop_name).await;
 
     // The survivor must have scc_id cleared (no longer in a cycle).

--- a/tests/e2e_replica_guard_tests.rs
+++ b/tests/e2e_replica_guard_tests.rs
@@ -100,8 +100,6 @@ async fn test_replica_guard_recovery_function_available() {
 
     // Also verify the extension's version function works (sanity check
     // that the extension is loaded correctly on this primary)
-    let version: String = db
-        .query_scalar("SELECT (pgtrickle.version()).extension_version")
-        .await;
+    let version: String = db.query_scalar("SELECT pgtrickle.version()").await;
     assert!(!version.is_empty(), "Extension version should be non-empty");
 }


### PR DESCRIPTION
# fix(tests): fix four E2E test failures — ownership race, circular drop, composite version, FK cascade

Fixes four distinct E2E test failures found during the third iteration of `just test-e2e`. All 1217 tests now pass.

## Changes

### 1. `tests/e2e/mod.rs` — Add `try_execute_with_role()` helper

`sqlx` treats every query string as a prepared statement; PostgreSQL rejects prepared statements that contain multiple commands (semicolons). Tests that needed to `SET ROLE ... ; <SQL> ; RESET ROLE` could not use the existing `try_execute()` helper.

Added `try_execute_with_role(setup_sql, target_sql, teardown_sql)` which acquires a **single connection** from the pool, runs the setup statement unconditionally, executes the target returning `Result`, then runs teardown regardless of outcome — preserving session state without multi-statement strings.

### 2. `tests/e2e_ownership_tests.rs` — Fix ownership tests (two bugs)

**Bug A — multi-statement prepared statement:**  
`test_ownership_nonowner_drop_denied` and `test_ownership_nonowner_alter_denied` passed semicolon-delimited SQL (`SET ROLE ...; SELECT ...; RESET ROLE`) to `try_execute()` — rejected by sqlx as a prepared statement.  
**Fix:** use the new `try_execute_with_role()` helper.

**Bug B — parallel role-creation race (TOCTOU + `unique_violation`):**  
PostgreSQL roles are cluster-level. Parallel tests both racing to `CREATE ROLE sec1_owner` hit two distinct errors:
- `duplicate_object` (42710) when PostgreSQL detects the race at the application level
- `unique_violation` (23505) when two concurrent INSERTs race on `pg_authid`

Using `EXCEPTION WHEN duplicate_object THEN NULL` only caught the first case. Fixed by catching both with `EXCEPTION WHEN duplicate_object OR unique_violation THEN NULL`.

### 3. `tests/e2e_property_circular_tests.rs` — Fix `test_prop_break_cycle_clears_scc_ids` drop order

In the cycle `A → B` and `B → A`, randomly choosing to drop `B` failed because `A` still references `B` — same root cause as PR #499.

**Fix:** before dropping the chosen member, ALTER the survivor's query to remove the back-reference to the target, then drop.

### 4. `src/lib.rs` + `tests/e2e_replica_guard_tests.rs` — Two schema/test bugs

**Bug A — fresh-install schema missing FK constraint (DB-2):**  
The upgrade script `pg_trickle--0.18.0--0.19.0.sql` added `ON DELETE CASCADE` FK on `pgt_refresh_history.pgt_id` for existing installations, but the fresh-install DDL in `src/lib.rs` never included the constraint. `test_upgrade_refresh_history_fk_cascade` uses a fresh extension install and asserted cascade-deletion worked — it didn't.  
**Fix:** add `REFERENCES pgtrickle.pgt_stream_tables(pgt_id) ON DELETE CASCADE` inline on the `pgt_id` column in `lib.rs`.

**Bug B — wrong SQL in `test_replica_guard_recovery_function_available`:**  
`(pgtrickle.version()).extension_version` uses composite-field access syntax, but `pgtrickle.version()` returns `text`, not a composite type, causing "column notation applied to type text" error.  
**Fix:** use `SELECT pgtrickle.version()` directly.

## Test results

```
Summary [1513s] 1217 tests run: 1217 passed (10 slow), 99 skipped
```
