### PR TITLE
ci(release): skip publish-docker-hub when DOCKERHUB secrets are absent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -479,6 +479,7 @@ jobs:
   publish-docker-hub:
     name: Publish Docker Hub image
     needs: [build-release, test-release]
+    if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Summary

The release workflow introduced in v0.19.0 (UX-2) publishes Docker images to Docker Hub. The `publish-docker-hub` job currently fails if the repository secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are not configured. This change gracefully skips the job when these secrets are absent, allowing releases to proceed without the Docker Hub publish step.

## Changes

- Added conditional skip to `publish-docker-hub` job: `if: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}`
- Allows releases on repositories without Docker Hub credentials configured

## Testing

- No functional changes to the extension itself
- The workflow will be tested on the next release tag

## Notes

To enable Docker Hub publishing on future releases, repository admins must add `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to the repository settings.
