### PR TITLE
ci: move TPC-H nightly to separate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@
 #   push → main    : + light E2E tests, + coverage upload
 #   Weekly (Mon)   : full unit matrix (Linux + macOS), E2E, dbt, CNPG smoke
 #   Manual         : all jobs, all platforms (including Windows + benchmarks)
+#
+# TPC-H nightly (TEST-10) is in tpch-nightly.yml — it can take up to 3–5 h
+# and must not block PRs or push-to-main gating.
 # =============================================================================
 name: CI
 
@@ -928,39 +931,6 @@ jobs:
 
           echo "CNPG smoke test passed!"
 
-  # ── TEST-10: TPC-H nightly at SF-1 and SF-10 ──────────────────────────
-  # Runs TPC-H correctness tests at higher scale factors to catch issues
-  # that only manifest with larger datasets (hash collisions, sort spill,
-  # parallel execution). SF-10 also serves as a performance soak test.
-  tpch-nightly:
-    name: TPC-H nightly (${{ matrix.scale }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    needs: [e2e-tests]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - scale: "SF-1"
-            tpch_scale: "1.0"
-            tpch_cycles: "3"
-          - scale: "SF-10"
-            tpch_scale: "10.0"
-            tpch_cycles: "2"
-    steps:
-      - uses: actions/checkout@v5
-
-      - name: Setup pgrx environment
-        uses: ./.github/actions/setup-pgrx
-
-      - name: Build E2E Docker image
-        run: ./tests/build_e2e_image.sh
-
-      - name: Run TPC-H at ${{ matrix.scale }}
-        env:
-          TPCH_SCALE: ${{ matrix.tpch_scale }}
-          TPCH_CYCLES: ${{ matrix.tpch_cycles }}
-        run: |
-          cargo nextest run --profile ci --test e2e_tpch_tests \
-            --run-ignored all --no-capture
+  # TEST-10 (TPC-H nightly SF-1 + SF-10) has been moved to
+  # .github/workflows/tpch-nightly.yml because it can exceed 120 min and
+  # must not block the ci.yml gate.

--- a/.github/workflows/tpch-nightly.yml
+++ b/.github/workflows/tpch-nightly.yml
@@ -1,0 +1,77 @@
+# =============================================================================
+# TPC-H Nightly — TEST-10: correctness at SF-1 and SF-10
+#
+# Separated from ci.yml because these jobs can take up to ~3 hours each and
+# must not block PRs or push-to-main gating.  They run daily and on manual
+# dispatch, matching the pattern established by stability-tests.yml.
+#
+#   SF-1  (600K lineitem rows, 3 cycles): timeout 180 min
+#   SF-10 (6M lineitem rows,  2 cycles): timeout 300 min
+# =============================================================================
+name: TPC-H Nightly
+
+on:
+  schedule:
+    - cron: '0 5 * * *'  # Daily 05:00 UTC (after ci.yml at 03:00)
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  NEXTEST_PROFILE: ci
+  PG_VERSION: "18"
+
+jobs:
+  # ── TEST-10: TPC-H nightly at SF-1 and SF-10 ─────────────────────────
+  # Runs TPC-H correctness tests at higher scale factors to catch issues
+  # that only manifest with larger datasets (hash collisions, sort spill,
+  # parallel execution). SF-10 also serves as a performance soak test.
+  tpch-nightly:
+    name: TPC-H nightly (${{ matrix.scale }})
+    runs-on: ubuntu-latest
+    timeout-minutes: ${{ matrix.timeout_minutes }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - scale: "SF-1"
+            tpch_scale: "1.0"
+            tpch_cycles: "3"
+            timeout_minutes: 180
+          - scale: "SF-10"
+            tpch_scale: "10.0"
+            tpch_cycles: "2"
+            timeout_minutes: 300
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup pgrx environment
+        uses: ./.github/actions/setup-pgrx
+
+      - name: Build E2E Docker image
+        run: ./tests/build_e2e_image.sh
+
+      - name: Run TPC-H at ${{ matrix.scale }}
+        env:
+          TPCH_SCALE: ${{ matrix.tpch_scale }}
+          TPCH_CYCLES: ${{ matrix.tpch_cycles }}
+        run: |
+          cargo nextest run --profile ci --test e2e_tpch_tests \
+            --run-ignored all --no-capture
+
+  # ── Final gate ────────────────────────────────────────────────────────
+  check:
+    name: TPC-H nightly gate
+    runs-on: ubuntu-latest
+    needs: [tpch-nightly]
+    if: always()
+    steps:
+      - name: Fail if any TPC-H job failed
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One or more TPC-H nightly jobs failed:"
+          echo "  tpch-nightly: ${{ needs.tpch-nightly.result }}"
+          exit 1


### PR DESCRIPTION
## Summary

Move TPC-H nightly tests (TEST-10, SF-1 and SF-10) to a dedicated workflow following the pattern established by `stability-tests.yml`. The TPC-H jobs can take 60–300 minutes depending on scale and were timing out at the 120-minute `ci.yml` limit, blocking the entire workflow.

## Changes

- **New:** `.github/workflows/tpch-nightly.yml`
  - Runs on daily schedule (05:00 UTC, after ci.yml at 03:00) and on manual dispatch
  - SF-1 job: 180-minute timeout, 3 cycles
  - SF-10 job: 300-minute timeout, 2 cycles
  - Uses per-matrix `timeout_minutes` (GitHub Actions supports via `${{ matrix.timeout_minutes }}`)
  - Includes final `check` gate job following stability-tests.yml convention

- **Modified:** `.github/workflows/ci.yml`
  - Remove `tpch-nightly` job entirely
  - Update header comment to note TEST-10 is in `tpch-nightly.yml`
  - Replace job with a brief comment at the end

## Testing

No new tests needed — this is a workflow refactor. Existing TPC-H tests remain unchanged.

## Notes

- SF-1 expected ~60–180 min (empirical basis: DI-10 planning); 180 min timeout provides headroom
- SF-10 expected up to ~5 hours; 300 min timeout accommodates slower systems
- Schedule is 05:00 UTC (staggered 2 hours after ci.yml daily run) to avoid resource contention
- Both workflows can be triggered independently via `gh workflow run` or the Actions UI
