### PR TITLE
fix(dog-feeding): COALESCE aux-sum injectors; fix GUC and INSERT tests

### DIFF
--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -1855,8 +1855,12 @@ pub fn inject_avg_aux(query: &str, avg_aux_columns: &[(String, String, String)])
     if let Some(pos) = find_top_level_keyword(query, "FROM") {
         let mut extra = String::new();
         for (sum_col, count_col, arg_sql) in avg_aux_columns {
+            // COALESCE ensures the NOT NULL aux-sum column receives 0 rather
+            // than NULL when every row in a group has a NULL expression value
+            // (e.g. NULLIF returning NULL for all rows).  COUNT already
+            // returns 0 for zero non-NULL values, so no COALESCE needed there.
             extra.push_str(&format!(
-                ", SUM({arg_sql}) AS {}, COUNT({arg_sql}) AS {}",
+                ", COALESCE(SUM({arg_sql}), 0) AS {}, COUNT({arg_sql}) AS {}",
                 quote_identifier(sum_col),
                 quote_identifier(count_col),
             ));
@@ -1879,8 +1883,9 @@ pub fn inject_sum2_aux(query: &str, sum2_aux_columns: &[(String, String)]) -> St
     if let Some(pos) = find_top_level_keyword(query, "FROM") {
         let mut extra = String::new();
         for (sum2_col, arg_sql) in sum2_aux_columns {
+            // COALESCE guards against NULL (e.g. when arg_sql is NULL for all rows).
             extra.push_str(&format!(
-                ", SUM(({arg_sql}) * ({arg_sql})) AS {}",
+                ", COALESCE(SUM(({arg_sql}) * ({arg_sql})), 0) AS {}",
                 quote_identifier(sum2_col),
             ));
         }
@@ -1933,6 +1938,8 @@ pub fn inject_covar_aux(query: &str, covar_aux_columns: &[(String, String)]) -> 
     if let Some(pos) = find_top_level_keyword(query, "FROM") {
         let mut extra = String::new();
         for (col_name, arg_sql) in covar_aux_columns {
+            // COALESCE guards each SUM against NULL when all values in a group
+            // are NULL (e.g. NULL arguments to CORR/COVAR/REGR_*).
             let expr = if col_name.starts_with("__pgt_aux_sumxy_") {
                 // arg_sql is "x_expr|y_expr"
                 let parts: Vec<&str> = arg_sql.splitn(2, '|').collect();
@@ -1941,14 +1948,14 @@ pub fn inject_covar_aux(query: &str, covar_aux_columns: &[(String, String)]) -> 
                 } else {
                     (arg_sql.as_str(), arg_sql.as_str())
                 };
-                format!("SUM(({x}) * ({y}))")
+                format!("COALESCE(SUM(({x}) * ({y})), 0)")
             } else if col_name.starts_with("__pgt_aux_sumx2_")
                 || col_name.starts_with("__pgt_aux_sumy2_")
             {
-                format!("SUM(({arg_sql}) * ({arg_sql}))")
+                format!("COALESCE(SUM(({arg_sql}) * ({arg_sql})), 0)")
             } else {
                 // sumx_ or sumy_ — simple SUM
-                format!("SUM({arg_sql})")
+                format!("COALESCE(SUM({arg_sql}), 0)")
             };
             extra.push_str(&format!(", {} AS {}", expr, quote_identifier(col_name)));
         }

--- a/tests/e2e_dog_feeding_tests.rs
+++ b/tests/e2e_dog_feeding_tests.rs
@@ -607,11 +607,13 @@ async fn test_auto_apply_initiated_by_dog_feed() {
     db.refresh_st("user_st").await;
 
     // Insert a DOG_FEED audit row directly to test CHECK constraint.
+    // data_timestamp is NOT NULL in pgt_refresh_history (used for
+    // ST-on-ST cascade logic); use now() as a stand-in for a SKIP row.
     db.execute(
         "INSERT INTO pgtrickle.pgt_refresh_history \
-         (pgt_id, start_time, action, status, delta_row_count, \
+         (pgt_id, data_timestamp, start_time, action, status, delta_row_count, \
           rows_inserted, initiated_by, error_message) \
-         SELECT pgt_id, now(), 'SKIP', 'COMPLETED', 0, 0, 'DOG_FEED', \
+         SELECT pgt_id, now(), now(), 'SKIP', 'COMPLETED', 0, 0, 'DOG_FEED', \
                 'auto_threshold 0.10 → 0.15' \
          FROM pgtrickle.pgt_stream_tables WHERE pgt_name = 'user_st'",
     )
@@ -637,24 +639,23 @@ async fn test_auto_apply_guc_values() {
     let db = E2eDb::new().await.with_extension().await;
 
     // Test all valid GUC values.
-    db.execute("SET pg_trickle.dog_feeding_auto_apply = 'off'")
-        .await;
+    // Use set_config() which sets the GUC and returns its new value in a
+    // single round-trip, avoiding connection-pool ambiguity (SET on one
+    // backend is not visible to a SHOW on a different backend).
     let v1: String = db
-        .query_scalar("SHOW pg_trickle.dog_feeding_auto_apply")
+        .query_scalar("SELECT set_config('pg_trickle.dog_feeding_auto_apply', 'off', false)")
         .await;
     assert_eq!(v1, "off");
 
-    db.execute("SET pg_trickle.dog_feeding_auto_apply = 'threshold_only'")
-        .await;
     let v2: String = db
-        .query_scalar("SHOW pg_trickle.dog_feeding_auto_apply")
+        .query_scalar(
+            "SELECT set_config('pg_trickle.dog_feeding_auto_apply', 'threshold_only', false)",
+        )
         .await;
     assert_eq!(v2, "threshold_only");
 
-    db.execute("SET pg_trickle.dog_feeding_auto_apply = 'full'")
-        .await;
     let v3: String = db
-        .query_scalar("SHOW pg_trickle.dog_feeding_auto_apply")
+        .query_scalar("SELECT set_config('pg_trickle.dog_feeding_auto_apply', 'full', false)")
         .await;
     assert_eq!(v3, "full");
 }


### PR DESCRIPTION
## Summary

Fixes 4 failing E2E tests in `e2e_dog_feeding_tests` that were introduced with
the v0.20.0 dog-feeding feature (#525). Two bugs were in production code; two
were in the tests themselves.

## Changes

### `src/api/helpers.rs` — COALESCE on aux-sum injection

`inject_avg_aux`, `inject_sum2_aux`, and `inject_covar_aux` generated bare
`SUM(expr)` SQL expressions. When all rows in a GROUP BY group yield a NULL
expression value — for example `NULLIF(rows_inserted + rows_deleted, 0)` when
both are 0 (as in every INITIAL populate record) — `SUM(NULL)` evaluates to
`NULL`. This violated the `NOT NULL DEFAULT 0` constraint on the
`__pgt_aux_sum_*` storage columns, causing the `df_efficiency_rolling` refresh
to error with:

```
null value in column "__pgt_aux_sum_avg_change_ratio" of relation
"df_efficiency_rolling" violates not-null constraint
```

**Fix:** wrap every `SUM(...)` in these three injectors with `COALESCE(..., 0)`.

### `tests/e2e_dog_feeding_tests.rs` — `test_auto_apply_guc_values`

`SET pg_trickle.dog_feeding_auto_apply = 'threshold_only'` and the subsequent
`SHOW` were dispatched to different backend connections by the sqlx connection
pool, making the GUC change invisible to the SHOW. The test reliably reported
`"off"` instead of `"threshold_only"`.

**Fix:** replace `execute()` + `query_scalar("SHOW …")` with a single
`query_scalar("SELECT set_config(…)")` call, which sets and returns the new
value atomically in one round-trip.

### `tests/e2e_dog_feeding_tests.rs` — `test_auto_apply_initiated_by_dog_feed`

The raw INSERT into `pgtrickle.pgt_refresh_history` omitted the `data_timestamp`
column, which is `NOT NULL`.

**Fix:** add `data_timestamp = now()` to the column list.

## Testing

All four previously failing tests now pass:

- `e2e_dog_feeding_tests::test_auto_apply_guc_values`
- `e2e_dog_feeding_tests::test_auto_apply_initiated_by_dog_feed`
- `e2e_dog_feeding_tests::test_anomaly_signals_detects_spikes`
- `e2e_dog_feeding_tests::test_cdc_health_no_false_alerts_for_df_sts`

`just fmt && just lint` passes with zero warnings.
