### PR TITLE
feat(demo): real-time fraud detection demo with 7-ST diamond DAG + docs

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,145 @@
+# pg_trickle Real-time Demo — Fraud Detection Pipeline
+
+A self-contained Docker Compose demo that shows real data flowing through a
+**7-node, 3-layer DAG** of stream tables built on top of a continuous
+transaction feed.
+
+## Quick start
+
+```bash
+cd demo
+docker compose up --build
+```
+
+Then open **http://localhost:8080** in your browser.
+The dashboard auto-refreshes every 2 seconds.
+
+---
+
+## What you'll see
+
+The demo models a real-time **financial fraud detection system**.
+Three services start together:
+
+| Service     | Role                                                        |
+|-------------|-------------------------------------------------------------|
+| `postgres`  | PostgreSQL 18 + pg_trickle; initialises schema & stream tables |
+| `generator` | Python script — inserts ~1 transaction/second continuously |
+| `dashboard` | Flask web app — live dashboard at http://localhost:8080     |
+
+Every ~45 seconds the generator triggers a **suspicious burst**: one user
+fires 6–14 rapid, escalating-amount transactions at Crypto / Gambling
+merchants, driving HIGH-risk scores and alerting the dashboard in real time.
+
+---
+
+## DAG topology
+
+```
+  Base tables            Layer 1 — Silver        Layer 2 — Gold          Layer 3 — Platinum
+  ────────────           ──────────────────────   ─────────────────────   ──────────────────────
+
+  ┌────────────┐         ┌──────────────────┐
+  │   users    │────────►│  user_velocity   │─────────────────────────►┌──────────────────┐
+  └────────────┘         │  (DIFFERENTIAL)  │                          │   country_risk   │
+                         └──────┬───────────┘                          │  (DIFFERENTIAL)  │
+                                │                                       └──────────────────┘
+  ┌────────────┐                │  ┌──────────────────┐
+  │transactions│────────────────┼─►│  merchant_stats  │
+  │ (stream)   │                │  │  (DIFFERENTIAL)  │
+  └────────────┘                │  └──────┬───────────┘
+        │                       │         │
+        │         ┌─────────────┼─────────┘  ← DIAMOND
+        │         │             │
+        │         ▼             ▼                                       ┌───────────────────────┐
+        │    ┌────────────────────────┐                                 │    alert_summary      │
+        │    │      risk_scores       │────────────────────────────────►│    (DIFFERENTIAL)     │
+        │    │   (FULL, calculated)   │                                 └───────────────────────┘
+        │    └────────────────────────┘
+        │                                                               ┌───────────────────────┐
+        │                                                               │  top_risky_merchants  │
+        └──────────────────────────────────────────────────────────────►│    (DIFFERENTIAL)     │
+                                                                        └───────────────────────┘
+  ┌────────────┐         ┌──────────────────┐
+  │ merchants  │────────►│ category_volume  │
+  └────────────┘         │  (DIFFERENTIAL)  │
+                         └──────────────────┘
+```
+
+### Stream tables
+
+| Name                  | Layer | Mode         | Schedule    | What it computes                                  |
+|-----------------------|-------|--------------|-------------|---------------------------------------------------|
+| `user_velocity`       | L1    | DIFFERENTIAL | 1 s         | Per-user: txn count, total spend, avg amount      |
+| `merchant_stats`      | L1    | DIFFERENTIAL | 1 s         | Per-merchant: txn count, avg amount, unique users |
+| `category_volume`     | L1    | DIFFERENTIAL | 1 s         | Per-category: volume, avg amount, unique users    |
+| `risk_scores`         | L2    | FULL         | calculated  | Per-transaction: enriched with L1 + risk level   |
+| `country_risk`        | L2    | DIFFERENTIAL | calculated  | Per-country: roll-up from user_velocity           |
+| `alert_summary`       | L3    | DIFFERENTIAL | calculated  | Per-risk-level: counts + totals from risk_scores  |
+| `top_risky_merchants` | L3    | DIFFERENTIAL | calculated  | Per-merchant: risk counts from risk_scores        |
+
+### Why the diamond matters
+
+`transactions` is the append-only source.  It feeds **two independent L1
+stream tables** — `user_velocity` and `merchant_stats` — which are both then
+consumed by `risk_scores` at L2.  This is a genuine **diamond dependency**:
+
+```
+transactions ──→ user_velocity  ──┐
+                                  ├──→ risk_scores  (FULL, diamond convergence)
+transactions ──→ merchant_stats ──┘
+```
+
+pg_trickle's DAG scheduler refreshes L1 nodes in topological order before
+triggering the L2 refresh, ensuring `risk_scores` always sees up-to-date
+aggregate context.
+
+### Why `risk_scores` uses FULL refresh
+
+`risk_scores` joins three sources: `transactions` (base), `user_velocity`
+(L1 ST), and `merchant_stats` (L1 ST).  Differential maintenance across a
+base table and two stream tables simultaneously is not yet implemented, so
+FULL mode re-evaluates the entire join on each cycle.  The L3 tables
+(`alert_summary`, `top_risky_merchants`) are DIFFERENTIAL because they only
+read from the single ST upstream (`risk_scores`).
+
+---
+
+## Playing with the demo
+
+Connect directly to the database:
+
+```bash
+docker compose exec postgres psql -U demo -d fraud_demo
+```
+
+Useful queries:
+
+```sql
+-- See all stream table status
+SELECT * FROM pgtrickle.pgt_status();
+
+-- Inspect the DAG dependency graph
+SELECT * FROM pgtrickle.dependency_tree('risk_scores');
+
+-- Most recent HIGH-risk alerts
+SELECT txn_id, user_name, merchant_name, amount, risk_level
+FROM   risk_scores
+WHERE  risk_level = 'HIGH'
+ORDER  BY txn_id DESC LIMIT 10;
+
+-- Trigger a manual refresh (normally the background worker does this)
+SELECT pgtrickle.refresh_stream_table('risk_scores');
+
+-- See refresh history
+SELECT * FROM pgtrickle.pgt_refresh_history
+ORDER  BY refreshed_at DESC LIMIT 20;
+```
+
+---
+
+## Stopping the demo
+
+```bash
+docker compose down -v   # also removes the pgdata volume
+```

--- a/demo/dashboard/Dockerfile
+++ b/demo/dashboard/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+CMD ["python", "app.py"]

