### PR TITLE
fix(tests): simplify soak test correctness verification logic

### DIFF
--- a/tests/e2e_soak_tests.rs
+++ b/tests/e2e_soak_tests.rs
@@ -305,98 +305,39 @@ async fn get_rss_kb(db: &E2eDb) -> Option<i64> {
 
 /// Verify stream table correctness by comparing contents to defining query.
 async fn verify_correctness(db: &E2eDb, st_name: &str) -> Result<(), String> {
-    verify_correctness_inner(db, st_name, false).await
-}
-
-/// Verify stream table correctness using a FULL refresh first.
-///
-/// A FULL refresh (TRUNCATE + INSERT) guarantees the stream table exactly
-/// matches the defining query, bypassing any incremental-maintenance drift.
-async fn verify_correctness_full(db: &E2eDb, st_name: &str) -> Result<(), String> {
-    verify_correctness_inner(db, st_name, true).await
-}
-
-async fn verify_correctness_inner(
-    db: &E2eDb,
-    st_name: &str,
-    force_full: bool,
-) -> Result<(), String> {
-    if force_full {
-        // Switch to FULL, refresh, then switch back to DIFFERENTIAL.
-        // FULL refresh is TRUNCATE + INSERT — guaranteed ground truth.
-        for attempt in 0u8..5 {
-            match db
-                .try_execute(&format!(
-                    "SELECT pgtrickle.alter_stream_table('{st_name}', refresh_mode => 'FULL')"
-                ))
-                .await
-            {
-                Ok(()) => break,
-                Err(_) if attempt < 4 => {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-                }
-                Err(e) => {
-                    return Err(format!("alter to FULL failed for {st_name}: {e}"));
-                }
-            }
-        }
-        for attempt in 0u8..5 {
-            match db
-                .try_execute(&format!(
-                    "SELECT pgtrickle.refresh_stream_table('{st_name}')"
-                ))
-                .await
-            {
-                Ok(()) => {
-                    if attempt < 4 {
-                        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-                        continue;
-                    }
-                    break;
-                }
-                Err(_) if attempt < 4 => {
-                    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-                }
-                Err(e) => {
-                    return Err(format!("FULL refresh failed for {st_name}: {e}"));
-                }
-            }
-        }
-        // Restore DIFFERENTIAL mode for subsequent soak cycles.
-        let _ = db
+    // Refresh first to ensure we're comparing against latest data.
+    //
+    // Retry up to 5 times with a short back-off because:
+    //   (a) The background worker may hold the catalog row lock, making
+    //       refresh_stream_table return RefreshSkipped (silently as Ok).  A
+    //       second call after the worker commits ensures a real refresh.
+    //   (b) A transient deadlock (cycles 162/167 pattern) can cause the
+    //       refresh to fail; retrying recovers without marking a false
+    //       correctness violation.
+    for attempt in 0u8..5 {
+        match db
             .try_execute(&format!(
-                "SELECT pgtrickle.alter_stream_table('{st_name}', refresh_mode => 'DIFFERENTIAL')"
+                "SELECT pgtrickle.refresh_stream_table('{st_name}')"
             ))
-            .await;
-    } else {
-        // DIFFERENTIAL refresh path (original logic).
-        // Retry up to 5 times with a short back-off because:
-        //   (a) The background worker may hold the catalog row lock, making
-        //       refresh_stream_table return RefreshSkipped (silently as Ok).  A
-        //       second call after the worker commits ensures a real refresh.
-        //   (b) A transient deadlock (cycles 162/167 pattern) can cause the
-        //       refresh to fail; retrying recovers without marking a false
-        //       correctness violation.
-        for attempt in 0u8..5 {
-            match db
-                .try_execute(&format!(
-                    "SELECT pgtrickle.refresh_stream_table('{st_name}')"
-                ))
-                .await
-            {
-                Ok(()) => {
-                    if attempt < 4 {
-                        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-                        continue;
-                    }
-                    break;
+            .await
+        {
+            Ok(()) => {
+                // Succeeded — but this might have been a silent RefreshSkipped
+                // (background worker still running).  Sleep briefly and retry
+                // once more to give the worker a chance to commit and allow a
+                // real catch-up refresh on the next iteration.
+                if attempt < 4 {
+                    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+                    continue;
                 }
-                Err(e) if attempt < 4 => {
-                    eprintln!("  [verify_correctness] retry {attempt}: {e}");
-                    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-                }
-                Err(e) => return Err(format!("refresh failed for {st_name}: {e}")),
+                break;
             }
+            Err(e) if attempt < 4 => {
+                // Transient failure (deadlock / lock timeout): wait and retry.
+                eprintln!("  [verify_correctness] retry {attempt}: {e}");
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+            }
+            Err(e) => return Err(format!("refresh failed for {st_name}: {e}")),
         }
     }
 
@@ -582,23 +523,8 @@ async fn test_soak_stability() {
             println!("  [{elapsed}s] Running correctness check...");
             for st in &active_sts {
                 if let Err(e) = verify_correctness(&db, st).await {
-                    if *st == "soak_join" {
-                        // Known TOCTOU limitation: many-to-many JOIN under
-                        // concurrent DML can accumulate phantom rows during
-                        // DIFFERENTIAL refresh.  The race occurs because
-                        // get_slot_positions() captures the frontier LSN in
-                        // one SPI call, but the MERGE reads the source table
-                        // (R₁) with a potentially newer READ COMMITTED
-                        // snapshot.  R₁ can see source changes beyond the
-                        // frontier that ΔR does not include, producing an
-                        // error term ΔL ⋈ ΔR_extra that accumulates across
-                        // cycles.  The final correctness check uses a FULL
-                        // refresh to verify ground-truth equality.
-                        println!("  [{elapsed}s] KNOWN JOIN DRIFT (ignored): {e}");
-                    } else {
-                        println!("  [{elapsed}s] CORRECTNESS FAIL: {e}");
-                        health_check_failures.push(format!("[{elapsed}s] {e}"));
-                    }
+                    println!("  [{elapsed}s] CORRECTNESS FAIL: {e}");
+                    health_check_failures.push(format!("[{elapsed}s] {e}"));
                 }
             }
             last_correctness = Instant::now();
@@ -616,12 +542,10 @@ async fn test_soak_stability() {
     println!("  Total DML operations: {total_dml_ops}");
     println!("  Total refreshes: {total_refreshes}");
 
-    // Final correctness check — uses FULL refresh (TRUNCATE + INSERT)
-    // to guarantee ground-truth equality, bypassing any incremental drift
-    // from the TOCTOU race in many-to-many join DIFFERENTIAL refresh.
-    println!("\n  Final correctness verification (FULL refresh)...");
+    // Final correctness check
+    println!("\n  Final correctness verification...");
     for st in &active_sts {
-        match verify_correctness_full(&db, st).await {
+        match verify_correctness(&db, st).await {
             Ok(()) => println!("    {st}: ✓"),
             Err(e) => {
                 println!("    {st}: FAIL — {e}");


### PR DESCRIPTION
# fix(tests): simplify soak test correctness verification logic

## Summary

Remove `verify_correctness_full()` and the special-case "KNOWN JOIN DRIFT" handling for the `soak_join` stream table. All stream tables now use the same differential refresh path for both periodic and final correctness checks.

## What Changed

- Merged `verify_correctness_full()` and `verify_correctness_inner()` back into `verify_correctness()`
- Removed the `force_full` parameter and the FULL-refresh mode-switch/restore logic
- Removed the `if *st == "soak_join"` guard that was logging "KNOWN JOIN DRIFT (ignored)"
- Final correctness check now calls `verify_correctness()` uniformly for all stream tables

## Why

The previous code worked around a known TOCTOU limitation in many-to-many JOIN differential refresh by:
1. Silently ignoring periodic `soak_join` correctness failures
2. Switching to FULL refresh (TRUNCATE + INSERT) only for the final check

This approach had two problems:
- **Masked regressions**: If the DVM engine accumulated join drift due to a real bug, the soak test would not catch it during intermediate checks
- **Diverged test behavior**: The final assertion used a different refresh mode than the rest of the test, making it a weaker signal

The soak test should apply the same correctness standard throughout. If `soak_join` fails differential-refresh correctness, the fix should go in `src/dvm/` — not in the test harness.

## Risk

If the TOCTOU race in many-to-many join differential refresh is still present, `test_soak_stability` may fail on `soak_join`. That would be a true positive indicating a correctness bug to fix in the engine.

## Checklist

- ✅ `just fmt` passes
- ✅ `just lint` passes (zero warnings)
- ✅ No logic changes to pg_trickle core
