### PR TITLE
fix: add data_timestamp to INSERT in test_upgrade_preserves_refresh_history

### DIFF
--- a/tests/e2e_dog_feeding_tests.rs
+++ b/tests/e2e_dog_feeding_tests.rs
@@ -435,11 +435,12 @@ async fn test_upgrade_preserves_refresh_history() {
     assert!(hist >= 1, "TEST-3: history rows must survive upgrade");
 
     // Verify initiated_by CHECK allows DOG_FEED.
+    // data_timestamp is NOT NULL in pgt_refresh_history; use now() for a SKIP row.
     db.execute(
         "INSERT INTO pgtrickle.pgt_refresh_history \
-         (pgt_id, start_time, action, status, delta_row_count, \
+         (pgt_id, data_timestamp, start_time, action, status, delta_row_count, \
           rows_inserted, initiated_by) \
-         SELECT pgt_id, now(), 'SKIP', 'COMPLETED', 0, 0, 'DOG_FEED' \
+         SELECT pgt_id, now(), now(), 'SKIP', 'COMPLETED', 0, 0, 'DOG_FEED' \
          FROM pgtrickle.pgt_stream_tables LIMIT 1",
     )
     .await;


### PR DESCRIPTION
## Summary

Fixes `test_upgrade_preserves_refresh_history` E2E failure from CI run #1665.

The test INSERT into `pgtrickle.pgt_refresh_history` was missing the `data_timestamp` column, which has a `NOT NULL` constraint. PostgreSQL rejected the row with:

```
null value in column "data_timestamp" of relation "pgt_refresh_history" violates not-null constraint
```

## Changes

- **tests/e2e_dog_feeding_tests.rs**: Add `data_timestamp` to both the column list and the `SELECT` clause of the INSERT in `test_upgrade_preserves_refresh_history`. Uses `now()` as the value (same pattern as the adjacent `test_auto_apply_initiated_by_dog_feed` test).

## Testing

- `just fmt` — no changes needed
- `just lint` — no warnings or errors
