### PR TITLE
fix: add idx_hist_pgt_start DDL, fix UNION syntax and scheduler_overhead CTE

### DIFF
--- a/src/api/dog_feeding.rs
+++ b/src/api/dog_feeding.rs
@@ -449,12 +449,24 @@ fn scheduler_overhead_impl() -> Result<
     )>,
     PgTrickleError,
 > {
+    // Use a flat subquery instead of a CTE to avoid potential pgrx SPI
+    // issues with CTE materialization in certain execution contexts.
     Spi::connect(|client| {
         let result = client
             .select(
-                "WITH stats AS (
+                "SELECT
+                    total_refs,
+                    df_refs,
+                    CASE WHEN total_refs > 0
+                         THEN df_refs::float8 / total_refs::float8
+                         ELSE NULL END AS df_fraction,
+                    avg_ms,
+                    avg_df_ms,
+                    total_s,
+                    df_total_s
+                 FROM (
                     SELECT
-                        count(*) AS total_refreshes,
+                        count(*)::bigint AS total_refs,
                         count(*) FILTER (
                             WHERE EXISTS (
                                 SELECT 1 FROM pgtrickle.pgt_stream_tables st
@@ -462,9 +474,9 @@ fn scheduler_overhead_impl() -> Result<
                                   AND st.pgt_schema = 'pgtrickle'
                                   AND st.pgt_name LIKE 'df_%'
                             )
-                        ) AS df_refreshes,
-                        avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000) AS avg_ms,
-                        avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000) FILTER (
+                        )::bigint AS df_refs,
+                        avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000.0) AS avg_ms,
+                        avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000.0) FILTER (
                             WHERE EXISTS (
                                 SELECT 1 FROM pgtrickle.pgt_stream_tables st
                                 WHERE st.pgt_id = h.pgt_id
@@ -484,18 +496,7 @@ fn scheduler_overhead_impl() -> Result<
                     FROM pgtrickle.pgt_refresh_history h
                     WHERE h.status = 'COMPLETED'
                       AND h.start_time > now() - interval '1 hour'
-                )
-                SELECT
-                    total_refreshes,
-                    df_refreshes,
-                    CASE WHEN total_refreshes > 0
-                         THEN df_refreshes::float / total_refreshes
-                         ELSE NULL END,
-                    avg_ms,
-                    avg_df_ms,
-                    total_s,
-                    df_total_s
-                FROM stats",
+                 ) sub",
                 None,
                 &[],
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,8 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_refresh_history (
 );
 
 CREATE INDEX IF NOT EXISTS idx_hist_pgt_ts ON pgtrickle.pgt_refresh_history (pgt_id, data_timestamp);
+-- PERF-1: Fast lookup by (pgt_id, start_time) for dog-feeding and scheduler_overhead queries.
+CREATE INDEX IF NOT EXISTS idx_hist_pgt_start ON pgtrickle.pgt_refresh_history (pgt_id, start_time);
 
 -- Per-source CDC slot tracking
 CREATE TABLE IF NOT EXISTS pgtrickle.pgt_change_tracking (

--- a/tests/e2e_dog_feeding_tests.rs
+++ b/tests/e2e_dog_feeding_tests.rs
@@ -590,11 +590,10 @@ async fn test_scheduling_interference_detects_overlap() {
     db.refresh_st("pgtrickle.df_scheduling_interference").await;
 
     // The interference table should exist and be queryable.
+    // Use EXISTS rather than LIMIT … UNION ALL which is invalid PostgreSQL syntax
+    // (LIMIT before UNION requires parentheses around the first SELECT).
     let queryable: bool = db
-        .query_scalar(
-            "SELECT true FROM pgtrickle.df_scheduling_interference LIMIT 1 \
-             UNION ALL SELECT true LIMIT 1",
-        )
+        .query_scalar("SELECT EXISTS (SELECT 1 FROM pgtrickle.df_scheduling_interference)")
         .await;
     assert!(
         queryable,


### PR DESCRIPTION
## Summary

Fixes three E2E CI failures in dog-feeding test suite:
- Missing `idx_hist_pgt_start` index in fresh-install DDL caused test_refresh_history_index_on_pgt_id_start_time to fail
- Invalid PostgreSQL syntax in test_scheduling_interference_detects_overlap (LIMIT before UNION requires parentheses)
- CTE materialization issue in scheduler_overhead_impl causing silent error and total_refreshes_1h=0 fallback

## Changes

- **src/lib.rs**: Add missing `idx_hist_pgt_start` index on `pgtrickle.pgt_refresh_history (pgt_id, start_time)` to fresh-install DDL. The index existed in migration SQL but was absent from the `extension_sql!` block used for new installs.

- **tests/e2e_dog_feeding_tests.rs**: Replace invalid PostgreSQL syntax `SELECT true FROM ... LIMIT 1 UNION ALL SELECT true LIMIT 1` with `SELECT EXISTS (SELECT 1 FROM pgtrickle.df_scheduling_interference)` in test_scheduling_interference_detects_overlap.

- **src/api/dog_feeding.rs**: Rewrite `scheduler_overhead_impl` to replace CTE (`WITH stats AS (...)`) with flat subquery (`FROM (...) sub`). The CTE had a potential pgrx 0.17 SPI materialization issue that silently returned Err, causing the function to fall back to total_refreshes_1h=0.

## Testing

All three failing tests now pass:
- test_refresh_history_index_on_pgt_id_start_time ✓
- test_scheduler_overhead_returns_valid_row ✓  
- test_scheduling_interference_detects_overlap ✓

Format and lint checks pass:
- `just fmt` — no changes needed
- `just lint` — no warnings or errors
