### PR TITLE
fix(tests): E2E stability — 30 s port retry + periodic scheduler nudge for circular fixpoint

### DIFF
--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -394,18 +394,18 @@ async fn shared_container() -> &'static SharedContainer {
 
             // Retry getting the mapped port — Docker's port-mapping metadata is
             // occasionally not yet published immediately after the "ready"
-            // log line, causing a transient `PortNotExposed` error.
+            // log line, causing a transient `PortNotExposed` error.  Use up to
+            // 30 attempts with a fixed 1-second gap (≤ 30 s total) so that
+            // even heavily-loaded Docker daemons (e.g. macOS Docker Desktop)
+            // have time to register the port before we give up.
             let port = {
                 let mut attempt = 0u32;
                 loop {
                     match container.get_host_port_ipv4(5432).await {
                         Ok(p) => break p,
-                        Err(e) if attempt < 5 => {
+                        Err(e) if attempt < 30 => {
                             attempt += 1;
-                            tokio::time::sleep(std::time::Duration::from_millis(
-                                500 * u64::from(attempt),
-                            ))
-                            .await;
+                            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
                             let _ = e; // suppress unused-variable warning
                         }
                         Err(e) => panic!("Failed to get mapped port after retries: {e}"),

--- a/tests/e2e_circular_tests.rs
+++ b/tests/e2e_circular_tests.rs
@@ -167,14 +167,24 @@ async fn test_circular_monotone_cycle_converges() {
     // direct-edge rows).  The transitive closure requires 2+ more iterations.
     // `last_fixpoint_iterations` is only set after all iterations converge, so
     // polling this column is the correct signal for data-correctness assertions.
+    //
+    // Nudge the scheduler periodically via pg_reload_conf() so that under
+    // Docker resource contention the background worker's latch is woken
+    // frequently enough to process the SCC fixpoint within the deadline.
     let fixpoint_converged = {
         let start = std::time::Instant::now();
-        let timeout = Duration::from_secs(300);
+        let timeout = Duration::from_secs(600);
+        let mut last_nudge = start;
         loop {
             if start.elapsed() > timeout {
                 break false;
             }
             tokio::time::sleep(Duration::from_millis(500)).await;
+            // Nudge every 5 seconds to wake a CPU-starved scheduler worker.
+            if last_nudge.elapsed() >= Duration::from_secs(5) {
+                db.nudge_launcher_rescan().await;
+                last_nudge = std::time::Instant::now();
+            }
             let done: bool = db
                 .query_scalar(
                     "SELECT EXISTS( \
@@ -191,7 +201,7 @@ async fn test_circular_monotone_cycle_converges() {
     };
     assert!(
         fixpoint_converged,
-        "fixpoint did not converge within 120s (last_fixpoint_iterations never set)"
+        "fixpoint did not converge within 600s (last_fixpoint_iterations never set)"
     );
 
     // Both STs should be ACTIVE after convergence


### PR DESCRIPTION
## Summary

Two E2E test stability fixes addressing flakiness observed under Docker Desktop load on macOS when running the full E2E suite (`max-threads = 4`).

## Changes

### 1. `tests/e2e/mod.rs` — Increase port-mapping retry budget to 30 s

PR #510 added a 5-attempt / 7.5-second retry loop around `get_host_port_ipv4`. Under sustained load (multiple consecutive E2E runs, 4 containers in parallel), Docker Desktop on macOS occasionally starts containers where port 5432 is never registered in the port-mapping API within that window.

Increasing to **30 attempts × 1 s** (≤ 30 s total) covers the long-tail cases where Docker's port proxy is slow to initialise. When port mapping genuinely fails (broken container), nextest's `retries = 2` mechanism starts a fresh process with a new container, which succeeds.

### 2. `tests/e2e_circular_tests.rs` — Periodic scheduler nudge in fixpoint wait

`test_circular_monotone_cycle_converges` failed under load because the pg_trickle background scheduler worker was CPU-starved by concurrent containers and did not complete the SCC fixpoint within the previous 300 s deadline. The test passed immediately (< 7 s) in isolation.

Changes:
- **Increase fixpoint timeout from 300 s to 600 s** to provide more headroom under Docker pressure.
- **Add a periodic `nudge_launcher_rescan()` call every 5 s** inside the wait loop. This sends SIGHUP via `pg_reload_conf()` + bumps the DAG version signal, waking the scheduler worker's latch even when it is waiting on a slow poll interval.
- **Fix stale error message** ("120s" → "600s") to match the actual timeout.

## Test Results

Three consecutive full E2E runs on this branch:
- Run 1: `1217 passed (10 slow, 1 flaky)` — getting_started port-mapping flake (TRY 2 in 3.7 s ✅)
- Run 2: `1217 passed (10 slow, 1 flaky)` — same pattern
- Run 3: `1217 passed (10 slow, 1 flaky)` — circular test now passes without flake ✅

- `just fmt` — ✅
- `just lint` — ✅ (zero warnings)
