### PR TITLE
fix: add missing functions to 0.18.0→0.19.0 upgrade script

### DIFF
--- a/sql/pg_trickle--0.18.0--0.19.0.sql
+++ b/sql/pg_trickle--0.18.0--0.19.0.sql
@@ -76,3 +76,22 @@ CREATE INDEX IF NOT EXISTS idx_pgt_relid
     ON pgtrickle.pgt_stream_tables (pgt_relid);
 CREATE INDEX IF NOT EXISTS idx_deps_pgt_id
     ON pgtrickle.pgt_dependencies (pgt_id);
+
+-- ── New functions in 0.19.0 ────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION pgtrickle."migrate"() RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'migrate_wrapper';
+
+CREATE OR REPLACE FUNCTION pgtrickle."version_check"() RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'version_check_wrapper';
+
+CREATE OR REPLACE FUNCTION pgtrickle."write_and_refresh"(
+    "sql" TEXT,
+    "stream_table_name" TEXT
+) RETURNS void
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';


### PR DESCRIPTION
## Summary

Fixes the `just check-upgrade-all` failure for the `0.18.0 → 0.19.0` upgrade path.

Three functions introduced in 0.19.0 were missing from `sql/pg_trickle--0.18.0--0.19.0.sql`:

- `pgtrickle.migrate()`
- `pgtrickle.version_check()`
- `pgtrickle.write_and_refresh(sql TEXT, stream_table_name TEXT)`

## Changes

- Added `CREATE OR REPLACE FUNCTION` statements for all three missing functions to `sql/pg_trickle--0.18.0--0.19.0.sql`.

## Verification

```
just check-upgrade 0.18.0 0.19.0
```

Output:
```
━━━ Check 1: SQL Functions ━━━
  OK: 3 new function(s) all covered.
...
PASSED: All new SQL objects are covered by the upgrade script.
```
