### PR TITLE
fix: change df_cdc_buffer_trends to FULL refresh mode

### DIFF
--- a/src/api/dog_feeding.rs
+++ b/src/api/dog_feeding.rs
@@ -181,7 +181,7 @@ fn df_st_config(name: &str) -> (&'static str, &'static str) {
         "df_efficiency_rolling" => ("48s", "AUTO"),
         "df_anomaly_signals" => ("48s", "AUTO"),
         "df_threshold_advice" => ("96s", "AUTO"),
-        "df_cdc_buffer_trends" => ("48s", "AUTO"),
+        "df_cdc_buffer_trends" => ("48s", "FULL"),
         "df_scheduling_interference" => ("96s", "FULL"),
         _ => ("60s", "AUTO"),
     }


### PR DESCRIPTION
## Summary

Fixes the persistent `health_check()` WARN status for `df_cdc_buffer_trends` by changing its refresh mode from AUTO (DIFFERENTIAL) to FULL. The moving 1-hour time window query naturally produces new results as time passes, which is incompatible with DIFFERENTIAL mode's delta-based approach.

## Root Cause

- `df_cdc_buffer_trends` query: `WHERE h.start_time > now() - interval '1 hour'` (moving window)
- In DIFFERENTIAL mode, the refresh engine compares old vs new rows to detect changes
- Since the actual rows don't change (only the window shifts), delta rows = 0
- Scheduler sees no changes and skips subsequent refreshes
- Meanwhile, time passes → `last_refresh_at` grows stale → `health_check()` warns

## Changes

- [src/api/dog_feeding.rs](src/api/dog_feeding.rs#L184): `df_cdc_buffer_trends` now configured as `("48s", "FULL")` instead of `("48s", "AUTO")`

## Testing

- ✅ Manual verification: `setup_dog_feeding()` creates `df_cdc_buffer_trends` with `mode=FULL`
- ✅ Refresh mode correctly detected in `pgt_refresh_history` (action=FULL)
- ✅ `health_check()` no longer reports stale warning
- ✅ `dog_feeding_status()` shows table as ACTIVE with refresh_type=FULL
- ✅ Scheduler processes refreshes on 48-second schedule

## Notes

The root issue applies equally to queries with any time-dependent logic. `df_scheduling_interference` was correctly configured as FULL from the start and serves as the reference implementation for this pattern.
