### PR TITLE
fix: prevent integer overflow in TPC-H datagen at SF-10

### DIFF
--- a/tests/tpch/datagen.sql
+++ b/tests/tpch/datagen.sql
@@ -148,8 +148,8 @@ SELECT
     -- Customers: use sparse key space (every 3rd customer has orders — matches TPC-H distribution)
     1 + ((i * 1013) % __SF_CUSTOMERS__) AS o_custkey,
     (ARRAY['O','F','P'])[1 + i % 3] AS o_orderstatus,
-    round((10000 + (i * 7919) % 500000)::numeric / 100, 2) AS o_totalprice,
-    DATE '1992-01-01' + ((i * 2609) % 2557)::int AS o_orderdate,  -- 7 years: 1992-01-01 to 1998-12-31
+    round((10000 + (i::bigint * 7919) % 500000)::numeric / 100, 2) AS o_totalprice,
+    DATE '1992-01-01' + ((i::bigint * 2609) % 2557)::int AS o_orderdate,  -- 7 years: 1992-01-01 to 1998-12-31
     (ARRAY['1-URGENT','2-HIGH','3-MEDIUM','4-NOT SPECIFIED','5-LOW'])[1 + i % 5] AS o_orderpriority,
     'Clerk#' || lpad((1 + i % 1000)::text, 9, '0') AS o_clerk,
     0 AS o_shippriority,
@@ -176,11 +176,11 @@ SELECT
     (ARRAY['A','N','R'])[1 + (o + ln) % 3] AS l_returnflag,
     (ARRAY['O','F'])[1 + (o + ln * 3) % 2] AS l_linestatus,
     -- shipdate: order date + 1..121 days
-    DATE '1992-01-01' + ((o * 2609) % 2557)::int + 1 + ((o * 3 + ln * 11) % 121) AS l_shipdate,
+    DATE '1992-01-01' + ((o::bigint * 2609) % 2557)::int + 1 + ((o * 3 + ln * 11) % 121) AS l_shipdate,
     -- commitdate: order date + 30..90 days
-    DATE '1992-01-01' + ((o * 2609) % 2557)::int + 30 + ((o * 7 + ln * 5) % 61) AS l_commitdate,
+    DATE '1992-01-01' + ((o::bigint * 2609) % 2557)::int + 30 + ((o * 7 + ln * 5) % 61) AS l_commitdate,
     -- receiptdate: shipdate + 1..30 days
-    DATE '1992-01-01' + ((o * 2609) % 2557)::int + 1 + ((o * 3 + ln * 11) % 121) + 1 + ((o + ln * 13) % 30) AS l_receiptdate,
+    DATE '1992-01-01' + ((o::bigint * 2609) % 2557)::int + 1 + ((o * 3 + ln * 11) % 121) + 1 + ((o + ln * 13) % 30) AS l_receiptdate,
     (ARRAY['DELIVER IN PERSON','COLLECT COD','NONE','TAKE BACK RETURN'])[1 + (o + ln) % 4] AS l_shipinstruct,
     (ARRAY['REG AIR','AIR','RAIL','SHIP','TRUCK','MAIL','FOB'])[1 + (o * 3 + ln) % 7] AS l_shipmode,
     'lineitem comment ' || o || '-' || ln AS l_comment


### PR DESCRIPTION
## Fix: Prevent integer overflow in TPC-H datagen SQL at SF-10

### Problem

`test_tpch_cross_query_consistency` failed with `integer out of range` error at SF-10 (Scale Factor 10.0), which generates 1,500,000 orders.

Root cause: PostgreSQL's `generate_series(1, N)` returns `integer` (int4) type. When multiplying by large constants (7919, 2609) for pseudo-random data generation, the result exceeds int4 range (max ~2.1 billion):
- `i * 7919` → max 11.8 billion at i=1,500,000 ✗
- `i * 2609` → max 3.9 billion at i=1,500,000 ✗

### Solution

Cast loop variables to `bigint` before large multiplications in:
- **orders table**: `o_totalprice` and `o_orderdate` 
- **lineitem table**: `l_shipdate`, `l_commitdate`, `l_receiptdate`

The result is then safely truncated via modulo operator (e.g., `% 500000`).

### Testing

- ✅ Verified fix is backward compatible (no schema changes)
- ✅ `just fmt && just lint` passes with zero warnings
- ✅ Arithmetic verified for all scale factors (SF 0.01 → 10.0)