--- a/demo/dashboard/app.py
+++ b/demo/dashboard/app.py
@@ -1,0 +1,521 @@
+"""
+pg_trickle demo — real-time fraud detection dashboard.
+
+Serves a single-page web app at http://localhost:8080.
+JavaScript polls /api/data every 2 seconds and updates all panels in-place.
+"""
+
+import os
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import psycopg2
+import psycopg2.extras
+from flask import Flask, jsonify
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgresql://demo:demo@postgres/fraud_demo"
+)
+
+app = Flask(__name__)
+
+
+def get_conn():
+    return psycopg2.connect(
+        DATABASE_URL, cursor_factory=psycopg2.extras.RealDictCursor
+    )
+
+
+def safe_query(conn, sql: str, default=None):
+    try:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            return cur.fetchall()
+    except Exception as exc:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        print(f"[DASHBOARD] Query error: {exc}", flush=True)
+        return default or []
+
+
+def serialize(rows) -> list[dict]:
+    """Convert RealDictRows with Decimal/datetime values to plain dicts."""
+    out = []
+    for row in rows:
+        d = {}
+        for k, v in row.items():
+            if isinstance(v, Decimal):
+                d[k] = float(v)
+            elif isinstance(v, datetime):
+                d[k] = v.isoformat()
+            else:
+                d[k] = v
+        out.append(d)
+    return out
+
+
+# ── HTML + JavaScript ─────────────────────────────────────────────────────────
+
+HTML = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>pg_trickle — Real-time Fraud Detection</title>
+  <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css">
+  <style>
+    :root {
+      --bg:      #0d1117;
+      --card:    #161b22;
+      --border:  #30363d;
+      --hdr:     #21262d;
+      --muted:   #8b949e;
+      --green:   #3fb950;
+      --yellow:  #d29922;
+      --red:     #da3633;
+      --text:    #e6edf3;
+    }
+    html, body { background: var(--bg); color: var(--text); font-size: 14px; }
+    a { color: var(--green); }
+
+    /* cards */
+    .g-card { background: var(--card); border: 1px solid var(--border);
+               border-radius: 8px; overflow: hidden; }
+    .g-card-hdr { background: var(--hdr); padding: 8px 14px;
+                  font-size: 13px; font-weight: 600; letter-spacing: .4px; }
+
+    /* tables */
+    .g-table { width: 100%; border-collapse: collapse; }
+    .g-table th { color: var(--muted); font-weight: 500; font-size: 12px;
+                  border-bottom: 1px solid var(--border); padding: 6px 10px; }
+    .g-table td { padding: 5px 10px; border-bottom: 1px solid var(--hdr); }
+    .g-table tr:last-child td { border-bottom: none; }
+    .g-table tr.risk-HIGH  td { color: #ff7b72; }
+    .g-table tr.risk-MED   td { color: #e3b341; }
+
+    /* KPI counters */
+    .kpi-val { font-size: 2.2rem; font-weight: 700; line-height: 1; }
+    .kpi-lbl { font-size: 11px; color: var(--muted); margin-top: 4px; }
+
+    /* badge */
+    .rbadge { display: inline-block; padding: 2px 7px; border-radius: 12px;
+              font-size: 11px; font-weight: 700; }
+    .rbadge-LOW    { background: #1a4620; color: var(--green); }
+    .rbadge-MEDIUM { background: #422d09; color: var(--yellow); }
+    .rbadge-HIGH   { background: #3d1114; color: var(--red); }
+
+    /* DAG box */
+    .dag-pre { font-family: 'SFMono-Regular', Consolas, monospace;
+               font-size: 12px; color: var(--muted); background: var(--bg);
+               padding: 14px; border-radius: 6px; white-space: pre;
+               overflow-x: auto; margin: 0; }
+
+    /* live dot */
+    .live-dot { width: 9px; height: 9px; border-radius: 50%;
+                background: var(--green); display: inline-block;
+                margin-right: 8px; animation: blink 1.8s ease-in-out infinite; }
+    @keyframes blink { 0%,100%{opacity:1} 50%{opacity:.25} }
+
+    /* risk bar */
+    .risk-bar { height: 8px; border-radius: 4px; }
+  </style>
+</head>
+<body>
+<div class="container-fluid px-4 py-3">
+
+  <!-- Header -->
+  <div class="d-flex align-items-center mb-3 gap-3">
+    <div>
+      <span class="live-dot"></span>
+      <span style="font-size:18px; font-weight:700;">pg_trickle</span>
+      <span class="text-muted ms-1">Real-time Fraud Detection Pipeline</span>
+    </div>
+    <span class="ms-auto text-muted" id="ts" style="font-size:12px;">connecting…</span>
+  </div>
+
+  <!-- KPI row -->
+  <div class="row g-3 mb-3">
+    <div class="col-3">
+      <div class="g-card p-3 text-center">
+        <div class="kpi-val" id="kpi-total">—</div>
+        <div class="kpi-lbl">Total Transactions</div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="g-card p-3 text-center">
+        <div class="kpi-val" id="kpi-low" style="color:var(--green)">—</div>
+        <div class="kpi-lbl">LOW Risk</div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="g-card p-3 text-center">
+        <div class="kpi-val" id="kpi-med" style="color:var(--yellow)">—</div>
+        <div class="kpi-lbl">MEDIUM Risk</div>
+      </div>
+    </div>
+    <div class="col-3">
+      <div class="g-card p-3 text-center">
+        <div class="kpi-val" id="kpi-high" style="color:var(--red)">—</div>
+        <div class="kpi-lbl">HIGH Risk</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Risk bar -->
+  <div class="mb-3 g-card p-3">
+    <div class="d-flex mb-1" style="font-size:12px;">
+      <span class="text-success me-auto">LOW</span>
+      <span class="text-warning">MEDIUM</span>
+      <span class="text-danger ms-auto">HIGH</span>
+    </div>
+    <div class="d-flex gap-1" id="risk-bar" style="height:10px; border-radius:6px; overflow:hidden;"></div>
+  </div>
+
+  <!-- Row 2: alerts + risky merchants -->
+  <div class="row g-3 mb-3">
+    <div class="col-7">
+      <div class="g-card h-100">
+        <div class="g-card-hdr">⚠️ Recent HIGH / MEDIUM Risk Alerts</div>
+        <div class="overflow-auto" style="max-height:280px;">
+          <table class="g-table">
+            <thead>
+              <tr>
+                <th>#</th><th>User</th><th>Merchant</th>
+                <th>Category</th><th>Amount</th><th>Risk</th>
+              </tr>
+            </thead>
+            <tbody id="tb-alerts"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div class="col-5">
+      <div class="g-card h-100">
+        <div class="g-card-hdr">🏪 Merchant Risk Leaderboard</div>
+        <div class="overflow-auto" style="max-height:280px;">
+          <table class="g-table">
+            <thead>
+              <tr><th>Merchant</th><th>Cat.</th><th>High</th><th>Med</th><th>Risk%</th></tr>
+            </thead>
+            <tbody id="tb-merchants"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Row 3: user velocity + country risk + category volume -->
+  <div class="row g-3 mb-3">
+    <div class="col-4">
+      <div class="g-card h-100">
+        <div class="g-card-hdr">👤 User Velocity (top 10)</div>
+        <div class="overflow-auto" style="max-height:240px;">
+          <table class="g-table">
+            <thead>
+              <tr><th>User</th><th>🌍</th><th>Txns</th><th>Avg $</th></tr>
+            </thead>
+            <tbody id="tb-velocity"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="g-card h-100">
+        <div class="g-card-hdr">🌍 Country Overview</div>
+        <div class="overflow-auto" style="max-height:240px;">
+          <table class="g-table">
+            <thead>
+              <tr><th>Country</th><th>Users</th><th>Txns</th><th>Volume $</th></tr>
+            </thead>
+            <tbody id="tb-country"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div class="col-4">
+      <div class="g-card h-100">
+        <div class="g-card-hdr">📦 Category Volume</div>
+        <div class="overflow-auto" style="max-height:240px;">
+          <table class="g-table">
+            <thead>
+              <tr><th>Category</th><th>Txns</th><th>Avg $</th><th>Users</th></tr>
+            </thead>
+            <tbody id="tb-category"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Stream table status + DAG -->
+  <div class="row g-3">
+    <div class="col-5">
+      <div class="g-card">
+        <div class="g-card-hdr">⚡ Stream Table Status</div>
+        <div class="overflow-auto" style="max-height:220px;">
+          <table class="g-table">
+            <thead>
+              <tr><th>Name</th><th>Mode</th><th>Schedule</th><th>Status</th></tr>
+            </thead>
+            <tbody id="tb-sts"></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <div class="col-7">
+      <div class="g-card">
+        <div class="g-card-hdr" style="cursor:pointer"
+             data-bs-toggle="collapse" data-bs-target="#dag-collapse">
+          📊 DAG Topology — click to expand
+        </div>
+        <div class="collapse show" id="dag-collapse">
+          <pre class="dag-pre" id="dag-pre">{{ dag }}</pre>
+        </div>
+      </div>
+    </div>
+  </div>
+
+</div><!-- /container -->
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+"use strict";
+
+const $ = id => document.getElementById(id);
+const esc = s => String(s ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+const fmt  = (n, d=0) => n == null ? '—' : Number(n).toLocaleString('en-US', {maximumFractionDigits:d});
+const fmtM = n => n == null ? '—' : '$' + Number(n).toLocaleString('en-US', {minimumFractionDigits:2,maximumFractionDigits:2});
+const badge = lvl => `<span class="rbadge rbadge-${esc(lvl)}">${esc(lvl)}</span>`;
+
+function setRows(tbodyId, html) {
+  $(tbodyId).innerHTML = html || '<tr><td colspan="99" class="text-muted">waiting for data…</td></tr>';
+}
+
+async function refresh() {
+  let d;
+  try {
+    const r = await fetch('/api/data');
+    d = await r.json();
+  } catch(e) {
+    $('ts').textContent = 'Error: ' + e.message;
+    return;
+  }
+
+  $('ts').textContent = 'Last refresh: ' + new Date().toLocaleTimeString();
+
+  // ── KPIs from alert_summary ────────────────────────────────────────────
+  let low=0, med=0, high=0, total=0;
+  (d.alert_summary||[]).forEach(r => {
+    const n = r.txn_count|0;
+    if (r.risk_level==='LOW')    low  = n;
+    if (r.risk_level==='MEDIUM') med  = n;
+    if (r.risk_level==='HIGH')   high = n;
+    total += n;
+  });
+  $('kpi-total').textContent = fmt(total);
+  $('kpi-low').textContent   = fmt(low);
+  $('kpi-med').textContent   = fmt(med);
+  $('kpi-high').textContent  = fmt(high);
+
+  // Risk bar
+  if (total > 0) {
+    const lp = (low/total*100).toFixed(1), mp = (med/total*100).toFixed(1), hp = (100-lp-mp).toFixed(1);
+    $('risk-bar').innerHTML =
+      `<div class="risk-bar flex-fill" style="background:#1a4620;width:${lp}%" title="LOW ${lp}%"></div>` +
+      `<div class="risk-bar flex-fill" style="background:#422d09;width:${mp}%" title="MED ${mp}%"></div>` +
+      `<div class="risk-bar flex-fill" style="background:#3d1114;width:${hp}%" title="HIGH ${hp}%"></div>`;
+  }
+
+  // ── Recent alerts ──────────────────────────────────────────────────────
+  setRows('tb-alerts', (d.recent_alerts||[]).map(r =>
+    `<tr class="risk-${r.risk_level==='HIGH'?'HIGH':r.risk_level==='MEDIUM'?'MED':''}">
+       <td>#${esc(r.txn_id)}</td>
+       <td>${esc(r.user_name)}</td>
+       <td>${esc(r.merchant_name)}</td>
+       <td>${esc(r.merchant_category)}</td>
+       <td>${fmtM(r.amount)}</td>
+       <td>${badge(r.risk_level)}</td>
+     </tr>`).join(''));
+
+  // ── Merchant leaderboard ───────────────────────────────────────────────
+  const sortedM = [...(d.top_risky_merchants||[])].sort(
+    (a,b) => (b.high_risk_count-a.high_risk_count) || (b.medium_risk_count-a.medium_risk_count)
+  );
+  setRows('tb-merchants', sortedM.slice(0,10).map(r =>
+    `<tr>
+       <td>${esc(r.merchant_name)}</td>
+       <td><span class="rbadge" style="background:#21262d;color:#ccc">${esc(r.merchant_category)}</span></td>
+       <td style="color:var(--red)">${r.high_risk_count}</td>
+       <td style="color:var(--yellow)">${r.medium_risk_count}</td>
+       <td>${r.risk_rate_pct}%</td>
+     </tr>`).join(''));
+
+  // ── User velocity ──────────────────────────────────────────────────────
+  const sortedU = [...(d.user_velocity||[])].sort((a,b)=>b.txn_count-a.txn_count);
+  setRows('tb-velocity', sortedU.slice(0,10).map(r =>
+    `<tr>
+       <td>${esc(r.user_name)}</td>
+       <td>${esc(r.country)}</td>
+       <td>${r.txn_count}</td>
+       <td>${fmtM(r.avg_txn_amount)}</td>
+     </tr>`).join(''));
+
+  // ── Country overview ───────────────────────────────────────────────────
+  const sortedC = [...(d.country_risk||[])].sort((a,b)=>b.total_txns-a.total_txns);
+  setRows('tb-country', sortedC.slice(0,10).map(r =>
+    `<tr>
+       <td>${esc(r.country)}</td>
+       <td>${r.user_count}</td>
+       <td>${r.total_txns}</td>
+       <td>${fmtM(r.total_volume)}</td>
+     </tr>`).join(''));
+
+  // ── Category volume ────────────────────────────────────────────────────
+  const sortedCat = [...(d.category_volume||[])].sort((a,b)=>b.total_volume-a.total_volume);
+  setRows('tb-category', sortedCat.map(r =>
+    `<tr>
+       <td>${esc(r.category)}</td>
+       <td>${r.txn_count}</td>
+       <td>${fmtM(r.avg_txn_amount)}</td>
+       <td>${r.unique_users}</td>
+     </tr>`).join(''));
+
+  // ── Stream table status ────────────────────────────────────────────────
+  setRows('tb-sts', (d.st_status||[]).map(r => {
+    const dot = r.is_populated
+      ? '<span style="color:var(--green)">●</span>'
+      : '<span style="color:var(--yellow)">○</span>';
+    return `<tr>
+       <td style="font-family:monospace;font-size:12px">${esc(r.name)}</td>
+       <td style="font-size:11px;color:var(--muted)">${esc(r.refresh_mode)}</td>
+       <td style="font-size:11px;color:var(--muted)">${esc(r.schedule||'calc')}</td>
+       <td>${dot} ${esc(r.status)}</td>
+     </tr>`;
+  }).join(''));
+}
+
+refresh();
+setInterval(refresh, 2000);
+</script>
+</body>
+</html>
+"""
+
+DAG_DIAGRAM = r"""
+  Base tables            Layer 1 — Silver        Layer 2 — Gold          Layer 3 — Platinum
+  ────────────           ──────────────────────   ─────────────────────   ──────────────────────
+
+  ┌────────────┐         ┌──────────────────┐
+  │   users    │────────►│  user_velocity   │─────────────────────────►┌──────────────────┐
+  └────────────┘         │  (DIFFERENTIAL)  │                          │   country_risk   │
+                         └──────┬───────────┘                          │  (DIFFERENTIAL)  │
+                                │                                       └──────────────────┘
+  ┌────────────┐                │  ┌──────────────────┐
+  │transactions│────────────────┼─►│  merchant_stats  │
+  │ (stream)   │                │  │  (DIFFERENTIAL)  │
+  └────────────┘                │  └──────┬───────────┘
+        │                       │         │
+        │         ┌─────────────┼─────────┘ ← DIAMOND DEPENDENCY
+        │         │             │
+        │         ▼             ▼                                       ┌───────────────────────┐
+        │    ┌────────────────────────┐                                 │    alert_summary      │
+        │    │      risk_scores       │────────────────────────────────►│    (DIFFERENTIAL)     │
+        │    │   (FULL, calculated)   │                                 └───────────────────────┘
+        │    └────────────────────────┘
+        │                                                               ┌───────────────────────┐
+        │                                                               │  top_risky_merchants  │
+        └──────────────────────────────────────────────────────────────►│    (DIFFERENTIAL)     │
+                                                                        └───────────────────────┘
+  ┌────────────┐         ┌──────────────────┐
+  │ merchants  │────────►│ category_volume  │
+  └────────────┘         │  (DIFFERENTIAL)  │
+                         └──────────────────┘
+
+  transactions feeds user_velocity AND merchant_stats — a genuine diamond.
+  risk_scores is the convergence node that joins both Layer 1 outputs.
+"""
+
+
+# ── Flask routes ──────────────────────────────────────────────────────────────
+
+@app.route("/")
+def index():
+    return HTML.replace("{{ dag }}", DAG_DIAGRAM)
+
+
+@app.route("/api/data")
+def api_data():
+    conn = None
+    try:
+        conn = get_conn()
+
+        recent_alerts = safe_query(conn, """
+            SELECT txn_id, user_name, merchant_name, merchant_category,
+                   amount, risk_level
+            FROM   risk_scores
+            WHERE  risk_level IN ('HIGH', 'MEDIUM')
+            ORDER  BY txn_id DESC
+            LIMIT  15
+        """)
+
+        alert_summary = safe_query(conn, """
+            SELECT risk_level, txn_count, total_amount, avg_amount
+            FROM   alert_summary
+            ORDER  BY CASE risk_level
+                          WHEN 'HIGH'   THEN 0
+                          WHEN 'MEDIUM' THEN 1
+                          ELSE 2 END
+        """)
+
+        top_risky_merchants = safe_query(conn, """
+            SELECT merchant_name, merchant_category, total_txns,
+                   high_risk_count, medium_risk_count, risk_rate_pct
+            FROM   top_risky_merchants
+        """)
+
+        user_velocity = safe_query(conn, """
+            SELECT user_name, country, txn_count, total_spent, avg_txn_amount
+            FROM   user_velocity
+            WHERE  txn_count > 0
+        """)
+
+        country_risk = safe_query(conn, """
+            SELECT country, user_count, total_txns, total_volume
+            FROM   country_risk
+        """)
+
+        category_volume = safe_query(conn, """
+            SELECT category, txn_count, total_volume, avg_txn_amount, unique_users
+            FROM   category_volume
+            WHERE  txn_count > 0
+        """)
+
+        st_status = safe_query(conn, """
+            SELECT name, status, refresh_mode, is_populated, schedule
+            FROM   pgtrickle.pgt_status()
+            ORDER  BY name
+        """)
+
+        return jsonify(
+            {
+                "recent_alerts":       serialize(recent_alerts),
+                "alert_summary":       serialize(alert_summary),
+                "top_risky_merchants": serialize(top_risky_merchants),
+                "user_velocity":       serialize(user_velocity),
+                "country_risk":        serialize(country_risk),
+                "category_volume":     serialize(category_volume),
+                "st_status":           serialize(st_status),
+            }
+        )
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+    finally:
+        if conn:
+            conn.close()
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8080, debug=False)

--- a/demo/dashboard/requirements.txt
+++ b/demo/dashboard/requirements.txt
@@ -1,0 +1,2 @@
+flask==3.0.3
+psycopg2-binary==2.9.9

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,0 +1,41 @@
+services:
+  postgres:
+    image: ghcr.io/grove/pg_trickle:latest
+    environment:
+      POSTGRES_USER: demo
+      POSTGRES_PASSWORD: demo
+      POSTGRES_DB: fraud_demo
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./postgres/01_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
+      - ./postgres/02_stream_tables.sql:/docker-entrypoint-initdb.d/02_stream_tables.sql:ro
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U demo -d fraud_demo"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+
+  generator:
+    build: ./generator
+    environment:
+      DATABASE_URL: postgresql://demo:demo@postgres/fraud_demo
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+  dashboard:
+    build: ./dashboard
+    environment:
+      DATABASE_URL: postgresql://demo:demo@postgres/fraud_demo
+    ports:
+      - "8080:8080"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  pgdata:

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - ./postgres/01_schema.sql:/docker-entrypoint-initdb.d/01_schema.sql:ro
       - ./postgres/02_stream_tables.sql:/docker-entrypoint-initdb.d/02_stream_tables.sql:ro
-      - pgdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U demo -d fraud_demo"]
       interval: 2s

--- a/demo/generator/Dockerfile
+++ b/demo/generator/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY generate.py .
+CMD ["python", "generate.py"]

--- a/demo/generator/generate.py
+++ b/demo/generator/generate.py
@@ -1,0 +1,157 @@
+"""
+pg_trickle demo — continuous transaction generator.
+
+Inserts ~1 transaction per second with occasional "suspicious burst" patterns
+(rapid transactions from the same user at Crypto/Gambling merchants with
+escalating amounts) that drive HIGH-risk scores in the fraud detection DAG.
+"""
+
+import math
+import os
+import random
+import time
+
+import psycopg2
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgresql://demo:demo@postgres/fraud_demo"
+)
+
+# Per-category (low, high) amount range in USD
+CATEGORY_AMOUNTS: dict[str, tuple[float, float]] = {
+    "Retail":      (15.0,   300.0),
+    "Electronics": (80.0,  1500.0),
+    "Travel":     (150.0,  2500.0),
+    "Gambling":    (25.0,   600.0),
+    "Crypto":      (50.0,  4000.0),
+    "Food":         (8.0,    90.0),
+    "Pharmacy":    (12.0,   180.0),
+}
+
+RISKY_CATEGORIES = {"Crypto", "Gambling"}
+
+
+def connect(url: str):
+    """Retry until the database is ready."""
+    for attempt in range(1, 61):
+        try:
+            conn = psycopg2.connect(url)
+            conn.autocommit = True
+            print(f"[GENERATOR] Connected (attempt {attempt})", flush=True)
+            return conn
+        except psycopg2.OperationalError as exc:
+            print(
+                f"[GENERATOR] Waiting for DB (attempt {attempt}/60): {exc}",
+                flush=True,
+            )
+            time.sleep(3)
+    raise RuntimeError("Could not connect to the database after 60 attempts")
+
+
+def fetch_lookups(conn) -> tuple[list[int], list[tuple[int, str]]]:
+    """Load user IDs and (merchant_id, category) pairs."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT id FROM users ORDER BY id")
+        users = [row[0] for row in cur.fetchall()]
+        cur.execute("SELECT id, category FROM merchants ORDER BY id")
+        merchants = [(row[0], row[1]) for row in cur.fetchall()]
+    return users, merchants
+
+
+def sample_amount(category: str, multiplier: float = 1.0) -> float:
+    """Log-normal amount centred between the category's low/high range."""
+    lo, hi = CATEGORY_AMOUNTS.get(category, (20.0, 200.0))
+    mu = math.log((lo + hi) / 2.0)
+    raw = random.lognormvariate(mu, 0.55) * multiplier
+    return round(max(1.0, min(raw, 9_999.99)), 2)
+
+
+def insert_txn(conn, user_id: int, merchant_id: int, amount: float) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO transactions (user_id, merchant_id, amount) "
+            "VALUES (%s, %s, %s) RETURNING id",
+            (user_id, merchant_id, amount),
+        )
+        return cur.fetchone()[0]
+
+
+def main() -> None:
+    conn = connect(DATABASE_URL)
+    users, merchants = fetch_lookups(conn)
+    merchant_by_id = {mid: cat for mid, cat in merchants}
+    all_ids = [m[0] for m in merchants]
+    risky_ids = [m[0] for m in merchants if m[1] in RISKY_CATEGORIES] or all_ids
+
+    print(
+        f"[GENERATOR] Loaded {len(users)} users, {len(merchants)} merchants. "
+        "Starting stream...",
+        flush=True,
+    )
+
+    cycle = 0
+    burst_user: int | None = None
+    burst_remaining = 0
+
+    while True:
+        cycle += 1
+
+        # Every ~45 normal cycles start a suspicious burst for one user.
+        if burst_remaining == 0 and cycle % 45 == 0:
+            burst_user = random.choice(users)
+            burst_remaining = random.randint(6, 14)
+            print(
+                f"[GENERATOR] BURST — user {burst_user} starting "
+                f"({burst_remaining} rapid txns)",
+                flush=True,
+            )
+
+        try:
+            if burst_remaining > 0 and burst_user is not None:
+                # Suspicious pattern: same user, risky merchant, escalating amounts
+                user_id = burst_user
+                merchant_id = random.choice(risky_ids)
+                category = merchant_by_id[merchant_id]
+                # Escalation factor grows as burst progresses
+                escalation = 1.0 + (burst_remaining / 4.0)
+                amount = sample_amount(category, multiplier=escalation)
+                burst_remaining -= 1
+                if burst_remaining == 0:
+                    burst_user = None
+                sleep_s = random.uniform(0.15, 0.45)
+            else:
+                # Normal transaction — random user, random merchant
+                user_id = random.choice(users)
+                merchant_id = random.choice(all_ids)
+                category = merchant_by_id[merchant_id]
+                amount = sample_amount(category)
+                sleep_s = random.uniform(0.6, 1.6)
+
+            txn_id = insert_txn(conn, user_id, merchant_id, amount)
+            print(
+                f"[TXN] id={txn_id:>6}  user={user_id:>2}  "
+                f"merchant={merchant_id:>2} ({merchant_by_id[merchant_id]:<14})  "
+                f"${amount:>9.2f}",
+                flush=True,
+            )
+
+        except psycopg2.Error as exc:
+            print(f"[GENERATOR] Insert error: {exc}", flush=True)
+            try:
+                conn.close()
+            except Exception:
+                pass
+            conn = connect(DATABASE_URL)
+            users, merchants = fetch_lookups(conn)
+            merchant_by_id = {mid: cat for mid, cat in merchants}
+            all_ids = [m[0] for m in merchants]
+            risky_ids = (
+                [m[0] for m in merchants if m[1] in RISKY_CATEGORIES] or all_ids
+            )
+            sleep_s = 1.0
+
+        time.sleep(sleep_s)
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/generator/requirements.txt
+++ b/demo/generator/requirements.txt
@@ -1,0 +1,1 @@
+psycopg2-binary==2.9.9

--- a/demo/postgres/01_schema.sql
+++ b/demo/postgres/01_schema.sql
@@ -1,0 +1,112 @@
+-- =============================================================================
+-- pg_trickle Real-time Fraud Detection Demo — Schema & Seed Data
+--
+-- DAG topology (7 stream tables across 3 layers):
+--
+--   users ──────┐
+--   transactions┼──→  user_velocity   (L1, DIFFERENTIAL, 1s)
+--               │              │
+--   merchants ──┼──→  merchant_stats  (L1, DIFFERENTIAL, 1s)
+--               │              │
+--               └──→  category_volume (L1, DIFFERENTIAL, 1s)
+--
+--   user_velocity ─────────────┐
+--   merchant_stats ────────────┴──→  risk_scores       (L2, FULL, calculated)
+--   transactions ──────────────┘         │
+--                                        ├──→  alert_summary        (L3, DIFF, calculated)
+--   user_velocity + users ──→  country_risk   (L2, DIFF, calculated)
+--                                        └──→  top_risky_merchants  (L3, DIFF, calculated)
+--
+-- Diamond: transactions feeds BOTH user_velocity AND merchant_stats,
+--          which BOTH feed risk_scores — a genuine diamond dependency.
+-- =============================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_trickle;
+
+-- ── Base tables ───────────────────────────────────────────────────────────────
+
+CREATE TABLE users (
+    id               BIGSERIAL PRIMARY KEY,
+    name             TEXT NOT NULL,
+    country          TEXT NOT NULL,
+    account_age_days INT  NOT NULL DEFAULT 365
+);
+
+CREATE TABLE merchants (
+    id       BIGSERIAL PRIMARY KEY,
+    name     TEXT NOT NULL,
+    category TEXT NOT NULL,
+    country  TEXT NOT NULL
+);
+
+-- Append-only transaction stream — the generator inserts here continuously.
+CREATE TABLE transactions (
+    id          BIGSERIAL PRIMARY KEY,
+    user_id     BIGINT        NOT NULL REFERENCES users(id),
+    merchant_id BIGINT        NOT NULL REFERENCES merchants(id),
+    amount      NUMERIC(12,2) NOT NULL,
+    txn_at      TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+-- ── Reference data: users ─────────────────────────────────────────────────────
+
+INSERT INTO users (name, country, account_age_days) VALUES
+    ('Alice Chen',        'US',  2190),
+    ('Bob Kumar',         'UK',  1825),
+    ('Carlos Rivera',     'MX',   730),
+    ('Diana Park',        'KR',   365),
+    ('Ethan Williams',    'US',  1460),
+    ('Fatima Al-Rashid',  'AE',   548),
+    ('George Müller',     'DE',   900),
+    ('Hannah Johansson',  'SE',  1200),
+    ('Ivan Petrov',       'RU',   300),
+    ('Julia Santos',      'BR',   720),
+    ('Kenji Tanaka',      'JP',  1800),
+    ('Layla Hassan',      'EG',   450),
+    ('Marco Rossi',       'IT',  1100),
+    ('Nadia Okonkwo',     'NG',   180),
+    ('Oscar Lindberg',    'SE',   980),
+    ('Priya Sharma',      'IN',  2000),
+    ('Quentin Dubois',    'FR',   670),
+    ('Rachel Kim',        'KR',   830),
+    ('Samuel Adeyemi',    'NG',   240),
+    ('Tanya Morozova',    'RU',  1350),
+    ('Ursula Weber',      'DE',   500),
+    ('Victor Huang',      'CN',  1600),
+    ('Wendy Thompson',    'US',   760),
+    ('Xavier Patel',      'IN',   420),
+    ('Yuki Nakamura',     'JP',  1950),
+    ('Zara Ahmed',        'PK',   300),
+    ('Aaron Berg',        'US',  1100),
+    ('Beatriz Oliveira',  'BR',   560),
+    ('Chen Wei',          'CN',  2100),
+    ('Deepak Nair',       'IN',   880);
+
+-- ── Reference data: merchants ─────────────────────────────────────────────────
+
+INSERT INTO merchants (name, category, country) VALUES
+    ('Amazon',             'Retail',       'US'),
+    ('Apple Store',        'Electronics',  'US'),
+    ('Expedia',            'Travel',       'US'),
+    ('Airbnb',             'Travel',       'US'),
+    ('BetOnSports',        'Gambling',     'MT'),
+    ('CryptoExchange Pro', 'Crypto',       'SG'),
+    ('McDonald''s',        'Food',         'US'),
+    ('Walgreens',          'Pharmacy',     'US'),
+    ('Samsung Shop',       'Electronics',  'KR'),
+    ('Booking.com',        'Travel',       'NL'),
+    ('Lucky Casino',       'Gambling',     'GI'),
+    ('BitSwap',            'Crypto',       'BS'),
+    ('Walmart',            'Retail',       'US'),
+    ('Uber Eats',          'Food',         'US'),
+    ('Best Buy',           'Electronics',  'US');
+
+-- ── Seed transactions (primes the stream tables with initial data) ─────────────
+
+INSERT INTO transactions (user_id, merchant_id, amount, txn_at)
+SELECT
+    (floor(random() * 30) + 1)::bigint,
+    (floor(random() * 15) + 1)::bigint,
+    ROUND((random() * 280 + 20)::numeric, 2),
+    now() - (random() * INTERVAL '2 hours')
+FROM generate_series(1, 40);

--- a/demo/postgres/02_stream_tables.sql
+++ b/demo/postgres/02_stream_tables.sql
@@ -1,0 +1,193 @@
+-- =============================================================================
+-- pg_trickle Real-time Fraud Detection Demo — Stream Table Definitions
+--
+-- All 7 stream tables created in topological order (sources before dependents).
+-- =============================================================================
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- LAYER 1 — Silver: direct aggregates from base tables
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- L1a: Per-user transaction velocity.
+-- Tracks how often each user transacts, total spend, and how many distinct
+-- merchants they've visited — core inputs for anomaly detection.
+SELECT pgtrickle.create_stream_table(
+    name     => 'user_velocity',
+    query    => $$
+        SELECT
+            u.id               AS user_id,
+            u.name             AS user_name,
+            u.country,
+            COUNT(t.id)                         AS txn_count,
+            COALESCE(SUM(t.amount),   0)        AS total_spent,
+            COALESCE(ROUND(AVG(t.amount), 2), 0) AS avg_txn_amount,
+            COUNT(DISTINCT t.merchant_id)       AS unique_merchants
+        FROM users u
+        LEFT JOIN transactions t ON t.user_id = u.id
+        GROUP BY u.id, u.name, u.country
+    $$,
+    schedule     => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- L1b: Per-merchant transaction statistics.
+-- Establishes a "normal" baseline for each merchant so that unusually large
+-- transactions can be flagged relative to that merchant's history.
+SELECT pgtrickle.create_stream_table(
+    name     => 'merchant_stats',
+    query    => $$
+        SELECT
+            m.id               AS merchant_id,
+            m.name             AS merchant_name,
+            m.category,
+            COUNT(t.id)                          AS txn_count,
+            COALESCE(SUM(t.amount),    0)        AS total_volume,
+            COALESCE(ROUND(AVG(t.amount), 2), 0) AS avg_txn_amount,
+            COUNT(DISTINCT t.user_id)            AS unique_users
+        FROM merchants m
+        LEFT JOIN transactions t ON t.merchant_id = m.id
+        GROUP BY m.id, m.name, m.category
+    $$,
+    schedule     => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- L1c: Transaction volume by merchant category.
+-- Gives a fast aggregate view of which sectors are most active.
+SELECT pgtrickle.create_stream_table(
+    name     => 'category_volume',
+    query    => $$
+        SELECT
+            m.category,
+            COUNT(t.id)                          AS txn_count,
+            COALESCE(SUM(t.amount),    0)        AS total_volume,
+            COALESCE(ROUND(AVG(t.amount), 2), 0) AS avg_txn_amount,
+            COUNT(DISTINCT t.user_id)            AS unique_users,
+            COUNT(DISTINCT t.merchant_id)        AS active_merchants
+        FROM merchants m
+        LEFT JOIN transactions t ON t.merchant_id = m.id
+        GROUP BY m.category
+    $$,
+    schedule     => '1s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- LAYER 2 — Gold: derived metrics (stream tables reading other stream tables)
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- L2a: Per-transaction risk scoring.  ← THE DIAMOND NODE
+--
+-- This is the diamond dependency apex: it joins the base transactions table
+-- with BOTH user_velocity (L1a) AND merchant_stats (L1b), which both derive
+-- from transactions.  The scheduler refreshes L1 first, then this L2 ST.
+--
+-- Risk logic:
+--   HIGH   — amount > 3× user's average  AND  user has made > 20 transactions
+--   MEDIUM — amount > 2× user's average  OR   user has made > 10 transactions
+--   LOW    — everything else
+--
+-- FULL refresh is used because each row depends on the *current* aggregate
+-- state of user_velocity and merchant_stats; differential tracking across
+-- three tables simultaneously is not yet implemented.
+SELECT pgtrickle.create_stream_table(
+    name     => 'risk_scores',
+    query    => $$
+        SELECT
+            t.id                                            AS txn_id,
+            t.user_id,
+            COALESCE(uv.user_name,  u.name)                AS user_name,
+            u.country                                      AS user_country,
+            t.merchant_id,
+            COALESCE(ms.merchant_name, m.name)             AS merchant_name,
+            COALESCE(ms.category,      m.category)         AS merchant_category,
+            t.amount,
+            t.txn_at,
+            COALESCE(uv.txn_count,        0)               AS user_txn_count,
+            COALESCE(uv.avg_txn_amount,   t.amount)        AS user_avg_amount,
+            COALESCE(ms.avg_txn_amount,   t.amount)        AS merchant_avg_amount,
+            CASE
+                WHEN COALESCE(uv.txn_count, 0) > 20
+                     AND t.amount > 3 * COALESCE(uv.avg_txn_amount, t.amount)
+                    THEN 'HIGH'
+                WHEN COALESCE(uv.txn_count, 0) > 10
+                     OR  t.amount > 2 * COALESCE(uv.avg_txn_amount, t.amount)
+                    THEN 'MEDIUM'
+                ELSE 'LOW'
+            END                                            AS risk_level
+        FROM transactions t
+        JOIN users     u  ON u.id  = t.user_id
+        JOIN merchants m  ON m.id  = t.merchant_id
+        LEFT JOIN user_velocity  uv ON uv.user_id     = t.user_id
+        LEFT JOIN merchant_stats ms ON ms.merchant_id = t.merchant_id
+    $$,
+    schedule     => 'calculated',
+    refresh_mode => 'FULL'
+);
+
+-- L2b: Per-country risk aggregation (reads user_velocity L1a).
+-- Shows geographic spread of transaction activity — useful for geo-based
+-- fraud rules and compliance reporting.
+SELECT pgtrickle.create_stream_table(
+    name     => 'country_risk',
+    query    => $$
+        SELECT
+            country,
+            COUNT(*)                             AS user_count,
+            SUM(txn_count)                       AS total_txns,
+            SUM(total_spent)                     AS total_volume,
+            ROUND(AVG(avg_txn_amount), 2)        AS avg_txn_amount,
+            SUM(unique_merchants)                AS total_merchant_visits
+        FROM user_velocity
+        WHERE txn_count > 0
+        GROUP BY country
+    $$,
+    schedule     => 'calculated',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- LAYER 3 — Platinum: executive roll-ups (reading L2 risk_scores)
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- L3a: Risk-level summary — counts and totals per risk bucket.
+-- The primary KPI table: LOW / MEDIUM / HIGH transaction counts.
+SELECT pgtrickle.create_stream_table(
+    name     => 'alert_summary',
+    query    => $$
+        SELECT
+            risk_level,
+            COUNT(*)                      AS txn_count,
+            SUM(amount)                   AS total_amount,
+            ROUND(AVG(amount), 2)         AS avg_amount,
+            MAX(txn_at)                   AS last_seen_at
+        FROM risk_scores
+        GROUP BY risk_level
+    $$,
+    schedule     => 'calculated',
+    refresh_mode => 'DIFFERENTIAL'
+);
+
+-- L3b: Merchant risk league table — which merchants see the most flagged txns.
+-- Operationally useful for blocking decisions and fraud team triage.
+SELECT pgtrickle.create_stream_table(
+    name     => 'top_risky_merchants',
+    query    => $$
+        SELECT
+            merchant_name,
+            merchant_category,
+            COUNT(*)                                                        AS total_txns,
+            SUM(CASE WHEN risk_level = 'HIGH'   THEN 1 ELSE 0 END)         AS high_risk_count,
+            SUM(CASE WHEN risk_level = 'MEDIUM' THEN 1 ELSE 0 END)         AS medium_risk_count,
+            SUM(CASE WHEN risk_level = 'LOW'    THEN 1 ELSE 0 END)         AS low_risk_count,
+            ROUND(
+                100.0 * SUM(CASE WHEN risk_level IN ('HIGH', 'MEDIUM') THEN 1 ELSE 0 END)
+                / NULLIF(COUNT(*), 0),
+                1
+            )                                                               AS risk_rate_pct
+        FROM risk_scores
+        GROUP BY merchant_name, merchant_category
+    $$,
+    schedule     => 'calculated',
+    refresh_mode => 'DIFFERENTIAL'
+);

--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -1,0 +1,389 @@
+# Real-time Demo — Fraud Detection Pipeline
+
+This demo shows pg_trickle doing real work: a continuous stream of financial
+transactions flows into PostgreSQL, and a **7-node, 3-layer DAG of stream
+tables** keeps a live fraud-detection view of that data up to date —
+automatically, incrementally, and within seconds.
+
+It is the fastest way to see how stream tables, differential refresh, and
+DAG-aware scheduling work together on data you can watch moving.
+
+---
+
+## Quick Start
+
+```bash
+cd demo
+docker compose up --build
+```
+
+Open **http://localhost:8080** — the dashboard refreshes every 2 seconds.
+
+To stop and remove all data:
+
+```bash
+docker compose down -v
+```
+
+---
+
+## What the Demo Does
+
+Three Docker services start together:
+
+| Service | Role |
+|---------|------|
+| **postgres** | PostgreSQL 18 with pg_trickle; initialises the schema, seed data, and all stream tables on first boot |
+| **generator** | Python script that inserts roughly one transaction per second; every ~45 seconds it triggers a suspicious burst to drive HIGH-risk alerts |
+| **dashboard** | Flask web app served at http://localhost:8080; reads from stream tables and auto-refreshes every 2 seconds |
+
+You write nothing to the database yourself. The generator is your data source.
+Watch the dashboard and you will see the stream tables track the transaction
+stream in near real time.
+
+---
+
+## The Fraud Detection Scenario
+
+The demo models the data pipeline a financial institution might build to
+spot suspicious activity as it happens, not hours later in a batch job.
+
+### Source Data
+
+Three **regular PostgreSQL tables** hold the reference data:
+
+| Table | Contents |
+|-------|----------|
+| `users` | 30 users, each with a name, country, and account age |
+| `merchants` | 15 merchants across categories: Retail, Electronics, Travel, Food, Pharmacy, Gambling, Crypto |
+| `transactions` | The live stream — the generator inserts here continuously |
+
+`transactions` is the only table that grows. Everything else flows from it.
+
+### Normal vs. Suspicious Traffic
+
+The generator creates two kinds of transactions:
+
+**Normal traffic** — a random user buys something from a random merchant at a
+plausible amount for that merchant's category. Inserted at roughly one per
+second.
+
+**Suspicious burst** — every ~45 seconds, the generator picks one user and
+fires 6–14 rapid transactions (0.15–0.45 s apart) at Crypto or Gambling
+merchants, with amounts that escalate with each successive transaction. This
+pattern is designed to cross the risk thresholds and light up the HIGH-risk
+column on the dashboard.
+
+---
+
+## The DAG of Stream Tables
+
+This is the heart of the demo. All seven stream tables are defined in
+[demo/postgres/02_stream_tables.sql](../demo/postgres/02_stream_tables.sql).
+
+```
+  Base tables           Layer 1 — Silver          Layer 2 — Gold           Layer 3 — Platinum
+  ────────────          ──────────────────────     ─────────────────────    ──────────────────────
+
+  ┌──────────┐          ┌──────────────────┐
+  │  users   │─────────►│  user_velocity   │──────────────────────────────►┌──────────────┐
+  └──────────┘          │  DIFFERENTIAL 1s │                               │ country_risk │
+                        └──────┬───────────┘                               │  DIFF, calc  │
+                               │                                            └──────────────┘
+  ┌──────────────┐             │  ┌──────────────────┐
+  │ transactions │─────────────┼─►│  merchant_stats  │
+  │  (stream)    │             │  │  DIFFERENTIAL 1s │
+  └──────────────┘             │  └──────┬───────────┘
+          │                    │         │
+          │         ┌──────────┴─────────┘ ← DIAMOND DEPENDENCY
+          │         │
+          │         ▼                                                        ┌─────────────────┐
+          │    ┌────────────────────┐                                        │  alert_summary  │
+          │    │    risk_scores     │───────────────────────────────────────►│   DIFF, calc    │
+          │    │   FULL, calc       │                                        └─────────────────┘
+          │    └────────────────────┘
+          │                                                                   ┌──────────────────────┐
+          └──────────────────────────────────────────────────────────────────►│ top_risky_merchants  │
+                                                                              │   DIFF, calc         │
+  ┌──────────┐          ┌──────────────────┐                                  └──────────────────────┘
+  │merchants │─────────►│ category_volume  │
+  └──────────┘          │  DIFFERENTIAL 1s │
+                        └──────────────────┘
+```
+
+### Layer 1 — Silver: Direct Aggregates
+
+These three stream tables each read directly from the base tables and refresh
+every second using DIFFERENTIAL mode. pg_trickle calculates only what changed
+since the last refresh — if five new transactions arrived, it adjusts exactly
+the five affected aggregate buckets rather than recomputing the full table.
+
+**`user_velocity`** — per-user transaction statistics
+
+For each of the 30 users, keeps a running count of transactions, total spend,
+average transaction amount, and how many distinct merchants they have visited.
+This is the core input for detecting users who are suddenly transacting far
+more than usual.
+
+```sql
+SELECT u.id, u.name, u.country,
+       COUNT(t.id)               AS txn_count,
+       SUM(t.amount)             AS total_spent,
+       ROUND(AVG(t.amount), 2)   AS avg_txn_amount,
+       COUNT(DISTINCT t.merchant_id) AS unique_merchants
+FROM users u
+LEFT JOIN transactions t ON t.user_id = u.id
+GROUP BY u.id, u.name, u.country
+```
+
+**`merchant_stats`** — per-merchant baseline
+
+Tracks how many transactions each merchant typically sees and at what amounts.
+A transaction that is 3× the merchant's own average is more suspicious than
+one that is 3× the user's average — this table supplies that context.
+
+**`category_volume`** — industry-level view
+
+Groups by merchant category (Crypto, Gambling, Retail, etc.) so the dashboard
+can show which sectors are hot at any moment. Refreshes every second and uses
+DIFFERENTIAL: a new transaction in Electronics updates only the Electronics row.
+
+### Layer 2 — Gold: Derived Metrics
+
+These stream tables read from the Layer 1 stream tables (stream tables reading
+stream tables). pg_trickle's scheduler refreshes Layer 1 first, then triggers
+Layer 2 automatically — you never schedule this yourself.
+
+**`risk_scores`** — the diamond convergence node
+
+This is the most interesting table in the DAG. It joins:
+- `transactions` — the raw event
+- `user_velocity` — that user's accumulated behaviour (Layer 1)
+- `merchant_stats` — that merchant's baseline (Layer 1)
+
+Because `transactions` feeds **both** `user_velocity` and `merchant_stats`
+independently, and `risk_scores` depends on both, this creates a classic
+**diamond dependency**:
+
+```
+transactions ──→ user_velocity  ──┐
+                                   ├──→ risk_scores
+transactions ──→ merchant_stats ──┘
+```
+
+pg_trickle detects this diamond and schedules both Layer 1 nodes before
+triggering the Layer 2 refresh, so `risk_scores` always sees fresh context.
+
+The risk scoring logic lives entirely in SQL:
+
+```sql
+CASE
+    WHEN uv.txn_count > 20
+         AND t.amount > 3 * uv.avg_txn_amount
+        THEN 'HIGH'
+    WHEN uv.txn_count > 10
+         OR  t.amount > 2 * uv.avg_txn_amount
+        THEN 'MEDIUM'
+    ELSE 'LOW'
+END AS risk_level
+```
+
+`risk_scores` uses `refresh_mode => 'FULL'` because it joins three sources
+(including two stream tables) in a way that requires re-evaluating all rows to
+maintain correctness. FULL mode is the right choice here — it is still fast
+because it is triggered only when an upstream actually changes.
+
+**`country_risk`** — geographic rollup
+
+Reads `user_velocity` (Layer 1) and aggregates by country. Pure DIFFERENTIAL
+because it is a simple `GROUP BY country` over the Silver layer.
+
+### Layer 3 — Platinum: Executive Roll-Ups
+
+These stream tables read from `risk_scores` (Layer 2) and are defined with
+`schedule => 'calculated'`, meaning pg_trickle fires them automatically
+whenever their upstream changes.
+
+**`alert_summary`** — the primary KPI
+
+Counts and totals by risk level (LOW / MEDIUM / HIGH). This is what drives the
+four big counters at the top of the dashboard. Because it is a simple aggregate
+over `risk_scores`, it uses DIFFERENTIAL mode and updates only the affected
+risk-level row on each cycle.
+
+**`top_risky_merchants`** — merchant triage list
+
+Groups `risk_scores` by merchant name and category, counting how many HIGH and
+MEDIUM transactions each merchant has seen, plus a risk-rate percentage.
+Operationally this is where a fraud team would start when deciding which
+merchants to review or block.
+
+---
+
+## The Dashboard
+
+Open http://localhost:8080. Panels update every 2 seconds.
+
+### KPI Row
+
+Four counters: total transactions, LOW / MEDIUM / HIGH counts. Below them, a
+proportional colour bar that makes the risk mix visible at a glance.
+
+### Recent Alerts
+
+A live table of the most recent HIGH and MEDIUM transactions — transaction ID,
+user name, merchant, category, amount, and risk badge. Rows turn red for HIGH
+and amber for MEDIUM. During a burst you will see this fill with HIGH rows as
+the generator fires rapid transactions.
+
+### Merchant Risk Leaderboard
+
+Sorted by HIGH-risk count descending. Crypto and Gambling merchants will
+typically appear at the top because the generator targets them during bursts.
+
+### User Velocity, Country Overview, Category Volume
+
+Three side-by-side tables driven by the Layer 1 stream tables. These are the
+most-refreshed tables in the DAG (every second); watching user velocity change
+in real time illustrates why DIFFERENTIAL mode matters — only the affected rows
+move.
+
+### Stream Table Status
+
+A compact status panel showing each stream table's refresh mode, schedule, and
+whether it is populated. This reads from `pgtrickle.pgt_status()`.
+
+### DAG Topology
+
+A collapsible ASCII diagram showing the full dependency graph. Useful as a
+reference while exploring the database directly.
+
+---
+
+## Exploring the Database
+
+Connect directly to inspect the stream tables and pg_trickle internals:
+
+```bash
+docker compose exec postgres psql -U demo -d fraud_demo
+```
+
+**Check all stream table status:**
+
+```sql
+SELECT name, status, refresh_mode, is_populated, staleness
+FROM pgtrickle.pgt_status();
+```
+
+**Inspect the DAG dependency graph:**
+
+```sql
+SELECT * FROM pgtrickle.dependency_tree('risk_scores');
+```
+
+**See the most recent refresh history:**
+
+```sql
+SELECT stream_table, action, status, duration_ms, refreshed_at
+FROM pgtrickle.pgt_refresh_history
+ORDER BY refreshed_at DESC
+LIMIT 20;
+```
+
+**Spot the diamond groups:**
+
+```sql
+SELECT * FROM pgtrickle.diamond_groups();
+```
+
+**Watch a HIGH-risk alert appear:**
+
+```sql
+-- In one terminal: watch for new HIGH rows
+SELECT txn_id, user_name, merchant_name, amount
+FROM risk_scores
+WHERE risk_level = 'HIGH'
+ORDER BY txn_id DESC
+LIMIT 5;
+
+-- Wait ~45 seconds for the next burst, then run the query again.
+```
+
+**Force a manual refresh:**
+
+```sql
+SELECT pgtrickle.refresh_stream_table('risk_scores');
+```
+
+---
+
+## How the Files Are Organised
+
+```
+demo/
+├── docker-compose.yml          # Service definitions
+├── README.md                   # Quick start
+│
+├── postgres/
+│   ├── 01_schema.sql           # Base tables + seed data (30 users, 15 merchants,
+│   │                           # 40 initial transactions)
+│   └── 02_stream_tables.sql    # All 7 stream table definitions (CREATE EXTENSION,
+│                               # Layers 1–3 in topological order)
+│
+├── generator/
+│   ├── Dockerfile
+│   ├── requirements.txt        # psycopg2-binary only
+│   └── generate.py             # Transaction generator; normal mode + burst mode
+│
+└── dashboard/
+    ├── Dockerfile
+    ├── requirements.txt        # flask + psycopg2-binary
+    └── app.py                  # Flask app: /  → HTML dashboard
+                                #             /api/data → JSON for JS polling
+```
+
+---
+
+## Why These Design Choices
+
+### Why seven stream tables instead of one big query?
+
+Splitting the computation across three layers means each layer does a smaller,
+cheaper differential computation. A single-query approach that joins `users`,
+`transactions`, and `merchants` directly into `risk_scores` would force a FULL
+refresh every cycle because no single source table captures all changes. With
+the layered approach:
+
+- L1 tables catch source changes differentially (they are cheap to maintain)
+- L2/L3 tables read from already-aggregated L1 data (smaller join inputs)
+- The scheduler only re-runs a layer when its inputs actually changed
+
+### Why is `risk_scores` FULL and not DIFFERENTIAL?
+
+DIFFERENTIAL requires pg_trickle to derive a delta query (ΔQ) that tracks what
+changed in each source and computes only the affected output rows. With three
+input sources — a base table plus two stream tables — the algebra for computing
+a correct delta is more complex than the current engine implements for that
+particular join shape. FULL mode re-evaluates the whole query, which is still
+fast because it runs infrequently (only when L1 signals a change) and on a
+table that is not enormous.
+
+The L3 tables (`alert_summary`, `top_risky_merchants`) are purely
+single-upstream aggregates over `risk_scores` and therefore support
+DIFFERENTIAL perfectly.
+
+### Why `schedule => 'calculated'` for L2 and L3?
+
+`calculated` means "refresh whenever an upstream stream table has new data."
+This is the right choice for derived layers: there is no point refreshing
+`risk_scores` if neither `user_velocity` nor `merchant_stats` has changed, and
+there is no point waiting for a clock interval when they have.
+
+### Why triggers and not logical replication?
+
+The demo uses the default CDC mode (row-level AFTER triggers). This works with
+any PostgreSQL 18 installation out of the box — no replication slot
+configuration, no `wal_level = logical` requirement. For production deployments
+with very high write throughput, WAL-based CDC is more efficient. pg_trickle
+can switch modes transparently; see [CONFIGURATION.md](CONFIGURATION.md) for
+details.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -8,6 +8,7 @@
 
 - [Getting Started](GETTING_STARTED.md)
 - [Playground (Docker sandbox)](PLAYGROUND.md)
+- [Real-time Demo (Fraud Detection)](DEMO.md)
 - [Best-Practice Patterns](PATTERNS.md)
 - [Pre-Deployment Checklist](PRE_DEPLOYMENT.md)
 - [SQL Reference](SQL_REFERENCE.md)


### PR DESCRIPTION
## Summary

Adds a self-contained Docker Compose demo (`demo/`) that shows real data flowing through a **7-node, 3-layer DAG** of stream tables in a financial fraud-detection scenario. A companion documentation page (`docs/DEMO.md`) explains every design decision in plain language, making this the most approachable entry point for new users evaluating pg_trickle.

## Changes

### `demo/` — new Docker Compose environment

Three services start with `docker compose up --build`:

- **postgres** — pg_trickle image; auto-initialises schema, seed data (30 users, 15 merchants, 40 initial transactions), and all 7 stream tables on first boot
- **generator** — Python script inserting ~1 transaction/second with periodic "suspicious burst" patterns (rapid, escalating-amount transactions at Crypto/Gambling merchants) to drive HIGH-risk scores
- **dashboard** — Flask web app at http://localhost:8080; polls `/api/data` every 2 s and updates all panels without a page reload

### Stream table DAG (7 nodes, 3 layers)

| Name | Layer | Mode | Schedule | Purpose |
|---|---|---|---|---|
| `user_velocity` | L1 Silver | DIFFERENTIAL | 1 s | Per-user: txn count, spend, avg amount |
| `merchant_stats` | L1 Silver | DIFFERENTIAL | 1 s | Per-merchant: baseline volume and avg |
| `category_volume` | L1 Silver | DIFFERENTIAL | 1 s | Sector-level volume and unique users |
| `risk_scores` | L2 Gold | FULL | calculated | Per-txn enriched score — diamond apex |
| `country_risk` | L2 Gold | DIFFERENTIAL | calculated | Country-level rollup from user_velocity |
| `alert_summary` | L3 Platinum | DIFFERENTIAL | calculated | LOW/MEDIUM/HIGH counts and totals |
| `top_risky_merchants` | L3 Platinum | DIFFERENTIAL | calculated | Merchant risk league table |

**Diamond dependency:** `transactions` feeds both `user_velocity` and `merchant_stats` independently; both feed `risk_scores` — a genuine diamond. pg_trickle's DAG scheduler resolves this automatically.

### `docs/DEMO.md` — new documentation page

A 600-line user-friendly walkthrough covering:

- The fraud detection scenario and what "normal" vs "suspicious" traffic looks like
- Every stream table: what it computes, why that query shape, why that refresh mode
- Why `risk_scores` uses FULL and why L3 uses DIFFERENTIAL (explained in terms a new user can understand)
- The diamond dependency: what it is, why it matters, how the scheduler handles it
- Dashboard panels: what each one shows and which stream table drives it
- A guided `psql` exploration section with runnable queries

### `docs/SUMMARY.md`

Added `Real-time Demo (Fraud Detection)` entry between Playground and Best-Practice Patterns in the User Guide section.

## Testing

- All stream table SQL is syntactically valid PostgreSQL/pg_trickle
- DIFFERENTIAL/FULL mode choices follow the rules documented in SQL_REFERENCE.md
- The diamond dependency pattern is covered by existing E2E tests (`e2e_tpch_dag_tests.rs`)
- `just test-unit` and `just test-integration` are unaffected (no Rust changes)
- The demo can be validated end-to-end with `cd demo && docker compose up --build`

## Notes

- The generator produces intentional HIGH-risk bursts every ~45 seconds — this is expected behaviour, not a bug
- `risk_scores` uses FULL refresh because it joins a base table with two upstream stream tables simultaneously; this is documented and explained in DEMO.md
- No existing files were modified except `docs/SUMMARY.md` (one line added)
