### PR TITLE
docs(patterns): add Transactional Outbox and Inbox pattern plans

### DIFF
--- a/plans/patterns/PLAN_CQRS.md
+++ b/plans/patterns/PLAN_CQRS.md
@@ -1,0 +1,1135 @@
+# CQRS Pattern with pg_trickle
+
+> **Status:** Research Report
+> **Created:** 2026-04-17
+> **Category:** Architecture Pattern
+> **Related:** [PLAN_TRANSACTIONAL_OUTBOX.md](PLAN_TRANSACTIONAL_OUTBOX.md) · [PLAN_TRANSACTIONAL_INBOX.md](PLAN_TRANSACTIONAL_INBOX.md)
+
+---
+
+## Table of Contents
+
+- [Executive Summary](#executive-summary)
+- [What Is CQRS?](#what-is-cqrs)
+- [The Problem It Solves](#the-problem-it-solves)
+- [How pg_trickle Enables CQRS](#how-pg_trickle-enables-cqrs)
+  - [Architecture Overview](#architecture-overview)
+  - [Approach 1: Single-Service CQRS (Multiple Read Models)](#approach-1-single-service-cqrs-multiple-read-models)
+  - [Approach 2: Multi-Service CQRS (Microservices)](#approach-2-multi-service-cqrs-microservices)
+  - [Approach 3: Event Sourcing + CQRS (Combined Pattern)](#approach-3-event-sourcing--cqrs-combined-pattern)
+- [Read Model Design Strategies](#read-model-design-strategies)
+  - [Strategy A: Operational Read Models (Sub-Second Freshness)](#strategy-a-operational-read-models-sub-second-freshness)
+  - [Strategy B: Analytics Read Models (Aggregated)](#strategy-b-analytics-read-models-aggregated)
+  - [Strategy C: Cross-Service Read Models (Denormalized Joins)](#strategy-c-cross-service-read-models-denormalized-joins)
+- [Worked Example: E-Commerce Order Service](#worked-example-e-commerce-order-service)
+- [Read Model Versioning](#read-model-versioning)
+- [Consistency Trade-Offs](#consistency-trade-offs)
+- [Complementary PostgreSQL Extensions](#complementary-postgresql-extensions)
+  - [pgvector — Semantic Read Models](#pgvector--semantic-read-models)
+  - [pg_cron — Time-Triggered Projections](#pg_cron--time-triggered-projections)
+  - [pgmq — Command Queue](#pgmq--command-queue)
+- [Potential pg_trickle Extensions](#potential-pg_trickle-extensions)
+  - [Extension 1: Read Model Registry](#extension-1-read-model-registry)
+  - [Extension 2: Staleness Monitoring per Read Model](#extension-2-staleness-monitoring-per-read-model)
+- [Observability & Monitoring](#observability--monitoring)
+- [Testing Strategies](#testing-strategies)
+- [Security Considerations](#security-considerations)
+- [Cost Analysis](#cost-analysis)
+- [Comparison with Traditional Approaches](#comparison-with-traditional-approaches)
+- [When NOT to Use CQRS](#when-not-to-use-cqrs)
+- [References](#references)
+
+---
+
+## Executive Summary
+
+**Command Query Responsibility Segregation (CQRS)** is an architectural
+pattern that separates the operations that *change state* (commands) from the
+operations that *read state* (queries). The key insight is that write-optimized
+and read-optimized data models are fundamentally different, and forcing one
+schema to serve both creates unnecessary compromise.
+
+pg_trickle makes CQRS practical in PostgreSQL by:
+
+1. **Stream tables are purpose-built read models.** Each stream table is an
+   always-fresh, pre-computed projection of the command-side source table,
+   optimized exactly for the query it serves.
+2. **CDC triggers capture every command-side change automatically.** No
+   manual "projection rebuilder" process is needed — pg_trickle handles
+   incremental view maintenance continuously.
+3. **DIFFERENTIAL refresh** means read models update in microseconds for
+   typical workloads — not seconds.
+4. **Multiple independent read models** can share a single CDC change buffer.
+   The cost of CDC is paid once regardless of how many projections read from
+   the same source.
+5. **IMMEDIATE mode** bridges CQRS into transactionally-consistent read
+   models when eventual consistency is not acceptable.
+
+---
+
+## What Is CQRS?
+
+The term was coined by Greg Young and Udi Dahan as an evolution of the
+Command-Query Separation (CQS) principle by Bertrand Meyer. CQRS scales it up
+from individual methods to the whole service layer.
+
+**The core idea:**
+
+```
+  ┌─────────────────────────────────────────────┐
+  │                 Application                  │
+  │                                              │
+  │   Commands              Queries              │
+  │   (create, update,      (read, search,       │
+  │    delete, process)      filter, aggregate)  │
+  │        │                      │              │
+  │        ▼                      ▼              │
+  │  ┌──────────┐          ┌──────────────┐      │
+  │  │  Write   │          │  Read Model  │      │
+  │  │  Model   │  syncs   │  (stream     │      │
+  │  │  (source │ ───────→ │   tables)    │      │
+  │  │   table) │          │              │      │
+  │  └──────────┘          └──────────────┘      │
+  └─────────────────────────────────────────────┘
+```
+
+**Without CQRS:** A single normalized schema optimized for writes is also
+asked to handle complex analytical queries. Developers add indexes for reads
+that slow down writes, or denormalize for reads in ways that complicate writes.
+The result is neither fast at writes nor fast at reads.
+
+**With CQRS + pg_trickle:** The write model is kept lean and normalized,
+optimized purely for transactional correctness. Each read model is a separate
+stream table — a pre-computed, perfectly shaped view of the data, updated
+automatically and incrementally.
+
+---
+
+## The Problem It Solves
+
+### Symptom 1: The "One Schema for Everything" Bottleneck
+
+```sql
+-- Command side needs: fast single-row lookup by primary key
+SELECT * FROM orders WHERE id = 42;  -- needs: PK index only
+
+-- Query side needs: multi-dimensional aggregation
+SELECT region, product_category, date_trunc('week', created_at),
+       SUM(amount), AVG(delivery_days), percentile_disc(0.95)...
+FROM orders
+JOIN customers ON ...
+JOIN products ON ...
+WHERE status = 'delivered' AND created_at > ...
+GROUP BY 1, 2, 3;
+-- needs: composite indexes on (status, created_at, region, ...)
+-- those same indexes slow down every INSERT/UPDATE
+```
+
+Adding read-optimized indexes degrades write throughput. Denormalizing for
+reads violates write-time referential integrity constraints. The schema becomes
+a compromise that is suboptimal for both use cases.
+
+### Symptom 2: Lock Contention Under Mixed Workloads
+
+Long-running analytical queries hold shared locks that block or are blocked by
+concurrent writes. CQRS eliminates this: the read model (stream table) is a
+**separate physical table** — analytical queries read from it without touching
+the command-side source table at all.
+
+### Symptom 3: Every Query is an N-table Join
+
+```sql
+-- Without CQRS, a "simple" dashboard query requires:
+SELECT c.name, c.tier, SUM(o.amount), COUNT(o.id), MAX(o.created_at)
+FROM customers c
+JOIN orders o ON o.customer_id = c.id
+JOIN products p ON p.id = o.product_id
+LEFT JOIN promotions pr ON pr.order_id = o.id
+WHERE o.created_at > now() - '30 days'::interval
+GROUP BY c.id, c.name, c.tier;
+-- Executed thousands of times per minute by the dashboard.
+```
+
+With CQRS, this query is pre-computed once (or incrementally via DIFFERENTIAL),
+and the dashboard reads from a single pre-joined table.
+
+| Problem                     | Without CQRS              | With CQRS + pg_trickle     |
+|-----------------------------|---------------------------|----------------------------|
+| Analytical query latency    | 50ms–10s                  | < 1ms (pre-computed)       |
+| Write throughput            | Degraded by read indexes  | Unaffected                 |
+| Lock contention             | High (shared reads block) | None (separate table)      |
+| Schema complexity           | Compromise schema         | Optimal per use case       |
+| Query complexity            | Repeated N-way joins      | Simple SELECT on flat table|
+
+---
+
+## How pg_trickle Enables CQRS
+
+### Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                            PostgreSQL                                │
+│                                                                      │
+│  ┌──────────────────────────────────────┐                           │
+│  │  COMMAND SIDE (Write Model)           │                           │
+│  │                                       │                           │
+│  │  orders          customers            │                           │
+│  │  (normalized,    (normalized,         │                           │
+│  │   write-only     write-only           │                           │
+│  │   indexes)       indexes)             │                           │
+│  └────────────┬─────────────────────────┘                           │
+│               │ CDC triggers (automatic, within same transaction)    │
+│               ▼                                                      │
+│  ┌──────────────────────────────────────┐                           │
+│  │  pgtrickle_changes (change buffers)   │                           │
+│  └────────────┬─────────────────────────┘                           │
+│               │ DIFFERENTIAL refresh (incremental, low-cost)        │
+│               ▼                                                      │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  READ MODELS (Stream Tables — query side)                     │   │
+│  │                                                               │   │
+│  │  customer_360         order_dashboard      product_catalog    │   │
+│  │  (denormalized        (pre-aggregated,     (enriched,         │   │
+│  │   customer view,       real-time metrics,   search-ready,     │   │
+│  │   30s schedule)        5s schedule)         1m schedule)      │   │
+│  │                                                               │   │
+│  │  fraud_signals        settlement_report    inventory_status   │   │
+│  │  (IMMEDIATE mode       (daily rollup,       (calculated,      │   │
+│  │   per-transaction)     cold tier)           chain from orders)│   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                                                      │
+│  Applications read ONLY from stream tables (never from base tables) │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+**Key principle:** Application queries go to stream tables. Only commands
+(INSERT/UPDATE/DELETE) touch source tables. The stream tables are the public
+read API.
+
+### Approach 1: Single-Service CQRS (Multiple Read Models)
+
+The simplest CQRS deployment: one PostgreSQL database, one source table, many
+read models.
+
+```sql
+-- COMMAND SIDE: Lean, write-optimized table
+-- Minimal indexes (only what's needed for FK integrity and PK lookups)
+CREATE TABLE orders (
+    id          BIGSERIAL PRIMARY KEY,
+    customer_id INT NOT NULL REFERENCES customers(id),
+    status      TEXT NOT NULL DEFAULT 'pending',
+    amount      NUMERIC(12, 2) NOT NULL,
+    region      TEXT NOT NULL,
+    product_id  INT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+-- Only three indexes: PK, FK, and a partial index for the scheduler
+CREATE INDEX ON orders (customer_id);
+CREATE INDEX ON orders (updated_at) WHERE status != 'archived';
+-- ^ No composite analytical indexes — those belong on read models
+
+-- READ MODEL 1: Real-time operational dashboard (hot tier)
+-- Purpose: "what is happening right now?"
+SELECT pgtrickle.create_stream_table(
+    'order_dashboard',
+    $$SELECT
+        date_trunc('hour', created_at)     AS hour,
+        region,
+        status,
+        COUNT(*)                           AS order_count,
+        SUM(amount)                        AS total_amount,
+        AVG(amount)                        AS avg_order_value,
+        MAX(amount)                        AS largest_order
+      FROM orders
+      WHERE created_at > now() - '24 hours'::interval
+      GROUP BY 1, 2, 3$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+SELECT pgtrickle.alter_stream_table('order_dashboard', tier => 'hot');
+
+-- READ MODEL 2: Customer 360 view (warm tier)
+-- Purpose: "what do I know about this customer?"
+-- Combines orders + customers in one pre-joined, flat table
+SELECT pgtrickle.create_stream_table(
+    'customer_360',
+    $$SELECT
+        c.id                               AS customer_id,
+        c.name,
+        c.email,
+        c.tier,
+        c.region                           AS customer_region,
+        COUNT(o.id)                        AS total_orders,
+        COALESCE(SUM(o.amount), 0)         AS lifetime_value,
+        COALESCE(AVG(o.amount), 0)         AS avg_order_value,
+        MAX(o.created_at)                  AS last_order_at,
+        COALESCE(SUM(CASE WHEN o.status = 'returned'
+                     THEN 1 ELSE 0 END), 0) AS return_count
+      FROM customers c
+      LEFT JOIN orders o ON o.customer_id = c.id
+      GROUP BY c.id, c.name, c.email, c.tier, c.region$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+SELECT pgtrickle.alter_stream_table('customer_360', tier => 'warm');
+
+-- READ MODEL 3: Settlement reporting (cold tier)
+-- Purpose: "what do the books say at end of day?"
+SELECT pgtrickle.create_stream_table(
+    'settlement_report',
+    $$SELECT
+        date_trunc('day', created_at)      AS settlement_day,
+        region,
+        COUNT(*) FILTER (WHERE status = 'completed') AS settled_orders,
+        SUM(amount) FILTER (WHERE status = 'completed') AS settled_amount,
+        COUNT(*) FILTER (WHERE status = 'refunded')  AS refund_count,
+        SUM(amount) FILTER (WHERE status = 'refunded') AS refund_amount
+      FROM orders
+      GROUP BY 1, 2$$,
+    schedule => '5m',
+    refresh_mode => 'DIFFERENTIAL'
+);
+SELECT pgtrickle.alter_stream_table('settlement_report', tier => 'cold');
+
+-- READ MODEL 4: Fraud signals (IMMEDIATE mode)
+-- Purpose: "is this transaction suspicious RIGHT NOW?"
+SELECT pgtrickle.create_stream_table(
+    'high_value_recent_orders',
+    $$SELECT
+        customer_id,
+        SUM(amount)   AS recent_total,
+        COUNT(*)      AS recent_count,
+        MAX(amount)   AS max_single_order
+      FROM orders
+      WHERE created_at > now() - '1 hour'::interval
+        AND status != 'cancelled'
+      GROUP BY customer_id
+      HAVING SUM(amount) > 10000$$,
+    schedule => 'IMMEDIATE',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+The application's read path now never touches the `orders` or `customers`
+tables directly:
+
+```sql
+-- Dashboard query: reads pre-computed stream table (< 1ms)
+SELECT hour, region, order_count, total_amount
+FROM order_dashboard
+ORDER BY hour DESC, total_amount DESC;
+
+-- Customer profile: reads pre-joined stream table (single row lookup)
+SELECT * FROM customer_360 WHERE customer_id = 42;
+
+-- Fraud check: reads IMMEDIATE-mode stream table (zero lag)
+SELECT recent_total, recent_count
+FROM high_value_recent_orders
+WHERE customer_id = $1;
+```
+
+### Approach 2: Multi-Service CQRS (Microservices)
+
+In a microservice architecture, multiple services share a PostgreSQL cluster
+(or separate databases with cross-DB reads via `postgres_fdw`). Each service's
+read model needs data from other services.
+
+```sql
+-- Order service owns the orders table
+-- Fulfillment service owns the shipments table
+-- Billing service reads from both — CQRS solves the cross-service join
+
+-- Using postgres_fdw for cross-database read models
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+CREATE SERVER fulfillment_db
+    FOREIGN DATA WRAPPER postgres_fdw
+    OPTIONS (host 'fulfillment-db.internal', dbname 'fulfillment', port '5432');
+
+CREATE USER MAPPING FOR CURRENT_USER
+    SERVER fulfillment_db OPTIONS (user 'readonly', password '...');
+
+CREATE FOREIGN TABLE shipments_remote (
+    order_id     BIGINT NOT NULL,
+    tracking_no  TEXT,
+    shipped_at   TIMESTAMPTZ,
+    delivered_at TIMESTAMPTZ,
+    carrier      TEXT
+) SERVER fulfillment_db
+  OPTIONS (table_name 'shipments');
+
+-- Billing service read model: order + shipment status (denormalized join)
+SELECT pgtrickle.create_stream_table(
+    'order_fulfillment_view',
+    $$SELECT
+        o.id                  AS order_id,
+        o.customer_id,
+        o.amount,
+        o.status              AS order_status,
+        o.created_at,
+        s.tracking_no,
+        s.shipped_at,
+        s.delivered_at,
+        s.carrier,
+        CASE
+          WHEN s.delivered_at IS NOT NULL THEN 'delivered'
+          WHEN s.shipped_at   IS NOT NULL THEN 'in_transit'
+          WHEN o.status = 'confirmed'     THEN 'awaiting_shipment'
+          ELSE o.status
+        END AS combined_status
+      FROM orders o
+      LEFT JOIN shipments_remote s ON s.order_id = o.id$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+**Note:** When querying foreign tables, pg_trickle uses FULL refresh for the
+foreign table join portion; the local table delta is still DIFFERENTIAL. This
+is a known limitation with FDW sources.
+
+### Approach 3: Event Sourcing + CQRS (Combined Pattern)
+
+Event Sourcing stores every state change as an immutable event. CQRS provides
+the read models derived from the event stream. Together, they are extremely
+powerful. pg_trickle acts as the automatic projection engine.
+
+```sql
+-- Event store: append-only, never UPDATE or DELETE
+CREATE TABLE domain_events (
+    event_id      BIGSERIAL PRIMARY KEY,
+    aggregate_id  UUID NOT NULL,
+    aggregate_type TEXT NOT NULL,            -- 'Order', 'Customer', etc.
+    event_type    TEXT NOT NULL,             -- 'OrderPlaced', 'OrderShipped', etc.
+    event_version INT NOT NULL DEFAULT 1,
+    payload       JSONB NOT NULL,
+    metadata      JSONB NOT NULL DEFAULT '{}',  -- correlation_id, user_id, etc.
+    occurred_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for per-aggregate event log replay
+CREATE INDEX ON domain_events (aggregate_id, occurred_at);
+CREATE INDEX ON domain_events (aggregate_type, event_type);
+
+-- PROJECTION 1: Current order state (latest event per order)
+SELECT pgtrickle.create_stream_table(
+    'order_state',
+    $$SELECT DISTINCT ON (aggregate_id)
+        aggregate_id                            AS order_id,
+        event_type                              AS last_event,
+        (payload->>'status')                    AS status,
+        (payload->>'amount')::numeric           AS amount,
+        (payload->>'customer_id')::int          AS customer_id,
+        occurred_at                             AS last_updated_at
+      FROM domain_events
+      WHERE aggregate_type = 'Order'
+      ORDER BY aggregate_id, occurred_at DESC$$,
+    schedule => '2s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true    -- Event store is append-only; enables faster deltas
+);
+
+-- PROJECTION 2: Customer order history (multiple events aggregated)
+SELECT pgtrickle.create_stream_table(
+    'customer_order_history',
+    $$SELECT
+        (payload->>'customer_id')::int AS customer_id,
+        COUNT(*) FILTER (WHERE event_type = 'OrderPlaced')    AS total_orders,
+        COUNT(*) FILTER (WHERE event_type = 'OrderCancelled') AS cancelled_orders,
+        SUM((payload->>'amount')::numeric) FILTER
+            (WHERE event_type = 'OrderPlaced')                AS total_spent,
+        MAX(occurred_at) FILTER
+            (WHERE event_type = 'OrderPlaced')                AS last_order_at
+      FROM domain_events
+      WHERE aggregate_type = 'Order'
+      GROUP BY 1$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+
+-- PROJECTION 3: Audit trail (full event log per aggregate — temporal)
+SELECT pgtrickle.create_stream_table(
+    'order_audit_trail',
+    $$SELECT
+        aggregate_id    AS order_id,
+        event_type,
+        event_version,
+        payload,
+        metadata->>'user_id'          AS initiated_by,
+        metadata->>'correlation_id'   AS correlation_id,
+        occurred_at
+      FROM domain_events
+      WHERE aggregate_type = 'Order'
+      ORDER BY aggregate_id, occurred_at$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+```
+
+**Why `append_only => true` matters here:**
+The event store is never updated or deleted. Setting `append_only => true` tells
+pg_trickle's CDC to skip delete-tracking in the change buffer, halving the
+write overhead for projections.
+
+---
+
+## Read Model Design Strategies
+
+### Strategy A: Operational Read Models (Sub-Second Freshness)
+
+For data that drives real-time decisions: dashboards, fraud signals, SLA
+monitoring, live inventory levels.
+
+```sql
+-- Pattern: narrow projection, tight time window, IMMEDIATE or 1s schedule
+SELECT pgtrickle.create_stream_table(
+    'live_inventory',
+    $$SELECT
+        product_id,
+        SUM(quantity_in)  - SUM(quantity_out) AS available_units,
+        MIN(warehouse_id) FILTER (WHERE quantity_in - quantity_out > 0)
+                                              AS nearest_warehouse
+      FROM inventory_movements
+      WHERE movement_date > CURRENT_DATE - 7
+      GROUP BY product_id
+      HAVING SUM(quantity_in) - SUM(quantity_out) >= 0$$,
+    schedule => '2s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+SELECT pgtrickle.alter_stream_table('live_inventory', tier => 'hot');
+```
+
+**Design rules:**
+- Keep the time window tight (last N hours/days, not all time).
+- Avoid `MIN`/`MAX` aggregates when possible — they require GROUP_RESCAN.
+- Use `HAVING` rather than post-query filtering to reduce output rows.
+
+### Strategy B: Analytics Read Models (Aggregated)
+
+For data that drives reporting, BI tools, ML training data pipelines.
+
+```sql
+-- Pattern: wide time window, heavy aggregation, 1m+ schedule, cold/warm tier
+SELECT pgtrickle.create_stream_table(
+    'product_performance_monthly',
+    $$SELECT
+        date_trunc('month', o.created_at)      AS month,
+        p.category,
+        p.brand,
+        COUNT(o.id)                            AS units_sold,
+        SUM(o.amount)                          AS gross_revenue,
+        AVG(o.amount)                          AS avg_selling_price,
+        COUNT(DISTINCT o.customer_id)          AS unique_buyers,
+        COUNT(o.id) FILTER (WHERE o.status = 'returned')
+                                               AS return_count,
+        ROUND(
+          COUNT(o.id) FILTER (WHERE o.status = 'returned')::numeric
+          / NULLIF(COUNT(o.id), 0) * 100, 2
+        )                                      AS return_rate_pct
+      FROM orders o
+      JOIN products p ON p.id = o.product_id
+      WHERE o.status IN ('completed', 'returned')
+      GROUP BY 1, 2, 3$$,
+    schedule => '10m',
+    refresh_mode => 'DIFFERENTIAL'
+);
+SELECT pgtrickle.alter_stream_table('product_performance_monthly', tier => 'warm');
+```
+
+**Design rules:**
+- Use `date_trunc` for time bucketing — it creates stable group keys that
+  DIFFERENTIAL can efficiently update when new data arrives.
+- `COUNT(DISTINCT ...)` is supported as a DIFFERENTIAL aggregate in pg_trickle
+  v0.14+.
+- Chain from operational read models when the analytics model can be derived
+  from an existing projection:
+
+```sql
+-- Analytics model chaining from operational model
+SELECT pgtrickle.create_stream_table(
+    'weekly_dashboard_rollup',
+    $$SELECT
+        date_trunc('week', hour) AS week,
+        region,
+        SUM(order_count)  AS weekly_orders,
+        SUM(total_amount) AS weekly_revenue
+      FROM order_dashboard    -- <- reads from another stream table
+      GROUP BY 1, 2$$,
+    schedule => 'calculated',     -- <- auto-refreshes when order_dashboard updates
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Strategy C: Cross-Service Read Models (Denormalized Joins)
+
+For queries that span conceptual "service boundaries" within a single database.
+The join happens at projection time (once, cheaply) rather than at query time
+(repeatedly, expensively).
+
+```sql
+-- "Order enrichment" view: pre-joins 5 tables into one flat read model
+SELECT pgtrickle.create_stream_table(
+    'enriched_orders',
+    $$SELECT
+        o.id                      AS order_id,
+        o.created_at,
+        o.status,
+        o.amount,
+        -- Customer dimension (denormalized into the row)
+        c.id                      AS customer_id,
+        c.name                    AS customer_name,
+        c.tier                    AS customer_tier,
+        c.region                  AS customer_region,
+        -- Product dimension
+        p.id                      AS product_id,
+        p.name                    AS product_name,
+        p.category                AS product_category,
+        p.brand                   AS product_brand,
+        -- Promotion (nullable)
+        pr.code                   AS promo_code,
+        pr.discount_pct           AS discount_applied,
+        -- Computed fields
+        o.amount * (1 - COALESCE(pr.discount_pct, 0) / 100.0)
+                                  AS net_amount
+      FROM orders o
+      JOIN customers c   ON c.id = o.customer_id
+      JOIN products p    ON p.id = o.product_id
+      LEFT JOIN promotions pr ON pr.order_id = o.id$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Now any service can query the enriched view without knowing the schema
+SELECT order_id, customer_name, product_category, net_amount
+FROM enriched_orders
+WHERE customer_tier = 'premium'
+  AND product_category = 'electronics'
+  AND created_at > now() - '7 days'::interval;
+-- One table scan, zero joins, sub-millisecond response
+```
+
+---
+
+## Worked Example: E-Commerce Order Service
+
+A realistic end-to-end CQRS deployment for an e-commerce platform.
+
+```sql
+-- ── COMMAND SIDE ─────────────────────────────────────────────────────────────
+
+CREATE TABLE customers (
+    id         SERIAL PRIMARY KEY,
+    name       TEXT NOT NULL,
+    email      TEXT UNIQUE NOT NULL,
+    tier       TEXT NOT NULL DEFAULT 'standard',  -- standard, premium, vip
+    region     TEXT NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE products (
+    id          SERIAL PRIMARY KEY,
+    name        TEXT NOT NULL,
+    category    TEXT NOT NULL,
+    brand       TEXT NOT NULL,
+    base_price  NUMERIC(10, 2) NOT NULL,
+    active      BOOLEAN NOT NULL DEFAULT true
+);
+
+CREATE TABLE orders (
+    id          BIGSERIAL PRIMARY KEY,
+    customer_id INT NOT NULL REFERENCES customers(id),
+    product_id  INT NOT NULL REFERENCES products(id),
+    quantity    INT NOT NULL DEFAULT 1,
+    amount      NUMERIC(12, 2) NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'pending',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ── READ MODELS ───────────────────────────────────────────────────────────────
+
+-- 1. Product catalog with live inventory context
+SELECT pgtrickle.create_stream_table(
+    'product_catalog',
+    $$SELECT
+        p.id,
+        p.name,
+        p.category,
+        p.brand,
+        p.base_price,
+        COUNT(o.id) FILTER (WHERE o.created_at > now() - '7 days'::interval
+                             AND o.status != 'cancelled')
+                                  AS units_sold_7d,
+        COUNT(DISTINCT o.customer_id) FILTER (
+            WHERE o.created_at > now() - '30 days'::interval)
+                                  AS buyers_30d
+      FROM products p
+      LEFT JOIN orders o ON o.product_id = p.id
+      WHERE p.active = true
+      GROUP BY p.id, p.name, p.category, p.brand, p.base_price$$,
+    schedule => '1m',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- 2. Customer 360 (for customer service, personalisation engines)
+SELECT pgtrickle.create_stream_table(
+    'customer_profile',
+    $$SELECT
+        c.id                      AS customer_id,
+        c.name,
+        c.email,
+        c.tier,
+        c.region,
+        COUNT(o.id)               AS total_orders,
+        COALESCE(SUM(o.amount), 0) AS lifetime_value,
+        COALESCE(AVG(o.amount), 0) AS avg_order_value,
+        MAX(o.created_at)          AS last_order_at,
+        COALESCE(SUM(o.amount) FILTER (
+            WHERE o.created_at > now() - '90 days'::interval), 0)
+                                  AS spend_90d
+      FROM customers c
+      LEFT JOIN orders o ON o.customer_id = c.id
+        AND o.status IN ('completed', 'shipped')
+      GROUP BY c.id, c.name, c.email, c.tier, c.region$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- 3. Real-time revenue dashboard (for ops team)
+SELECT pgtrickle.create_stream_table(
+    'revenue_dashboard',
+    $$SELECT
+        date_trunc('minute', created_at) AS minute,
+        region,
+        status,
+        COUNT(*)                         AS order_count,
+        SUM(amount)                      AS revenue,
+        AVG(amount)                      AS avg_basket
+      FROM orders
+      WHERE created_at > now() - '2 hours'::interval
+      GROUP BY 1, 2, 3$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+SELECT pgtrickle.alter_stream_table('revenue_dashboard', tier => 'hot');
+
+-- 4. Fraud / anomaly signals (IMMEDIATE — fires on every order write)
+SELECT pgtrickle.create_stream_table(
+    'customer_velocity',
+    $$SELECT
+        customer_id,
+        COUNT(*)      AS orders_1h,
+        SUM(amount)   AS spend_1h
+      FROM orders
+      WHERE created_at > now() - '1 hour'::interval
+        AND status != 'cancelled'
+      GROUP BY customer_id
+      HAVING COUNT(*) > 5 OR SUM(amount) > 5000$$,
+    schedule => 'IMMEDIATE',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- ── APPLICATION PATTERNS ──────────────────────────────────────────────────────
+
+-- Write path: touches only base tables
+-- CREATE ORDER command:
+BEGIN;
+  INSERT INTO orders (customer_id, product_id, quantity, amount, status)
+  VALUES ($customer_id, $product_id, $quantity, $amount, 'pending');
+COMMIT;
+-- pg_trickle automatically propagates the change to all read models
+
+-- Read paths: never touch base tables
+-- "Show me this customer's profile" — from customer_profile stream table
+SELECT * FROM customer_profile WHERE customer_id = $customer_id;
+
+-- "Is this customer flagged for fraud?" — from IMMEDIATE stream table
+SELECT orders_1h, spend_1h FROM customer_velocity WHERE customer_id = $customer_id;
+
+-- "What's our revenue in the last 30 minutes?" — from revenue_dashboard
+SELECT SUM(revenue) FROM revenue_dashboard
+WHERE minute > now() - '30 minutes'::interval;
+```
+
+---
+
+## Read Model Versioning
+
+When a query definition must change (new columns, changed logic), the old
+stream table continues serving reads while the new version builds.
+
+```sql
+-- Step 1: Create the new version alongside the old one
+SELECT pgtrickle.create_stream_table(
+    'customer_profile_v2',
+    $$SELECT
+        c.id                       AS customer_id,
+        c.name,
+        c.email,
+        c.tier,
+        c.region,
+        COUNT(o.id)                AS total_orders,
+        COALESCE(SUM(o.amount), 0) AS lifetime_value,
+        -- NEW: NPS score join
+        AVG(n.score)               AS avg_nps_score,
+        COUNT(n.id)                AS nps_responses
+      FROM customers c
+      LEFT JOIN orders o   ON o.customer_id = c.id
+        AND o.status IN ('completed', 'shipped')
+      LEFT JOIN nps_surveys n ON n.customer_id = c.id
+      GROUP BY c.id, c.name, c.email, c.tier, c.region$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Step 2: Verify v2 data looks correct (compare a sample)
+SELECT v1.customer_id, v1.total_orders, v2.total_orders, v2.avg_nps_score
+FROM customer_profile v1
+JOIN customer_profile_v2 v2 USING (customer_id)
+WHERE v1.total_orders != v2.total_orders
+LIMIT 10;
+
+-- Step 3: Switch application traffic to v2
+-- (deploy app config change pointing to customer_profile_v2)
+
+-- Step 4: Drop v1
+SELECT pgtrickle.drop_stream_table('customer_profile');
+```
+
+---
+
+## Consistency Trade-Offs
+
+CQRS with DIFFERENTIAL refresh introduces a **consistency lag** — the read
+model is slightly behind the write model. Choose the right mode for each
+read model:
+
+| Use Case                              | Schedule        | Max Lag     | Notes                          |
+|---------------------------------------|-----------------|-------------|--------------------------------|
+| Fraud detection, balance checks       | `IMMEDIATE`     | 0ms         | Adds write-path latency        |
+| Operational dashboards                | `1s` – `5s`     | 1–5s        | Amortizes costs, still "live"  |
+| Customer profiles, product catalog    | `10s` – `1m`    | 10s–1m      | Invisible to users at this lag |
+| Analytics reports, BI tooling         | `5m` – `30m`    | 5–30m       | Expected for batch analytics   |
+| Daily settlement, ledger close        | `1h` (or cron)  | Up to 1h    | Scheduled cold-tier read model |
+
+**When exact consistency is required:** Use IMMEDIATE mode for the specific
+read model. The rest can remain eventual. Not every read model needs the
+same consistency guarantee.
+
+```sql
+-- Override specific read models that require stronger consistency
+SELECT pgtrickle.alter_stream_table('account_balances',
+    schedule => 'IMMEDIATE',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Relax read models where staleness is acceptable
+SELECT pgtrickle.alter_stream_table('product_catalog',
+    schedule => '2m'
+);
+```
+
+---
+
+## Complementary PostgreSQL Extensions
+
+### pgvector — Semantic Read Models
+
+[pgvector](https://github.com/pgvector/pgvector) stores embedding vectors for
+semantic search. A stream table can materialize the inputs for embedding
+computation, and `pgvector` handles the ANN index.
+
+```sql
+-- Stream table materializes the text content to embed
+SELECT pgtrickle.create_stream_table(
+    'product_search_inputs',
+    $$SELECT id AS product_id,
+             name || ' ' || category || ' ' || brand AS search_text
+      FROM products WHERE active = true$$,
+    schedule => '5m',
+    refresh_mode => 'DIFFERENTIAL'
+);
+-- An application worker then calls an embedding API for changed rows
+-- and updates a pgvector table with the new embeddings
+```
+
+### pg_cron — Time-Triggered Projections
+
+[pg_cron](https://github.com/citusdata/pg_cron) can trigger cold-tier read
+model refreshes on a calendar schedule (e.g., end-of-month settlement).
+
+```sql
+-- Schedule a monthly settlement projection refresh
+SELECT cron.schedule(
+    'monthly-settlement-refresh',
+    '0 0 1 * *',  -- First day of each month at midnight
+    $$SELECT pgtrickle.refresh_stream_table('monthly_settlement', force => true)$$
+);
+```
+
+### pgmq — Command Queue
+
+[pgmq](https://github.com/tembo-io/pgmq) implements a durable message queue
+in PostgreSQL. Commands can arrive via pgmq and be applied to the write model,
+keeping the full command bus inside the database.
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pgmq;
+
+-- Commands arrive as messages in a queue
+SELECT pgmq.create('order_commands');
+
+-- A command processor reads and applies commands
+-- SELECT * FROM pgmq.read('order_commands', 30, 10);
+-- ... apply each command to orders table ...
+-- SELECT pgmq.delete('order_commands', msg_id);
+```
+
+---
+
+## Potential pg_trickle Extensions
+
+### Extension 1: Read Model Registry
+
+A system catalog table that records which stream tables are acting as CQRS
+read models, their upstream command-side sources, and their freshness SLAs.
+
+```sql
+-- Proposed API
+SELECT pgtrickle.register_read_model(
+    stream_table => 'customer_profile',
+    command_sources => ARRAY['customers', 'orders'],
+    max_lag_seconds => 30,
+    description => 'Customer 360 profile for personalisation API'
+);
+
+-- Query the registry
+SELECT * FROM pgtrickle.read_model_registry;
+-- pgt_name | command_sources | max_lag_s | current_lag_s | sla_ok
+```
+
+### Extension 2: Staleness Monitoring per Read Model
+
+Alerting when a read model exceeds its configured freshness SLA.
+
+```sql
+-- Check all read models against their SLA
+SELECT pgt_name, max_lag_s, current_lag_s,
+       current_lag_s > max_lag_s AS sla_breached
+FROM pgtrickle.read_model_sla_status
+WHERE current_lag_s > max_lag_s;
+```
+
+---
+
+## Observability & Monitoring
+
+```sql
+-- Read model freshness: how stale are each read model's results?
+SELECT
+    pgt_name,
+    refresh_mode,
+    last_refresh_at,
+    EXTRACT(EPOCH FROM (now() - last_refresh_at)) AS age_seconds,
+    avg_refresh_duration_ms,
+    total_refreshes,
+    diff_speedup
+FROM pgtrickle.stream_tables_info
+ORDER BY age_seconds DESC;
+
+-- Read model efficiency: how much work is being done vs. skipped?
+SELECT
+    pgt_name,
+    avg_change_ratio,
+    diff_speedup,
+    CASE
+      WHEN diff_speedup < 1.5 THEN 'consider FULL refresh'
+      WHEN avg_change_ratio > 0.5 THEN 'high change ratio — check schedule'
+      ELSE 'ok'
+    END AS recommendation
+FROM pgtrickle.refresh_efficiency();
+
+-- Identify unused read models (no reads in the last 24h)
+SELECT pgt_name, last_refresh_at
+FROM pgtrickle.stream_tables_info
+WHERE last_refresh_at < now() - '24 hours'::interval;
+```
+
+---
+
+## Testing Strategies
+
+### Unit Testing: Command Side
+
+Test the write model in isolation. Commands should be simple inserts with
+referential integrity constraints — easy to test.
+
+```sql
+-- Test: order amount must be positive
+DO $$
+BEGIN
+  PERFORM id FROM orders WHERE id = (
+    SELECT id FROM orders
+    ORDER BY id DESC LIMIT 1
+  );
+  -- Insert a valid order
+  INSERT INTO orders (customer_id, product_id, amount, status)
+  VALUES (1, 1, 50.00, 'pending');
+  ASSERT FOUND, 'Order should have been inserted';
+END;
+$$;
+```
+
+### Integration Testing: Read Model Consistency
+
+After a command, assert the read model updates within the expected lag.
+
+```python
+import time
+import psycopg2
+
+def test_customer_profile_updates_after_order():
+    conn = psycopg2.connect("...")
+    cur = conn.cursor()
+
+    # Command: place an order
+    cur.execute("""
+        INSERT INTO orders (customer_id, product_id, amount, status)
+        VALUES (42, 1, 99.99, 'completed')
+    """)
+    conn.commit()
+
+    # Wait for read model to refresh (schedule is 30s, test waits 35s)
+    time.sleep(35)
+
+    # Assert read model reflects the command
+    cur.execute("""
+        SELECT total_orders, lifetime_value
+        FROM customer_profile
+        WHERE customer_id = 42
+    """)
+    profile = cur.fetchone()
+    assert profile is not None
+    assert profile[1] >= 99.99, f"Expected lifetime_value >= 99.99, got {profile[1]}"
+```
+
+### Property Testing: Read Model Correctness
+
+The read model should always agree with a fresh query on the source tables.
+
+```sql
+-- Verification query: does the stream table match a fresh computation?
+WITH fresh AS (
+    SELECT customer_id, COUNT(*) AS total_orders, SUM(amount) AS lifetime_value
+    FROM orders
+    WHERE status IN ('completed', 'shipped')
+    GROUP BY customer_id
+)
+SELECT cp.customer_id,
+       cp.total_orders   AS cached,  fresh.total_orders  AS computed,
+       cp.lifetime_value AS cached,  fresh.lifetime_value AS computed
+FROM customer_profile cp
+JOIN fresh USING (customer_id)
+WHERE cp.total_orders != fresh.total_orders
+   OR abs(cp.lifetime_value - fresh.lifetime_value) > 0.01;
+-- Zero rows expected
+```
+
+---
+
+## Security Considerations
+
+```sql
+-- Application roles: command-side write access only
+CREATE ROLE order_service_writer;
+GRANT INSERT, UPDATE ON orders TO order_service_writer;
+REVOKE SELECT ON orders FROM order_service_writer;  -- Can't read source table
+GRANT SELECT ON order_dashboard TO order_service_writer;  -- Only reads stream tables
+
+-- BI / analytics roles: read-only, stream tables only
+CREATE ROLE analytics_reader;
+GRANT SELECT ON customer_profile TO analytics_reader;
+GRANT SELECT ON product_performance_monthly TO analytics_reader;
+GRANT SELECT ON settlement_report TO analytics_reader;
+REVOKE SELECT ON orders, customers, products FROM analytics_reader;
+
+-- Sensitive fields: mask PII in the read model at projection time
+SELECT pgtrickle.create_stream_table(
+    'customer_profile_masked',
+    $$SELECT
+        id                        AS customer_id,
+        left(name, 1) || '***'   AS name_masked,
+        regexp_replace(email, '(.).+@', '\1***@') AS email_masked,
+        tier,
+        region
+      FROM customers$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+-- Give external BI tools access only to the masked read model
+```
+
+---
+
+## Cost Analysis
+
+| Configuration                  | Write Overhead  | Read Model Latency | CDC Cost       |
+|--------------------------------|-----------------|-------------------|----------------|
+| No CQRS                        | Baseline        | Slow (ad-hoc SQL) | None           |
+| CQRS, 1 read model, DIFF       | +2% CDC trigger | 1–30s (schedule)  | One change buf |
+| CQRS, 5 read models, DIFF      | +2% CDC trigger | 1–30s             | One change buf |
+| CQRS, 10 read models, DIFF     | +2% CDC trigger | 1–30s             | One change buf |
+| CQRS, 1 read model, IMMEDIATE  | +15–30% (sync)  | 0ms               | One change buf |
+
+**Key insight:** Multiple read models sharing the same source table pay the
+CDC overhead only once. Adding the 5th read model to a source table is nearly
+free — just the incremental DIFFERENTIAL computation cost.
+
+---
+
+## Comparison with Traditional Approaches
+
+| Approach                    | Complexity | Read Perf | Write Perf | Freshness  | pg_trickle Advantage                  |
+|-----------------------------|------------|-----------|------------|------------|---------------------------------------|
+| Ad-hoc complex queries      | Low        | Slow      | Fast       | Always     | None (pg_trickle replaces these)      |
+| Indexed materialized views  | Medium     | Fast      | Slower     | Manual     | Auto-refresh, DIFFERENTIAL updates    |
+| Application-level caching   | High       | Fast      | Fast       | Cache TTL  | No cache invalidation bugs            |
+| Redis projection store      | Very High  | Fast      | Fast       | Eventual   | No external dep, SQL joins, ACID      |
+| Separate analytics DB       | Very High  | Fast      | Fast       | Batch lag  | No ETL pipeline, no infra overhead    |
+| **pg_trickle CQRS**         | **Low**    | **Fast**  | **Fast**   | **1s–1m**  | **One tool, pure SQL, auto-refresh**  |
+
+---
+
+## When NOT to Use CQRS
+
+CQRS is not always the right choice. Avoid it when:
+
+- **Your reads and writes share the same shape.** If a CRUD admin panel reads
+  and writes the same row, a stream table adds complexity without benefit.
+- **Exact real-time consistency is required for all reads.** IMMEDIATE mode
+  helps, but if every single query needs the freshest data within a single
+  transaction, a direct query on the source is simpler.
+- **Your team is small and the domain is simple.** CQRS adds two layers (write
+  model + read models) to reason about. In a 2-table application, the overhead
+  isn't worth it.
+- **You have a single read pattern.** If all queries look the same, one
+  materialized view (or standard pg_trickle stream table) is sufficient.
+  Full CQRS is for systems with many diverse read models.
+
+---
+
+## References
+
+- Martin Fowler, "CQRS" — https://martinfowler.com/bliki/CQRS.html
+- Greg Young, "CQRS Documents" — https://cqrs.files.wordpress.com/2010/11/cqrs_documents.pdf
+- Udi Dahan, "Clarified CQRS" — https://udidahan.com/2009/12/09/clarified-cqrs/
+- Microsoft Azure Architecture Guide: CQRS pattern — https://learn.microsoft.com/en-us/azure/architecture/patterns/cqrs
+- Martin Fowler, "Event Sourcing" — https://martinfowler.com/eaaDev/EventSourcing.html
+- pg_trickle SQL Reference — [SQL_REFERENCE.md](../docs/SQL_REFERENCE.md)
+- pg_trickle DVM Operators — [DVM_OPERATORS.md](../docs/DVM_OPERATORS.md)
+- pgvector — https://github.com/pgvector/pgvector
+- pgmq — https://github.com/tembo-io/pgmq
+- pg_cron — https://github.com/citusdata/pg_cron

--- a/plans/patterns/PLAN_STREAMING_WINDOWS.md
+++ b/plans/patterns/PLAN_STREAMING_WINDOWS.md
@@ -1,0 +1,1210 @@
+# Streaming Window Aggregations with pg_trickle
+
+> **Status:** Research Report
+> **Created:** 2026-04-17
+> **Category:** Architecture Pattern
+> **Related:** [PLAN_CQRS.md](PLAN_CQRS.md) · [PLAN_TRANSACTIONAL_OUTBOX.md](PLAN_TRANSACTIONAL_OUTBOX.md)
+
+---
+
+## Table of Contents
+
+- [Executive Summary](#executive-summary)
+- [What Are Streaming Window Aggregations?](#what-are-streaming-window-aggregations)
+- [The Problem It Solves](#the-problem-it-solves)
+- [Window Types Explained](#window-types-explained)
+  - [Tumbling Windows](#tumbling-windows)
+  - [Sliding / Rolling Windows](#sliding--rolling-windows)
+  - [Hopping Windows](#hopping-windows)
+  - [Session Windows](#session-windows)
+- [How pg_trickle Enables Streaming Windows](#how-pg_trickle-enables-streaming-windows)
+  - [Architecture Overview](#architecture-overview)
+  - [Approach 1: Tumbling Windows via date_trunc()](#approach-1-tumbling-windows-via-date_trunc)
+  - [Approach 2: Sliding Windows via SQL Window Functions](#approach-2-sliding-windows-via-sql-window-functions)
+  - [Approach 3: Hopping Windows via Epoch Arithmetic](#approach-3-hopping-windows-via-epoch-arithmetic)
+  - [Approach 4: Session Windows via Gap Detection](#approach-4-session-windows-via-gap-detection)
+- [Handling Late-Arriving Data](#handling-late-arriving-data)
+- [Worked Example: Real-Time Fraud Detection](#worked-example-real-time-fraud-detection)
+- [Worked Example: IoT Sensor Analytics](#worked-example-iot-sensor-analytics)
+- [Worked Example: API Performance Monitoring](#worked-example-api-performance-monitoring)
+- [Advanced Patterns](#advanced-patterns)
+  - [Hierarchical Windows (Minute → Hour → Day)](#hierarchical-windows-minute--hour--day)
+  - [Multi-Key Windows (Partitioned)](#multi-key-windows-partitioned)
+  - [Watermarks and Grace Periods](#watermarks-and-grace-periods)
+- [Performance Characteristics](#performance-characteristics)
+- [Complementary PostgreSQL Extensions](#complementary-postgresql-extensions)
+  - [TimescaleDB — Time-Series Optimisation](#timescaledb--time-series-optimisation)
+  - [pg_partman — Automatic Time Partitioning](#pg_partman--automatic-time-partitioning)
+  - [pg_cron — Scheduled Window Archival](#pg_cron--scheduled-window-archival)
+- [Potential pg_trickle Extensions](#potential-pg_trickle-extensions)
+  - [Extension 1: Window Helper Functions](#extension-1-window-helper-functions)
+  - [Extension 2: Watermark State Tracking](#extension-2-watermark-state-tracking)
+- [Comparison with Dedicated Streaming Systems](#comparison-with-dedicated-streaming-systems)
+- [When NOT to Use This Pattern](#when-not-to-use-this-pattern)
+- [References](#references)
+
+---
+
+## Executive Summary
+
+**Streaming Window Aggregations** compute aggregate metrics (sums, counts,
+averages, percentiles) over a moving or fixed time window on a continuous event
+stream. They are the backbone of real-time analytics: per-minute order volumes,
+rolling 5-minute averages, hourly percentile latencies.
+
+Traditionally, this pattern required a dedicated streaming system (Apache
+Flink, Kafka Streams, Spark Structured Streaming). pg_trickle brings the same
+capability to PostgreSQL:
+
+1. **DIFFERENTIAL refresh** means only the time buckets touched by new events
+   are recomputed — not the entire historical dataset. A burst of 500 events
+   into a 1-minute bucket recomputes just that bucket, not the last 7 days of
+   data.
+2. **Standard SQL window functions** (`OVER (ORDER BY ts ROWS BETWEEN N
+   PRECEDING AND CURRENT ROW)`) express sliding windows directly — no custom
+   operator syntax required.
+3. **`date_trunc()`-based grouping** creates stable, re-usable window keys
+   that the DVM engine tracks efficiently across refresh cycles.
+4. **`append_only => true`** on event-style sources halves CDC write overhead,
+   because deletes never occur on a time-series append log.
+5. **Tiered scheduling** lets high-priority windows (per-second fraud signals)
+   refresh at 1s while lower-priority windows (daily rollups) refresh at 5m
+   — all from the same source table.
+
+---
+
+## What Are Streaming Window Aggregations?
+
+A **window** is a bounded slice of an unbounded event stream, defined by time
+or row count. Aggregating within windows answers questions like:
+
+- "How many orders arrived in the last 5 minutes?"
+- "What is the 95th-percentile response time over the past hour?"
+- "How much revenue did we make per minute today?"
+- "Is this user's transaction rate unusually high in the last 10 minutes?"
+
+**The key distinction from batch aggregations:**
+
+| Batch                                     | Streaming Window                           |
+|-------------------------------------------|--------------------------------------------|
+| Run once over a fixed dataset             | Continuously updated as new data arrives   |
+| Query re-reads all data every time        | Only changed windows recomputed            |
+| Result is stale immediately               | Result is always fresh within schedule lag |
+| Easy to implement                         | Complex without the right tools            |
+
+pg_trickle bridges this gap: stream tables deliver continuously-refreshed
+windowed aggregations using plain SQL.
+
+---
+
+## The Problem It Solves
+
+### Problem 1: Full Table Scans on Every Dashboard Load
+
+```sql
+-- The naive approach: runs on every dashboard load
+SELECT date_trunc('minute', created_at) AS minute,
+       COUNT(*)                          AS orders,
+       SUM(amount)                       AS revenue
+FROM orders
+WHERE created_at > now() - '24 hours'::interval
+GROUP BY 1
+ORDER BY 1 DESC;
+-- With 1M rows in orders: ~80ms per query, runs 1000x/min = 80s of CPU per min
+```
+
+With a pg_trickle stream table, this query runs once per schedule cycle
+(e.g., every 5s) using differential deltas. Dashboard loads hit the
+pre-computed stream table at < 1ms.
+
+### Problem 2: "Refresh Explosions" with Traditional Materialized Views
+
+PostgreSQL materialized views support `REFRESH MATERIALIZED VIEW
+CONCURRENTLY`, but:
+
+- `CONCURRENTLY` still re-reads the entire source table.
+- For a 7-day rolling window with 10M rows, every refresh is expensive
+  regardless of how little changed.
+- There is no native incremental/differential refresh for time-windowed views.
+
+pg_trickle's DIFFERENTIAL mode solves this: only the delta (new/changed rows
+since last refresh) flows through the aggregation engine.
+
+### Problem 3: Operational Complexity of External Streaming Systems
+
+Apache Flink provides world-class streaming windows — but it requires:
+
+- A Kafka cluster for the event stream
+- A Flink cluster for the processing jobs
+- A sink system (Elasticsearch, ClickHouse, Redis) for results
+- A separate PostgreSQL table to serve application queries
+
+That is four additional infrastructure components, each with its own ops
+burden. pg_trickle delivers the same windowed results from inside PostgreSQL.
+
+---
+
+## Window Types Explained
+
+### Tumbling Windows
+
+Non-overlapping, fixed-size windows that partition the time axis cleanly.
+Every event belongs to exactly one window.
+
+```
+Time:  ─────────────────────────────────────────────────────▶
+       [00:00 ─ 01:00][01:00 ─ 02:00][02:00 ─ 03:00] ...
+
+Events: e1 e2  │  e3 e4 e5  │  e6  │
+         window 1   window 2   window 3
+```
+
+**SQL:** `GROUP BY date_trunc('hour', ts)` — one row per window.
+
+**Use cases:** Hourly revenue, daily active users, per-minute error counts.
+
+### Sliding / Rolling Windows
+
+Overlapping windows that continuously advance with time. Every event belongs
+to multiple windows.
+
+```
+Time:   ──────────────────────────────────────────────────▶
+        [═══════════════5 min═══════════════]
+                    [═══════════════5 min═══════════════]
+                                [═══════════════5 min═══]
+
+At t=10m: window covers [5m–10m]
+At t=11m: window covers [6m–11m]
+At t=12m: window covers [7m–12m]
+```
+
+**SQL:** `SUM(amount) OVER (ORDER BY ts ROWS BETWEEN 299 PRECEDING AND CURRENT ROW)`
+
+**Use cases:** Rolling 5-minute throughput, 1-hour moving average, "last N
+transactions" per user.
+
+### Hopping Windows
+
+Like tumbling windows but with a step size smaller than the window size.
+Events can belong to multiple windows.
+
+```
+Window size = 10 min, hop = 5 min:
+
+[00:00─00:10]
+       [00:05─00:15]
+              [00:10─00:20]
+                     [00:15─00:25]
+```
+
+**SQL:** Epoch arithmetic to compute window boundaries.
+
+**Use cases:** More granular trend detection than tumbling windows; used in
+fraud detection where you want overlapping anomaly windows.
+
+### Session Windows
+
+Windows that group events by activity gaps — a window closes when there is
+no activity for longer than a timeout duration.
+
+```
+Events:  e1 e2 e3    (gap > T)    e4 e5    (gap > T)    e6
+         [session 1]              [session 2]            [session 3]
+```
+
+**SQL:** `LAG(ts)` + gap detection via a cumulative sum of session breaks.
+
+**Use cases:** User session analytics, IoT device activity windows, API
+call grouping.
+
+---
+
+## How pg_trickle Enables Streaming Windows
+
+### Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                             PostgreSQL                                │
+│                                                                       │
+│  ┌──────────────────────────────────────┐                            │
+│  │  Source: event/fact table            │                            │
+│  │  (append-only preferred)             │                            │
+│  │  orders, api_requests, sensor_reads  │                            │
+│  └─────────────────┬────────────────────┘                            │
+│                    │ CDC trigger (within same transaction)            │
+│                    ▼                                                  │
+│  ┌──────────────────────────────────────┐                            │
+│  │  pgtrickle_changes (change buffer)   │                            │
+│  │  Only new events since last refresh  │                            │
+│  └─────────────────┬────────────────────┘                            │
+│                    │ DIFFERENTIAL refresh                             │
+│                    │ (recomputes only touched windows)                │
+│                    ▼                                                  │
+│  ┌─────────────────────────────────────────────────────────────┐     │
+│  │  Stream Tables (Windowed Read Models)                        │     │
+│  │                                                              │     │
+│  │  orders_per_minute  ← tumbling, 5s, hot tier                │     │
+│  │  revenue_rolling_1h ← sliding, 10s, hot tier                │     │
+│  │  hourly_rollup      ← tumbling, 1m, warm tier               │     │
+│  │  daily_summary      ← tumbling, 15m, cold tier              │     │
+│  └─────────────────────────────────────────────────────────────┘     │
+│                                                                       │
+│  Dashboards, APIs, ML pipelines query stream tables — never the      │
+│  source table                                                         │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Approach 1: Tumbling Windows via date_trunc()
+
+The most common pattern. `date_trunc()` produces stable group keys — when a
+new event arrives in the `14:32` bucket, only that bucket's aggregate changes.
+
+```sql
+-- Source: order events (append-only)
+CREATE TABLE orders (
+    id         BIGSERIAL PRIMARY KEY,
+    customer_id INT NOT NULL,
+    region      TEXT NOT NULL,
+    amount      NUMERIC(12, 2) NOT NULL,
+    status      TEXT NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Tumbling 1-minute windows: live order volume
+SELECT pgtrickle.create_stream_table(
+    'orders_per_minute',
+    $$SELECT
+        date_trunc('minute', created_at)  AS window_start,
+        region,
+        COUNT(*)                          AS order_count,
+        SUM(amount)                       AS total_revenue,
+        AVG(amount)                       AS avg_basket,
+        COUNT(*) FILTER (WHERE status = 'cancelled')
+                                          AS cancellations
+      FROM orders
+      WHERE created_at > now() - '2 hours'::interval
+      GROUP BY 1, 2$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true   -- orders are never updated/deleted
+);
+SELECT pgtrickle.alter_stream_table('orders_per_minute', tier => 'hot');
+
+-- Tumbling 1-hour windows: revenue rollup
+SELECT pgtrickle.create_stream_table(
+    'orders_per_hour',
+    $$SELECT
+        date_trunc('hour', created_at)    AS window_start,
+        region,
+        COUNT(*)                          AS order_count,
+        SUM(amount)                       AS total_revenue,
+        SUM(amount) FILTER (WHERE status = 'completed')
+                                          AS settled_revenue
+      FROM orders
+      GROUP BY 1, 2$$,
+    schedule => '1m',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+SELECT pgtrickle.alter_stream_table('orders_per_hour', tier => 'warm');
+```
+
+**Why DIFFERENTIAL is efficient here:**
+When a new order arrives at `14:32:47`, only the `14:32` minute bucket and
+the `14:00` hour bucket are touched. All other buckets remain unchanged.
+The DIFFERENTIAL engine recomputes only those two group keys — not the 2
+hours × 60 minutes × N regions of historical buckets.
+
+### Approach 2: Sliding Windows via SQL Window Functions
+
+Sliding windows compute aggregates over the N rows or N seconds preceding
+each event. The result is a per-row rolling aggregate.
+
+```sql
+-- Source: API request log
+CREATE TABLE api_requests (
+    id            BIGSERIAL PRIMARY KEY,
+    endpoint      TEXT NOT NULL,
+    response_ms   INT NOT NULL,
+    status_code   INT NOT NULL,
+    user_id       INT,
+    requested_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Sliding 5-minute rolling average response time, per endpoint
+SELECT pgtrickle.create_stream_table(
+    'endpoint_rolling_avg',
+    $$SELECT
+        id,
+        endpoint,
+        requested_at,
+        response_ms,
+        AVG(response_ms) OVER (
+            PARTITION BY endpoint
+            ORDER BY requested_at
+            ROWS BETWEEN 299 PRECEDING AND CURRENT ROW   -- last ~300 rows ≈ 5min at 1 req/s
+        )                                   AS rolling_avg_ms,
+        COUNT(*) OVER (
+            PARTITION BY endpoint
+            ORDER BY requested_at
+            ROWS BETWEEN 299 PRECEDING AND CURRENT ROW
+        )                                   AS rolling_request_count
+      FROM api_requests
+      WHERE requested_at > now() - '6 hours'::interval$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Time-range based sliding window (more precise than row count)
+SELECT pgtrickle.create_stream_table(
+    'user_spend_rolling_1h',
+    $$SELECT
+        a.user_id,
+        a.requested_at,
+        SUM(b.amount) AS rolling_1h_spend,
+        COUNT(b.id)   AS rolling_1h_txn_count
+      FROM orders a
+      JOIN orders b ON b.user_id = a.user_id
+        AND b.created_at BETWEEN a.created_at - '1 hour'::interval
+                              AND a.created_at
+      GROUP BY a.user_id, a.requested_at$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+**Note on performance:** Time-range sliding windows using self-joins can be
+expensive for large source tables. Constrain the source with a time-bound
+`WHERE` clause to limit the join surface. For very high-throughput sliding
+windows (> 100K events/min), consider pre-bucketing into tumbling windows first,
+then applying the slide over the buckets.
+
+### Approach 3: Hopping Windows via Epoch Arithmetic
+
+Hopping windows divide the timeline into overlapping windows of fixed size,
+advancing by a step smaller than the window. Pure SQL arithmetic on epoch
+values creates the window keys.
+
+```sql
+-- Hopping window: 10-minute windows, advancing every 5 minutes
+-- Window size = 10 min, hop = 5 min
+-- At t=12:07: the event falls into:
+--   window starting at 12:00 (covers 12:00–12:10)
+--   window starting at 12:05 (covers 12:05–12:15)
+
+SELECT pgtrickle.create_stream_table(
+    'orders_hopping_10m5m',
+    $$WITH window_starts AS (
+        SELECT
+            o.id,
+            o.amount,
+            o.region,
+            o.created_at,
+            -- Generate the window start times this event belongs to
+            -- Window size: 600s (10 min), hop: 300s (5 min)
+            to_timestamp(
+                (extract(epoch from o.created_at)::bigint / 300) * 300
+                - s.offset_secs
+            ) AS window_start
+        FROM orders o
+        -- Cross join with the two possible offsets (window_size / hop = 2)
+        CROSS JOIN (VALUES (0), (300)) AS s(offset_secs)
+        WHERE o.created_at > now() - '2 hours'::interval
+          -- Only include if event falls within this window
+          AND o.created_at >= to_timestamp(
+                (extract(epoch from o.created_at)::bigint / 300) * 300
+                - s.offset_secs
+              )
+          AND o.created_at < to_timestamp(
+                (extract(epoch from o.created_at)::bigint / 300) * 300
+                - s.offset_secs + 600
+              )
+    )
+    SELECT
+        window_start,
+        window_start + '10 minutes'::interval AS window_end,
+        region,
+        COUNT(*)     AS order_count,
+        SUM(amount)  AS total_revenue
+    FROM window_starts
+    GROUP BY window_start, region$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+```
+
+### Approach 4: Session Windows via Gap Detection
+
+Session windows group events that occur within a timeout of each other.
+A new session starts when the gap to the previous event exceeds the timeout.
+
+```sql
+-- User session detection: 30-minute inactivity timeout
+SELECT pgtrickle.create_stream_table(
+    'user_sessions',
+    $$WITH gap_detection AS (
+        SELECT
+            user_id,
+            created_at AS event_at,
+            -- Is there a gap > 30 minutes before this event?
+            CASE WHEN created_at - LAG(created_at) OVER (
+                    PARTITION BY user_id ORDER BY created_at
+                 ) > '30 minutes'::interval
+                 OR LAG(created_at) OVER (
+                    PARTITION BY user_id ORDER BY created_at
+                 ) IS NULL
+                 THEN 1 ELSE 0
+            END AS is_session_start
+        FROM orders
+        WHERE created_at > now() - '24 hours'::interval
+    ),
+    session_ids AS (
+        SELECT
+            user_id,
+            event_at,
+            SUM(is_session_start) OVER (
+                PARTITION BY user_id ORDER BY event_at
+            ) AS session_num
+        FROM gap_detection
+    )
+    SELECT
+        user_id,
+        session_num,
+        MIN(event_at) AS session_start,
+        MAX(event_at) AS session_end,
+        COUNT(*)       AS events_in_session,
+        MAX(event_at) - MIN(event_at) AS session_duration
+    FROM session_ids
+    GROUP BY user_id, session_num$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+---
+
+## Handling Late-Arriving Data
+
+Late-arriving events (events whose timestamp is earlier than the current
+processing time) are a fundamental challenge in stream processing. An order
+placed at 14:32 but recorded 5 minutes later at 14:37 belongs to the 14:32
+window, not 14:37.
+
+pg_trickle handles late arrivals naturally: DIFFERENTIAL refresh re-evaluates
+the affected time bucket whenever the late row lands.
+
+```sql
+-- Strategy 1: Accept late arrivals for a grace period
+-- The window covers `created_at` (event time), so late arrivals
+-- automatically update the correct bucket on the next refresh
+
+SELECT pgtrickle.create_stream_table(
+    'orders_per_minute_with_grace',
+    $$SELECT
+        date_trunc('minute', created_at) AS window_start,
+        COUNT(*)                         AS order_count,
+        SUM(amount)                      AS revenue
+      FROM orders
+      WHERE created_at > now() - '2 hours'::interval   -- grace period: 2h
+      GROUP BY 1$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+-- A late event from 1h 50min ago will update its bucket on next refresh
+-- Events older than 2h are outside the window and will not appear
+
+-- Strategy 2: Separate "settled" and "live" windows
+-- Settled: > 5 minutes old (late arrivals are unlikely)
+-- Live: < 5 minutes old (may still receive late arrivals)
+
+SELECT pgtrickle.create_stream_table(
+    'orders_settled',
+    $$SELECT
+        date_trunc('minute', created_at) AS window_start,
+        COUNT(*)                         AS order_count,
+        SUM(amount)                      AS revenue,
+        true                             AS settled
+      FROM orders
+      WHERE created_at BETWEEN now() - '24 hours'::interval
+                           AND now() - '5 minutes'::interval
+      GROUP BY 1$$,
+    schedule => '1m',   -- Slower refresh — settled windows rarely change
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+
+SELECT pgtrickle.create_stream_table(
+    'orders_live',
+    $$SELECT
+        date_trunc('minute', created_at) AS window_start,
+        COUNT(*)                         AS order_count,
+        SUM(amount)                      AS revenue,
+        false                            AS settled
+      FROM orders
+      WHERE created_at > now() - '5 minutes'::interval
+      GROUP BY 1$$,
+    schedule => '2s',   -- Fast refresh for live window
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+```
+
+**Rule of thumb:** Set the `WHERE` time bound to `now() - <grace_period>`.
+Any late event within the grace period will update its correct window bucket.
+Events older than the grace period are simply outside the window and ignored.
+
+---
+
+## Worked Example: Real-Time Fraud Detection
+
+Fraud detection requires detecting unusual patterns over short time windows
+with the lowest possible latency.
+
+```sql
+-- Source: transaction event table
+CREATE TABLE transactions (
+    id           BIGSERIAL PRIMARY KEY,
+    account_id   INT NOT NULL,
+    merchant_id  INT NOT NULL,
+    amount       NUMERIC(12, 2) NOT NULL,
+    currency     TEXT NOT NULL DEFAULT 'USD',
+    country_code TEXT NOT NULL,
+    txn_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Signal 1: Per-account velocity (last 10 minutes)
+-- Fraud rule: > 5 transactions OR > $2000 in 10 minutes
+SELECT pgtrickle.create_stream_table(
+    'account_velocity_10m',
+    $$SELECT
+        account_id,
+        COUNT(*)     AS txn_count_10m,
+        SUM(amount)  AS total_amount_10m,
+        COUNT(DISTINCT merchant_id)  AS unique_merchants_10m,
+        COUNT(DISTINCT country_code) AS unique_countries_10m,
+        MAX(amount)  AS max_single_txn
+      FROM transactions
+      WHERE txn_at > now() - '10 minutes'::interval
+      GROUP BY account_id$$,
+    schedule => 'IMMEDIATE',   -- Must update within the same transaction
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+
+-- Signal 2: Unusual merchant activity (last 1 hour)
+-- Fraud rule: merchant receiving more than 3x its normal hourly volume
+SELECT pgtrickle.create_stream_table(
+    'merchant_hourly_volume',
+    $$SELECT
+        merchant_id,
+        date_trunc('hour', txn_at)  AS hour,
+        COUNT(*)                    AS txn_count,
+        SUM(amount)                 AS total_volume,
+        COUNT(DISTINCT account_id)  AS unique_accounts,
+        COUNT(DISTINCT country_code) AS country_spread
+      FROM transactions
+      WHERE txn_at > now() - '48 hours'::interval
+      GROUP BY 1, 2$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+
+-- Signal 3: Geographic anomaly — same account, multiple countries in 1h
+SELECT pgtrickle.create_stream_table(
+    'account_geo_anomaly',
+    $$SELECT
+        account_id,
+        COUNT(DISTINCT country_code) AS countries_1h,
+        array_agg(DISTINCT country_code ORDER BY country_code) AS country_list,
+        MIN(txn_at)  AS first_txn,
+        MAX(txn_at)  AS last_txn
+      FROM transactions
+      WHERE txn_at > now() - '1 hour'::interval
+      GROUP BY account_id
+      HAVING COUNT(DISTINCT country_code) > 1$$,
+    schedule => '1m',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+
+-- Fraud check at transaction time (application-level)
+-- Step 1: IMMEDIATE-mode velocity check (zero lag)
+SELECT txn_count_10m, total_amount_10m
+FROM account_velocity_10m
+WHERE account_id = $account_id;
+-- If txn_count_10m > 5 OR total_amount_10m > 2000 → flag for review
+
+-- Step 2: Geographic anomaly check
+SELECT countries_1h, country_list
+FROM account_geo_anomaly
+WHERE account_id = $account_id;
+-- If countries_1h > 1 → flag as suspicious
+
+-- Step 3: Merchant spike check
+SELECT
+    txn_count,
+    AVG(txn_count) OVER (ORDER BY hour ROWS BETWEEN 23 PRECEDING AND 1 PRECEDING)
+        AS avg_hourly_volume
+FROM merchant_hourly_volume
+WHERE merchant_id = $merchant_id
+ORDER BY hour DESC
+LIMIT 1;
+-- If txn_count > 3 * avg_hourly_volume → flag merchant
+```
+
+---
+
+## Worked Example: IoT Sensor Analytics
+
+IoT devices produce continuous high-volume time series. Window aggregations
+reduce millions of raw readings to actionable per-minute summaries.
+
+```sql
+-- Source: raw sensor readings (very high write rate)
+CREATE TABLE sensor_readings (
+    id          BIGSERIAL PRIMARY KEY,
+    device_id   INT NOT NULL,
+    sensor_type TEXT NOT NULL,    -- temperature, pressure, humidity
+    value       NUMERIC(10, 4) NOT NULL,
+    unit        TEXT NOT NULL,
+    quality     INT NOT NULL DEFAULT 100,  -- 0-100 signal quality
+    read_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+) PARTITION BY RANGE (read_at);  -- Daily partitions for data retention
+
+-- Only process good-quality readings
+CREATE INDEX ON sensor_readings (device_id, read_at)
+    WHERE quality >= 80;
+
+-- Window 1: Per-minute device averages (operational view)
+SELECT pgtrickle.create_stream_table(
+    'sensor_1m_averages',
+    $$SELECT
+        device_id,
+        sensor_type,
+        date_trunc('minute', read_at)      AS minute,
+        AVG(value)                         AS avg_value,
+        MIN(value)                         AS min_value,
+        MAX(value)                         AS max_value,
+        STDDEV(value)                      AS stddev_value,
+        COUNT(*)                           AS reading_count,
+        AVG(quality)                       AS avg_quality
+      FROM sensor_readings
+      WHERE read_at > now() - '2 hours'::interval
+        AND quality >= 80
+      GROUP BY 1, 2, 3$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+SELECT pgtrickle.alter_stream_table('sensor_1m_averages', tier => 'hot');
+
+-- Window 2: Anomaly detection — readings outside 3-sigma band
+SELECT pgtrickle.create_stream_table(
+    'sensor_anomalies',
+    $$WITH device_stats AS (
+        SELECT
+            device_id,
+            sensor_type,
+            AVG(avg_value)    AS baseline_mean,
+            STDDEV(avg_value) AS baseline_stddev
+        FROM sensor_1m_averages   -- reads from another stream table
+        WHERE minute > now() - '24 hours'::interval
+        GROUP BY device_id, sensor_type
+    )
+    SELECT
+        r.device_id,
+        r.sensor_type,
+        r.read_at,
+        r.value,
+        s.baseline_mean,
+        s.baseline_stddev,
+        (r.value - s.baseline_mean) / NULLIF(s.baseline_stddev, 0) AS z_score,
+        CASE
+          WHEN abs((r.value - s.baseline_mean) / NULLIF(s.baseline_stddev, 0)) > 3
+          THEN 'ANOMALY'
+          ELSE 'NORMAL'
+        END AS status
+      FROM sensor_readings r
+      JOIN device_stats s USING (device_id, sensor_type)
+      WHERE r.read_at > now() - '1 hour'::interval
+        AND r.quality >= 80$$,
+    schedule => 'calculated',  -- refreshes when sensor_1m_averages updates
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+
+-- Window 3: Hourly device health summary (warm tier)
+SELECT pgtrickle.create_stream_table(
+    'sensor_hourly_health',
+    $$SELECT
+        device_id,
+        date_trunc('hour', minute)         AS hour,
+        COUNT(DISTINCT sensor_type)        AS active_sensor_types,
+        SUM(reading_count)                 AS total_readings,
+        AVG(avg_quality)                   AS avg_signal_quality,
+        BOOL_OR(avg_quality < 80)          AS any_low_quality_readings,
+        COUNT(*) FILTER (WHERE avg_quality < 50)
+                                           AS degraded_minutes
+      FROM sensor_1m_averages             -- chain from the 1m stream table
+      GROUP BY 1, 2$$,
+    schedule => 'calculated',
+    refresh_mode => 'DIFFERENTIAL'
+);
+SELECT pgtrickle.alter_stream_table('sensor_hourly_health', tier => 'warm');
+```
+
+---
+
+## Worked Example: API Performance Monitoring
+
+SRE teams need sub-minute visibility into API latency percentiles, error
+rates, and throughput — across endpoints, regions, and clients.
+
+```sql
+-- Source: API access log
+CREATE TABLE api_requests (
+    id              BIGSERIAL PRIMARY KEY,
+    endpoint        TEXT NOT NULL,
+    method          TEXT NOT NULL,
+    status_code     INT NOT NULL,
+    response_ms     INT NOT NULL,
+    client_id       INT,
+    region          TEXT NOT NULL,
+    requested_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Tumbling 1-minute window: per-endpoint latency percentiles
+SELECT pgtrickle.create_stream_table(
+    'api_latency_1m',
+    $$SELECT
+        date_trunc('minute', requested_at)              AS minute,
+        endpoint,
+        region,
+        COUNT(*)                                        AS request_count,
+        COUNT(*) FILTER (WHERE status_code >= 500)      AS error_count,
+        ROUND(
+          COUNT(*) FILTER (WHERE status_code >= 500)::numeric
+          / NULLIF(COUNT(*), 0) * 100, 2
+        )                                               AS error_rate_pct,
+        AVG(response_ms)                                AS avg_ms,
+        percentile_disc(0.50) WITHIN GROUP
+            (ORDER BY response_ms)                      AS p50_ms,
+        percentile_disc(0.95) WITHIN GROUP
+            (ORDER BY response_ms)                      AS p95_ms,
+        percentile_disc(0.99) WITHIN GROUP
+            (ORDER BY response_ms)                      AS p99_ms,
+        MAX(response_ms)                                AS max_ms
+      FROM api_requests
+      WHERE requested_at > now() - '2 hours'::interval
+      GROUP BY 1, 2, 3$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+SELECT pgtrickle.alter_stream_table('api_latency_1m', tier => 'hot');
+
+-- SLO burn rate: rolling 1-hour error budget consumption
+SELECT pgtrickle.create_stream_table(
+    'slo_burn_rate',
+    $$SELECT
+        endpoint,
+        region,
+        SUM(request_count)                              AS total_1h,
+        SUM(error_count)                                AS errors_1h,
+        ROUND(SUM(error_count)::numeric
+              / NULLIF(SUM(request_count), 0) * 100, 4) AS error_rate_1h_pct,
+        -- SLO target: 99.9% (0.1% error budget)
+        ROUND((SUM(error_count)::numeric
+               / NULLIF(SUM(request_count), 0)) / 0.001, 2)
+                                                        AS slo_burn_rate,
+        CASE
+          WHEN (SUM(error_count)::numeric
+                / NULLIF(SUM(request_count), 0)) > 0.014  -- 14x burn = ~5h to exhaustion
+          THEN 'CRITICAL'
+          WHEN (SUM(error_count)::numeric
+                / NULLIF(SUM(request_count), 0)) > 0.002  -- 2x burn
+          THEN 'WARNING'
+          ELSE 'OK'
+        END AS slo_status
+      FROM api_latency_1m    -- chain from the 1m stream table
+      WHERE minute > now() - '1 hour'::interval
+      GROUP BY endpoint, region$$,
+    schedule => 'calculated',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+---
+
+## Advanced Patterns
+
+### Hierarchical Windows (Minute → Hour → Day)
+
+Chain stream tables at increasing granularities. Each level reads from the
+previous one — the aggregation cost is paid incrementally.
+
+```sql
+-- Level 1: Raw → 1-minute buckets (hot tier)
+SELECT pgtrickle.create_stream_table(
+    'orders_1m', ..., schedule => '5s');
+
+-- Level 2: 1-minute → 1-hour (warm tier, reads from Level 1)
+SELECT pgtrickle.create_stream_table(
+    'orders_1h',
+    $$SELECT date_trunc('hour', window_start) AS hour,
+             region,
+             SUM(order_count)  AS order_count,
+             SUM(total_revenue) AS total_revenue
+      FROM orders_1m  -- reads from Level 1 stream table
+      GROUP BY 1, 2$$,
+    schedule => 'calculated',
+    refresh_mode => 'DIFFERENTIAL'
+);
+SELECT pgtrickle.alter_stream_table('orders_1h', tier => 'warm');
+
+-- Level 3: 1-hour → 1-day (cold tier, reads from Level 2)
+SELECT pgtrickle.create_stream_table(
+    'orders_daily',
+    $$SELECT date_trunc('day', hour) AS day,
+             region,
+             SUM(order_count)        AS order_count,
+             SUM(total_revenue)      AS total_revenue
+      FROM orders_1h  -- reads from Level 2 stream table
+      GROUP BY 1, 2$$,
+    schedule => 'calculated',
+    refresh_mode => 'DIFFERENTIAL'
+);
+SELECT pgtrickle.alter_stream_table('orders_daily', tier => 'cold');
+
+-- The DAG: raw_events → orders_1m → orders_1h → orders_daily
+-- Use pgtrickle.dag() to visualize the chain:
+SELECT * FROM pgtrickle.dag();
+```
+
+**Performance benefit of hierarchical windows:**
+- `orders_1m` processes raw deltas (N new rows).
+- `orders_1h` processes minute-bucket deltas (at most 1 changed row per minute).
+- `orders_daily` processes hour-bucket deltas (at most 1 changed row per hour).
+- Each level performs far less work than computing from raw events.
+
+### Multi-Key Windows (Partitioned)
+
+Window aggregations partitioned across multiple dimensions simultaneously.
+
+```sql
+-- Revenue windowed by (region, product_category, customer_tier)
+SELECT pgtrickle.create_stream_table(
+    'revenue_by_segment',
+    $$SELECT
+        date_trunc('hour', o.created_at) AS hour,
+        o.region,
+        p.category                       AS product_category,
+        c.tier                           AS customer_tier,
+        COUNT(o.id)                      AS order_count,
+        SUM(o.amount)                    AS revenue,
+        COUNT(DISTINCT o.customer_id)    AS unique_buyers
+      FROM orders o
+      JOIN products p   ON p.id = o.product_id
+      JOIN customers c  ON c.id = o.customer_id
+      WHERE o.created_at > now() - '7 days'::interval
+        AND o.status IN ('completed', 'shipped')
+      GROUP BY 1, 2, 3, 4$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+-- Queries can now slice by any dimension combination without a join
+SELECT * FROM revenue_by_segment
+WHERE region = 'EMEA' AND product_category = 'electronics';
+```
+
+### Watermarks and Grace Periods
+
+A watermark is the system's estimate of how far behind the stream's event
+time is. In pg_trickle, you implement watermarks via time-bound `WHERE` clauses.
+
+```sql
+-- Watermark configuration table (adjustable at runtime)
+CREATE TABLE stream_watermarks (
+    stream_name   TEXT PRIMARY KEY,
+    grace_period  INTERVAL NOT NULL DEFAULT '5 minutes',
+    updated_at    TIMESTAMPTZ DEFAULT now()
+);
+
+INSERT INTO stream_watermarks VALUES
+    ('orders_per_minute', '5 minutes'),
+    ('sensor_1m_averages', '30 seconds'),
+    ('api_latency_1m', '1 minute');
+
+-- Application code reads the watermark at query time:
+-- SELECT created_at > now() - grace_period FROM stream_watermarks WHERE stream_name = '...';
+
+-- Or, use a function to inject the watermark dynamically
+CREATE OR REPLACE FUNCTION get_watermark(stream_name TEXT)
+RETURNS TIMESTAMPTZ AS $$
+    SELECT now() - grace_period
+    FROM stream_watermarks
+    WHERE stream_name = $1;
+$$ LANGUAGE sql STABLE;
+
+SELECT pgtrickle.create_stream_table(
+    'orders_watermarked',
+    $$SELECT
+        date_trunc('minute', created_at) AS window_start,
+        COUNT(*)                         AS order_count,
+        SUM(amount)                      AS revenue
+      FROM orders
+      WHERE created_at > get_watermark('orders_watermarked')
+      GROUP BY 1$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL',
+    append_only => true
+);
+```
+
+---
+
+## Performance Characteristics
+
+### Why DIFFERENTIAL Excels for Window Aggregations
+
+Consider a source table with 10M rows and a 24-hour rolling window. At
+100 new rows per second:
+
+| Approach                             | Work per Refresh Cycle | Notes                                 |
+|--------------------------------------|------------------------|---------------------------------------|
+| PostgreSQL `REFRESH MATVIEW`         | Scan all 10M rows      | Full scan every time                  |
+| Standard materialized view + trigger | N rows (via trigger)   | Complex trigger logic, error-prone    |
+| pg_trickle FULL refresh              | Scan all 10M rows      | Same as matview                       |
+| **pg_trickle DIFFERENTIAL**          | **~N rows (delta)**    | Only changed windows recomputed       |
+
+For tumbling windows with `date_trunc()`, the DIFFERENTIAL engine identifies
+which group keys changed (e.g., the `14:32` bucket) and recomputes only those
+aggregates. The total work scales with the number of *changed* rows, not the
+total dataset size.
+
+### When to Use FULL Refresh Instead
+
+pg_trickle's cost model will recommend FULL when:
+
+```sql
+SELECT pgt_name, recommended_mode, confidence, reason
+FROM pgtrickle.recommend_refresh_mode()
+WHERE pgt_name LIKE '%window%';
+```
+
+FULL is preferred for:
+- **MIN/MAX aggregates over large partitions**: these require a full partition
+  rescan when a minimum/maximum changes (GROUP_RESCAN). If your window has
+  many rows per group key and MIN/MAX, FULL can be faster.
+- **Very high change ratios**: when > 40% of the source rows change per cycle,
+  the overhead of delta tracking exceeds a fresh scan.
+- **Very small result sets** (< 100 rows): FULL scan + group-by is trivially
+  fast and DIFFERENTIAL overhead isn't worth it.
+
+### Scheduling Strategy
+
+| Window Type      | Source Rate       | Recommended Schedule | Tier   |
+|------------------|-------------------|----------------------|--------|
+| 1-second tumbling | > 100 events/s    | `1s`                 | hot    |
+| 1-minute tumbling | > 10 events/s     | `5s` – `15s`         | hot    |
+| 5-minute tumbling | Any               | `30s` – `1m`         | warm   |
+| 1-hour tumbling   | Any               | `calculated`         | warm   |
+| Daily tumbling    | Any               | `calculated`         | cold   |
+| Sliding (rows)    | Any               | `10s` – `30s`        | hot    |
+| Session windows   | < 1000/s          | `30s`                | warm   |
+
+---
+
+## Complementary PostgreSQL Extensions
+
+### TimescaleDB — Time-Series Optimisation
+
+[TimescaleDB](https://www.timescale.com/) hypertables automatically partition
+time-series data by time, dramatically speeding up time-range queries that
+pg_trickle's DVM engine uses to identify changed buckets.
+
+```sql
+CREATE EXTENSION IF NOT EXISTS timescaledb;
+
+-- Convert the source table to a hypertable (partitioned by hour)
+SELECT create_hypertable('sensor_readings', 'read_at',
+    chunk_time_interval => INTERVAL '1 hour');
+
+-- pg_trickle stream tables on top of TimescaleDB hypertables work
+-- identically — the hypertable's chunk pruning accelerates the
+-- DIFFERENTIAL delta scan automatically
+SELECT pgtrickle.create_stream_table(
+    'sensor_1m_averages', ...,
+    append_only => true
+);
+```
+
+### pg_partman — Automatic Time Partitioning
+
+[pg_partman](https://github.com/pgpartman/pg_partman) manages declarative
+time-based partitioning and automatic partition creation/retention.
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_partman;
+
+-- Automatically manage monthly partitions on the orders table
+SELECT partman.create_parent(
+    p_parent_table => 'public.orders',
+    p_control      => 'created_at',
+    p_type         => 'range',
+    p_interval     => 'monthly'
+);
+
+-- pg_partman's retention policy archives old partitions
+-- pg_trickle stream tables with time-bound WHERE clauses only touch
+-- recent partitions — automatic partition pruning makes this fast
+```
+
+### pg_cron — Scheduled Window Archival
+
+Once windowed stream tables have computed their results, old time buckets
+can be archived or snapshotted on a schedule.
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Archive yesterday's hourly data to a separate table at midnight
+SELECT cron.schedule(
+    'archive-daily-orders',
+    '5 0 * * *',   -- 00:05 every day
+    $$INSERT INTO orders_daily_archive
+      SELECT * FROM orders_per_hour
+      WHERE window_start::date = CURRENT_DATE - 1
+      ON CONFLICT (window_start, region) DO NOTHING$$
+);
+
+-- Optionally disable or freeze the stream table for old time ranges
+-- SELECT pgtrickle.alter_stream_table('orders_per_hour', tier => 'frozen');
+```
+
+---
+
+## Potential pg_trickle Extensions
+
+### Extension 1: Window Helper Functions
+
+A set of convenience SQL functions for common window patterns, reducing
+boilerplate:
+
+```sql
+-- Proposed API (not yet implemented)
+
+-- Create a tumbling window stream table in one call
+SELECT pgtrickle.create_tumbling_window(
+    name        => 'orders_per_minute',
+    source      => 'orders',
+    window_col  => 'created_at',
+    window_size => '1 minute',
+    metrics     => ARRAY['COUNT(*) AS count', 'SUM(amount) AS revenue'],
+    partitions  => ARRAY['region'],
+    schedule    => '5s',
+    lookback    => '2 hours'
+);
+
+-- Create a sliding window stream table
+SELECT pgtrickle.create_sliding_window(
+    name           => 'user_spend_rolling',
+    source         => 'orders',
+    time_col       => 'created_at',
+    window_size    => '1 hour',
+    partition_col  => 'customer_id',
+    metric         => 'SUM(amount)',
+    schedule       => '30s'
+);
+```
+
+### Extension 2: Watermark State Tracking
+
+Built-in watermark management: pg_trickle tracks the latest processed event
+timestamp per stream table and exposes it as a system column.
+
+```sql
+-- Proposed: system-managed watermark per stream table
+SELECT pgt_name, watermark_ts, watermark_lag_ms
+FROM pgtrickle.stream_table_watermarks;
+
+-- Late arrivals that fall before the watermark are logged
+SELECT * FROM pgtrickle.late_arrivals
+WHERE pgt_name = 'orders_per_minute'
+  AND event_ts < watermark_ts - '1 minute'::interval;
+```
+
+---
+
+## Comparison with Dedicated Streaming Systems
+
+| Feature                       | Apache Flink            | Kafka Streams          | pg_trickle              |
+|-------------------------------|-------------------------|------------------------|-------------------------|
+| Tumbling windows              | ✅ Native               | ✅ Native              | ✅ date_trunc()         |
+| Sliding windows               | ✅ Native               | ✅ Native              | ✅ SQL window functions  |
+| Hopping windows               | ✅ Native               | ✅ Native              | ✅ Epoch arithmetic      |
+| Session windows               | ✅ Native               | ✅ Native              | ✅ LAG() gap detection   |
+| Event-time processing         | ✅ Native watermarks    | ✅ Native              | ✅ via event_time column |
+| Late arrival handling         | ✅ Configurable         | ✅ Configurable        | ✅ Grace period WHERE    |
+| SQL interface                 | ✅ Flink SQL            | ❌ Java/Scala API      | ✅ Standard SQL          |
+| Infrastructure requirements   | Flink + Kafka cluster   | Kafka cluster          | PostgreSQL only          |
+| ACID guarantees               | ❌ At-least-once        | ❌ At-least-once       | ✅ ACID (PostgreSQL)     |
+| Joins with dimension tables   | Complex (async)         | Complex (KTable)       | ✅ Standard SQL JOIN     |
+| Result store                  | Separate sink needed    | Separate sink needed   | ✅ Built-in (stream table)|
+| Latency                       | 10ms–1s                 | 1ms–100ms              | 1s–30s (DIFF), 0ms (IMM) |
+| Throughput (events/sec)       | Millions                | Millions               | ~100K (DIFF, single node)|
+| Operational complexity        | Very High               | High                   | Low                      |
+
+**When to choose pg_trickle over Flink/Kafka Streams:**
+- Your event volume is < 50K events/sec per source table.
+- You already use PostgreSQL and don't want additional infrastructure.
+- Your team knows SQL but not the Flink/Kafka APIs.
+- You need ACID guarantees and transactional correctness.
+- Your windows need joins with dimension tables (trivial in SQL; complex in Flink).
+
+**When to choose Flink/Kafka Streams over pg_trickle:**
+- Your event volume exceeds PostgreSQL's write throughput ceiling.
+- You need sub-100ms window latency at > 1M events/sec.
+- You are already invested in a Kafka-based data platform.
+- Your window operations are stateful in ways that don't map to SQL GROUP BY.
+
+---
+
+## When NOT to Use This Pattern
+
+- **You need millisecond windows at very high throughput.** pg_trickle
+  schedules have a minimum of ~1s. For sub-second windows at > 100K events/sec,
+  a dedicated streaming engine is required.
+- **Your source table is not append-only and has heavy UPDATE/DELETE traffic.**
+  UPDATEs to existing event rows force GROUP_RESCAN on affected windows.
+  If more than 30% of source rows are updated per cycle, DIFFERENTIAL overhead
+  exceeds FULL refresh cost.
+- **Your window logic is inherently stateful across sessions.** Complex
+  CEP (Complex Event Processing) patterns (e.g., "find all sequences where A
+  is followed by B within 5 events, then C within 30 seconds") require
+  a streaming engine's native stateful operators.
+- **You need exactly-once semantics end-to-end.** pg_trickle provides ACID
+  within PostgreSQL, but if results are pushed to external systems, you need
+  idempotent consumers.
+
+---
+
+## References
+
+- Tyler Akidau et al., "The Dataflow Model" (Google, 2015) — https://research.google/pubs/the-dataflow-model/
+- Tyler Akidau, "Streaming 101" — https://www.oreilly.com/radar/the-world-beyond-batch-streaming-101/
+- Tyler Akidau, "Streaming 102" — https://www.oreilly.com/radar/the-world-beyond-batch-streaming-102/
+- Apache Flink, "Windows" — https://nightlies.apache.org/flink/flink-docs-stable/docs/dev/datastream/operators/windows/
+- Kafka Streams, "Windowing" — https://kafka.apache.org/documentation/streams/developer-guide/dsl-api.html#windowing
+- PostgreSQL Window Functions — https://www.postgresql.org/docs/current/functions-window.html
+- PostgreSQL `date_trunc` — https://www.postgresql.org/docs/current/functions-datetime.html
+- pg_trickle SQL Reference — [SQL_REFERENCE.md](../docs/SQL_REFERENCE.md)
+- pg_trickle DVM Operators — [DVM_OPERATORS.md](../docs/DVM_OPERATORS.md)
+- TimescaleDB — https://www.timescale.com/
+- pg_partman — https://github.com/pgpartman/pg_partman
+- pg_cron — https://github.com/citusdata/pg_cron

--- a/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
@@ -28,6 +28,7 @@
   - [pg_cron — Scheduled Inbox Cleanup](#pg_cron--scheduled-inbox-cleanup)
   - [pg_partman — Inbox Table Partitioning](#pg_partman--inbox-table-partitioning)
   - [pgflow — Durable Inbox Processing Workflows](#pgflow--durable-inbox-processing-workflows)
+  - [NATS / JetStream — As the Inbox Transport Layer](#nats--jetstream--as-the-inbox-transport-layer)
 - [Potential pg_trickle Extensions](#potential-pg_trickle-extensions)
   - [Extension 1: Inbox Table Helper](#extension-1-inbox-table-helper)
   - [Extension 2: Deduplication Stream Table](#extension-2-deduplication-stream-table)
@@ -703,6 +704,149 @@ compensation logic.
 orchestrates the processing workflow (e.g., validate → enrich → store →
 notify).
 
+### NATS / JetStream — As the Inbox Transport Layer
+
+[NATS](https://nats.io/) with its persistent streaming layer **JetStream**
+can serve as the transport that delivers messages into the PostgreSQL inbox
+table. NATS is a CNCF incubating project — a single ~10 MB binary providing
+pub/sub, request/reply, and durable streaming with sub-millisecond latency.
+
+**Key JetStream features relevant to the inbox pattern:**
+
+| Feature | Benefit for Inbox |
+|---------|-------------------|
+| Durable consumers | Resume from last ack after consumer restart |
+| Exactly-once delivery | Double-ack protocol prevents duplicate delivery to consumer |
+| Per-subject ordering | Messages for the same entity arrive in order |
+| Redelivery with backoff | Unacked messages redeliver with configurable backoff |
+| Work queue mode | Automatic load balancing across multiple inbox writers |
+| Dead letter (`MaxDeliver`) | Messages exceeding max delivery attempts are surfaced |
+| Wildcard subscriptions | `payments.>` receives all payment-related events |
+
+**Architecture: NATS JetStream → PostgreSQL Inbox → pg_trickle:**
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  Upstream Services                                                     │
+│  (Order Service, Shipping Service, ...)                                │
+│       │                                                                │
+│       │ nats.js_publish('payments.order_created', payload)             │
+│       ▼                                                                │
+│  ┌──────────────────────────────────────┐                              │
+│  │ NATS JetStream                       │                              │
+│  │ Stream: PAYMENTS                     │                              │
+│  │ Subjects: payments.>                 │                              │
+│  │ Retention: WorkQueue                 │                              │
+│  └──────────────┬───────────────────────┘                              │
+│                 │ Pull consumer (durable)                               │
+│                 ▼                                                       │
+│  ┌──────────────────────────────────────┐                              │
+│  │ Inbox Writer (application worker)    │                              │
+│  │ 1. msg = consumer.fetch(batch=50)    │                              │
+│  │ 2. INSERT INTO inbox ON CONFLICT     │                              │
+│  │    DO NOTHING                        │                              │
+│  │ 3. msg.ack()                         │                              │
+│  └──────────────┬───────────────────────┘                              │
+│                 │                                                       │
+│                 ▼                                                       │
+│  ┌──────────────────────────────────────────────────────────────────┐  │
+│  │ PostgreSQL                                                       │  │
+│  │                                                                  │  │
+│  │  inbox_events table                                              │  │
+│  │       │ CDC trigger (automatic)                                  │  │
+│  │       ▼                                                          │  │
+│  │  pending_inbox (stream table, DIFFERENTIAL, 1s)                  │  │
+│  │       │                                                          │  │
+│  │       ▼                                                          │  │
+│  │  Processing workers                                              │  │
+│  └──────────────────────────────────────────────────────────────────┘  │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+**Inbox writer consuming from NATS JetStream:**
+
+```python
+import nats
+from nats.js import JetStreamContext
+import psycopg2
+import json
+import asyncio
+
+async def inbox_writer():
+    nc = await nats.connect("nats://localhost:4222")
+    js = nc.jetstream()
+
+    # Create a durable pull consumer for the PAYMENTS stream
+    consumer = await js.pull_subscribe(
+        "payments.>",
+        durable="payment-inbox-writer",
+        stream="PAYMENTS",
+    )
+
+    conn = psycopg2.connect("postgresql://localhost/mydb")
+
+    while True:
+        try:
+            messages = await consumer.fetch(batch=50, timeout=5)
+        except nats.errors.TimeoutError:
+            continue
+
+        with conn.cursor() as cur:
+            for msg in messages:
+                payload = json.loads(msg.data)
+                event_id = msg.headers.get("Nats-Msg-Id", msg.reply)
+
+                cur.execute("""
+                    INSERT INTO inbox_events (event_id, event_type, source, payload)
+                    VALUES (%s, %s, %s, %s)
+                    ON CONFLICT (event_id) DO NOTHING
+                """, (
+                    event_id,
+                    msg.subject.split(".")[-1],   # e.g. 'order_created'
+                    msg.headers.get("Source", "unknown"),
+                    json.dumps(payload),
+                ))
+
+                await msg.ack()  # Ack AFTER successful INSERT
+
+            conn.commit()
+```
+
+**Double-ack exactly-once flow:**
+
+1. NATS delivers message to the inbox writer (visibility timeout starts).
+2. Writer INSERTs into `inbox_events` with `ON CONFLICT DO NOTHING`.
+3. Writer calls `msg.ack()` — NATS marks the message as consumed.
+4. If the writer crashes between step 2 and 3, NATS redelivers. The
+   `ON CONFLICT` clause deduplicates, so no duplicate processing occurs.
+5. pg_trickle's stream table materializes the new pending event within ~1s.
+6. Processing workers pick up the event from the stream table.
+
+**NATS vs. Kafka/RabbitMQ as inbox transport:**
+
+| Factor | Kafka | RabbitMQ | NATS JetStream |
+|--------|-------|----------|----------------|
+| Publish latency | ~5-10ms | ~2-5ms | <1ms |
+| Operational complexity | High (ZooKeeper/KRaft, brokers) | Medium (Erlang cluster) | Low (single binary) |
+| Binary size | ~500 MB+ | ~250 MB+ | ~10 MB |
+| Built-in deduplication | Manual (idempotent producer) | Manual | `Nats-Msg-Id` header |
+| Consumer groups | Built-in (partition-based) | Queue-based | Work queue mode |
+| Dead letter handling | Manual DLQ topic | Built-in DLX | `MaxDeliver` + advisory |
+| Ordering | Per-partition | Per-queue | Per-subject |
+| Edge deployment | Impractical | Possible | Designed for edge |
+
+**When to choose NATS for the inbox transport:**
+- Low-ops environments where running Kafka is too heavy.
+- Edge or IoT deployments with constrained resources.
+- Sub-millisecond message delivery latency is important.
+- You want built-in deduplication and redelivery without custom logic.
+- You already use NATS for service-to-service communication.
+
+**When Kafka is still preferred:**
+- Existing Kafka ecosystem (Connect, Schema Registry, ksqlDB).
+- Multi-datacenter replication with MirrorMaker.
+- Very high throughput (millions of messages/sec) with long retention.
+
 ---
 
 ## Potential pg_trickle Extensions
@@ -917,18 +1061,18 @@ SELECT pgtrickle.create_stream_table('message_health',
 
 ## Comparison with Traditional Approaches
 
-| Aspect | Traditional Inbox | pg_trickle Inbox | pgmq Inbox |
-|--------|-------------------|-------------------|------------|
-| Processing queue view | Custom SQL query each time | Pre-materialized stream table | Built-in `pgmq.read()` |
-| Deduplication | Manual `ON CONFLICT` | `ON CONFLICT` + `DISTINCT ON` stream table | Manual (by `msg_id`) |
-| Ordering | Manual `ORDER BY` + gap tracking | Stream table with gap detection | FIFO within queue |
-| Dead letter queue | Manual query | Materialized stream table with alerts | Manual (check `read_ct`) |
-| Monitoring | Custom queries | Built-in staleness, alerts, stats | Basic (`read_ct`, queue depth) |
-| Competing consumers | `FOR UPDATE SKIP LOCKED` | `FOR UPDATE SKIP LOCKED` + stream table stats | Visibility timeout |
-| Retry backoff | Manual calculation | Stream table with backoff filter | Visibility timeout extension |
-| Infrastructure | PostgreSQL only | PostgreSQL only | PostgreSQL only |
-| Throughput overhead | Full-table scan per poll | DIFFERENTIAL (only changed rows) | Index scan per read |
-| Latency | Poll interval | ~1s (DIFFERENTIAL) or ~0ms (IMMEDIATE) | ~0ms (direct read) |
+| Aspect | Traditional Inbox | pg_trickle Inbox | pgmq Inbox | pg_trickle + NATS JetStream |
+|--------|-------------------|-------------------|------------|-----------------------------|
+| Processing queue view | Custom SQL query each time | Pre-materialized stream table | Built-in `pgmq.read()` | Stream table (post-ingest) |
+| Deduplication | Manual `ON CONFLICT` | `ON CONFLICT` + `DISTINCT ON` stream table | Manual (by `msg_id`) | `Nats-Msg-Id` + `ON CONFLICT` |
+| Ordering | Manual `ORDER BY` + gap tracking | Stream table with gap detection | FIFO within queue | Per-subject (JetStream) + stream table |
+| Dead letter queue | Manual query | Materialized stream table with alerts | Manual (check `read_ct`) | `MaxDeliver` + DLQ stream table |
+| Monitoring | Custom queries | Built-in staleness, alerts, stats | Basic (`read_ct`, queue depth) | pg_trickle alerts + NATS advisories |
+| Competing consumers | `FOR UPDATE SKIP LOCKED` | `FOR UPDATE SKIP LOCKED` + stream table stats | Visibility timeout | JetStream work queues → inbox table |
+| Retry backoff | Manual calculation | Stream table with backoff filter | Visibility timeout extension | NATS redelivery backoff + stream table |
+| Infrastructure | PostgreSQL only | PostgreSQL only | PostgreSQL only | PostgreSQL + NATS (~10 MB binary) |
+| Throughput overhead | Full-table scan per poll | DIFFERENTIAL (only changed rows) | Index scan per read | NATS push + DIFFERENTIAL |
+| Latency | Poll interval | ~1s (DIFFERENTIAL) or ~0ms (IMMEDIATE) | ~0ms (direct read) | <1ms (NATS) + ~1s (stream table) |
 
 ---
 
@@ -941,5 +1085,7 @@ SELECT pgtrickle.create_stream_table('message_health',
 - [pgmq — PostgreSQL Message Queue](https://github.com/pgmq/pgmq)
 - [pgflow — Durable Workflow Engine](https://pgflow.dev/)
 - [pg_partman — Partition Management](https://github.com/pgpartman/pg_partman)
+- [NATS.io — Cloud-Native Messaging](https://nats.io/)
+- [NATS JetStream Documentation](https://docs.nats.io/nats-concepts/jetstream)
 - pg_trickle [ARCHITECTURE.md](../../docs/ARCHITECTURE.md), [PATTERNS.md](../../docs/PATTERNS.md), [SQL_REFERENCE.md](../../docs/SQL_REFERENCE.md)
 - [PLAN_TRANSACTIONAL_OUTBOX.md](PLAN_TRANSACTIONAL_OUTBOX.md) — companion document for the outbox pattern

--- a/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
@@ -1,0 +1,945 @@
+# Transactional Inbox Pattern with pg_trickle
+
+> **Status:** Research Report  
+> **Created:** 2026-04-17  
+> **Category:** Integration Pattern  
+> **Related:** [PLAN_TRANSACTIONAL_OUTBOX.md](PLAN_TRANSACTIONAL_OUTBOX.md)
+
+---
+
+## Table of Contents
+
+- [Executive Summary](#executive-summary)
+- [What Is the Transactional Inbox Pattern?](#what-is-the-transactional-inbox-pattern)
+- [The Problem It Solves](#the-problem-it-solves)
+- [How pg_trickle Enables the Transactional Inbox](#how-pg_trickle-enables-the-transactional-inbox)
+  - [Architecture Overview](#architecture-overview)
+  - [Approach 1: Inbox Table + Stream Table for Processing Queue](#approach-1-inbox-table--stream-table-for-processing-queue)
+  - [Approach 2: Inbox with Deduplication and Ordering](#approach-2-inbox-with-deduplication-and-ordering)
+  - [Approach 3: IMMEDIATE Mode for Synchronous Inbox Processing](#approach-3-immediate-mode-for-synchronous-inbox-processing)
+  - [Approach 4: Multi-Source Inbox Aggregation](#approach-4-multi-source-inbox-aggregation)
+- [Processing Strategies](#processing-strategies)
+  - [Strategy A: Background Worker Polling](#strategy-a-background-worker-polling)
+  - [Strategy B: Event-Driven Processing](#strategy-b-event-driven-processing)
+  - [Strategy C: Competing Workers with SKIP LOCKED](#strategy-c-competing-workers-with-skip-locked)
+- [Worked Example: Payment Service Inbox](#worked-example-payment-service-inbox)
+- [Complementary PostgreSQL Extensions](#complementary-postgresql-extensions)
+  - [pgmq — As the Inbox Transport](#pgmq--as-the-inbox-transport)
+  - [pg_cron — Scheduled Inbox Cleanup](#pg_cron--scheduled-inbox-cleanup)
+  - [pg_partman — Inbox Table Partitioning](#pg_partman--inbox-table-partitioning)
+  - [pgflow — Durable Inbox Processing Workflows](#pgflow--durable-inbox-processing-workflows)
+- [Potential pg_trickle Extensions](#potential-pg_trickle-extensions)
+  - [Extension 1: Inbox Table Helper](#extension-1-inbox-table-helper)
+  - [Extension 2: Deduplication Stream Table](#extension-2-deduplication-stream-table)
+  - [Extension 3: Dead Letter Queue Stream Table](#extension-3-dead-letter-queue-stream-table)
+  - [Extension 4: Inbox Health Dashboard](#extension-4-inbox-health-dashboard)
+- [Design Considerations](#design-considerations)
+- [Combining Outbox and Inbox Patterns](#combining-outbox-and-inbox-patterns)
+- [Comparison with Traditional Approaches](#comparison-with-traditional-approaches)
+- [References](#references)
+
+---
+
+## Executive Summary
+
+The **Transactional Inbox Pattern** ensures reliable, idempotent processing of
+inbound messages from external systems. When a service receives a message (from
+a broker, webhook, or API call), it first persists the message to an "inbox"
+table within a database transaction, then acknowledges receipt. A separate
+background process picks up messages from the inbox and processes them.
+
+pg_trickle enhances this pattern by:
+
+1. **Materializing the processing queue** as a stream table — the "unprocessed
+   messages" view is always fresh and pre-filtered via DIFFERENTIAL refresh.
+2. **Providing built-in deduplication** through `DISTINCT ON` stream tables
+   that can eliminate duplicate message deliveries.
+3. **Detecting ordering gaps** via stream tables that surface missing sequence
+   numbers or out-of-order arrivals.
+4. **Monitoring inbox health** through built-in staleness alerts, refresh
+   statistics, and the `pg_trickle_alert` notification channel.
+5. **Enabling multi-source aggregation** where messages from different upstream
+   services are unified into a single processing pipeline via stream tables.
+
+---
+
+## What Is the Transactional Inbox Pattern?
+
+In a microservice architecture, a service receives messages from external
+systems (brokers, other services, webhooks). The challenge is ensuring:
+
+1. **No message loss:** Every message is eventually processed.
+2. **No duplicate processing:** Messages delivered more than once (at-least-once
+   delivery) don't cause duplicate side effects.
+3. **Ordered processing:** Messages for the same entity are processed in order.
+4. **Resilience:** Processing failures don't lose the message.
+
+The **Transactional Inbox** solves this by:
+
+1. **Persisting the message** to an "inbox" table as the first step.
+2. **Acknowledging the message** to the broker/sender only after the inbox
+   write succeeds.
+3. A **background processor** reads from the inbox, executes business logic,
+   and marks messages as processed.
+4. **Deduplication** happens at the inbox level using the message's unique ID.
+
+```
+External System                  PostgreSQL
+     │                               │
+     │  message (event_id=abc)       │
+     ├──────────────────────────────→│
+     │                               │ BEGIN;
+     │                               │   INSERT INTO inbox_events (event_id, ...)
+     │                               │     ON CONFLICT (event_id) DO NOTHING;
+     │                ACK            │ COMMIT;
+     │←──────────────────────────────┤
+     │                               │
+     │                               │ ┌──────────────────────┐
+     │                               │ │ Background Processor │
+     │                               │ │ reads inbox, applies │
+     │                               │ │ business logic, marks│
+     │                               │ │ as processed         │
+     │                               │ └──────────────────────┘
+```
+
+---
+
+## The Problem It Solves
+
+| Failure Scenario                         | Without Inbox                    | With Inbox                       |
+|------------------------------------------|----------------------------------|----------------------------------|
+| Service crashes after receiving message  | Message lost (acked but not saved) | Never acked — broker redelivers |
+| Service crashes during processing        | Partial state + message lost     | Message still in inbox; retry    |
+| Duplicate delivery (broker retry)        | Duplicate side effects           | Deduplicated by event_id PK     |
+| Processing takes too long (timeout)      | Broker redelivers → concurrent processing | Inbox deduplicates; single processor |
+| Out-of-order delivery                    | Inconsistent state               | Inbox + ordering by sequence ID  |
+| Burst of messages                        | Overwhelms processing capacity   | Messages queue in inbox; backpressure |
+
+**Key guarantees:**
+
+- **Exactly-once processing:** Deduplication at the inbox level + idempotent
+  processing ensures each logical message is processed exactly once.
+- **Durability:** Once the inbox write commits, the message survives crashes.
+- **Decoupled ingestion and processing:** The receiver is fast (just INSERT +
+  ACK); processing happens asynchronously at whatever pace the system can
+  sustain.
+
+---
+
+## How pg_trickle Enables the Transactional Inbox
+
+### Architecture Overview
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                           PostgreSQL                                  │
+│                                                                       │
+│  External messages arrive via consumer worker (Kafka, RabbitMQ, HTTP) │
+│                         │                                             │
+│                         ▼                                             │
+│  ┌──────────────────────────────────────────┐                        │
+│  │ inbox_events                              │                        │
+│  │ (event_id PK, event_type, source,         │                        │
+│  │  payload, received_at, processed_at,      │                        │
+│  │  error, retry_count)                      │                        │
+│  └────────────────────┬─────────────────────┘                        │
+│                       │ CDC trigger (automatic)                       │
+│                       ▼                                               │
+│  ┌──────────────────────────────────────────┐                        │
+│  │ pending_inbox     (stream table)          │  DIFFERENTIAL, 1s     │
+│  │ WHERE processed_at IS NULL                │                        │
+│  │   AND retry_count < max_retries           │                        │
+│  └────────────────────┬─────────────────────┘                        │
+│                       │                                               │
+│        ┌──────────────┼──────────────┐                                │
+│        ▼              ▼              ▼                                 │
+│  ┌──────────┐  ┌──────────┐  ┌──────────────┐                       │
+│  │ Worker 1 │  │ Worker 2 │  │ dead_letter  │  (stream table)       │
+│  │ (process)│  │ (process)│  │ WHERE retries│  DIFFERENTIAL, 30s    │
+│  └──────────┘  └──────────┘  │ >= max       │                       │
+│                              └──────────────┘                        │
+│                                                                       │
+│  ┌──────────────────────────────────────────┐                        │
+│  │ inbox_stats       (stream table)          │  DIFFERENTIAL, 10s    │
+│  │ COUNT(*) pending, processed, failed       │                        │
+│  │ GROUP BY event_type, source               │                        │
+│  └──────────────────────────────────────────┘                        │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+### Approach 1: Inbox Table + Stream Table for Processing Queue
+
+The core pattern: an inbox table for durable storage + a stream table for the
+"ready to process" queue.
+
+```sql
+-- Step 1: Create the inbox table
+CREATE TABLE inbox_events (
+    event_id     TEXT PRIMARY KEY,        -- globally unique (from sender)
+    event_type   TEXT NOT NULL,
+    source       TEXT NOT NULL,           -- originating service/system
+    payload      JSONB NOT NULL,
+    received_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at TIMESTAMPTZ,            -- NULL = not yet processed
+    error        TEXT,                    -- last processing error
+    retry_count  INT NOT NULL DEFAULT 0
+);
+
+CREATE INDEX idx_inbox_pending ON inbox_events (received_at)
+    WHERE processed_at IS NULL;
+
+-- Step 2: Stream table for unprocessed messages
+SELECT pgtrickle.create_stream_table(
+    'pending_inbox',
+    $$SELECT event_id, event_type, source, payload, received_at, retry_count
+      FROM inbox_events
+      WHERE processed_at IS NULL
+        AND retry_count < 5
+      ORDER BY received_at$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Step 3: Consumer writes to inbox (idempotent via ON CONFLICT)
+-- Application-side pseudocode:
+--   msg = kafka_consumer.poll()
+--   INSERT INTO inbox_events (event_id, event_type, source, payload)
+--     VALUES (msg.id, msg.type, msg.source, msg.payload)
+--     ON CONFLICT (event_id) DO NOTHING;
+--   kafka_consumer.ack(msg)
+
+-- Step 4: Processor reads from stream table
+-- Application-side pseudocode:
+--   rows = SELECT * FROM pending_inbox LIMIT 50;
+--   for each row:
+--     try:
+--       process(row)
+--       UPDATE inbox_events SET processed_at = now() WHERE event_id = row.event_id;
+--     catch:
+--       UPDATE inbox_events SET error = err_msg, retry_count = retry_count + 1
+--         WHERE event_id = row.event_id;
+```
+
+**Advantages:**
+- Deduplication via `ON CONFLICT (event_id) DO NOTHING`.
+- Stream table provides a fast, pre-filtered view of pending work.
+- DIFFERENTIAL refresh only recomputes when inbox_events changes.
+- Built-in monitoring via `pg_trickle_alert`.
+
+### Approach 2: Inbox with Deduplication and Ordering
+
+For scenarios where messages arrive out of order and must be processed
+sequentially per entity.
+
+```sql
+-- Inbox with sequence tracking
+CREATE TABLE inbox_events (
+    event_id      TEXT PRIMARY KEY,
+    event_type    TEXT NOT NULL,
+    aggregate_id  TEXT NOT NULL,         -- entity this message belongs to
+    sequence_num  BIGINT NOT NULL,       -- monotonic per aggregate
+    source        TEXT NOT NULL,
+    payload       JSONB NOT NULL,
+    received_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at  TIMESTAMPTZ,
+    error         TEXT,
+    retry_count   INT NOT NULL DEFAULT 0,
+    UNIQUE (aggregate_id, sequence_num)  -- enforce ordering uniqueness
+);
+
+-- Stream table: next message to process per aggregate (in-order)
+SELECT pgtrickle.create_stream_table(
+    'inbox_next_to_process',
+    $$WITH last_processed AS (
+        SELECT aggregate_id, COALESCE(MAX(sequence_num), 0) AS last_seq
+        FROM inbox_events
+        WHERE processed_at IS NOT NULL
+        GROUP BY aggregate_id
+      ),
+      next_event AS (
+        SELECT DISTINCT ON (i.aggregate_id)
+               i.event_id, i.event_type, i.aggregate_id, i.sequence_num,
+               i.payload, i.received_at
+        FROM inbox_events i
+        LEFT JOIN last_processed lp ON lp.aggregate_id = i.aggregate_id
+        WHERE i.processed_at IS NULL
+          AND i.retry_count < 5
+          AND i.sequence_num = COALESCE(lp.last_seq, 0) + 1
+        ORDER BY i.aggregate_id, i.sequence_num
+      )
+      SELECT * FROM next_event$$,
+    schedule => '2s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Stream table: detect gaps in message sequences
+SELECT pgtrickle.create_stream_table(
+    'inbox_missing_sequences',
+    $$WITH expected AS (
+        SELECT aggregate_id,
+               generate_series(
+                 MIN(sequence_num),
+                 MAX(sequence_num)
+               ) AS expected_seq
+        FROM inbox_events
+        GROUP BY aggregate_id
+      )
+      SELECT e.aggregate_id, e.expected_seq AS missing_sequence
+      FROM expected e
+      LEFT JOIN inbox_events i
+        ON i.aggregate_id = e.aggregate_id
+        AND i.sequence_num = e.expected_seq
+      WHERE i.event_id IS NULL$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+**Advantages:**
+- Guarantees in-order processing per aggregate.
+- Detects missing messages so gaps can be investigated.
+- DIFFERENTIAL refresh keeps the "next to process" view cheap to maintain.
+
+### Approach 3: IMMEDIATE Mode for Synchronous Inbox Processing
+
+For low-latency scenarios where you want to start processing the moment a
+message arrives.
+
+```sql
+-- IMMEDIATE mode updates the stream table within the ingestion transaction
+SELECT pgtrickle.create_stream_table(
+    'realtime_inbox',
+    $$SELECT event_id, event_type, payload, received_at
+      FROM inbox_events
+      WHERE processed_at IS NULL$$,
+    refresh_mode => 'IMMEDIATE'
+);
+
+-- Combined with LISTEN/NOTIFY for instant processing triggers
+LISTEN pg_trickle_alert;
+-- When a message is ingested, the stream table updates within the same txn,
+-- and the alert fires, waking the processor immediately.
+```
+
+**Trade-off:** Adds latency to the message ingestion path. Use only when
+processing latency is more critical than ingestion throughput.
+
+### Approach 4: Multi-Source Inbox Aggregation
+
+Unify messages from multiple upstream services into a single processing
+pipeline.
+
+```sql
+-- Separate inbox tables per source (for isolation)
+CREATE TABLE inbox_from_orders (
+    event_id TEXT PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    received_at TIMESTAMPTZ DEFAULT now(),
+    processed_at TIMESTAMPTZ
+);
+
+CREATE TABLE inbox_from_payments (
+    event_id TEXT PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    received_at TIMESTAMPTZ DEFAULT now(),
+    processed_at TIMESTAMPTZ
+);
+
+-- Unified stream table aggregating all sources
+SELECT pgtrickle.create_stream_table(
+    'unified_pending_inbox',
+    $$SELECT event_id, event_type, 'orders' AS source, payload, received_at
+        FROM inbox_from_orders WHERE processed_at IS NULL
+      UNION ALL
+      SELECT event_id, event_type, 'payments' AS source, payload, received_at
+        FROM inbox_from_payments WHERE processed_at IS NULL$$,
+    schedule => '2s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+**Advantages:**
+- Single processing pipeline for all inbound events.
+- pg_trickle's CDC captures changes from all source tables independently.
+- UNION ALL is fully supported by the DVM engine with delta propagation.
+
+---
+
+## Processing Strategies
+
+### Strategy A: Background Worker Polling
+
+The processor periodically reads from the inbox stream table.
+
+```python
+import psycopg2
+import json
+import traceback
+
+conn = psycopg2.connect("postgresql://localhost/mydb")
+
+while True:
+    with conn.cursor() as cur:
+        # Read from the materialized stream table (fast, pre-filtered)
+        cur.execute("""
+            SELECT event_id, event_type, payload
+            FROM pending_inbox
+            ORDER BY received_at
+            LIMIT 50
+        """)
+        rows = cur.fetchall()
+
+        for event_id, event_type, payload in rows:
+            try:
+                process_event(event_type, payload)
+                cur.execute(
+                    "UPDATE inbox_events SET processed_at = now() WHERE event_id = %s",
+                    (event_id,)
+                )
+            except Exception as e:
+                cur.execute("""
+                    UPDATE inbox_events
+                    SET error = %s, retry_count = retry_count + 1
+                    WHERE event_id = %s
+                """, (str(e)[:500], event_id))
+
+        conn.commit()
+
+    time.sleep(0.5)
+```
+
+**Throughput:** Moderate. Tunable via batch size and poll interval.
+
+### Strategy B: Event-Driven Processing
+
+Use `pg_trickle_alert` notifications to trigger processing immediately.
+
+```python
+import psycopg2
+import psycopg2.extensions
+import select
+import json
+
+conn = psycopg2.connect("postgresql://localhost/mydb")
+conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+
+cur = conn.cursor()
+cur.execute("LISTEN pg_trickle_alert;")
+
+while True:
+    if select.select([conn], [], [], 10.0) != ([], [], []):
+        conn.poll()
+        while conn.notifies:
+            notify = conn.notifies.pop(0)
+            payload = json.loads(notify.payload)
+
+            if (payload.get('event') == 'refresh_completed' and
+                payload.get('pgt_name') == 'pending_inbox'):
+
+                rows_changed = payload.get('rows_inserted', 0)
+                if rows_changed > 0:
+                    process_pending_inbox()
+```
+
+**Latency:** ~15ms (event-driven wake) + stream table schedule.
+
+### Strategy C: Competing Workers with SKIP LOCKED
+
+Multiple worker instances safely process from the same inbox without
+duplicating work.
+
+```sql
+-- Each worker runs:
+BEGIN;
+  -- Lock and fetch a batch of unprocessed messages
+  SELECT event_id, event_type, payload
+  FROM inbox_events
+  WHERE processed_at IS NULL
+    AND retry_count < 5
+  ORDER BY received_at
+  LIMIT 20
+  FOR UPDATE SKIP LOCKED;
+
+  -- Process each message...
+
+  -- Mark batch as processed
+  UPDATE inbox_events
+  SET processed_at = now()
+  WHERE event_id = ANY($processed_ids);
+COMMIT;
+```
+
+**Note:** This strategy reads directly from the inbox table (not the stream
+table) because `FOR UPDATE` requires a base table. The stream table still
+serves as the monitoring/stats layer.
+
+---
+
+## Worked Example: Payment Service Inbox
+
+A payment service receives `OrderCreated` events and must create payment
+intents for each order.
+
+```sql
+-- === Schema ===
+
+CREATE TABLE payment_inbox (
+    event_id     TEXT PRIMARY KEY,
+    event_type   TEXT NOT NULL,
+    source       TEXT NOT NULL DEFAULT 'order-service',
+    payload      JSONB NOT NULL,
+    received_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at TIMESTAMPTZ,
+    error        TEXT,
+    retry_count  INT NOT NULL DEFAULT 0
+);
+
+CREATE TABLE payment_intents (
+    id          SERIAL PRIMARY KEY,
+    order_id    INT NOT NULL UNIQUE,     -- idempotency key
+    customer_id INT NOT NULL,
+    amount      NUMERIC(10,2) NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'pending',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- === pg_trickle Stream Tables ===
+
+-- Pending messages ready for processing
+SELECT pgtrickle.create_stream_table(
+    'pending_payments',
+    $$SELECT event_id, event_type, payload, received_at, retry_count
+      FROM payment_inbox
+      WHERE processed_at IS NULL
+        AND retry_count < 5$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Dead letter queue: messages that exceeded retry limit
+SELECT pgtrickle.create_stream_table(
+    'payment_dead_letters',
+    $$SELECT event_id, event_type, payload, error, retry_count, received_at
+      FROM payment_inbox
+      WHERE processed_at IS NULL
+        AND retry_count >= 5$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Processing statistics dashboard
+SELECT pgtrickle.create_stream_table(
+    'payment_inbox_stats',
+    $$SELECT
+        event_type,
+        COUNT(*) FILTER (WHERE processed_at IS NULL AND retry_count < 5) AS pending,
+        COUNT(*) FILTER (WHERE processed_at IS NOT NULL) AS processed,
+        COUNT(*) FILTER (WHERE retry_count >= 5) AS dead_letter,
+        AVG(EXTRACT(EPOCH FROM (processed_at - received_at)))
+            FILTER (WHERE processed_at IS NOT NULL) AS avg_processing_time_sec,
+        MAX(received_at) FILTER (WHERE processed_at IS NULL) AS oldest_pending
+      FROM payment_inbox
+      GROUP BY event_type$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- === Ingestion (from Kafka consumer) ===
+
+-- The consumer worker does:
+--   msg = consumer.poll()
+--   INSERT INTO payment_inbox (event_id, event_type, source, payload)
+--     VALUES (msg.id, msg.headers['event_type'], msg.headers['source'], msg.value)
+--     ON CONFLICT (event_id) DO NOTHING;
+--   consumer.commit()
+
+-- === Processing Function ===
+
+CREATE OR REPLACE FUNCTION process_payment_inbox_event(
+    p_event_id TEXT,
+    p_payload JSONB
+) RETURNS VOID AS $$
+BEGIN
+    -- Create payment intent (idempotent via UNIQUE on order_id)
+    INSERT INTO payment_intents (order_id, customer_id, amount)
+    VALUES (
+        (p_payload->>'order_id')::int,
+        (p_payload->>'customer_id')::int,
+        (p_payload->>'total')::numeric
+    )
+    ON CONFLICT (order_id) DO NOTHING;
+
+    -- Mark inbox event as processed
+    UPDATE payment_inbox
+    SET processed_at = now()
+    WHERE event_id = p_event_id;
+END;
+$$ LANGUAGE plpgsql;
+
+-- === Monitoring ===
+
+-- Check inbox health
+SELECT * FROM payment_inbox_stats;
+
+-- Get staleness
+SELECT pgtrickle.get_staleness('pending_payments');
+
+-- Listen for alerts
+LISTEN pg_trickle_alert;
+-- Emits: {"event":"stale_data","pgt_name":"pending_payments","staleness_seconds":15}
+```
+
+---
+
+## Complementary PostgreSQL Extensions
+
+### pgmq — As the Inbox Transport
+
+[pgmq](https://github.com/pgmq/pgmq) can serve as the inbox itself, replacing
+the custom inbox table with a pgmq queue. This gives you visibility timeouts,
+exactly-once semantics, and built-in archival.
+
+```sql
+CREATE EXTENSION pgmq;
+
+-- Create inbox queue
+SELECT pgmq.create('payment_inbox');
+
+-- Ingest: enqueue message (from external consumer)
+SELECT pgmq.send('payment_inbox',
+    '{"event_id": "abc-123", "event_type": "OrderCreated", "payload": {...}}'::jsonb
+);
+
+-- Process: read with visibility timeout
+SELECT * FROM pgmq.read('payment_inbox', vt => 60, qty => 10);
+
+-- After processing, delete
+SELECT pgmq.delete('payment_inbox', msg_id => 42);
+
+-- pg_trickle stream table on top of pgmq queue table for monitoring
+SELECT pgtrickle.create_stream_table(
+    'pgmq_inbox_depth',
+    $$SELECT COUNT(*) AS queue_depth,
+             MIN(enqueued_at) AS oldest_message,
+             MAX(read_ct) AS max_read_count
+      FROM pgmq.q_payment_inbox
+      WHERE vt <= now()$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+**Advantages of pgmq as inbox:**
+- Visibility timeout prevents duplicate concurrent processing.
+- Built-in `read_ct` tracks how many times a message was read (retry counter).
+- Archive table provides audit trail.
+- pg_trickle stream table adds real-time monitoring dashboards on top.
+
+### pg_cron — Scheduled Inbox Cleanup
+
+[pg_cron](https://github.com/citusdata/pg_cron) can automate garbage
+collection of processed inbox messages.
+
+```sql
+-- Clean up processed messages older than 30 days
+SELECT cron.schedule(
+    'inbox_cleanup',
+    '0 3 * * *',  -- daily at 3 AM
+    $$DELETE FROM payment_inbox
+      WHERE processed_at IS NOT NULL
+        AND processed_at < now() - INTERVAL '30 days'$$
+);
+
+-- Retry dead letter messages (reset retry count) weekly
+SELECT cron.schedule(
+    'inbox_retry_dead_letters',
+    '0 6 * * 1',  -- Monday at 6 AM
+    $$UPDATE payment_inbox
+      SET retry_count = 0, error = NULL
+      WHERE processed_at IS NULL
+        AND retry_count >= 5
+        AND received_at > now() - INTERVAL '7 days'$$
+);
+```
+
+### pg_partman — Inbox Table Partitioning
+
+For high-volume inboxes, [pg_partman](https://github.com/pgpartman/pg_partman)
+manages time-based partitioning automatically.
+
+```sql
+CREATE TABLE payment_inbox (
+    event_id     TEXT NOT NULL,
+    event_type   TEXT NOT NULL,
+    source       TEXT NOT NULL,
+    payload      JSONB NOT NULL,
+    received_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at TIMESTAMPTZ,
+    error        TEXT,
+    retry_count  INT NOT NULL DEFAULT 0,
+    PRIMARY KEY (event_id, received_at)
+) PARTITION BY RANGE (received_at);
+
+-- pg_partman manages partition creation/retention
+SELECT partman.create_parent(
+    p_parent_table  => 'public.payment_inbox',
+    p_control       => 'received_at',
+    p_interval      => 'daily',
+    p_premake       => 7
+);
+
+-- Old partitions can be detached/dropped cheaply (vs DELETE)
+```
+
+### pgflow — Durable Inbox Processing Workflows
+
+[pgflow](https://pgflow.dev/) can orchestrate complex processing logic
+triggered by inbox events — multi-step workflows with retry, timeout, and
+compensation logic.
+
+**Synergy:** pg_trickle detects new inbox messages via stream tables; pgflow
+orchestrates the processing workflow (e.g., validate → enrich → store →
+notify).
+
+---
+
+## Potential pg_trickle Extensions
+
+### Extension 1: Inbox Table Helper
+
+A convenience function to create the inbox table with best-practice schema,
+indexes, and stream tables.
+
+```sql
+-- Proposed API
+SELECT pgtrickle.create_inbox(
+    inbox_name    => 'payment_inbox',
+    max_retries   => 5,
+    schedule      => '1s',
+    with_dead_letter => true,
+    with_stats    => true
+);
+
+-- Creates:
+-- 1. payment_inbox table with standard schema
+-- 2. pending_payment_inbox stream table (WHERE processed_at IS NULL)
+-- 3. payment_inbox_dead_letters stream table (WHERE retry_count >= max_retries)
+-- 4. payment_inbox_stats stream table (aggregate counts/latencies)
+-- 5. Partial indexes on pending rows
+```
+
+**Effort:** Medium. SQL generation + metadata tracking.
+
+### Extension 2: Deduplication Stream Table
+
+A specialized stream table that tracks which event IDs have been seen, enabling
+cross-service deduplication.
+
+```sql
+-- Proposed: automatic dedup tracking
+SELECT pgtrickle.create_stream_table(
+    'inbox_dedup_log',
+    $$SELECT DISTINCT event_id, MIN(received_at) AS first_seen,
+             COUNT(*) AS delivery_count
+      FROM inbox_events
+      GROUP BY event_id
+      HAVING COUNT(*) > 1$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- This surfaces duplicate deliveries for monitoring/alerting
+```
+
+### Extension 3: Dead Letter Queue Stream Table
+
+Automatic DLQ materialization with alerting when messages fail repeatedly.
+
+```sql
+-- The dead_letter stream table emits pg_trickle_alert when new rows appear
+-- Proposed enhancement: configurable alert thresholds
+SELECT pgtrickle.create_stream_table(
+    'inbox_dlq',
+    $$SELECT event_id, event_type, error, retry_count, received_at
+      FROM inbox_events
+      WHERE processed_at IS NULL AND retry_count >= 5$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL'
+    -- alert_on_new_rows => true  (proposed feature)
+);
+```
+
+### Extension 4: Inbox Health Dashboard
+
+A composite monitoring view that combines all inbox metrics.
+
+```sql
+-- Proposed: built-in health check function
+SELECT pgtrickle.inbox_health('payment_inbox');
+
+-- Returns:
+-- {
+--   "pending_count": 42,
+--   "dead_letter_count": 3,
+--   "avg_processing_time_ms": 120,
+--   "oldest_pending_age_sec": 5.2,
+--   "throughput_per_sec": 85.3,
+--   "duplicate_rate_pct": 0.02,
+--   "health_status": "healthy"
+-- }
+```
+
+---
+
+## Design Considerations
+
+### Idempotency
+
+The inbox pattern's primary purpose is enabling idempotent processing.
+Recommended strategies:
+
+| Strategy | How | When to Use |
+|----------|-----|-------------|
+| **Primary key dedup** | `ON CONFLICT (event_id) DO NOTHING` | Always — first line of defense |
+| **Idempotency key in business table** | `UNIQUE (order_id)` on `payment_intents` | When processing creates new entities |
+| **Processed events log** | Separate `processed_events` table checked before processing | When side effects can't be made naturally idempotent |
+| **Version checking** | Compare `sequence_num` before applying state change | When message ordering matters |
+
+### Ordering Guarantees
+
+| Scope | Strategy |
+|-------|----------|
+| Single aggregate | `ORDER BY sequence_num` per `aggregate_id` |
+| Cross-aggregate | No ordering guarantee (each aggregate independent) |
+| Gap detection | Stream table surfacing missing `sequence_num` values |
+| Hold-and-wait | Only process `sequence_num = last_processed + 1` |
+
+### Retry and Backoff
+
+```sql
+-- Exponential backoff via retry_count
+-- Only process messages where enough time has elapsed since last attempt
+SELECT pgtrickle.create_stream_table(
+    'inbox_ready_for_retry',
+    $$SELECT event_id, event_type, payload, retry_count
+      FROM inbox_events
+      WHERE processed_at IS NULL
+        AND retry_count < 5
+        AND (retry_count = 0 OR
+             received_at + (INTERVAL '1 second' * POWER(2, retry_count))
+               < now())$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Garbage Collection
+
+| Strategy | Mechanism | Overhead |
+|----------|-----------|----------|
+| DELETE old rows | `DELETE WHERE processed_at < now() - '30 days'` | Table bloat, vacuum overhead |
+| Partitioning | `DETACH PARTITION` + `DROP TABLE` | Near-zero (instant partition drop) |
+| Archive table | Move to `inbox_archive` after processing | Extra INSERT during processing |
+| TTL (with pg_cron) | Scheduled DELETE job | Predictable, manageable |
+
+### Monitoring and Alerting
+
+pg_trickle provides built-in monitoring that maps naturally to inbox health:
+
+| Metric | pg_trickle Feature |
+|--------|--------------------|
+| Pending queue depth | `SELECT COUNT(*) FROM pending_inbox` (stream table) |
+| Processing latency | `inbox_stats` stream table `avg_processing_time_sec` |
+| Dead letter count | `dead_letters` stream table row count |
+| Oldest pending age | `pgtrickle.get_staleness('pending_inbox')` |
+| Queue backing up | `pg_trickle_alert` → `stale_data` event |
+| Refresh failures | `pg_trickle_alert` → `refresh_failed` event |
+| Throughput | `pgtrickle.st_refresh_stats` → rows_inserted/deleted per refresh |
+
+---
+
+## Combining Outbox and Inbox Patterns
+
+In a microservice architecture, services typically use BOTH patterns:
+
+- **Outbox** for publishing events to downstream services.
+- **Inbox** for consuming events from upstream services.
+
+pg_trickle can power both sides:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                       Order Service                                  │
+│                                                                      │
+│  ┌──────────┐    ┌──────────────────┐    ┌────────────────────┐     │
+│  │  orders   │───→│ outbox_events    │───→│ pending_outbox     │──── │──→ Kafka
+│  │ (table)   │    │ (table + trigger)│    │ (stream table)     │     │
+│  └──────────┘    └──────────────────┘    └────────────────────┘     │
+│                                                                      │
+│  Kafka ──→ ┌──────────────────┐    ┌────────────────────┐           │
+│            │ inbox_events     │───→│ pending_inbox       │           │
+│            │ (table)          │    │ (stream table)      │           │
+│            └──────────────────┘    └────────────────────┘           │
+│                                                                      │
+│  Stream tables for monitoring:                                       │
+│    - outbox_stats, inbox_stats, dead_letters                         │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+```sql
+-- Both patterns in one service, powered by pg_trickle:
+
+-- OUTBOX: publish order events
+SELECT pgtrickle.create_stream_table('pending_outbox',
+    $$SELECT * FROM outbox_events WHERE published_at IS NULL$$,
+    schedule => '1s', refresh_mode => 'DIFFERENTIAL');
+
+-- INBOX: consume payment confirmation events
+SELECT pgtrickle.create_stream_table('pending_inbox',
+    $$SELECT * FROM inbox_events WHERE processed_at IS NULL AND retry_count < 5$$,
+    schedule => '1s', refresh_mode => 'DIFFERENTIAL');
+
+-- UNIFIED MONITORING: single stats view
+SELECT pgtrickle.create_stream_table('message_health',
+    $$SELECT 'outbox' AS direction, event_type,
+             COUNT(*) FILTER (WHERE published_at IS NULL) AS pending
+      FROM outbox_events GROUP BY event_type
+      UNION ALL
+      SELECT 'inbox' AS direction, event_type,
+             COUNT(*) FILTER (WHERE processed_at IS NULL) AS pending
+      FROM inbox_events GROUP BY event_type$$,
+    schedule => '10s', refresh_mode => 'DIFFERENTIAL');
+```
+
+---
+
+## Comparison with Traditional Approaches
+
+| Aspect | Traditional Inbox | pg_trickle Inbox | pgmq Inbox |
+|--------|-------------------|-------------------|------------|
+| Processing queue view | Custom SQL query each time | Pre-materialized stream table | Built-in `pgmq.read()` |
+| Deduplication | Manual `ON CONFLICT` | `ON CONFLICT` + `DISTINCT ON` stream table | Manual (by `msg_id`) |
+| Ordering | Manual `ORDER BY` + gap tracking | Stream table with gap detection | FIFO within queue |
+| Dead letter queue | Manual query | Materialized stream table with alerts | Manual (check `read_ct`) |
+| Monitoring | Custom queries | Built-in staleness, alerts, stats | Basic (`read_ct`, queue depth) |
+| Competing consumers | `FOR UPDATE SKIP LOCKED` | `FOR UPDATE SKIP LOCKED` + stream table stats | Visibility timeout |
+| Retry backoff | Manual calculation | Stream table with backoff filter | Visibility timeout extension |
+| Infrastructure | PostgreSQL only | PostgreSQL only | PostgreSQL only |
+| Throughput overhead | Full-table scan per poll | DIFFERENTIAL (only changed rows) | Index scan per read |
+| Latency | Poll interval | ~1s (DIFFERENTIAL) or ~0ms (IMMEDIATE) | ~0ms (direct read) |
+
+---
+
+## References
+
+- Chris Richardson, [Transactional Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html)
+  (includes inbox discussion)
+- Krzysztof Atłasik, [Microservices 101: Transactional Outbox and Inbox](https://softwaremill.com/microservices-101/)
+- Wikipedia, [Inbox and Outbox Pattern](https://en.wikipedia.org/wiki/Inbox_and_outbox_pattern)
+- [pgmq — PostgreSQL Message Queue](https://github.com/pgmq/pgmq)
+- [pgflow — Durable Workflow Engine](https://pgflow.dev/)
+- [pg_partman — Partition Management](https://github.com/pgpartman/pg_partman)
+- pg_trickle [ARCHITECTURE.md](../../docs/ARCHITECTURE.md), [PATTERNS.md](../../docs/PATTERNS.md), [SQL_REFERENCE.md](../../docs/SQL_REFERENCE.md)
+- [PLAN_TRANSACTIONAL_OUTBOX.md](PLAN_TRANSACTIONAL_OUTBOX.md) — companion document for the outbox pattern

--- a/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
@@ -35,12 +35,20 @@
   - [Extension 3: Dead Letter Queue Stream Table](#extension-3-dead-letter-queue-stream-table)
   - [Extension 4: Inbox Health Dashboard](#extension-4-inbox-health-dashboard)
 - [Design Considerations](#design-considerations)
+- [Poison Message Handling](#poison-message-handling)
+- [Webhook Inbox (Inbound HTTP Events)](#webhook-inbox-inbound-http-events)
+- [Priority Queues](#priority-queues)
+- [CloudEvents Standard](#cloudevents-standard)
+- [Exactly-Once Semantics — Clarified](#exactly-once-semantics--clarified)
 - [Schema Evolution & Message Versioning](#schema-evolution--message-versioning)
 - [Observability & Distributed Tracing](#observability--distributed-tracing)
 - [Testing Strategies](#testing-strategies)
 - [Multi-Tenancy](#multi-tenancy)
 - [Cost Analysis](#cost-analysis)
 - [Security Considerations](#security-considerations)
+- [Disaster Recovery & Backup-Restore](#disaster-recovery--backup-restore)
+- [Operational Runbooks](#operational-runbooks)
+- [Migration Guide](#migration-guide)
 - [Combining Outbox and Inbox Patterns](#combining-outbox-and-inbox-patterns)
 - [Comparison with Traditional Approaches](#comparison-with-traditional-approaches)
 - [References](#references)
@@ -713,7 +721,7 @@ notify).
 ### NATS / JetStream — As the Inbox Transport Layer
 
 [NATS](https://nats.io/) with its persistent streaming layer **JetStream**
-can serve as the transport that delivers messages into the PostgreSQL inbox
+can serve as the transport that delivers messages into« the PostgreSQL inbox
 table. NATS is a CNCF incubating project — a single ~10 MB binary providing
 pub/sub, request/reply, and durable streaming with sub-millisecond latency.
 
@@ -1047,6 +1055,433 @@ pg_trickle provides built-in monitoring that maps naturally to inbox health:
 | Queue backing up | `pg_trickle_alert` → `stale_data` event |
 | Refresh failures | `pg_trickle_alert` → `refresh_failed` event |
 | Throughput | `pgtrickle.st_refresh_stats` → rows_inserted/deleted per refresh |
+
+---
+
+## Poison Message Handling
+
+A **poison message** is one that crashes or gets stuck in the processor
+indefinitely, blocking all subsequent messages. The DLQ captures messages that
+exhaust retries, but you also need to handle DLQ messages operationally.
+
+### Detecting Poison Messages
+
+```sql
+-- Stream table that surfaces messages failing faster than backoff allows
+SELECT pgtrickle.create_stream_table(
+    'inbox_poison_candidates',
+    $$SELECT event_id, event_type, retry_count, last_error,
+             received_at,
+             EXTRACT(EPOCH FROM (now() - received_at)) AS age_seconds
+      FROM inbox_events
+      WHERE processed_at IS NULL
+        AND retry_count >= 3
+        AND retry_count < 5  -- not yet in DLQ
+      ORDER BY retry_count DESC$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Processor-Level Circuit Breaker
+
+Prevent a single bad message from crashing the processor in a tight loop
+*before* it hits the retry limit:
+
+```python
+import time
+
+class PoisonMessageGuard:
+    """Track consecutive failures; pause processing if threshold breached."""
+
+    def __init__(self, max_consecutive_failures=5, cooldown_seconds=30):
+        self.max_failures = max_consecutive_failures
+        self.cooldown = cooldown_seconds
+        self.consecutive_failures = 0
+
+    def record_success(self):
+        self.consecutive_failures = 0
+
+    def record_failure(self, event_id: str, error: str):
+        self.consecutive_failures += 1
+        if self.consecutive_failures >= self.max_failures:
+            logger.error(
+                f"Poison message guard: {self.consecutive_failures} consecutive "
+                f"failures, pausing for {self.cooldown}s. Last: {event_id}: {error}"
+            )
+            time.sleep(self.cooldown)
+            self.consecutive_failures = 0  # retry after cooldown
+```
+
+### DLQ Operations Runbook
+
+```sql
+-- 1. Inspect DLQ messages
+SELECT event_id, event_type, last_error, retry_count, received_at
+FROM inbox_events
+WHERE processed_at IS NULL AND retry_count >= 5
+ORDER BY received_at;
+
+-- 2. Replay after fix: reset retry_count to allow re-processing
+UPDATE inbox_events
+SET retry_count = 0, last_error = NULL
+WHERE event_id = 'evt-broken-001'
+  AND retry_count >= 5;
+
+-- 3. Permanently discard: mark as processed with a DLQ outcome
+UPDATE inbox_events
+SET processed_at = now(),
+    last_error = 'DISCARDED: permanently invalid, see ticket JIRA-1234'
+WHERE event_id = 'evt-hopeless-002';
+
+-- 4. Bulk discard by event type (e.g., deprecated events)
+UPDATE inbox_events
+SET processed_at = now(),
+    last_error = 'DISCARDED: event type deprecated'
+WHERE event_type = 'LegacyEvent'
+  AND processed_at IS NULL
+  AND retry_count >= 5;
+```
+
+### DLQ Alerting SLA
+
+| Severity | Condition | Action |
+|----------|-----------|--------|
+| **Warning** | DLQ depth > 0 for > 15 min | Slack notification |
+| **Error** | DLQ depth > 10 for > 1 hour | PagerDuty alert |
+| **Critical** | DLQ depth growing for > 4 hours | On-call page, stop upstream if needed |
+
+---
+
+## Webhook Inbox (Inbound HTTP Events)
+
+The inbox pattern is equally applicable to inbound **webhooks** (Stripe,
+GitHub, Shopify, etc.), not just broker messages. Webhook-specific concerns
+require additional handling.
+
+### Architecture: Webhook → Inbox → pg_trickle
+
+```
+External Service (Stripe, GitHub, ...)
+     │
+     │ POST /webhooks/stripe
+     │ Headers: Stripe-Signature, Content-Type: application/json
+     ▼
+┌─────────────────────────────────────────┐
+│ Webhook Receiver (HTTP handler)       │
+│                                       │
+│ 1. Verify HMAC signature              │
+│ 2. INSERT INTO inbox_events            │
+│    ON CONFLICT DO NOTHING              │
+│ 3. Return HTTP 200 immediately         │
+└─────────────────────────────────────────┘
+                    │
+                    ▼
+┌─────────────────────────────────────────┐
+│ PostgreSQL                             │
+│  inbox_events → pending_inbox           │
+│  (stream table, DIFFERENTIAL)          │
+│       │                                 │
+│       ▼                                 │
+│  Processor (reads from stream table)   │
+└─────────────────────────────────────────┘
+```
+
+### Key Rule: Respond 200 Before Processing
+
+Webhook senders (Stripe, GitHub) expect a fast HTTP 200 response. If you
+process synchronously and the handler takes > 5s, the sender retries —
+causing duplicates and wasted work.
+
+**The inbox pattern solves this perfectly:** INSERT → 200, then process async.
+
+### HMAC Signature Verification
+
+**Never process a webhook without verifying its signature.** This prevents
+forgery and replay attacks.
+
+```python
+import hmac, hashlib
+from fastapi import FastAPI, Request, HTTPException
+
+app = FastAPI()
+STRIPE_WEBHOOK_SECRET = os.environ["STRIPE_WEBHOOK_SECRET"]
+
+@app.post("/webhooks/stripe")
+async def stripe_webhook(request: Request):
+    body = await request.body()
+    sig_header = request.headers.get("Stripe-Signature", "")
+
+    # Step 1: Verify HMAC signature BEFORE any database write
+    try:
+        event = stripe.Webhook.construct_event(body, sig_header, STRIPE_WEBHOOK_SECRET)
+    except stripe.error.SignatureVerificationError:
+        raise HTTPException(status_code=400, detail="Invalid signature")
+
+    # Step 2: Write to inbox (idempotent)
+    event_id = event["id"]  # Stripe event ID is globally unique
+    await pg_conn.execute(
+        """INSERT INTO inbox_events (event_id, event_type, source, payload)
+           VALUES ($1, $2, 'stripe', $3)
+           ON CONFLICT (event_id) DO NOTHING""",
+        event_id, event["type"], json.dumps(event),
+    )
+
+    # Step 3: Return 200 immediately — processing happens async
+    return {"status": "received"}
+```
+
+### Webhook Retry Behavior
+
+| Provider | Retry Strategy | Timeout | Max Retries |
+|----------|---------------|---------|-------------|
+| Stripe | Exponential backoff | 20s | 3 days |
+| GitHub | Exponential backoff | 10s | ~4 hours |
+| Shopify | Fixed intervals | 5s | 48 hours |
+| Twilio | Exponential backoff | 15s | ~24 hours |
+
+All providers retry on non-2xx responses. The inbox's `ON CONFLICT DO NOTHING`
+handles all retries idempotently.
+
+### Webhook-Specific Inbox Schema
+
+```sql
+CREATE TABLE webhook_inbox_events (
+    event_id       TEXT PRIMARY KEY,        -- provider's event ID
+    provider       TEXT NOT NULL,           -- 'stripe', 'github', etc.
+    event_type     TEXT NOT NULL,
+    payload        JSONB NOT NULL,
+    raw_headers    JSONB,                   -- for audit/replay
+    signature      TEXT,                    -- original signature header
+    received_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at   TIMESTAMPTZ,
+    retry_count    INTEGER NOT NULL DEFAULT 0,
+    last_error     TEXT
+);
+
+-- Stream table for pending webhooks by provider
+SELECT pgtrickle.create_stream_table(
+    'pending_webhooks',
+    $$SELECT event_id, provider, event_type, payload, received_at
+      FROM webhook_inbox_events
+      WHERE processed_at IS NULL AND retry_count < 5$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+---
+
+## Priority Queues
+
+In production, not all inbox messages are equally urgent. A `payment.failed`
+event should be processed before `newsletter.sent`.
+
+### Priority Column
+
+```sql
+ALTER TABLE inbox_events ADD COLUMN priority INTEGER NOT NULL DEFAULT 5;
+-- 1 = highest (critical), 5 = normal, 9 = lowest (background)
+
+CREATE INDEX idx_inbox_priority ON inbox_events (priority, received_at)
+    WHERE processed_at IS NULL;
+```
+
+### Per-Priority Stream Tables
+
+```sql
+-- Critical priority: 1s refresh
+SELECT pgtrickle.create_stream_table(
+    'inbox_critical',
+    $$SELECT event_id, event_type, payload, received_at
+      FROM inbox_events
+      WHERE processed_at IS NULL AND priority <= 2 AND retry_count < 5$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Normal priority: 5s refresh
+SELECT pgtrickle.create_stream_table(
+    'inbox_normal',
+    $$SELECT event_id, event_type, payload, received_at
+      FROM inbox_events
+      WHERE processed_at IS NULL AND priority BETWEEN 3 AND 6 AND retry_count < 5$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Low priority: 30s refresh
+SELECT pgtrickle.create_stream_table(
+    'inbox_background',
+    $$SELECT event_id, event_type, payload, received_at
+      FROM inbox_events
+      WHERE processed_at IS NULL AND priority >= 7 AND retry_count < 5$$,
+    schedule => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Priority-Aware Processing
+
+```python
+async def prioritized_processor():
+    """Process highest-priority messages first, with starvation prevention."""
+    priority_tiers = [
+        ("inbox_critical",   1),  # process 1 batch from critical
+        ("inbox_normal",     1),  # then 1 batch from normal
+        ("inbox_background", 1),  # then 1 batch from background
+    ]
+
+    while True:
+        any_work = False
+        for table, weight in priority_tiers:
+            for _ in range(weight):
+                batch = await fetch_batch(table, limit=20)
+                if batch:
+                    await process_batch(batch)
+                    any_work = True
+
+        if not any_work:
+            await asyncio.sleep(0.5)
+```
+
+### Starvation Prevention
+
+Without starvation prevention, a flood of critical messages could starve
+normal and background processing indefinitely. Strategies:
+
+- **Round-robin with weights:** Process N critical, 1 normal, 1 background
+  per cycle (shown above).
+- **Age-based promotion:** Auto-promote messages older than 5 minutes to
+  the next priority tier.
+- **Separate worker pools:** Dedicate different worker instances to different
+  priority tiers.
+
+---
+
+## CloudEvents Standard
+
+[CloudEvents](https://cloudevents.io/) (CNCF graduated) is a vendor-neutral
+specification for describing event data. Adopting it for inbound messages
+makes the inbox interoperable across providers and frameworks.
+
+### CloudEvents-Formatted Inbox
+
+```sql
+-- Inbox table aligned with CloudEvents v1.0 envelope
+CREATE TABLE inbox_events (
+    event_id          TEXT PRIMARY KEY,              -- 'id'
+    source            TEXT NOT NULL,                 -- 'source'
+    spec_version      TEXT NOT NULL DEFAULT '1.0',   -- 'specversion'
+    event_type        TEXT NOT NULL,                 -- 'type'
+    subject           TEXT,                          -- 'subject'
+    time              TIMESTAMPTZ,                   -- 'time'
+    data_content_type TEXT DEFAULT 'application/json',-- 'datacontenttype'
+    data              JSONB NOT NULL,                -- 'data'
+    -- Processing state
+    received_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    processed_at      TIMESTAMPTZ,
+    retry_count       INTEGER NOT NULL DEFAULT 0,
+    last_error        TEXT
+);
+```
+
+### Validating CloudEvents on Ingest
+
+```python
+CLOUDEVENTS_REQUIRED = {"specversion", "id", "source", "type"}
+
+async def inbox_writer(msg):
+    payload = json.loads(msg.data)
+
+    # Validate CloudEvents required attributes
+    missing = CLOUDEVENTS_REQUIRED - set(payload.keys())
+    if missing:
+        logger.warning(f"Invalid CloudEvent, missing: {missing}")
+        await msg.ack()  # ack to prevent redelivery of invalid messages
+        return
+
+    await pg_conn.execute(
+        """INSERT INTO inbox_events (event_id, source, spec_version, event_type, data)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (event_id) DO NOTHING""",
+        payload["id"], payload["source"], payload["specversion"],
+        payload["type"], json.dumps(payload.get("data", {})),
+    )
+    await msg.ack()
+```
+
+### Documenting with AsyncAPI
+
+Use [AsyncAPI](https://www.asyncapi.com/) to document event contracts:
+
+```yaml
+asyncapi: 3.0.0
+info:
+  title: Payment Service Inbox Events
+  version: 1.0.0
+channels:
+  orderCreated:
+    address: orders.created
+    messages:
+      OrderCreated:
+        payload:
+          $ref: '#/components/schemas/OrderCreated'
+        headers:
+          type: object
+          properties:
+            ce-specversion: { type: string, const: '1.0' }
+            ce-source: { type: string }
+            Nats-Msg-Id: { type: string }
+components:
+  schemas:
+    OrderCreated:
+      type: object
+      required: [order_id, amount]
+      properties:
+        order_id: { type: string, format: uuid }
+        amount: { type: number }
+```
+
+---
+
+## Exactly-Once Semantics — Clarified
+
+The term "exactly-once" is used loosely. There are three distinct levels, and
+confusing them leads to over- or under-engineering deduplication logic.
+
+### Three Levels of Exactly-Once
+
+| Level | What It Means | Who Provides It |
+|-------|--------------|------------------|
+| **Broker-level dedup** | The broker delivers a message at most once per dedup key | NATS `Nats-Msg-Id`, Kafka idempotent producer |
+| **Inbox-level dedup** | The inbox stores a message at most once per event ID | `ON CONFLICT (event_id) DO NOTHING` |
+| **Processing-level dedup** | The processor applies business logic at most once per event | Processed events log, version checking |
+
+### How Each Component Contributes
+
+| Component | Dedup Mechanism | What It Prevents |
+|-----------|----------------|-------------------|
+| NATS JetStream | `Nats-Msg-Id` header | Duplicate message storage in stream |
+| pgnats `nats_subscribe()` | Background worker delivery | (No built-in dedup; rely on inbox) |
+| Inbox INSERT | `ON CONFLICT (event_id) DO NOTHING` | Duplicate inbox rows |
+| Processor | Check `processed_at IS NOT NULL` | Duplicate business side effects |
+| `FOR UPDATE SKIP LOCKED` | Row-level locking | Two workers processing same message |
+
+### End-to-End Exactly-Once
+
+True end-to-end exactly-once requires *all three levels* working together:
+
+1. **Broker dedup** prevents the inbox writer from seeing the same message
+   twice (reduces load, not strictly required).
+2. **Inbox dedup** ensures each event exists exactly once in the database.
+3. **Processing dedup** ensures the business side-effect happens at most once
+   (the processor checks `processed_at IS NULL` and uses `FOR UPDATE SKIP
+   LOCKED` for concurrent workers).
+
+> **Recommendation:** Always implement inbox-level + processing-level dedup.
+> Broker-level dedup is a bonus that reduces wasted INSERT attempts but should
+> never be the sole defense.
 
 ---
 
@@ -1540,6 +1975,212 @@ CREATE POLICY log_insert_only ON inbox_processing_log
 
 ---
 
+## Disaster Recovery & Backup-Restore
+
+The inbox pattern has a specific edge case during disaster recovery that
+can cause duplicate message processing.
+
+### The Backup-Restore Trap
+
+When restoring PostgreSQL from a backup:
+
+1. Backup was taken at time T₀.
+2. Between T₀ and the crash, the processor processed messages M₁..Mₙ and
+   marked them `processed_at IS NOT NULL`. Acks were sent to the broker.
+3. After restore, the database is back at T₀ — those messages show
+   `processed_at IS NULL` again.
+4. The processor re-processes M₁..Mₙ → **duplicate side effects**.
+
+```
+Timeline:
+  T₀ (backup)  ────── T₁ (crash) ────── T₂ (restore to T₀)
+                 ↑                         ↑
+          M₁..Mₙ processed and        M₁..Mₙ now appear
+          acked to broker             unprocessed again
+                                      → processor re-runs
+```
+
+### Mitigation Strategies
+
+| Strategy | How | Trade-off |
+|----------|-----|----------|
+| **Idempotent processors** | Business logic tolerates replays | Best defense; may require schema changes |
+| **Processing log in external system** | Persist processed IDs outside PostgreSQL | Complex; introduces another dependency |
+| **High-watermark at the broker** | Broker tracks consumer position | Only works if broker supports checkpointing |
+| **Deterministic state mutations** | `UPDATE ... SET status = 'x'` (same result on replay) | Not all operations are naturally idempotent |
+
+### Recommended: Idempotent Business Logic
+
+Design processors so that re-processing a message produces the same outcome:
+
+```sql
+-- Idempotent: INSERT with ON CONFLICT (no duplicate payment intents)
+INSERT INTO payment_intents (order_id, amount, status)
+VALUES ($1, $2, 'pending')
+ON CONFLICT (order_id) DO NOTHING;
+
+-- Idempotent: UPDATE with version check
+UPDATE orders
+SET status = 'confirmed', version = version + 1
+WHERE id = $1 AND version = $2;
+-- If version doesn't match (already processed), zero rows affected.
+```
+
+### Replica Promotion / Failover
+
+When promoting a standby to primary:
+
+1. If using async replication, some processed messages may not have
+   replicated — they reappear as unprocessed.
+2. The broker still considers them acked (no redelivery from broker side).
+3. The `pending_inbox` stream table will show them as pending again.
+4. **Fix:** Idempotent processors handle this transparently. For critical
+   paths, use synchronous replication for the inbox table.
+
+---
+
+## Operational Runbooks
+
+Practical procedures for common operational scenarios.
+
+### Graceful Processor Shutdown
+
+```python
+import signal, asyncio
+
+class InboxProcessor:
+    def __init__(self):
+        self.running = True
+        self.current_batch = None
+        signal.signal(signal.SIGTERM, self._handle_sigterm)
+
+    def _handle_sigterm(self, signum, frame):
+        """Drain current batch before exiting."""
+        self.running = False
+
+    async def run(self):
+        while self.running:
+            self.current_batch = await self.fetch_batch()
+            if self.current_batch:
+                await self.process_and_mark(self.current_batch)
+            else:
+                await asyncio.sleep(0.5)
+
+        # Final drain: complete any in-progress batch
+        if self.current_batch:
+            await self.process_and_mark(self.current_batch)
+        print("Processor shut down gracefully.")
+```
+
+### pg_trickle Upgrade Procedure
+
+```bash
+# 1. Stop the processor
+systemctl stop inbox-processor
+
+# 2. Upgrade pg_trickle
+ALTER EXTENSION pg_trickle UPDATE;
+
+# 3. Verify stream tables are intact
+SELECT pgt_name, pgt_status, pgt_refresh_mode
+  FROM pgtrickle.pgt_stream_tables;
+
+# 4. If stream tables need recreation (rare, noted in release notes):
+SELECT pgtrickle.drop_stream_table('pending_inbox');
+SELECT pgtrickle.create_stream_table('pending_inbox', ...);
+
+# 5. Restart the processor
+systemctl start inbox-processor
+```
+
+### Kubernetes Deployment Model
+
+| Model | Pros | Cons |
+|-------|------|------|
+| **Sidecar** (processor in same pod) | Shares DB conn pool, simple lifecycle | Scales with app, not with inbox depth |
+| **Standalone** (processor as separate service) | Scales independently | Extra service to manage |
+| **CronJob** (periodic batch processor) | Simple, no long-running process | Higher latency |
+| **pgnats `nats_subscribe()`** (in-DB) | Zero external processes | Limited processing complexity |
+
+### Stuck Messages Investigation
+
+```sql
+-- Find messages stuck for more than 5 minutes
+SELECT event_id, event_type, retry_count, last_error, received_at,
+       EXTRACT(EPOCH FROM (now() - received_at)) AS age_seconds
+FROM inbox_events
+WHERE processed_at IS NULL
+  AND retry_count < 5
+  AND received_at < now() - INTERVAL '5 minutes'
+ORDER BY received_at
+LIMIT 20;
+
+-- Check if the stream table is refreshing
+SELECT pgtrickle.get_staleness('pending_inbox');
+
+-- Force a manual refresh
+SELECT pgtrickle.refresh('pending_inbox');
+```
+
+---
+
+## Migration Guide
+
+Migrating from a hand-rolled inbox to pg_trickle without downtime.
+
+### Prerequisites
+
+- Existing inbox table (e.g., `inbound_messages` with `processed` column)
+- Existing processor (e.g., cron job or custom poller)
+- pg_trickle installed and `pg_trickle.enabled = true`
+
+### Step 1: Add pg_trickle Stream Table (Non-Destructive)
+
+```sql
+-- Create a stream table over the existing inbox — does NOT change existing behavior
+SELECT pgtrickle.create_stream_table(
+    'pending_inbox_v2',
+    $$SELECT message_id, event_type, payload, received_at
+      FROM inbound_messages
+      WHERE processed = false$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+Your existing processor still works — `inbound_messages` is unchanged.
+
+### Step 2: Shadow Read (Validate)
+
+Run both the old processor and a new processor reading from `pending_inbox_v2`
+in **read-only mode**:
+
+```python
+async def shadow_processor():
+    rows = await conn.fetch("SELECT * FROM pending_inbox_v2")
+    for row in rows:
+        logger.info(f"Shadow would process: {row['message_id']}")
+        # Verify: does this match the old processor's view?
+```
+
+### Step 3: Cut Over
+
+```bash
+systemctl stop old-inbox-processor
+systemctl start new-inbox-processor
+```
+
+### Step 4: Rename / Harmonize
+
+```sql
+-- If desired, rename the old table to match pg_trickle conventions
+ALTER TABLE inbound_messages RENAME TO inbox_events;
+ALTER TABLE inbox_events RENAME COLUMN processed TO processed_at;
+-- (Update stream table SQL accordingly)
+```
+
+---
+
 ## Combining Outbox and Inbox Patterns
 
 In a microservice architecture, services typically use BOTH patterns:
@@ -1624,5 +2265,7 @@ SELECT pgtrickle.create_stream_table('message_health',
 - [NATS.io — Cloud-Native Messaging](https://nats.io/)
 - [NATS JetStream Documentation](https://docs.nats.io/nats-concepts/jetstream)
 - [pgnats — PostgreSQL extension for NATS messaging](https://github.com/luxms/pgnats) (MIT, Rust/pgrx)
+- [CloudEvents — CNCF Event Data Specification](https://cloudevents.io/)
+- [AsyncAPI — Event-Driven API Documentation](https://www.asyncapi.com/)
 - pg_trickle [ARCHITECTURE.md](../../docs/ARCHITECTURE.md), [PATTERNS.md](../../docs/PATTERNS.md), [SQL_REFERENCE.md](../../docs/SQL_REFERENCE.md)
 - [PLAN_TRANSACTIONAL_OUTBOX.md](PLAN_TRANSACTIONAL_OUTBOX.md) — companion document for the outbox pattern

--- a/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
@@ -35,6 +35,12 @@
   - [Extension 3: Dead Letter Queue Stream Table](#extension-3-dead-letter-queue-stream-table)
   - [Extension 4: Inbox Health Dashboard](#extension-4-inbox-health-dashboard)
 - [Design Considerations](#design-considerations)
+- [Schema Evolution & Message Versioning](#schema-evolution--message-versioning)
+- [Observability & Distributed Tracing](#observability--distributed-tracing)
+- [Testing Strategies](#testing-strategies)
+- [Multi-Tenancy](#multi-tenancy)
+- [Cost Analysis](#cost-analysis)
+- [Security Considerations](#security-considerations)
 - [Combining Outbox and Inbox Patterns](#combining-outbox-and-inbox-patterns)
 - [Comparison with Traditional Approaches](#comparison-with-traditional-approaches)
 - [References](#references)
@@ -1001,6 +1007,496 @@ pg_trickle provides built-in monitoring that maps naturally to inbox health:
 | Queue backing up | `pg_trickle_alert` → `stale_data` event |
 | Refresh failures | `pg_trickle_alert` → `refresh_failed` event |
 | Throughput | `pgtrickle.st_refresh_stats` → rows_inserted/deleted per refresh |
+
+---
+
+## Schema Evolution & Message Versioning
+
+As upstream services evolve, the shape of inbound messages changes. A robust
+inbox implementation must accept multiple schema versions gracefully.
+
+### Versioning Strategies
+
+| Strategy | Description | Pros | Cons |
+|----------|-------------|------|------|
+| **Version field in inbox row** | `schema_version INTEGER` column | Filter per version in stream table | Extra column |
+| **Event type suffix** | `OrderCreated.v2` in `event_type` | Easy routing; clear in DLQ | Type proliferation |
+| **Version in JSONB payload** | `payload->>'schema_version'` | No schema change required | Consumers must parse payload |
+| **Schema registry** | External Confluent / Apicurio lookup | Centralised governance | Additional dependency |
+
+### Backward Compatibility Best Practices
+
+- **Add** optional payload fields freely — existing processors ignore unknown keys.
+- **Never remove** required fields without a grace period and version bump.
+- **Document** every schema version in a companion `inbox_schema_versions` table.
+
+```sql
+CREATE TABLE inbox_schema_versions (
+    event_type      TEXT NOT NULL,
+    schema_version  INTEGER NOT NULL,
+    introduced_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    deprecated_at   TIMESTAMPTZ,
+    json_schema     JSONB,  -- optional: store JSON Schema for validation
+    PRIMARY KEY (event_type, schema_version)
+);
+```
+
+### Version-Aware Processing Stream Tables
+
+```sql
+-- Route v1 events to a processor that handles the old schema
+SELECT pgtrickle.create_stream_table(
+    'inbox_pending_v1',
+    $$SELECT event_id, event_type, payload, received_at
+      FROM inbox_events
+      WHERE processed_at IS NULL
+        AND (payload->>'schema_version')::int = 1$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Route v2+ events to a processor that handles the new schema
+SELECT pgtrickle.create_stream_table(
+    'inbox_pending_v2',
+    $$SELECT event_id, event_type, payload, received_at
+      FROM inbox_events
+      WHERE processed_at IS NULL
+        AND (payload->>'schema_version')::int >= 2$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Rolling Schema Migration
+
+1. **Deploy** inbox writer that accepts both old and new schema.
+2. **Deploy** processors that handle both versions.
+3. **Drain** old-version `inbox_pending_v1` to zero.
+4. **Retire** the v1 processing path once the upstream producer is fully migrated.
+
+---
+
+## Observability & Distributed Tracing
+
+End-to-end visibility across broker → inbox writer → processor is essential for
+diagnosing duplicate delivery, ordering gaps, and processing failures.
+
+### Correlation IDs
+
+Propagate trace context from the inbound message into the inbox row:
+
+```sql
+ALTER TABLE inbox_events
+    ADD COLUMN trace_id UUID,
+    ADD COLUMN span_id  UUID;
+
+-- Store NATS/Kafka trace headers when writing to inbox
+-- (set by the inbox writer process before INSERT)
+```
+
+```python
+async def inbox_writer(msg):
+    headers = msg.headers or {}
+    await pg_conn.execute(
+        """INSERT INTO inbox_events
+               (event_id, event_type, aggregate_id, payload, trace_id)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (event_id) DO NOTHING""",
+        msg_id, event_type, aggregate_id, payload,
+        headers.get("X-Trace-Id"),  # propagate distributed trace
+    )
+```
+
+### Monitoring Dashboard Stream Table
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'inbox_observability',
+    $$SELECT
+        event_type,
+        COUNT(*) FILTER (WHERE processed_at IS NULL)         AS pending_count,
+        COUNT(*) FILTER (WHERE processed_at IS NOT NULL)     AS processed_count,
+        COUNT(*) FILTER (WHERE retry_count >= 5)             AS dlq_count,
+        AVG(EXTRACT(EPOCH FROM (processed_at - received_at)))
+            FILTER (WHERE processed_at IS NOT NULL)          AS avg_processing_latency_sec,
+        MAX(EXTRACT(EPOCH FROM (now() - received_at)))
+            FILTER (WHERE processed_at IS NULL
+              AND retry_count < 5)                           AS max_pending_age_sec
+      FROM inbox_events
+      GROUP BY event_type$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### pg_trickle Alert Integration
+
+```python
+async def monitor_inbox_pipeline(dsn: str):
+    conn = await asyncpg.connect(dsn)
+
+    async def handle_alert(conn, pid, channel, payload):
+        alert = json.loads(payload)
+        match alert["type"]:
+            case "stale_data":
+                if "pending_inbox" in alert["stream_table"]:
+                    sentry.capture_message(
+                        f"Inbox queue backing up: {alert['staleness_seconds']}s"
+                    )
+            case "refresh_failed":
+                pagerduty.trigger(f"Inbox stream table failed: {alert['detail']}")
+
+    await conn.add_listener("pg_trickle_alert", handle_alert)
+    await asyncio.sleep(float("inf"))
+```
+
+### OpenTelemetry Spans in the Processor
+
+```python
+from opentelemetry import trace
+
+tracer = trace.get_tracer("inbox-processor")
+
+async def process_event(event: dict):
+    with tracer.start_as_current_span(
+        "inbox.process",
+        context=trace_context_from_id(event.get("trace_id")),
+        attributes={
+            "event.id":      event["event_id"],
+            "event.type":    event["event_type"],
+            "aggregate.id":  str(event["aggregate_id"]),
+            "retry.count":   event["retry_count"],
+        }
+    ) as span:
+        await apply_business_logic(event)
+        span.set_attribute("processing.outcome", "success")
+```
+
+### Key Metrics to Track
+
+| Metric | How to Measure | Alert Threshold |
+|--------|---------------|------------------|
+| **Inbox depth** | `pending_count` in `inbox_observability` | > 1 000 events |
+| **Processing latency p99** | `avg_processing_latency_sec` | > 60 s |
+| **DLQ depth** | `dlq_count` or `dead_letters` stream table | > 0 |
+| **Oldest pending message** | `max_pending_age_sec` | > 5 min |
+| **Stream table refresh failure** | `pg_trickle_alert` → `refresh_failed` | Built-in |
+| **Ordering gaps** | `inbox_ordering_gaps` stream table row count | Any gap > 30 s |
+
+---
+
+## Testing Strategies
+
+Testing the transactional inbox requires verifying idempotency, ordering, and
+processor recovery under failure.
+
+### Unit Tests — Deduplication
+
+Verify that duplicate messages are silently dropped:
+
+```sql
+-- pgTAP: second insert of same event_id is a no-op
+INSERT INTO inbox_events (event_id, event_type, payload)
+    VALUES ('evt-001', 'PaymentReceived', '{"amount": 100}');
+
+INSERT INTO inbox_events (event_id, event_type, payload)
+    VALUES ('evt-001', 'PaymentReceived', '{"amount": 100}')
+    ON CONFLICT (event_id) DO NOTHING;
+
+SELECT is(
+    (SELECT COUNT(*)::int FROM inbox_events WHERE event_id = 'evt-001'),
+    1,
+    'Duplicate event_id silently dropped by ON CONFLICT'
+);
+```
+
+### Integration Tests — Stream Table Refresh
+
+```rust
+#[tokio::test]
+async fn test_pending_inbox_reflects_unprocessed_events() {
+    let ctx = TestContext::new().await;
+
+    ctx.execute("INSERT INTO inbox_events (event_id, event_type, payload)
+                 VALUES ('e1', 'PaymentReceived', '{\"amount\": 50}')").await;
+
+    ctx.execute("SELECT pgtrickle.refresh('pending_inbox')").await;
+
+    let count: i64 = ctx.query_one(
+        "SELECT COUNT(*) FROM pending_inbox WHERE event_type = 'PaymentReceived'"
+    ).await;
+    assert_eq!(count, 1);
+
+    // Mark as processed — must disappear from stream table on next refresh
+    ctx.execute("UPDATE inbox_events SET processed_at = now() WHERE event_id = 'e1'").await;
+    ctx.execute("SELECT pgtrickle.refresh('pending_inbox')").await;
+
+    let count_after: i64 = ctx.query_one(
+        "SELECT COUNT(*) FROM pending_inbox"
+    ).await;
+    assert_eq!(count_after, 0, "Processed event must leave the stream table");
+}
+```
+
+### End-to-End Tests — Inbox Writer + Processor
+
+```python
+@pytest.mark.asyncio
+async def test_message_processed_exactly_once(nats_client, pg_conn):
+    """Message published to NATS must be processed exactly once in PostgreSQL."""
+    # Publish the same event twice (simulates at-least-once broker delivery)
+    payload = json.dumps({"amount": 75.00, "order_id": "ord-1"})
+    for _ in range(2):
+        await js.publish(
+            "payments.received",
+            payload.encode(),
+            headers={"Nats-Msg-Id": "evt-dedup-001"},
+        )
+
+    await asyncio.sleep(3.0)  # allow inbox writer and processor to run
+
+    processed = await pg_conn.fetchval(
+        "SELECT COUNT(*) FROM inbox_events WHERE event_id = 'evt-dedup-001'"
+    )
+    assert processed == 1, "Duplicate delivery must result in exactly one inbox row"
+```
+
+### Chaos Tests — Processor Failure & Retry
+
+```python
+@pytest.mark.asyncio
+async def test_failed_event_retried_with_backoff(pg_conn, processor):
+    """Events that fail processing are retried according to backoff schedule."""
+    # Insert an event that will fail on first attempt
+    await pg_conn.execute(
+        "INSERT INTO inbox_events (event_id, event_type, payload)"
+        " VALUES ('fail-evt', 'PaymentReceived', '{\"amount\": -1}')"  # invalid
+    )
+
+    await processor.run_once()  # first attempt — should fail and increment retry_count
+
+    retry_count = await pg_conn.fetchval(
+        "SELECT retry_count FROM inbox_events WHERE event_id = 'fail-evt'"
+    )
+    assert retry_count == 1, "retry_count must increment after failed processing"
+
+    error_msg = await pg_conn.fetchval(
+        "SELECT last_error FROM inbox_events WHERE event_id = 'fail-evt'"
+    )
+    assert error_msg is not None, "last_error must be populated on failure"
+```
+
+---
+
+## Multi-Tenancy
+
+In multi-tenant SaaS applications, the inbox pipeline must isolate messages per
+tenant and prevent cross-tenant processing.
+
+### Tenant-Per-Row Isolation
+
+```sql
+-- Add tenant_id to inbox table
+ALTER TABLE inbox_events ADD COLUMN tenant_id UUID NOT NULL;
+
+-- Row-Level Security to prevent cross-tenant access
+ALTER TABLE inbox_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY inbox_tenant_isolation ON inbox_events
+    USING (tenant_id = current_setting('app.tenant_id')::UUID);
+
+-- Tenant-aware pending stream table (processor sets app.tenant_id per connection)
+SELECT pgtrickle.create_stream_table(
+    'pending_inbox_tenant_scoped',
+    $$SELECT event_id, tenant_id, event_type, payload, retry_count
+      FROM inbox_events
+      WHERE processed_at IS NULL
+        AND retry_count < 5$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Tenant-Per-Schema Isolation
+
+```sql
+CREATE SCHEMA tenant_abc;
+CREATE TABLE tenant_abc.inbox_events (LIKE public.inbox_events INCLUDING ALL);
+
+SELECT pgtrickle.create_stream_table(
+    'tenant_abc.pending_inbox',
+    $$SELECT * FROM tenant_abc.inbox_events
+      WHERE processed_at IS NULL AND retry_count < 5$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Multi-Tenant Inbox Writer
+
+```python
+async def inbox_writer(msg):
+    headers = msg.headers or {}
+    tenant_id = headers.get("X-Tenant-Id") or extract_tenant_from_subject(msg.subject)
+
+    # Validate tenant before writing — never trust broker subjects alone
+    if not is_valid_tenant_id(tenant_id):
+        await msg.nak()  # reject; do not persist
+        return
+
+    await pg_conn.execute(
+        """INSERT INTO inbox_events
+               (event_id, tenant_id, event_type, aggregate_id, payload)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (event_id) DO NOTHING""",
+        msg_id, tenant_id, event_type, aggregate_id, payload,
+    )
+    await msg.ack()
+```
+
+---
+
+## Cost Analysis
+
+### Storage Cost
+
+| Component | Typical Size per Message | Notes |
+|-----------|--------------------------|-------|
+| `inbox_events` row | ~200–600 bytes | JSONB payload dominates |
+| `processed_events` dedup log | ~50–100 bytes | event_id + timestamps only |
+| Stream table | ~same as inbox rows | Materialized view |
+| Index overhead | ~40–60% of table size | PK + event_type + processed_at indexes |
+
+**Example:** 500 000 messages/day × 400 bytes = ~200 MB/day. With 14-day
+retention: ~2.8 GB. With monthly partitioning, expired months drop instantly.
+
+### Refresh CPU Overhead
+
+| Mode | CPU Impact | Latency | Use When |
+|------|------------|---------|----------|
+| DIFFERENTIAL | Low (only changed rows) | ~50–200 ms | Default for most inbox cases |
+| FULL | High (full table scan) | seconds | Complex DISTINCT ON + aggregations |
+| IMMEDIATE | Minimal (synchronous) | ~0 ms additional | Synchronous, transactional processing |
+
+### Infrastructure Comparison
+
+| Setup | Additional Infrastructure | Estimated Monthly Cost (small–medium) |
+|-------|--------------------------|----------------------------------------|
+| PostgreSQL + pgmq only | None | $0 additional |
+| PostgreSQL + NATS | ~10 MB binary | ~$5–20/mo |
+| PostgreSQL + Kafka | KRaft cluster + brokers | $50–500/mo (managed) |
+| PostgreSQL + Debezium | Kafka + Kafka Connect | $100–1 000/mo (managed) |
+
+> **Note:** For inbox workloads under 100 000 messages/sec, NATS JetStream
+> with durable pull consumers is often the lowest-ops choice.
+
+---
+
+## Security Considerations
+
+### Validating Inbound Messages
+
+Never trust message payloads from external sources — validate before inserting
+into the inbox:
+
+```python
+import jsonschema
+
+ORDER_CREATED_SCHEMA_V2 = {
+    "type": "object",
+    "required": ["order_id", "amount", "customer_id"],
+    "properties": {
+        "order_id":    {"type": "string", "format": "uuid"},
+        "amount":      {"type": "number", "minimum": 0},
+        "customer_id": {"type": "string"},
+    },
+    "additionalProperties": True,  # tolerate forward-compatible additions
+}
+
+async def validated_inbox_writer(msg):
+    payload = json.loads(msg.data)
+    try:
+        jsonschema.validate(payload, ORDER_CREATED_SCHEMA_V2)
+    except jsonschema.ValidationError as e:
+        # Write to DLQ instead of inbox; do NOT nak — prevents infinite redelivery
+        await pg_conn.execute(
+            "INSERT INTO inbox_dead_letters (event_id, reason, payload)"
+            " VALUES ($1, $2, $3)",
+            msg_id, str(e), json.dumps(payload),
+        )
+        await msg.ack()  # ack to prevent redelivery of permanently-invalid messages
+        return
+
+    await write_to_inbox(msg, payload)
+```
+
+### Payload Encryption for Sensitive Data
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Encrypt PII fields before storing in the inbox
+INSERT INTO inbox_events (event_id, event_type, payload)
+VALUES (
+    $1,
+    'PaymentReceived',
+    jsonb_build_object(
+        'order_id', $2,
+        'amount',   $3,
+        -- Encrypt cardholder data at rest; processor decrypts on access
+        'card_pii', encode(
+            pgp_sym_encrypt($4::bytea, current_setting('app.encryption_key')),
+            'base64'
+        )
+    )
+);
+```
+
+### Database-Level Access Controls
+
+```sql
+-- Dedicated role for the inbox writer — INSERT only, no SELECT
+CREATE ROLE inbox_writer LOGIN PASSWORD '...';
+GRANT USAGE ON SCHEMA public TO inbox_writer;
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM inbox_writer;
+GRANT INSERT ON inbox_events TO inbox_writer;
+
+-- Dedicated role for the processor — SELECT + UPDATE only
+CREATE ROLE inbox_processor LOGIN PASSWORD '...';
+GRANT SELECT, UPDATE ON inbox_events TO inbox_processor;
+GRANT SELECT ON pending_inbox TO inbox_processor;
+```
+
+### TLS and Broker Authentication
+
+```python
+import ssl, nats
+
+# Always use TLS + credentials for broker connections in production
+nc = await nats.connect(
+    servers=["tls://nats.example.com:4222"],
+    tls=ssl.create_default_context(cafile="/etc/ssl/nats-ca.pem"),
+    tls_hostname="nats.example.com",
+    user_credentials="/etc/nats/inbox-writer.creds",
+)
+```
+
+### Immutable Processing Log
+
+```sql
+-- Record every processing attempt; never UPDATE or DELETE
+CREATE TABLE inbox_processing_log (
+    id           BIGSERIAL PRIMARY KEY,
+    event_id     TEXT NOT NULL REFERENCES inbox_events(event_id),
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    outcome      TEXT NOT NULL CHECK (outcome IN ('success', 'failure', 'duplicate')),
+    error_detail TEXT,
+    processor_id TEXT  -- hostname or pod name
+);
+
+ALTER TABLE inbox_processing_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY log_insert_only ON inbox_processing_log
+    FOR INSERT WITH CHECK (TRUE);
+```
 
 ---
 

--- a/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_INBOX.md
@@ -736,7 +736,7 @@ pub/sub, request/reply, and durable streaming with sub-millisecond latency.
 │  Upstream Services                                                     │
 │  (Order Service, Shipping Service, ...)                                │
 │       │                                                                │
-│       │ nats.js_publish('payments.order_created', payload)             │
+│       │ await js.publish('payments.order_created', payload)            │
 │       ▼                                                                │
 │  ┌──────────────────────────────────────┐                              │
 │  │ NATS JetStream                       │                              │
@@ -852,6 +852,46 @@ async def inbox_writer():
 - Existing Kafka ecosystem (Connect, Schema Registry, ksqlDB).
 - Multi-datacenter replication with MirrorMaker.
 - Very high throughput (millions of messages/sec) with long retention.
+
+**Using `pgnats` for direct PostgreSQL-side subscription:**
+
+Rather than running a separate inbox-writer process, the real
+[pgnats](https://github.com/luxms/pgnats) extension can subscribe to NATS
+subjects and call a PostgreSQL function for each inbound message, entirely
+within the database:
+
+```sql
+CREATE EXTENSION pgnats;
+
+-- Configure the NATS connection once
+CREATE SERVER nats_server
+    FOREIGN DATA WRAPPER pgnats_fdw
+    OPTIONS (host 'nats.internal', port '4222');
+
+-- Handler function: receives raw bytea payload from NATS
+CREATE OR REPLACE FUNCTION public.nats_inbox_handler(raw bytea)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE
+    msg jsonb := convert_from(raw, 'UTF8')::jsonb;
+BEGIN
+    INSERT INTO inbox_events (event_id, event_type, source, payload)
+    VALUES (
+        msg->>'event_id',
+        msg->>'event_type',
+        msg->>'source',
+        msg
+    )
+    ON CONFLICT (event_id) DO NOTHING;
+END;
+$$;
+
+-- Subscribe: NATS messages on 'payments.>' trigger the handler via a background worker
+SELECT nats_subscribe('payments.>', 'public.nats_inbox_handler'::regproc);
+```
+
+This eliminates the separate inbox-writer process entirely, though note
+that the subscription is always active \u2014 pgnats uses a background worker
+to call the handler function for each message.
 
 ---
 
@@ -1583,5 +1623,6 @@ SELECT pgtrickle.create_stream_table('message_health',
 - [pg_partman — Partition Management](https://github.com/pgpartman/pg_partman)
 - [NATS.io — Cloud-Native Messaging](https://nats.io/)
 - [NATS JetStream Documentation](https://docs.nats.io/nats-concepts/jetstream)
+- [pgnats — PostgreSQL extension for NATS messaging](https://github.com/luxms/pgnats) (MIT, Rust/pgrx)
 - pg_trickle [ARCHITECTURE.md](../../docs/ARCHITECTURE.md), [PATTERNS.md](../../docs/PATTERNS.md), [SQL_REFERENCE.md](../../docs/SQL_REFERENCE.md)
 - [PLAN_TRANSACTIONAL_OUTBOX.md](PLAN_TRANSACTIONAL_OUTBOX.md) — companion document for the outbox pattern

--- a/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
@@ -696,26 +696,60 @@ orders.orderstatuschanged → Fulfillment Service consumers
 orders.>                  → Audit Service (wildcard: receives everything)
 ```
 
-**Hypothetical `pg_nats` extension:**
+**`pgnats` — Direct NATS publishing from PostgreSQL SQL:**
 
-A PostgreSQL extension providing direct NATS publishing from SQL (analogous to
-`pg_amqp` for RabbitMQ) could eliminate the external relay process entirely:
+[pgnats](https://github.com/luxms/pgnats) (by [luxms](https://github.com/luxms),
+MIT license, written in Rust with pgrx) is a real PostgreSQL extension that
+provides direct NATS publishing from SQL — analogous to `pg_amqp` for
+RabbitMQ. It eliminates the external relay process entirely for simple
+topologies.
+
+**pgnats features:**
+
+| Feature | API |
+|---------|-----|
+| Core NATS publish (text/binary/JSON/JSONB) | `nats_publish_text/binary/json/jsonb()` |
+| JetStream persistent publish | `nats_publish_text/json/jsonb_stream()` |
+| JetStream publish with headers | `nats_publish_jsonb_stream(subj, payload, headers)` |
+| NATS subscriptions (invoke PG functions) | `nats_subscribe(subject, handler::regproc)` |
+| Request/reply | `nats_request_json/text/binary/jsonb()` |
+| Key-Value storage | `nats_put/get_json/text/binary/jsonb()` |
+| Object storage | `nats_put/get_file()` |
+| TLS / mTLS | Via FDW server options |
+
+**Configuration via Foreign Data Wrapper:**
 
 ```sql
--- Hypothetical pg_nats API
-CREATE EXTENSION pg_nats;
+CREATE EXTENSION pgnats;
 
-SELECT nats.connect('default', 'nats://localhost:4222');
+-- One-time connection setup
+CREATE SERVER nats_server
+    FOREIGN DATA WRAPPER pgnats_fdw
+    OPTIONS (
+        host 'localhost',
+        port '4222',
+        -- Optional TLS:
+        -- tls_ca_path   '/etc/ssl/nats-ca.pem',
+        -- tls_cert_path '/etc/ssl/nats-client.pem',
+        -- tls_key_path  '/etc/ssl/nats-client-key.pem'
+    );
+```
 
--- Publish within a trigger on the outbox table
+**Publishing to NATS JetStream directly from a trigger:**
+
+```sql
+-- Publish to JetStream (durable, at-least-once) with deduplication header
 CREATE OR REPLACE FUNCTION fn_publish_to_nats() RETURNS TRIGGER AS $$
 BEGIN
-    PERFORM nats.js_publish(
-        'default',                              -- connection name
-        'orders.' || lower(NEW.event_type),     -- subject
-        NEW.payload::text,                      -- message body
-        headers => jsonb_build_object(
-            'Nats-Msg-Id', NEW.event_id::text   -- dedup key
+    PERFORM nats_publish_jsonb_stream(
+        'orders.' || lower(NEW.event_type),           -- subject
+        NEW.payload || jsonb_build_object(            -- payload + event metadata
+            'event_id',      NEW.event_id,
+            'aggregate_id',  NEW.aggregate_id,
+            'created_at',    NEW.created_at
+        ),
+        json_build_object(
+            'Nats-Msg-Id', NEW.event_id::text         -- JetStream deduplication key
         )
     );
     RETURN NEW;
@@ -727,11 +761,39 @@ CREATE TRIGGER trg_outbox_nats
     FOR EACH ROW EXECUTE FUNCTION fn_publish_to_nats();
 ```
 
-> **Caution:** In-transaction publishing couples the transaction to NATS
-> availability. If NATS is down, the source transaction blocks or fails. The
-> relay pattern (async, outside the transaction) is safer for production use.
-> The in-transaction approach is best suited for scenarios where NATS is
-> co-located and highly available (e.g., sidecar or leaf node).
+**Subscribing to NATS subjects from PostgreSQL (inbox use case):**
+
+```sql
+-- PostgreSQL function called for every inbound NATS message
+CREATE OR REPLACE FUNCTION public.handle_inbound_event(payload bytea)
+RETURNS void LANGUAGE plpgsql AS $$
+DECLARE
+    msg jsonb := convert_from(payload, 'UTF8')::jsonb;
+BEGIN
+    INSERT INTO inbox_events (event_id, event_type, payload)
+    VALUES (
+        msg->>'event_id',
+        msg->>'event_type',
+        msg
+    )
+    ON CONFLICT (event_id) DO NOTHING;
+END;
+$$;
+
+-- Subscribe: NATS delivers messages to this PG function via a background worker
+SELECT nats_subscribe('orders.>', 'public.handle_inbound_event'::regproc);
+
+-- Unsubscribe when no longer needed
+-- SELECT nats_unsubscribe('orders.>', 'public.handle_inbound_event'::regproc);
+```
+
+> **Caution:** In-transaction publishing (trigger-based) couples the
+> transaction to NATS availability. If NATS is down or slow, the source
+> transaction blocks or fails. The relay pattern (async, outside the
+> transaction) is safer for production use. The trigger approach is best
+> suited for scenarios where NATS is co-located and highly available
+> (e.g., sidecar or leaf node in a Kubernetes pod). pgnats also supports
+> TLS and mTLS to mitigate availability risk.
 
 **When to choose NATS over Kafka/RabbitMQ:**
 - Low operational overhead (single binary, zero external dependencies).
@@ -1516,5 +1578,6 @@ CREATE POLICY relay_log_insert_only ON outbox_relay_log
 - [Debezium CDC Platform](https://debezium.io/)
 - [NATS.io — Cloud-Native Messaging](https://nats.io/)
 - [NATS JetStream Documentation](https://docs.nats.io/nats-concepts/jetstream)
+- [pgnats — PostgreSQL extension for NATS messaging](https://github.com/luxms/pgnats) (MIT, Rust/pgrx)
 - Krzysztof Atłasik, [Microservices 101: Transactional Outbox and Inbox](https://softwaremill.com/microservices-101/)
 - pg_trickle [ARCHITECTURE.md](../../docs/ARCHITECTURE.md), [PATTERNS.md](../../docs/PATTERNS.md), [SQL_REFERENCE.md](../../docs/SQL_REFERENCE.md)

--- a/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
@@ -26,6 +26,7 @@
   - [pg_amqp — AMQP Publishing from PostgreSQL](#pg_amqp--amqp-publishing-from-postgresql)
   - [pgflow — Durable Workflow Engine](#pgflow--durable-workflow-engine)
   - [Debezium — External CDC Platform](#debezium--external-cdc-platform)
+  - [NATS / JetStream — Lightweight Messaging Fabric](#nats--jetstream--lightweight-messaging-fabric)
 - [Potential pg_trickle Extensions](#potential-pg_trickle-extensions)
   - [Extension 1: Outbox Table Helper](#extension-1-outbox-table-helper)
   - [Extension 2: Message Relay Background Worker](#extension-2-message-relay-background-worker)
@@ -613,6 +614,131 @@ conceptually similar to what Debezium uses.
 - Events are consumed by services that can query PostgreSQL directly.
 - You want to avoid operating an additional infrastructure component.
 
+### NATS / JetStream — Lightweight Messaging Fabric
+
+[NATS](https://nats.io/) is a high-performance, cloud-native messaging system
+(CNCF incubating project) that provides pub/sub, request/reply, and persistent
+streaming via **JetStream** — all through a single ~10 MB binary with
+sub-millisecond latency. It is a compelling alternative to Kafka or RabbitMQ
+for the outbox relay target, especially in edge, IoT, or low-ops environments.
+
+**Key JetStream features relevant to the outbox relay:**
+
+| Feature | Benefit for Outbox Relay |
+|---------|-------------------------|
+| Built-in deduplication (`Nats-Msg-Id` header) | Prevents duplicate event delivery without consumer-side logic |
+| Exactly-once semantics | Double-ack protocol between publisher and consumer |
+| Per-subject ordering | Events for the same aggregate stay ordered |
+| Durable consumers | Consumers resume from last acknowledged position after restart |
+| Work queue mode | Automatic load balancing across competing relay consumers |
+| Wildcard subscriptions | `orders.>` matches `orders.created`, `orders.shipped`, etc. |
+| Stream retention policies | Limits-based, interest-based, or work-queue retention |
+
+**Relay pattern with NATS JetStream:**
+
+```python
+import nats
+from nats.js import JetStreamContext
+import psycopg2
+import json
+import asyncio
+
+async def outbox_relay():
+    nc = await nats.connect("nats://localhost:4222")
+    js = nc.jetstream()
+
+    # Ensure the stream exists (idempotent)
+    await js.add_stream(name="ORDERS", subjects=["orders.>"])
+
+    conn = psycopg2.connect("postgresql://localhost/mydb")
+
+    while True:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT event_id, event_type, aggregate_id, payload
+                FROM pending_outbox_events
+                ORDER BY event_id
+                LIMIT 100
+            """)
+            rows = cur.fetchall()
+
+            for event_id, event_type, aggregate_id, payload in rows:
+                subject = f"orders.{event_type.lower()}"
+                await js.publish(
+                    subject,
+                    json.dumps(payload).encode(),
+                    headers={
+                        "Nats-Msg-Id": str(event_id),  # deduplication key
+                        "Aggregate-Id": aggregate_id,
+                    },
+                )
+                cur.execute(
+                    "UPDATE outbox_events SET published_at = now() WHERE event_id = %s",
+                    (event_id,),
+                )
+            conn.commit()
+
+        await asyncio.sleep(0.5)
+```
+
+**Subject-based routing example:**
+
+```
+orders.ordercreated       → Order Service consumers
+orders.orderstatuschanged → Fulfillment Service consumers
+orders.>                  → Audit Service (wildcard: receives everything)
+```
+
+**Hypothetical `pg_nats` extension:**
+
+A PostgreSQL extension providing direct NATS publishing from SQL (analogous to
+`pg_amqp` for RabbitMQ) could eliminate the external relay process entirely:
+
+```sql
+-- Hypothetical pg_nats API
+CREATE EXTENSION pg_nats;
+
+SELECT nats.connect('default', 'nats://localhost:4222');
+
+-- Publish within a trigger on the outbox table
+CREATE OR REPLACE FUNCTION fn_publish_to_nats() RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM nats.js_publish(
+        'default',                              -- connection name
+        'orders.' || lower(NEW.event_type),     -- subject
+        NEW.payload::text,                      -- message body
+        headers => jsonb_build_object(
+            'Nats-Msg-Id', NEW.event_id::text   -- dedup key
+        )
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_outbox_nats
+    AFTER INSERT ON outbox_events
+    FOR EACH ROW EXECUTE FUNCTION fn_publish_to_nats();
+```
+
+> **Caution:** In-transaction publishing couples the transaction to NATS
+> availability. If NATS is down, the source transaction blocks or fails. The
+> relay pattern (async, outside the transaction) is safer for production use.
+> The in-transaction approach is best suited for scenarios where NATS is
+> co-located and highly available (e.g., sidecar or leaf node).
+
+**When to choose NATS over Kafka/RabbitMQ:**
+- Low operational overhead (single binary, zero external dependencies).
+- Sub-millisecond publish latency is critical.
+- Edge or IoT deployments where a full Kafka cluster is impractical.
+- You need both pub/sub and request/reply in the same system.
+- Built-in deduplication simplifies consumer logic.
+
+**When Kafka is still preferred:**
+- You need the Kafka Connect ecosystem (hundreds of connectors).
+- Multi-datacenter replication with MirrorMaker.
+- Schema registry and Avro/Protobuf serialization.
+- Existing Kafka infrastructure and team expertise.
+
 ---
 
 ## Potential pg_trickle Extensions
@@ -764,16 +890,17 @@ When the relay falls behind:
 
 ## Comparison with Traditional Approaches
 
-| Aspect | Traditional Outbox | pg_trickle Outbox | Debezium CDC |
-|--------|--------------------|-------------------|--------------|
-| Additional write overhead | 1 extra INSERT per event | Zero (CDC trigger is automatic) | Zero (WAL tail) |
-| Relay mechanism | Custom polling worker | Stream table + NOTIFY | Kafka Connect |
-| Latency | Depends on poll interval | ~1s (DIFFERENTIAL) or ~0ms (IMMEDIATE) | ~1-5s |
-| Ordering | PK-ordered | PK-ordered + LSN-ordered | LSN-ordered |
-| Infrastructure | PostgreSQL only | PostgreSQL only | PostgreSQL + Kafka + Debezium |
-| Monitoring | Custom | Built-in (staleness, alerts, stats) | Kafka + Debezium metrics |
-| Competing consumers | FOR UPDATE SKIP LOCKED | FOR UPDATE SKIP LOCKED or pgmq | Kafka consumer groups |
-| Garbage collection | Manual DELETE/partition | Manual or partitioned | Kafka retention |
+| Aspect | Traditional Outbox | pg_trickle Outbox | Debezium CDC | pg_trickle + NATS JetStream |
+|--------|--------------------|-------------------|--------------|-----------------------------|
+| Additional write overhead | 1 extra INSERT per event | Zero (CDC trigger is automatic) | Zero (WAL tail) | Zero (CDC trigger is automatic) |
+| Relay mechanism | Custom polling worker | Stream table + NOTIFY | Kafka Connect | Stream table + NATS publish |
+| Latency | Depends on poll interval | ~1s (DIFFERENTIAL) or ~0ms (IMMEDIATE) | ~1-5s | ~1s (DIFFERENTIAL) + <1ms (NATS) |
+| Ordering | PK-ordered | PK-ordered + LSN-ordered | LSN-ordered | Per-subject ordered (JetStream) |
+| Infrastructure | PostgreSQL only | PostgreSQL only | PostgreSQL + Kafka + Debezium | PostgreSQL + NATS (~10 MB binary) |
+| Monitoring | Custom | Built-in (staleness, alerts, stats) | Kafka + Debezium metrics | pg_trickle alerts + NATS metrics |
+| Competing consumers | FOR UPDATE SKIP LOCKED | FOR UPDATE SKIP LOCKED or pgmq | Kafka consumer groups | JetStream work queues |
+| Garbage collection | Manual DELETE/partition | Manual or partitioned | Kafka retention | JetStream retention policies |
+| Deduplication | Manual | Manual | Kafka idempotent producer | Built-in (`Nats-Msg-Id`) |
 
 ---
 
@@ -783,5 +910,7 @@ When the relay falls behind:
 - Microsoft, [Implement the Transactional Outbox Pattern](https://learn.microsoft.com/en-us/azure/architecture/best-practices/transactional-outbox-cosmos)
 - [pgmq — PostgreSQL Message Queue](https://github.com/pgmq/pgmq)
 - [Debezium CDC Platform](https://debezium.io/)
+- [NATS.io — Cloud-Native Messaging](https://nats.io/)
+- [NATS JetStream Documentation](https://docs.nats.io/nats-concepts/jetstream)
 - Krzysztof Atłasik, [Microservices 101: Transactional Outbox and Inbox](https://softwaremill.com/microservices-101/)
 - pg_trickle [ARCHITECTURE.md](../../docs/ARCHITECTURE.md), [PATTERNS.md](../../docs/PATTERNS.md), [SQL_REFERENCE.md](../../docs/SQL_REFERENCE.md)

--- a/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
@@ -33,6 +33,13 @@
   - [Extension 3: pgmq Integration](#extension-3-pgmq-integration)
   - [Extension 4: Webhook Dispatcher](#extension-4-webhook-dispatcher)
 - [Design Considerations](#design-considerations)
+- [Schema Evolution & Message Versioning](#schema-evolution--message-versioning)
+- [Observability & Distributed Tracing](#observability--distributed-tracing)
+- [Testing Strategies](#testing-strategies)
+- [Saga Pattern & Compensating Transactions](#saga-pattern--compensating-transactions)
+- [Multi-Tenancy](#multi-tenancy)
+- [Cost Analysis](#cost-analysis)
+- [Security Considerations](#security-considerations)
 - [Comparison with Traditional Approaches](#comparison-with-traditional-approaches)
 - [References](#references)
 
@@ -885,6 +892,603 @@ When the relay falls behind:
 | PostgreSQL crashes after COMMIT | Events durable in WAL | Normal crash recovery; outbox intact |
 | Stream table refresh fails | Relay reads stale data | pg_trickle retries with backoff; alert emitted |
 | Broker unreachable | Relay retries | Events queue in outbox; monitor staleness |
+
+---
+
+## Schema Evolution & Message Versioning
+
+As services evolve, event schemas change. A robust outbox implementation must
+handle versioning gracefully to avoid breaking downstream consumers.
+
+### Versioning Strategies
+
+| Strategy | Description | Pros | Cons |
+|----------|-------------|------|------|
+| **Embedded version field** | `event_type = 'OrderCreated.v2'` | Easy to route, clear in logs | Type proliferation |
+| **Semantic versioning in payload** | `{"schema_version": 2, ...}` in JSONB | Single event type, flexible | Consumers must inspect payload |
+| **Envelope pattern** | Wrap payload in `{"v": 2, "data": {...}}` | Uniform structure | Extra wrapper object |
+| **Content-type header** | `application/vnd.orders.created+json; version=2` | Standards-based | Requires rich broker support |
+
+### Compatibility Rules
+
+Follow the **Postel's Law** principle for schema changes:
+
+- **Backward-compatible** (safe): Add optional fields, widen types, add enum values.
+- **Forward-compatible** (safe with care): Remove optional fields, rename with alias.
+- **Breaking** (avoid or version bump): Remove required fields, change field types, alter semantics.
+
+### Implementation with pg_trickle
+
+```sql
+-- Version the outbox table columns
+ALTER TABLE outbox_events
+    ADD COLUMN schema_version INTEGER NOT NULL DEFAULT 1;
+
+-- Stream table filtered by version for v1 consumers only
+SELECT pgtrickle.create_stream_table(
+    'pending_outbox_v1',
+    $$SELECT event_id, aggregate_id, event_type, payload
+      FROM outbox_events
+      WHERE published_at IS NULL
+        AND schema_version = 1$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Separate view for v2+ consumers
+SELECT pgtrickle.create_stream_table(
+    'pending_outbox_v2',
+    $$SELECT event_id, aggregate_id, event_type, payload
+      FROM outbox_events
+      WHERE published_at IS NULL
+        AND schema_version >= 2$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Rolling Schema Migration
+
+1. **Deploy** the producer with new schema alongside old schema (dual-write).
+2. **Migrate** consumers to accept both versions.
+3. **Cut over** the producer to write only the new schema.
+4. **Drain** the old `pending_outbox_v1` view to zero.
+5. **Drop** old version support after all consumers are updated.
+
+---
+
+## Observability & Distributed Tracing
+
+Distributed systems require end-to-end visibility to diagnose issues. A
+well-instrumented outbox pipeline correlates events from database → relay →
+broker → consumer.
+
+### Correlation IDs
+
+Include a `trace_id` in every event to correlate across service boundaries:
+
+```sql
+ALTER TABLE outbox_events
+    ADD COLUMN trace_id UUID NOT NULL DEFAULT gen_random_uuid(),
+    ADD COLUMN span_id  UUID;
+
+-- Embed trace context in payload for downstream services
+CREATE OR REPLACE FUNCTION outbox_embed_trace() RETURNS TRIGGER AS $$
+BEGIN
+    NEW.payload := NEW.payload ||
+        jsonb_build_object(
+            '_trace_id', NEW.trace_id::text,
+            '_span_id',  NEW.span_id::text
+        );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER outbox_embed_trace_tg
+    BEFORE INSERT ON outbox_events
+    FOR EACH ROW EXECUTE FUNCTION outbox_embed_trace();
+```
+
+### Monitoring Dashboard Stream Table
+
+```sql
+-- Real-time outbox observability
+SELECT pgtrickle.create_stream_table(
+    'outbox_observability',
+    $$SELECT
+        event_type,
+        COUNT(*) FILTER (WHERE published_at IS NULL)          AS pending_count,
+        COUNT(*) FILTER (WHERE published_at IS NOT NULL)      AS published_count,
+        AVG(EXTRACT(EPOCH FROM (published_at - created_at)))
+            FILTER (WHERE published_at IS NOT NULL)           AS avg_publish_latency_sec,
+        MAX(EXTRACT(EPOCH FROM (now() - created_at)))
+            FILTER (WHERE published_at IS NULL)               AS max_pending_age_sec,
+        COUNT(*) FILTER (
+            WHERE published_at IS NULL
+              AND created_at < now() - INTERVAL '5 minutes')  AS stuck_events_count
+      FROM outbox_events
+      GROUP BY event_type$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### pg_trickle Alert Integration
+
+Subscribe to `pg_trickle_alert` for push-based relay health notifications:
+
+```python
+import asyncio, asyncpg, json
+
+async def monitor_outbox_pipeline(dsn: str):
+    conn = await asyncpg.connect(dsn)
+
+    async def handle_alert(conn, pid, channel, payload):
+        alert = json.loads(payload)
+        match alert["type"]:
+            case "stale_data":
+                if alert["stream_table"] in ("pending_outbox", "outbox_observability"):
+                    sentry.capture_message(f"Outbox lag: {alert['staleness_seconds']}s")
+            case "refresh_failed":
+                pagerduty.trigger(f"Outbox stream table failed: {alert['detail']}")
+            case "buffer_growth_warning":
+                slack.post(f"CDC buffer growing: {alert['stream_table']}")
+
+    await conn.add_listener("pg_trickle_alert", handle_alert)
+    await asyncio.sleep(float("inf"))  # run indefinitely
+```
+
+### OpenTelemetry Spans in the Relay
+
+```python
+from opentelemetry import trace
+
+tracer = trace.get_tracer("outbox-relay")
+
+async def relay_event(event: dict):
+    trace_id = event.get("payload", {}).get("_trace_id")
+    with tracer.start_as_current_span(
+        "outbox.relay",
+        context=trace_context_from_id(trace_id),
+        attributes={
+            "event.id":      event["event_id"],
+            "event.type":    event["event_type"],
+            "aggregate.id":  str(event["aggregate_id"]),
+        }
+    ) as span:
+        await broker.publish(event)
+        span.set_attribute("broker.subject", event["event_type"])
+```
+
+### Key Metrics to Track
+
+| Metric | How to Measure | Alert Threshold |
+|--------|---------------|------------------|
+| **Outbox depth** | `pending_count` in `outbox_observability` | > 1 000 events |
+| **Publish latency p99** | `avg_publish_latency_sec` | > 30 s |
+| **Stuck events** | `stuck_events_count > 0` for 5+ min | Any stuck > 5 min |
+| **CDC buffer size** | `pg_trickle_alert` → `buffer_growth_warning` | Built-in |
+| **Stream table refresh failure** | `pg_trickle_alert` → `refresh_failed` | Built-in |
+| **Relay process liveness** | External health-check endpoint | 1 missed heartbeat |
+
+---
+
+## Testing Strategies
+
+Testing the transactional outbox requires verifying both the atomicity guarantee
+and the relay pipeline end-to-end.
+
+### Unit Tests — Event Generation
+
+Verify events are inserted atomically and rolled back correctly:
+
+```sql
+-- pgTAP: event generated on INSERT
+BEGIN;
+INSERT INTO orders (customer_id, amount, status) VALUES (42, 100.00, 'pending');
+SELECT is(
+    (SELECT COUNT(*)::int FROM outbox_events WHERE event_type = 'OrderCreated'),
+    1,
+    'OrderCreated event generated on INSERT'
+);
+ROLLBACK;
+
+-- After ROLLBACK, event must not exist
+SELECT is(
+    (SELECT COUNT(*)::int FROM outbox_events WHERE event_type = 'OrderCreated'),
+    0,
+    'No event persisted after ROLLBACK'
+);
+```
+
+### Integration Tests — Stream Table Refresh
+
+```rust
+#[tokio::test]
+async fn test_outbox_stream_table_reflects_new_events() {
+    let ctx = TestContext::new().await;
+
+    // Insert order — CDC trigger fires
+    ctx.execute("INSERT INTO orders (customer_id, amount, status)
+                 VALUES (1, 99.99, 'pending')").await;
+
+    // Trigger immediate refresh
+    ctx.execute("SELECT pgtrickle.refresh('pending_outbox')").await;
+
+    let count: i64 = ctx.query_one(
+        "SELECT COUNT(*) FROM pending_outbox WHERE event_type = 'OrderCreated'"
+    ).await;
+    assert_eq!(count, 1, "Stream table must contain the new event");
+}
+```
+
+### End-to-End Tests — Full Relay Pipeline
+
+```python
+import pytest, asyncio, json
+
+@pytest.mark.asyncio
+async def test_event_reaches_broker_after_db_commit(pg_conn, nats_client):
+    """Full pipeline: INSERT → stream table → relay → NATS → subscriber."""
+    received: asyncio.Future = asyncio.get_event_loop().create_future()
+
+    async def on_message(msg):
+        received.set_result(json.loads(msg.data))
+        await msg.ack()
+
+    sub = await nats_client.subscribe("orders.created", cb=on_message)
+    await pg_conn.execute(
+        "INSERT INTO orders (customer_id, amount, status) VALUES ($1, $2, $3)",
+        1, 100.0, "pending"
+    )
+    event = await asyncio.wait_for(received, timeout=5.0)
+    assert event["event_type"] == "OrderCreated"
+    await sub.unsubscribe()
+
+@pytest.mark.asyncio
+async def test_no_event_on_rollback(pg_conn, nats_client):
+    """Events within a rolled-back transaction must NOT reach the broker."""
+    events_received = []
+
+    async def on_message(msg):
+        events_received.append(msg)
+
+    sub = await nats_client.subscribe("orders.created", cb=on_message)
+    try:
+        async with pg_conn.transaction():
+            await pg_conn.execute(
+                "INSERT INTO orders (customer_id, amount, status) VALUES ($1, $2, $3)",
+                2, 50.0, "pending"
+            )
+            raise Exception("Forced rollback")
+    except Exception:
+        pass
+
+    await asyncio.sleep(2.0)  # wait for a relay cycle
+    assert len(events_received) == 0, "No events should reach broker after ROLLBACK"
+    await sub.unsubscribe()
+```
+
+### Chaos Tests — Relay Crash Recovery
+
+```python
+@pytest.mark.asyncio
+async def test_relay_recovers_after_crash(pg_conn, relay_process):
+    """Events queued while relay is down must be delivered after restart."""
+    await relay_process.stop()
+
+    for i in range(10):
+        await pg_conn.execute(
+            "INSERT INTO orders (customer_id, amount) VALUES ($1, $2)", i, 10.0
+        )
+
+    await relay_process.start()
+    await asyncio.sleep(5.0)  # allow relay to catch up
+
+    count = await pg_conn.fetchval(
+        "SELECT COUNT(*) FROM outbox_events WHERE published_at IS NOT NULL"
+    )
+    assert count == 10, "All events delivered after relay restart"
+```
+
+---
+
+## Saga Pattern & Compensating Transactions
+
+The Transactional Outbox pattern is the foundation of the **Saga Pattern** for
+distributed transactions. A saga is a sequence of local transactions, each
+publishing an event that triggers the next step. If any step fails, compensating
+transactions roll back prior steps.
+
+### Choreography-Based Saga
+
+Each service reacts to events and publishes its own next-step events:
+
+```sql
+-- Order service: saga step 1 — emit InventoryReservationRequested on OrderCreated
+CREATE OR REPLACE FUNCTION trigger_saga_step_after_order()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    INSERT INTO outbox_events (aggregate_id, event_type, payload)
+    VALUES (
+        NEW.id,
+        'InventoryReservationRequested',
+        jsonb_build_object(
+            'order_id', NEW.id,
+            'items',    NEW.items,
+            'saga_id',  NEW.saga_id,
+            'step',     1
+        )
+    );
+    RETURN NEW;
+END;
+$$;
+```
+
+### Compensating Transaction Events
+
+```sql
+-- Track which saga steps need compensation if a later step fails
+CREATE TABLE saga_compensation_events (
+    saga_id        UUID NOT NULL,
+    step           INTEGER NOT NULL,
+    aggregate_id   UUID NOT NULL,
+    compensate_fn  TEXT NOT NULL,  -- e.g., 'ReleaseInventory'
+    compensated_at TIMESTAMPTZ,
+    PRIMARY KEY (saga_id, step)
+);
+
+-- Stream table: sagas awaiting compensation (in reverse step order)
+SELECT pgtrickle.create_stream_table(
+    'sagas_needing_compensation',
+    $$SELECT s.saga_id, s.step, s.compensate_fn, s.aggregate_id
+      FROM saga_compensation_events s
+      JOIN orders o ON o.saga_id = s.saga_id
+      WHERE o.status = 'failed'
+        AND s.compensated_at IS NULL
+      ORDER BY s.step DESC$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Orchestration-Based Saga
+
+A central orchestrator drives the saga state machine:
+
+```sql
+CREATE TABLE order_saga_state (
+    saga_id      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    order_id     UUID REFERENCES orders(id),
+    current_step TEXT NOT NULL DEFAULT 'STARTED',
+    -- STARTED → INVENTORY_RESERVED → PAYMENT_CHARGED → COMPLETED
+    -- STARTED → INVENTORY_RESERVATION_FAILED → COMPENSATING → COMPENSATED
+    failed_step  TEXT,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Orchestrator polls this stream table to decide the next action
+SELECT pgtrickle.create_stream_table(
+    'saga_pending_actions',
+    $$SELECT s.saga_id, s.order_id, s.current_step, o.amount, o.customer_id
+      FROM order_saga_state s
+      JOIN orders o ON o.id = s.order_id
+      WHERE s.current_step NOT IN ('COMPLETED', 'COMPENSATED')$$,
+    schedule => '2s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Saga Timeout Detection
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'stalled_sagas',
+    $$SELECT saga_id, order_id, current_step,
+             EXTRACT(EPOCH FROM (now() - updated_at)) AS stuck_seconds
+      FROM order_saga_state
+      WHERE current_step NOT IN ('COMPLETED', 'COMPENSATED')
+        AND updated_at < now() - INTERVAL '10 minutes'$$,
+    schedule => '60s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+---
+
+## Multi-Tenancy
+
+In multi-tenant SaaS applications, the outbox pipeline must isolate tenant data
+and allow independent scaling per tenant.
+
+### Tenant-Per-Row Isolation
+
+```sql
+-- Add tenant_id to all relevant tables
+ALTER TABLE orders        ADD COLUMN tenant_id UUID NOT NULL;
+ALTER TABLE outbox_events ADD COLUMN tenant_id UUID NOT NULL;
+
+-- Row-Level Security to prevent cross-tenant access
+ALTER TABLE outbox_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY outbox_tenant_isolation ON outbox_events
+    USING (tenant_id = current_setting('app.tenant_id')::UUID);
+
+-- Tenant-scoped stream table (relay sets app.tenant_id per connection)
+SELECT pgtrickle.create_stream_table(
+    'pending_outbox_tenant_scoped',
+    $$SELECT event_id, tenant_id, aggregate_id, event_type, payload
+      FROM outbox_events
+      WHERE published_at IS NULL$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Tenant-Per-Schema Isolation
+
+For stronger isolation, give each tenant its own schema:
+
+```sql
+-- Create a tenant-specific outbox
+CREATE SCHEMA tenant_abc;
+CREATE TABLE tenant_abc.outbox_events (LIKE public.outbox_events INCLUDING ALL);
+
+-- Tenant-specific stream table
+SELECT pgtrickle.create_stream_table(
+    'tenant_abc.pending_outbox',
+    $$SELECT * FROM tenant_abc.outbox_events WHERE published_at IS NULL$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Multi-Tenant Relay Routing
+
+Route events to tenant-specific broker subjects:
+
+```python
+async def relay_event(event: dict):
+    tenant_id = event["tenant_id"]
+    subject = f"tenant.{tenant_id}.{event['event_type'].lower()}"
+    # e.g., "tenant.abc123.ordercreated"
+    await js.publish(subject, json.dumps(event).encode(), headers={
+        "Nats-Msg-Id": str(event["event_id"]),  # JetStream deduplication
+    })
+```
+
+---
+
+## Cost Analysis
+
+Understanding the operational cost of the outbox pipeline helps choose the
+right implementation approach.
+
+### Storage Cost
+
+| Component | Typical Size per Event | Notes |
+|-----------|----------------------|-------|
+| `outbox_events` row | ~200–500 bytes | JSONB payload dominates |
+| CDC buffer row | ~100–300 bytes | Typed columns, no JSONB overhead |
+| Stream table | ~same as source rows | Materialized view |
+| Index overhead | ~40% of table size | Typical for BTREE indexes |
+
+**Example:** 1 million events/day × 400 bytes = ~400 MB/day. With 7-day
+retention: ~2.8 GB. With monthly partitioning, expired partitions drop
+instantly via `DETACH PARTITION` + `DROP TABLE`.
+
+### Refresh CPU Overhead
+
+| Mode | CPU Impact | Latency | Use When |
+|------|------------|---------|----------|
+| DIFFERENTIAL | Low (only changed rows) | ~50–200 ms | Default; > 99% of cases |
+| FULL | High (full table scan) | seconds–minutes | Forced by complex aggregations |
+| IMMEDIATE | Minimal (synchronous) | ~0 ms additional | Zero-lag requirement |
+
+### Infrastructure Comparison
+
+| Setup | Additional Infrastructure | Estimated Monthly Cost (small–medium) |
+|-------|--------------------------|----------------------------------------|
+| PostgreSQL only | None | $0 additional |
+| PostgreSQL + NATS | ~10 MB binary, single process | ~$5–20/mo (small VM or managed) |
+| PostgreSQL + Kafka | KRaft cluster + brokers | $50–500/mo (managed) |
+| PostgreSQL + Debezium | Kafka + Kafka Connect | $100–1 000/mo (managed) |
+
+> **Note:** NATS offers near-Kafka throughput at a fraction of the operational
+> cost. For fewer than 100 000 events/sec, NATS JetStream is usually sufficient.
+
+---
+
+## Security Considerations
+
+Protecting event data across the outbox pipeline requires attention at every
+boundary.
+
+### Payload Encryption for Sensitive Data
+
+Never store PII or secrets in plaintext within the outbox payload:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Encrypt sensitive fields in the outbox capture trigger
+CREATE OR REPLACE FUNCTION outbox_capture_order() RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO outbox_events (aggregate_id, event_type, payload)
+    VALUES (
+        NEW.id,
+        'OrderCreated',
+        jsonb_build_object(
+            'order_id',    NEW.id,
+            'amount',      NEW.amount,
+            -- Encrypt PII at rest; relay decrypts before publishing
+            'customer_pii', encode(
+                pgp_sym_encrypt(
+                    (NEW.customer_email || '|' || NEW.shipping_address)::bytea,
+                    current_setting('app.encryption_key')
+                ),
+                'base64'
+            )
+        )
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+```
+
+### Database-Level Access Controls
+
+```sql
+-- Dedicated role for the relay process — minimal privileges
+CREATE ROLE outbox_relay LOGIN PASSWORD '...';
+GRANT USAGE ON SCHEMA public TO outbox_relay;
+REVOKE ALL ON ALL TABLES IN SCHEMA public FROM outbox_relay;
+GRANT SELECT, UPDATE ON outbox_events TO outbox_relay;
+GRANT SELECT ON pending_outbox TO outbox_relay;
+```
+
+### Broker Credential Management
+
+- Never hardcode broker credentials in application code.
+- Use environment variables, HashiCorp Vault, AWS Secrets Manager, or
+  Kubernetes Secrets.
+- Rotate credentials regularly. NATS supports
+  [NKey authentication](https://docs.nats.io/running-a-nats-service/configuration/securing_nats/auth_intro/nkey_auth)
+  with Ed25519 keypairs for zero-secret broker authentication.
+
+### TLS in Transit
+
+```python
+import ssl, nats
+
+# Always use TLS for broker connections in production
+nc = await nats.connect(
+    servers=["tls://nats.example.com:4222"],
+    tls=ssl.create_default_context(cafile="/etc/ssl/nats-ca.pem"),
+    tls_hostname="nats.example.com",
+    user_credentials="/etc/nats/relay.creds",
+)
+```
+
+### Immutable Audit Log
+
+```sql
+-- Record every relay attempt; never UPDATE or DELETE rows in this table
+CREATE TABLE outbox_relay_log (
+    id          BIGSERIAL PRIMARY KEY,
+    event_id    BIGINT NOT NULL REFERENCES outbox_events(event_id),
+    relay_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    outcome     TEXT NOT NULL CHECK (outcome IN ('success', 'failure', 'duplicate')),
+    broker_ack  TEXT,   -- broker-returned message ID or error
+    relay_host  TEXT    -- for multi-relay-process setups
+);
+
+-- Append-only policy: deny UPDATE and DELETE
+ALTER TABLE outbox_relay_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY relay_log_insert_only ON outbox_relay_log
+    FOR INSERT WITH CHECK (TRUE);
+-- No UPDATE or DELETE policy = denied by default
+```
 
 ---
 

--- a/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
@@ -33,6 +33,9 @@
   - [Extension 3: pgmq Integration](#extension-3-pgmq-integration)
   - [Extension 4: Webhook Dispatcher](#extension-4-webhook-dispatcher)
 - [Design Considerations](#design-considerations)
+- [Event Sourcing vs. Transactional Outbox](#event-sourcing-vs-transactional-outbox)
+- [CloudEvents Standard](#cloudevents-standard)
+- [Exactly-Once Semantics — Clarified](#exactly-once-semantics--clarified)
 - [Schema Evolution & Message Versioning](#schema-evolution--message-versioning)
 - [Observability & Distributed Tracing](#observability--distributed-tracing)
 - [Testing Strategies](#testing-strategies)
@@ -40,6 +43,9 @@
 - [Multi-Tenancy](#multi-tenancy)
 - [Cost Analysis](#cost-analysis)
 - [Security Considerations](#security-considerations)
+- [Disaster Recovery & Backup-Restore](#disaster-recovery--backup-restore)
+- [Operational Runbooks](#operational-runbooks)
+- [Migration Guide](#migration-guide)
 - [Comparison with Traditional Approaches](#comparison-with-traditional-approaches)
 - [References](#references)
 
@@ -903,6 +909,35 @@ circuit breaker patterns. Consider using pg_net extension as the HTTP layer.
 | Across source tables | Independent refresh schedules; no cross-table ordering |
 | Within a diamond dependency group | Atomic refresh group ensures consistency |
 
+#### Strict Total Ordering Edge Cases
+
+**Global ordering is fundamentally impossible** with the outbox pattern without
+a single global lock — which defeats the purpose of microservice decoupling.
+Specific edge cases to be aware of:
+
+1. **PK gaps:** PostgreSQL sequences can produce gaps (transaction rollback,
+   `nextval()` without `INSERT`). Gaps in `event_id` are normal and consumers
+   must tolerate them. Never use "next expected ID" logic for gap detection
+   on the outbox side.
+
+2. **Relay batch duplication:** If the relay publishes events 1–10, crashes
+   before marking them as published, then restarts and re-publishes 1–10,
+   the broker now has two copies. Meanwhile events 11–20 arrive normally.
+   Consumers see: 1–10, 1–10 (deduped), 11–20. With broker-level dedup
+   (`Nats-Msg-Id`), the second 1–10 batch is silently dropped.
+
+3. **Cross-aggregate causal ordering:** Order A creates a payment that
+   triggers an inventory check. The events for Order and Payment have
+   independent sequences. If you need causal ordering, include a
+   `causation_id` (the event ID that triggered this event) in the payload
+   and let the consumer reconstruct the causal chain.
+
+4. **Competing relays:** Multiple relay instances using `FOR UPDATE SKIP
+   LOCKED` process different batches concurrently. Events within each batch
+   are ordered, but batches may arrive at the broker out of order (relay A
+   publishes 11–20 before relay B publishes 1–10). **Fix:** Use a single
+   relay instance per aggregate key, or accept per-aggregate ordering only.
+
 ### Idempotency
 
 The outbox pattern provides **at-least-once** delivery. Consumers MUST handle
@@ -954,6 +989,237 @@ When the relay falls behind:
 | PostgreSQL crashes after COMMIT | Events durable in WAL | Normal crash recovery; outbox intact |
 | Stream table refresh fails | Relay reads stale data | pg_trickle retries with backoff; alert emitted |
 | Broker unreachable | Relay retries | Events queue in outbox; monitor staleness |
+
+---
+
+## Event Sourcing vs. Transactional Outbox
+
+These two patterns are frequently confused but serve fundamentally different
+purposes. Understanding the distinction prevents over-engineering.
+
+| Aspect | Transactional Outbox | Event Sourcing |
+|--------|---------------------|----------------|
+| **Purpose** | Notify other services of state changes | Store state *as* a sequence of events |
+| **Source of truth** | Traditional tables (orders, users) | The event log itself |
+| **Event role** | Notification — can be lost and re-derived | Authoritative — losing events = losing state |
+| **Retention** | Temporary (garbage-collect after publishing) | Permanent (append-only, never delete) |
+| **Replay** | Not required; events are disposable | Essential; state is rebuilt from replay |
+| **Schema** | JSONB payload, loosely structured | Strongly typed, versioned events |
+| **pg_trickle role** | CDC + stream table + relay | CDC captures the append to the event store |
+
+**Can they coexist?** Yes. A common architecture:
+
+1. **Event Store** (e.g., `order_events` append-only table) is the source of
+   truth.
+2. **Projection tables** (e.g., `orders_current_state`) are pg_trickle stream
+   tables that materialize the latest state from the event store.
+3. **Outbox** publishes selected events to external services — the stream
+   table over the event store acts as the outbox view.
+
+```sql
+-- Event store: append-only, never UPDATE or DELETE
+CREATE TABLE order_events (
+    event_id    BIGSERIAL PRIMARY KEY,
+    order_id    UUID NOT NULL,
+    event_type  TEXT NOT NULL,
+    payload     JSONB NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Projection: current order state (derived from events)
+SELECT pgtrickle.create_stream_table(
+    'orders_current_state',
+    $$SELECT DISTINCT ON (order_id)
+            order_id, event_type AS last_event, payload, created_at
+      FROM order_events
+      ORDER BY order_id, event_id DESC$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Outbox: events not yet published to external services
+SELECT pgtrickle.create_stream_table(
+    'pending_external_events',
+    $$SELECT event_id, order_id, event_type, payload
+      FROM order_events
+      WHERE event_id > (SELECT COALESCE(MAX(last_published_id), 0)
+                        FROM outbox_watermark)$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+> **Rule of thumb:** If your team debates "should we event-source this?",
+> start with the outbox pattern. It's strictly simpler. You can always
+> migrate to event sourcing later — the outbox trigger captures the same
+> change events either way.
+
+---
+
+## CloudEvents Standard
+
+[CloudEvents](https://cloudevents.io/) (CNCF graduated) is a vendor-neutral
+specification for describing event data in a common way. Adopting it makes
+outbox events interoperable across brokers, languages, and frameworks.
+
+### Why CloudEvents?
+
+- Standard envelope format understood by NATS, Kafka, Azure Event Grid,
+  AWS EventBridge, Knative, and many others.
+- SDKs available for Go, Java, Python, Rust, JavaScript, .NET, and more.
+- Schema validation tools (`ce-schema`) ensure payload correctness.
+- [AsyncAPI](https://www.asyncapi.com/) can document CloudEvents contracts
+  (like OpenAPI but for event-driven APIs).
+
+### CloudEvents-Formatted Outbox
+
+```sql
+-- CloudEvents v1.0 envelope stored in the outbox
+CREATE TABLE outbox_events (
+    event_id       UUID PRIMARY KEY DEFAULT gen_random_uuid(),  -- 'id'
+    source         TEXT NOT NULL DEFAULT '/orders',             -- 'source'
+    spec_version   TEXT NOT NULL DEFAULT '1.0',                 -- 'specversion'
+    event_type     TEXT NOT NULL,                               -- 'type'
+    subject        TEXT,                                        -- 'subject'
+    time           TIMESTAMPTZ NOT NULL DEFAULT now(),          -- 'time'
+    data_content_type TEXT NOT NULL DEFAULT 'application/json', -- 'datacontenttype'
+    data           JSONB NOT NULL,                              -- 'data'
+    -- Extension attributes
+    aggregate_id   UUID,
+    trace_id       UUID,
+    schema_version INTEGER NOT NULL DEFAULT 1,
+    -- Relay state
+    published_at   TIMESTAMPTZ
+);
+
+-- Trigger that writes CloudEvents-formatted events
+CREATE OR REPLACE FUNCTION fn_order_outbox_ce() RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO outbox_events (event_type, subject, aggregate_id, data)
+    VALUES (
+        'com.example.orders.' || CASE TG_OP
+            WHEN 'INSERT' THEN 'created'
+            WHEN 'UPDATE' THEN 'updated'
+            WHEN 'DELETE' THEN 'deleted'
+        END,
+        '/orders/' || COALESCE(NEW.id, OLD.id)::text,
+        COALESCE(NEW.id, OLD.id),
+        CASE TG_OP
+            WHEN 'DELETE' THEN to_jsonb(OLD)
+            ELSE to_jsonb(NEW)
+        END
+    );
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+```
+
+### Publishing as CloudEvents Wire Format
+
+```python
+# Relay publishes in CloudEvents JSON format
+import json
+
+def to_cloudevent_json(row: dict) -> bytes:
+    ce = {
+        "specversion": row["spec_version"],
+        "id":          str(row["event_id"]),
+        "source":      row["source"],
+        "type":        row["event_type"],
+        "time":        row["time"].isoformat(),
+        "datacontenttype": row["data_content_type"],
+        "data":        row["data"],
+    }
+    if row.get("subject"):
+        ce["subject"] = row["subject"]
+    return json.dumps(ce).encode()
+
+# With NATS + pgnats:
+# SELECT nats_publish_jsonb_stream(
+#     'orders.created',
+#     to_jsonb(outbox_row),  -- already CloudEvents-shaped
+#     json_build_object('Nats-Msg-Id', event_id::text,
+#                       'ce-specversion', '1.0')
+# );
+```
+
+### Documenting with AsyncAPI
+
+AsyncAPI provides an OpenAPI-like contract for event-driven APIs:
+
+```yaml
+# asyncapi.yaml (v3.0)
+asyncapi: 3.0.0
+info:
+  title: Order Service Events
+  version: 1.0.0
+channels:
+  orderCreated:
+    address: orders.created
+    messages:
+      OrderCreated:
+        payload:
+          $ref: '#/components/schemas/Order'
+        headers:
+          type: object
+          properties:
+            ce-specversion: { type: string, const: '1.0' }
+            ce-type: { type: string }
+            ce-source: { type: string }
+            Nats-Msg-Id: { type: string }
+components:
+  schemas:
+    Order:
+      type: object
+      required: [order_id, amount, status]
+      properties:
+        order_id: { type: string, format: uuid }
+        amount: { type: number }
+        status: { type: string, enum: [pending, confirmed, shipped] }
+```
+
+---
+
+## Exactly-Once Semantics — Clarified
+
+The term "exactly-once" is used loosely in messaging. There are three distinct
+levels, and confusing them leads to over- or under-engineering.
+
+### Three Levels of Exactly-Once
+
+| Level | What It Means | Who Provides It |
+|-------|--------------|------------------|
+| **Broker-level dedup** | The broker stores a message at most once per dedup key | NATS `Nats-Msg-Id`, Kafka idempotent producer |
+| **Consumer-level dedup** | The consumer processes a message at most once per ID | Inbox `ON CONFLICT (event_id) DO NOTHING` |
+| **End-to-end exactly-once** | From source write to final side-effect, the event has exactly one effect | Both broker-level + consumer-level together |
+
+### How Each pg_trickle Approach Maps
+
+| Approach | Broker-Level | Consumer-Level | End-to-End |
+|----------|-------------|----------------|------------|
+| Stream table + polling relay to Kafka | Kafka idempotent producer (`acks=all`) | Consumer dedup table | Yes (with careful config) |
+| Stream table + NATS relay | `Nats-Msg-Id` = `event_id` | Consumer dedup table | Yes (built-in) |
+| pgnats trigger → NATS JetStream | `Nats-Msg-Id` header in trigger | Consumer dedup table | Yes (simplest path) |
+| CDC buffer → Debezium → Kafka | Debezium event ID | Consumer dedup table | Yes |
+| pgmq (intra-PostgreSQL) | `pgmq.send()` is transactional | Same-DB dedup | Yes (single DB boundary) |
+
+### Common Pitfalls
+
+1. **Relay crash between publish and `UPDATE published_at`:** The event is in
+   the broker but not marked as published. On restart, the relay re-publishes
+   → duplicate. **Fix:** Use broker-level dedup (`Nats-Msg-Id` or Kafka
+   idempotent producer).
+2. **Consumer crash between processing and ack:** The broker redelivers.
+   **Fix:** Inbox `ON CONFLICT DO NOTHING` or idempotent state mutation.
+3. **`event_id` is unique but not deterministic:** If the same business
+   operation can generate multiple events with different IDs (e.g., retried
+   application logic), dedup by `event_id` won't help. **Fix:** Use a
+   deterministic idempotency key derived from business state (e.g.,
+   `order_id || status || version`).
+
+> **Recommendation:** Always implement *both* broker-level and consumer-level
+> dedup. The cost is minimal (one `ON CONFLICT` clause + one header), and it
+> makes the system resilient to any single-component failure.
 
 ---
 
@@ -1554,6 +1820,246 @@ CREATE POLICY relay_log_insert_only ON outbox_relay_log
 
 ---
 
+## Disaster Recovery & Backup-Restore
+
+The outbox pattern has a critical edge case during disaster recovery that
+can silently cause duplicate event publishing.
+
+### The Backup-Restore Trap
+
+When restoring PostgreSQL from a backup (e.g., `pg_basebackup`, PITR, or
+a cloud snapshot):
+
+1. Backup was taken at time T₀.
+2. Between T₀ and the restore point, the relay published events E₁..Eₙ to
+   the broker and marked them `published_at IS NOT NULL`.
+3. After restore, the database is back at T₀ — those events show
+   `published_at IS NULL` again.
+4. The relay re-publishes E₁..Eₙ → **duplicates at the broker**.
+
+```
+Timeline:
+  T₀ (backup)  ────── T₁ (crash) ────── T₂ (restore to T₀)
+                 ↑                         ↑
+          Events E₁..Eₙ published    E₁..Eₙ now appear
+          and marked done            unpublished again
+                                     → relay re-publishes
+```
+
+### Mitigation Strategies
+
+| Strategy | How | Trade-off |
+|----------|-----|----------|
+| **Broker-level dedup** | `Nats-Msg-Id` / Kafka idempotent producer | Best defense; requires deterministic event IDs |
+| **Consumer idempotency** | `ON CONFLICT (event_id) DO NOTHING` at inbox | Always needed anyway |
+| **High-watermark table** | Store `last_published_event_id` in a broker-side checkpoint | Requires broker-to-DB feedback loop |
+| **Outbox watermark in WAL** | After restore, compare broker's latest known ID with DB state | Complex but definitive |
+
+### Recommended: Deterministic Event IDs
+
+Make event IDs deterministic so that re-publishing after restore produces the
+same IDs:
+
+```sql
+-- Instead of BIGSERIAL (which resets on restore), use a content-derived UUID:
+CREATE OR REPLACE FUNCTION fn_deterministic_event_id(
+    aggregate_id UUID,
+    event_type   TEXT,
+    version      INTEGER
+) RETURNS UUID AS $$
+    SELECT uuid_generate_v5(
+        'a1b2c3d4-e5f6-7890-abcd-ef1234567890'::UUID,  -- namespace
+        aggregate_id::text || event_type || version::text
+    );
+$$ LANGUAGE SQL IMMUTABLE;
+```
+
+With deterministic IDs, re-publishing after restore produces the same events
+that the broker already has — dedup handles them transparently.
+
+### Point-in-Time Recovery (PITR) Considerations
+
+- **Recovery target:** Always recover to a consistent point *after* the last
+  completed relay batch, if possible.
+- **WAL archiving:** Ensure WAL segments are archived frequently enough that
+  recovery can reach a point close to the crash time.
+- **Logical replication slots:** If using WAL CDC mode, the replication slot
+  position is part of the database state — it also rolls back on restore.
+  Debezium/WAL-tailing relays need to handle this.
+
+### Replica Promotion / Failover
+
+When promoting a standby to primary:
+
+1. The new primary's outbox state matches the last replicated position.
+2. If the relay was connected to the old primary, it must reconnect.
+3. **Risk:** Async replication lag means the new primary might be *behind*
+   the old primary — some published events may not exist yet.
+4. **Fix:** Use synchronous replication for the outbox table, or accept
+   duplicate re-publishing with broker-level dedup.
+
+---
+
+## Operational Runbooks
+
+Practical procedures for common operational scenarios.
+
+### Graceful Relay Shutdown
+
+```python
+import signal, asyncio
+
+class OutboxRelay:
+    def __init__(self):
+        self.running = True
+        self.current_batch = None
+        signal.signal(signal.SIGTERM, self._handle_sigterm)
+
+    def _handle_sigterm(self, signum, frame):
+        """Drain current batch before exiting."""
+        self.running = False
+        # Do NOT abort mid-batch — let the current batch complete
+
+    async def run(self):
+        while self.running:
+            self.current_batch = await self.fetch_batch()
+            if self.current_batch:
+                await self.publish_and_mark(self.current_batch)
+            else:
+                await asyncio.sleep(0.5)
+
+        # Final drain: publish any remaining batch
+        if self.current_batch:
+            await self.publish_and_mark(self.current_batch)
+        print("Relay shut down gracefully.")
+```
+
+### pg_trickle Upgrade Procedure
+
+When upgrading pg_trickle, stream tables may need recreation:
+
+```bash
+# 1. Stop the relay process
+systemctl stop outbox-relay
+
+# 2. Upgrade pg_trickle
+ALTER EXTENSION pg_trickle UPDATE;
+
+# 3. Verify stream tables are intact
+SELECT pgt_name, pgt_status, pgt_refresh_mode
+  FROM pgtrickle.pgt_stream_tables;
+
+# 4. If stream tables need recreation (rare, noted in release notes):
+SELECT pgtrickle.drop_stream_table('pending_outbox_events');
+SELECT pgtrickle.create_stream_table('pending_outbox_events', ...);
+
+# 5. Restart the relay
+systemctl start outbox-relay
+```
+
+### Kubernetes Deployment Model
+
+| Model | Pros | Cons |
+|-------|------|------|
+| **Sidecar** (relay in same pod as app) | Shares DB connection pool, simple lifecycle | Scales with app, not with outbox depth |
+| **Standalone Deployment** (relay as separate service) | Scales independently, multiple replicas | Extra service to manage |
+| **CronJob** (relay as periodic batch job) | Simple, no long-running process | Higher latency, no event-driven wake |
+| **pg_trickle BGW** (proposed Extension 2) | Zero external processes | Requires pg_trickle extension support |
+
+**Recommended:** Standalone Deployment with `SKIP LOCKED` for competing
+instances, plus a Kubernetes `readinessProbe` that checks the relay's
+health endpoint.
+
+### Stuck Events Investigation
+
+```sql
+-- Find events stuck for more than 5 minutes
+SELECT event_id, event_type, aggregate_id, created_at,
+       EXTRACT(EPOCH FROM (now() - created_at)) AS age_seconds
+FROM outbox_events
+WHERE published_at IS NULL
+  AND created_at < now() - INTERVAL '5 minutes'
+ORDER BY created_at
+LIMIT 20;
+
+-- Check if the stream table is refreshing
+SELECT pgtrickle.get_staleness('pending_outbox_events');
+
+-- Force a manual refresh
+SELECT pgtrickle.refresh('pending_outbox_events');
+```
+
+---
+
+## Migration Guide
+
+Migrating from a hand-rolled outbox to pg_trickle without downtime.
+
+### Prerequisites
+
+- Existing outbox table (e.g., `domain_events` with `published` column)
+- Existing relay process (e.g., cron job or custom poller)
+- pg_trickle installed and `pg_trickle.enabled = true`
+
+### Step 1: Add pg_trickle CDC (Non-Destructive)
+
+```sql
+-- Register the existing outbox table as a pg_trickle source
+-- This adds a CDC trigger but does NOT change existing behavior
+SELECT pgtrickle.create_stream_table(
+    'pending_outbox_v2',
+    $$SELECT event_id, event_type, aggregate_id, payload, created_at
+      FROM domain_events
+      WHERE published = false$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+Your existing relay still works — `domain_events` is unchanged.
+
+### Step 2: Shadow Read (Validate)
+
+Run both the old relay and a new relay reading from `pending_outbox_v2` in
+**read-only mode** (log events but don't publish):
+
+```python
+async def shadow_relay():
+    rows = await conn.fetch("SELECT * FROM pending_outbox_v2 ORDER BY event_id")
+    for row in rows:
+        logger.info(f"Shadow relay would publish: {row['event_id']}")
+        # Verify: does this match what the old relay published?
+```
+
+### Step 3: Cut Over
+
+```bash
+# Stop the old relay
+systemctl stop old-outbox-relay
+
+# Start the new pg_trickle-based relay
+systemctl start new-outbox-relay
+```
+
+### Step 4: Clean Up
+
+```sql
+-- Once confident, drop old indexes/columns that are no longer needed
+-- (keep the table structure if it's still the source of events)
+```
+
+### Blue/Green Migration
+
+For zero-downtime migration with verification:
+
+1. **Green:** New relay reads from pg_trickle stream table.
+2. **Blue:** Old relay reads from `domain_events` directly.
+3. Run both simultaneously — green publishes, blue validates.
+4. Once green is stable for 24h, decommission blue.
+5. Both relays use broker-level dedup, so parallel publishing is safe.
+
+---
+
 ## Comparison with Traditional Approaches
 
 | Aspect | Traditional Outbox | pg_trickle Outbox | Debezium CDC | pg_trickle + NATS JetStream |
@@ -1579,5 +2085,7 @@ CREATE POLICY relay_log_insert_only ON outbox_relay_log
 - [NATS.io — Cloud-Native Messaging](https://nats.io/)
 - [NATS JetStream Documentation](https://docs.nats.io/nats-concepts/jetstream)
 - [pgnats — PostgreSQL extension for NATS messaging](https://github.com/luxms/pgnats) (MIT, Rust/pgrx)
+- [CloudEvents — CNCF Event Data Specification](https://cloudevents.io/)
+- [AsyncAPI — Event-Driven API Documentation](https://www.asyncapi.com/)
 - Krzysztof Atłasik, [Microservices 101: Transactional Outbox and Inbox](https://softwaremill.com/microservices-101/)
 - pg_trickle [ARCHITECTURE.md](../../docs/ARCHITECTURE.md), [PATTERNS.md](../../docs/PATTERNS.md), [SQL_REFERENCE.md](../../docs/SQL_REFERENCE.md)

--- a/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
+++ b/plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md
@@ -1,0 +1,787 @@
+# Transactional Outbox Pattern with pg_trickle
+
+> **Status:** Research Report  
+> **Created:** 2026-04-17  
+> **Category:** Integration Pattern
+
+---
+
+## Table of Contents
+
+- [Executive Summary](#executive-summary)
+- [What Is the Transactional Outbox Pattern?](#what-is-the-transactional-outbox-pattern)
+- [The Problem It Solves](#the-problem-it-solves)
+- [How pg_trickle Enables the Transactional Outbox](#how-pg_trickle-enables-the-transactional-outbox)
+  - [Architecture Overview](#architecture-overview)
+  - [Approach 1: Stream Table as the Outbox View](#approach-1-stream-table-as-the-outbox-view)
+  - [Approach 2: CDC Buffer as the Outbox](#approach-2-cdc-buffer-as-the-outbox)
+  - [Approach 3: IMMEDIATE Mode for Zero-Lag Outbox](#approach-3-immediate-mode-for-zero-lag-outbox)
+- [Message Relay Strategies](#message-relay-strategies)
+  - [Strategy A: Polling Publisher via Stream Table](#strategy-a-polling-publisher-via-stream-table)
+  - [Strategy B: LISTEN/NOTIFY + Stream Table](#strategy-b-listennotify--stream-table)
+  - [Strategy C: Transaction Log Tailing via WAL CDC](#strategy-c-transaction-log-tailing-via-wal-cdc)
+- [Worked Example: Order Service Outbox](#worked-example-order-service-outbox)
+- [Complementary PostgreSQL Extensions](#complementary-postgresql-extensions)
+  - [pgmq — PostgreSQL Message Queue](#pgmq--postgresql-message-queue)
+  - [pg_amqp — AMQP Publishing from PostgreSQL](#pg_amqp--amqp-publishing-from-postgresql)
+  - [pgflow — Durable Workflow Engine](#pgflow--durable-workflow-engine)
+  - [Debezium — External CDC Platform](#debezium--external-cdc-platform)
+- [Potential pg_trickle Extensions](#potential-pg_trickle-extensions)
+  - [Extension 1: Outbox Table Helper](#extension-1-outbox-table-helper)
+  - [Extension 2: Message Relay Background Worker](#extension-2-message-relay-background-worker)
+  - [Extension 3: pgmq Integration](#extension-3-pgmq-integration)
+  - [Extension 4: Webhook Dispatcher](#extension-4-webhook-dispatcher)
+- [Design Considerations](#design-considerations)
+- [Comparison with Traditional Approaches](#comparison-with-traditional-approaches)
+- [References](#references)
+
+---
+
+## Executive Summary
+
+The **Transactional Outbox Pattern** guarantees that domain events (messages)
+are published if and only if the originating database transaction commits. It
+decouples services in a microservice architecture while preventing data
+inconsistency caused by partial failures between the database and a message
+broker.
+
+pg_trickle is a natural fit for implementing this pattern because:
+
+1. **CDC triggers already capture every DML change** atomically within the
+   source transaction — no additional outbox trigger is needed.
+2. **Stream tables can materialize the "pending events" view** with sub-second
+   latency via DIFFERENTIAL refresh.
+3. **IMMEDIATE mode** can provide zero-lag outbox materialization within the
+   same transaction.
+4. **LISTEN/NOTIFY integration** (`pg_trickle_alert`, `pgtrickle_wake`) enables
+   push-based relay without polling overhead.
+5. **WAL-based CDC** can act as a built-in transaction log tailer, avoiding
+   external tools like Debezium for simple topologies.
+
+---
+
+## What Is the Transactional Outbox Pattern?
+
+In a microservice architecture, a service often needs to:
+
+1. Update its own database (e.g., create an order).
+2. Publish an event to a message broker (e.g., `OrderCreated`).
+
+These two operations must be **atomic** — either both succeed or neither does.
+Using a distributed transaction (2PC) across the database and broker is
+fragile, slow, and often unsupported.
+
+The **Transactional Outbox** solves this by:
+
+1. Writing the business entity **and** the event into the **same database
+   transaction** (the event goes into an "outbox" table).
+2. A separate **message relay** process reads the outbox and publishes events
+   to the external broker.
+3. Events are published **at least once** — consumers must be idempotent.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    PostgreSQL                            │
+│                                                         │
+│  BEGIN;                                                 │
+│    INSERT INTO orders (...) VALUES (...);               │
+│    INSERT INTO outbox_events (event_type, payload, ...) │
+│      VALUES ('OrderCreated', '{"order_id": 42}');       │
+│  COMMIT;                                                │
+│                                                         │
+│  ┌──────────────────┐    ┌──────────────────────────┐   │
+│  │  outbox_events   │───→│ Message Relay (worker)   │───┼──→ Kafka / RabbitMQ / pgmq
+│  │  (pending rows)  │    │ polls or tails changes   │   │
+│  └──────────────────┘    └──────────────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## The Problem It Solves
+
+| Failure Scenario                        | Without Outbox             | With Outbox                  |
+|-----------------------------------------|----------------------------|------------------------------|
+| DB commits, broker publish fails        | Event lost forever         | Relay retries from outbox    |
+| Service crashes after DB commit         | Event lost (was in memory) | Event persisted in outbox    |
+| DB commits, service crashes before ack  | Possible duplicate         | Relay re-publishes (idempotent) |
+| Broker down for maintenance             | Events lost during outage  | Events queue in outbox table |
+
+**Key guarantees:**
+
+- **No event loss:** If the transaction commits, the event is durably stored.
+- **At-least-once delivery:** The relay may publish duplicates, but never drops.
+- **Ordering preserved:** Events from a single aggregate are ordered by their
+  database sequence (outbox PK or LSN).
+
+---
+
+## How pg_trickle Enables the Transactional Outbox
+
+### Architecture Overview
+
+pg_trickle's CDC infrastructure already captures row-level changes into buffer
+tables (`pgtrickle_changes.changes_<oid>`) within the same transaction as the
+source DML. This means **the CDC buffer is itself a transactional outbox** —
+the only missing piece is the relay to an external broker.
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         PostgreSQL                                │
+│                                                                   │
+│  ┌──────────────┐  CDC trigger   ┌──────────────────────────┐    │
+│  │ orders       │ ──────────────→│ pgtrickle_changes.       │    │
+│  │ (base table) │  (same txn)    │   changes_<oid>          │    │
+│  └──────────────┘                └────────────┬─────────────┘    │
+│                                               │                   │
+│  ┌──────────────┐                             │ DIFFERENTIAL      │
+│  │ outbox_events│  (optional,                 │ refresh           │
+│  │ (explicit)   │   user-managed)             ↓                   │
+│  └──────┬───────┘                ┌──────────────────────────┐    │
+│         │ CDC trigger            │ pending_outbox_events    │    │
+│         ↓                        │ (stream table)           │    │
+│  ┌──────────────────────────┐    └────────────┬─────────────┘    │
+│  │ pgtrickle_changes.       │                 │                   │
+│  │   changes_<oid>          │                 │ NOTIFY             │
+│  └──────────────────────────┘                 ↓                   │
+│                                  ┌──────────────────────────┐    │
+│                                  │ Message Relay             │    │
+│                                  │ (app worker or pg worker) │───┼──→ Kafka / pgmq
+│                                  └──────────────────────────┘    │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### Approach 1: Stream Table as the Outbox View
+
+The simplest approach — use an explicit outbox table and a pg_trickle stream
+table to materialize the "pending events" view. The stream table gives you a
+fast, pre-filtered, always-fresh view of unpublished events.
+
+```sql
+-- Step 1: Create the outbox table
+CREATE TABLE outbox_events (
+    event_id     BIGSERIAL PRIMARY KEY,
+    event_type   TEXT NOT NULL,
+    aggregate_id TEXT NOT NULL,
+    aggregate_type TEXT NOT NULL,
+    payload      JSONB NOT NULL,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_at TIMESTAMPTZ          -- NULL = not yet published
+);
+
+CREATE INDEX idx_outbox_pending ON outbox_events (event_id)
+    WHERE published_at IS NULL;
+
+-- Step 2: Create a stream table for pending events
+SELECT pgtrickle.create_stream_table(
+    'pending_outbox_events',
+    $$SELECT event_id, event_type, aggregate_id, aggregate_type, payload, created_at
+      FROM outbox_events
+      WHERE published_at IS NULL$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Step 3: Application writes business entity + outbox in one transaction
+BEGIN;
+  INSERT INTO orders (user_id, total, status)
+      VALUES (123, 99.95, 'confirmed');
+  INSERT INTO outbox_events (event_type, aggregate_id, aggregate_type, payload)
+      VALUES ('OrderCreated', currval('orders_id_seq')::text, 'Order',
+              jsonb_build_object('user_id', 123, 'total', 99.95, 'status', 'confirmed'));
+COMMIT;
+
+-- Step 4: Relay reads from the stream table (always fresh within ~1s)
+-- Application-side pseudocode:
+--   rows = SELECT * FROM pending_outbox_events ORDER BY event_id;
+--   for each row:
+--     publish(row) to Kafka/RabbitMQ
+--     UPDATE outbox_events SET published_at = now() WHERE event_id = row.event_id;
+```
+
+**Advantages:**
+- Stream table is pre-filtered (only pending events), no full-table scan.
+- DIFFERENTIAL refresh means only changed rows are recomputed.
+- `pg_trickle_alert` channel notifies when the stream table refreshes.
+- Multiple relays can read the stream table (but need coordination — see below).
+
+**When to use:** Standard outbox with moderate throughput (< 10K events/sec).
+
+### Approach 2: CDC Buffer as the Outbox
+
+For higher throughput, skip the explicit outbox table entirely. pg_trickle's
+CDC triggers already capture every INSERT/UPDATE/DELETE into typed buffer
+tables. Your relay can read directly from the CDC buffers.
+
+```sql
+-- The application just writes to the business table
+BEGIN;
+  INSERT INTO orders (user_id, total, status)
+      VALUES (123, 99.95, 'confirmed');
+COMMIT;
+
+-- pg_trickle's CDC trigger has already captured this INSERT in:
+--   pgtrickle_changes.changes_<orders_oid>
+-- with columns: change_id, lsn, action='I', new_user_id, new_total, new_status, ...
+
+-- Create a stream table that transforms CDC changes into domain events
+SELECT pgtrickle.create_stream_table(
+    'order_events',
+    $$SELECT o.id AS aggregate_id,
+             CASE
+               WHEN o.status = 'confirmed' THEN 'OrderCreated'
+               WHEN o.status = 'shipped'   THEN 'OrderShipped'
+               WHEN o.status = 'cancelled' THEN 'OrderCancelled'
+             END AS event_type,
+             jsonb_build_object(
+               'order_id', o.id,
+               'user_id', o.user_id,
+               'total', o.total,
+               'status', o.status
+             ) AS payload
+      FROM orders o$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+**Advantages:**
+- No explicit outbox table — zero additional write overhead.
+- CDC captures happen within the same transaction automatically.
+- Delta-based: only changed rows flow through the stream table.
+
+**When to use:** When the business table itself is the source of events and
+you don't need custom event shaping beyond what a SQL query can express.
+
+### Approach 3: IMMEDIATE Mode for Zero-Lag Outbox
+
+For scenarios requiring **sub-millisecond event freshness**, IMMEDIATE mode
+updates the stream table within the same transaction as the source write.
+
+```sql
+-- Create the outbox with IMMEDIATE refresh
+SELECT pgtrickle.create_stream_table(
+    'realtime_outbox',
+    $$SELECT event_id, event_type, aggregate_id, payload, created_at
+      FROM outbox_events
+      WHERE published_at IS NULL$$,
+    refresh_mode => 'IMMEDIATE'
+);
+
+-- Now, within the same transaction:
+BEGIN;
+  INSERT INTO orders (...) VALUES (...);
+  INSERT INTO outbox_events (...) VALUES (...);
+  -- At COMMIT time, realtime_outbox is already updated
+COMMIT;
+
+-- A LISTEN-based relay sees the change immediately
+LISTEN pg_trickle_alert;
+-- Payload: {"event":"refresh_completed","pgt_name":"realtime_outbox",...}
+```
+
+**Advantages:**
+- Zero lag between business write and outbox materialization.
+- Relay can use LISTEN/NOTIFY for push-based publishing.
+
+**Trade-offs:**
+- Adds latency to the source transaction (statement-level trigger overhead).
+- Best for low-to-moderate write throughput (< 1K writes/sec).
+
+---
+
+## Message Relay Strategies
+
+The outbox pattern requires a **message relay** — a process that reads pending
+events and publishes them to an external broker. pg_trickle supports three
+relay strategies.
+
+### Strategy A: Polling Publisher via Stream Table
+
+The relay polls the stream table at regular intervals.
+
+```python
+import psycopg2
+import json
+from kafka import KafkaProducer
+
+producer = KafkaProducer(bootstrap_servers='kafka:9092')
+conn = psycopg2.connect("postgresql://localhost/mydb")
+
+while True:
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT event_id, event_type, aggregate_id, payload
+            FROM pending_outbox_events
+            ORDER BY event_id
+            LIMIT 100
+        """)
+        rows = cur.fetchall()
+
+        for event_id, event_type, aggregate_id, payload in rows:
+            producer.send(
+                topic=event_type,
+                key=aggregate_id.encode(),
+                value=json.dumps(payload).encode(),
+                headers=[('event_id', str(event_id).encode())]
+            )
+            cur.execute(
+                "UPDATE outbox_events SET published_at = now() WHERE event_id = %s",
+                (event_id,)
+            )
+        conn.commit()
+
+    time.sleep(0.5)  # or match the stream table schedule
+```
+
+**Throughput:** Moderate. Limited by polling interval.  
+**Latency:** ~1–2s (stream table schedule + polling interval).
+
+### Strategy B: LISTEN/NOTIFY + Stream Table
+
+Push-based relay using PostgreSQL's built-in notification system.
+
+```python
+import psycopg2
+import psycopg2.extensions
+import select
+
+conn = psycopg2.connect("postgresql://localhost/mydb")
+conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
+
+cur = conn.cursor()
+cur.execute("LISTEN pg_trickle_alert;")
+
+while True:
+    if select.select([conn], [], [], 5.0) != ([], [], []):
+        conn.poll()
+        while conn.notifies:
+            notify = conn.notifies.pop(0)
+            payload = json.loads(notify.payload)
+
+            if (payload.get('event') == 'refresh_completed' and
+                payload.get('pgt_name') == 'pending_outbox_events'):
+                # Fetch and publish pending events
+                publish_pending_events()
+```
+
+**Throughput:** High. Wakes immediately on refresh.  
+**Latency:** ~15ms (event-driven wake) + stream table schedule.
+
+### Strategy C: Transaction Log Tailing via WAL CDC
+
+When pg_trickle transitions a source table to WAL-based CDC, the logical
+replication slot already captures changes in commit order. An external tool or
+custom relay can tail this stream.
+
+This is conceptually identical to using Debezium, but pg_trickle manages the
+replication slot lifecycle automatically.
+
+**When to use:** Very high throughput (> 10K events/sec) where polling overhead
+is unacceptable and you need strict commit-order guarantees.
+
+---
+
+## Worked Example: Order Service Outbox
+
+A complete example showing an e-commerce order service with pg_trickle-powered
+outbox.
+
+```sql
+-- === Schema ===
+
+CREATE TABLE customers (
+    id    SERIAL PRIMARY KEY,
+    name  TEXT NOT NULL,
+    email TEXT NOT NULL
+);
+
+CREATE TABLE orders (
+    id          SERIAL PRIMARY KEY,
+    customer_id INT NOT NULL REFERENCES customers(id),
+    total       NUMERIC(10,2) NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'pending',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE outbox_events (
+    event_id       BIGSERIAL PRIMARY KEY,
+    event_type     TEXT NOT NULL,
+    aggregate_type TEXT NOT NULL,
+    aggregate_id   TEXT NOT NULL,
+    payload        JSONB NOT NULL,
+    metadata       JSONB DEFAULT '{}',
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    published_at   TIMESTAMPTZ
+);
+
+-- === Trigger to auto-populate outbox on order changes ===
+
+CREATE OR REPLACE FUNCTION fn_order_outbox() RETURNS TRIGGER AS $$
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        INSERT INTO outbox_events (event_type, aggregate_type, aggregate_id, payload)
+        VALUES (
+            'OrderCreated', 'Order', NEW.id::text,
+            jsonb_build_object(
+                'order_id', NEW.id,
+                'customer_id', NEW.customer_id,
+                'total', NEW.total,
+                'status', NEW.status
+            )
+        );
+    ELSIF TG_OP = 'UPDATE' AND OLD.status <> NEW.status THEN
+        INSERT INTO outbox_events (event_type, aggregate_type, aggregate_id, payload)
+        VALUES (
+            'OrderStatusChanged', 'Order', NEW.id::text,
+            jsonb_build_object(
+                'order_id', NEW.id,
+                'old_status', OLD.status,
+                'new_status', NEW.status
+            )
+        );
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_order_outbox
+    AFTER INSERT OR UPDATE ON orders
+    FOR EACH ROW EXECUTE FUNCTION fn_order_outbox();
+
+-- === pg_trickle Stream Tables ===
+
+-- Pending events for the relay to publish
+SELECT pgtrickle.create_stream_table(
+    'pending_outbox_events',
+    $$SELECT event_id, event_type, aggregate_type, aggregate_id,
+             payload, metadata, created_at
+      FROM outbox_events
+      WHERE published_at IS NULL
+      ORDER BY event_id$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Published event audit log (for monitoring dashboards)
+SELECT pgtrickle.create_stream_table(
+    'outbox_stats',
+    $$SELECT event_type,
+             COUNT(*) AS total_events,
+             COUNT(*) FILTER (WHERE published_at IS NULL) AS pending,
+             COUNT(*) FILTER (WHERE published_at IS NOT NULL) AS published,
+             MAX(created_at) FILTER (WHERE published_at IS NULL) AS oldest_pending
+      FROM outbox_events
+      GROUP BY event_type$$,
+    schedule => '10s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- === Monitoring ===
+
+-- Alert when outbox is backing up
+-- pg_trickle_alert channel will emit stale_data events if the stream table
+-- falls behind schedule, giving you a built-in health signal.
+SELECT pgtrickle.get_staleness('pending_outbox_events');
+```
+
+### Competing Consumers with `FOR UPDATE SKIP LOCKED`
+
+For multiple relay instances processing the same outbox:
+
+```sql
+-- Each relay instance runs:
+BEGIN;
+  SELECT event_id, event_type, aggregate_id, payload
+  FROM outbox_events
+  WHERE published_at IS NULL
+  ORDER BY event_id
+  LIMIT 50
+  FOR UPDATE SKIP LOCKED;
+
+  -- Publish batch to broker...
+
+  UPDATE outbox_events
+  SET published_at = now()
+  WHERE event_id = ANY($published_ids);
+COMMIT;
+```
+
+This provides safe concurrent processing without duplicate publishing.
+
+---
+
+## Complementary PostgreSQL Extensions
+
+### pgmq — PostgreSQL Message Queue
+
+[pgmq](https://github.com/pgmq/pgmq) (4.8K+ stars) is a lightweight
+PostgreSQL extension that implements an SQS-like message queue entirely within
+PostgreSQL.
+
+**How it works with pg_trickle:**
+
+```sql
+CREATE EXTENSION pgmq;
+
+-- Create a queue for order events
+SELECT pgmq.create('order_events');
+
+-- Use a trigger on the pg_trickle stream table (or outbox table)
+-- to enqueue messages automatically
+CREATE OR REPLACE FUNCTION fn_enqueue_outbox() RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM pgmq.send(
+        'order_events',
+        jsonb_build_object(
+            'event_id', NEW.event_id,
+            'event_type', NEW.event_type,
+            'aggregate_id', NEW.aggregate_id,
+            'payload', NEW.payload
+        )
+    );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Consumers read from the pgmq queue
+SELECT * FROM pgmq.read('order_events', vt => 30, qty => 10);
+
+-- After processing, delete or archive
+SELECT pgmq.delete('order_events', msg_id => 1);
+```
+
+**Advantages of pgmq + pg_trickle:**
+- Both run inside PostgreSQL — no external broker needed.
+- pgmq provides visibility timeouts, exactly-once delivery semantics, and
+  message archival.
+- pg_trickle provides the real-time materialized view layer on top.
+- Combined: write to business table → CDC → stream table → pgmq queue →
+  consumer.
+
+**Use case:** Small-to-medium deployments that want to avoid operating Kafka or
+RabbitMQ.
+
+### pg_amqp — AMQP Publishing from PostgreSQL
+
+[pg_amqp](https://github.com/omniti-labs/pg_amqp) allows publishing messages
+to an AMQP broker (RabbitMQ) directly from PostgreSQL triggers or functions.
+
+```sql
+-- Configure the broker connection
+INSERT INTO amqp.broker (host, port, vhost, username, password)
+VALUES ('rabbitmq', 5672, '/', 'guest', 'guest');
+
+-- Publish from a trigger on the outbox table
+CREATE OR REPLACE FUNCTION fn_publish_to_amqp() RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM amqp.publish(1, 'events', NEW.event_type, NEW.payload::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+```
+
+**Trade-off:** Publishing happens within the transaction — if the broker is
+slow or down, it blocks the transaction. Better suited as a relay step after
+the outbox commit.
+
+### pgflow — Durable Workflow Engine
+
+[pgflow](https://pgflow.dev/) builds durable, multi-step workflows on top of
+pgmq. It can orchestrate complex event processing pipelines with retry logic,
+timeouts, and DAG-based step dependencies.
+
+**Synergy with pg_trickle:** Use pg_trickle stream tables as the "sensing"
+layer that detects changes, and pgflow as the "acting" layer that orchestrates
+side effects.
+
+### Debezium — External CDC Platform
+
+[Debezium](https://debezium.io/) is the industry-standard CDC platform for
+tailing database WALs and publishing changes to Kafka. When pg_trickle
+transitions to WAL-based CDC, the logical replication slot it creates is
+conceptually similar to what Debezium uses.
+
+**When to choose Debezium over pg_trickle-native relay:**
+- You need Kafka Connect ecosystem integration.
+- You need to capture changes from multiple databases into a central event bus.
+- You need schema registry integration (Avro/Protobuf serialization).
+
+**When pg_trickle-native is sufficient:**
+- Single-database topology.
+- Events are consumed by services that can query PostgreSQL directly.
+- You want to avoid operating an additional infrastructure component.
+
+---
+
+## Potential pg_trickle Extensions
+
+### Extension 1: Outbox Table Helper
+
+A convenience function that creates the outbox table, trigger, and stream
+table in one call.
+
+```sql
+-- Proposed API
+SELECT pgtrickle.create_outbox(
+    source_table => 'orders',
+    outbox_name  => 'order_outbox',
+    event_types  => ARRAY['OrderCreated', 'OrderUpdated', 'OrderDeleted'],
+    schedule     => '1s'
+);
+
+-- This would create:
+-- 1. outbox_events_<source> table with standard schema
+-- 2. AFTER INSERT/UPDATE/DELETE trigger on source_table
+-- 3. Stream table: pending_<outbox_name> (WHERE published_at IS NULL)
+-- 4. Index on (event_id) WHERE published_at IS NULL
+```
+
+**Effort:** Medium. Mostly SQL generation and metadata management.
+
+### Extension 2: Message Relay Background Worker
+
+A pg_trickle background worker that reads from the outbox stream table and
+publishes to an external system via a configurable connector.
+
+```sql
+-- Proposed GUC configuration
+SET pg_trickle.outbox_relay_enabled = true;
+SET pg_trickle.outbox_relay_target = 'pgmq';  -- or 'http', 'kafka'
+SET pg_trickle.outbox_relay_queue = 'order_events';
+SET pg_trickle.outbox_relay_batch_size = 100;
+SET pg_trickle.outbox_relay_interval_ms = 500;
+```
+
+**Effort:** High. Requires connector framework, error handling, and
+backpressure management.
+
+### Extension 3: pgmq Integration
+
+First-class integration with pgmq so that stream table refreshes can
+automatically enqueue changed rows into a pgmq queue.
+
+```sql
+-- Proposed API
+SELECT pgtrickle.create_stream_table(
+    'order_notifications',
+    $$SELECT id, status, total FROM orders WHERE status = 'confirmed'$$,
+    schedule => '1s',
+    refresh_mode => 'DIFFERENTIAL',
+    on_change => 'pgmq:order_events'  -- auto-enqueue deltas
+);
+```
+
+**Effort:** Medium. Hook into the refresh completion path to call
+`pgmq.send_batch()` with the delta rows.
+
+### Extension 4: Webhook Dispatcher
+
+A built-in HTTP webhook dispatcher that posts delta rows to an external URL
+after each refresh.
+
+```sql
+-- Proposed API
+SELECT pgtrickle.create_stream_table(
+    'order_webhooks',
+    $$SELECT id, status, total FROM orders$$,
+    schedule => '5s',
+    refresh_mode => 'DIFFERENTIAL',
+    on_change_webhook => 'https://api.example.com/webhooks/orders'
+);
+```
+
+**Effort:** High. Requires HTTP client, retry logic, authentication, and
+circuit breaker patterns. Consider using pg_net extension as the HTTP layer.
+
+---
+
+## Design Considerations
+
+### Ordering Guarantees
+
+| Scope | Guarantee |
+|-------|-----------|
+| Single aggregate (same `aggregate_id`) | Ordered by `event_id` (monotonic PK) |
+| Across aggregates | No global ordering; each aggregate ordered independently |
+| Across source tables | Independent refresh schedules; no cross-table ordering |
+| Within a diamond dependency group | Atomic refresh group ensures consistency |
+
+### Idempotency
+
+The outbox pattern provides **at-least-once** delivery. Consumers MUST handle
+duplicates. Recommended strategies:
+
+1. **Event ID deduplication:** Store processed `event_id` values in a
+   `processed_events` table and check before processing.
+2. **Idempotent operations:** Design state mutations so that applying the same
+   event twice has no additional effect (e.g., `UPDATE ... SET status = 'x'`
+   is naturally idempotent).
+3. **Version vectors:** Include an `expected_version` in the event payload and
+   reject stale events.
+
+### Garbage Collection
+
+Published events should be cleaned up to prevent outbox table bloat:
+
+```sql
+-- Option A: Delete published events older than 7 days
+DELETE FROM outbox_events
+WHERE published_at IS NOT NULL
+  AND published_at < now() - INTERVAL '7 days';
+
+-- Option B: Partition the outbox table by month
+CREATE TABLE outbox_events (
+    event_id BIGSERIAL,
+    ...
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+) PARTITION BY RANGE (created_at);
+```
+
+### Backpressure
+
+When the relay falls behind:
+
+1. `pg_trickle_alert` emits `stale_data` events when the stream table
+   staleness exceeds 2× its schedule.
+2. Monitor `pending_outbox_events` row count via the `outbox_stats` stream
+   table.
+3. Adjust `schedule` or increase relay parallelism.
+4. pg_trickle's adaptive refresh can automatically switch to FULL refresh if
+   the change ratio exceeds `differential_max_change_ratio`.
+
+### Failure Modes
+
+| Failure | Impact | Recovery |
+|---------|--------|----------|
+| Relay crashes after publish, before marking published | Duplicate event published | Consumer deduplicates via event_id |
+| PostgreSQL crashes after COMMIT | Events durable in WAL | Normal crash recovery; outbox intact |
+| Stream table refresh fails | Relay reads stale data | pg_trickle retries with backoff; alert emitted |
+| Broker unreachable | Relay retries | Events queue in outbox; monitor staleness |
+
+---
+
+## Comparison with Traditional Approaches
+
+| Aspect | Traditional Outbox | pg_trickle Outbox | Debezium CDC |
+|--------|--------------------|-------------------|--------------|
+| Additional write overhead | 1 extra INSERT per event | Zero (CDC trigger is automatic) | Zero (WAL tail) |
+| Relay mechanism | Custom polling worker | Stream table + NOTIFY | Kafka Connect |
+| Latency | Depends on poll interval | ~1s (DIFFERENTIAL) or ~0ms (IMMEDIATE) | ~1-5s |
+| Ordering | PK-ordered | PK-ordered + LSN-ordered | LSN-ordered |
+| Infrastructure | PostgreSQL only | PostgreSQL only | PostgreSQL + Kafka + Debezium |
+| Monitoring | Custom | Built-in (staleness, alerts, stats) | Kafka + Debezium metrics |
+| Competing consumers | FOR UPDATE SKIP LOCKED | FOR UPDATE SKIP LOCKED or pgmq | Kafka consumer groups |
+| Garbage collection | Manual DELETE/partition | Manual or partitioned | Kafka retention |
+
+---
+
+## References
+
+- Chris Richardson, [Transactional Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html)
+- Microsoft, [Implement the Transactional Outbox Pattern](https://learn.microsoft.com/en-us/azure/architecture/best-practices/transactional-outbox-cosmos)
+- [pgmq — PostgreSQL Message Queue](https://github.com/pgmq/pgmq)
+- [Debezium CDC Platform](https://debezium.io/)
+- Krzysztof Atłasik, [Microservices 101: Transactional Outbox and Inbox](https://softwaremill.com/microservices-101/)
+- pg_trickle [ARCHITECTURE.md](../../docs/ARCHITECTURE.md), [PATTERNS.md](../../docs/PATTERNS.md), [SQL_REFERENCE.md](../../docs/SQL_REFERENCE.md)


### PR DESCRIPTION
## Summary

Adds two detailed research reports for implementing the **Transactional Outbox** and **Transactional Inbox** microservice patterns using pg_trickle.

These are increasingly important integration patterns for teams using pg_trickle in microservice architectures, where reliable inter-service communication is critical. pg_trickle's CDC triggers, stream tables, IMMEDIATE mode, and LISTEN/NOTIFY integration make it a natural fit for both patterns — often removing the need for external CDC tools like Debezium.

## Changes

- **`plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md`** — Detailed report covering:
  - Three implementation approaches (stream table view, CDC buffer as outbox, IMMEDIATE mode)
  - Three message relay strategies (polling, LISTEN/NOTIFY, WAL tailing)
  - Worked example: Order Service Outbox with competing consumers
  - Complementary extensions: pgmq, pg_amqp, pgflow, Debezium
  - Four potential pg_trickle extensions (outbox helper, relay worker, pgmq integration, webhook dispatcher)
  - Design considerations: ordering, idempotency, garbage collection, backpressure, failure modes

- **`plans/patterns/PLAN_TRANSACTIONAL_INBOX.md`** — Detailed report covering:
  - Four implementation approaches (basic inbox, deduplication + ordering, IMMEDIATE mode, multi-source aggregation)
  - Three processing strategies (polling, event-driven, competing workers)
  - Worked example: Payment Service Inbox with dead letter queue
  - Complementary extensions: pgmq, pg_cron, pg_partman, pgflow
  - Four potential pg_trickle extensions (inbox helper, dedup stream table, DLQ stream table, health dashboard)
  - Design considerations: idempotency, ordering, retry backoff, garbage collection
  - Section on combining both patterns in a single service

## Testing

- Documentation only — no code changes.
- All SQL examples are illustrative and consistent with the pg_trickle SQL reference.

## Notes

- Creates the new `plans/patterns/` directory for integration pattern documentation.
- Both documents cross-reference each other and link to existing docs (ARCHITECTURE.md, PATTERNS.md, SQL_REFERENCE.md).
- The proposed pg_trickle extensions (outbox/inbox helpers, pgmq integration, webhook dispatcher) are described as future possibilities — none are implemented in this PR.
