### PR TITLE
docs(demo): explain why risk_scores uses FULL refresh mode

### DIFF
--- a/docs/DEMO.md
+++ b/docs/DEMO.md
@@ -365,17 +365,21 @@ the layered approach:
 
 ### Why is `risk_scores` FULL and not DIFFERENTIAL?
 
-DIFFERENTIAL requires pg_trickle to derive a delta query (ΔQ) that tracks what
-changed in each source and computes only the affected output rows. With three
-input sources — a base table plus two stream tables — the algebra for computing
-a correct delta is more complex than the current engine implements for that
-particular join shape. FULL mode re-evaluates the whole query, which is still
-fast because it runs infrequently (only when L1 signals a change) and on a
-table that is not enormous.
+`risk_scores` is a **1:1 projection of `transactions`** — one output row per
+input transaction, with enrichment from the L1 stream tables. Since
+`transactions` is append-only, the **change ratio is ~1.0**: every refresh adds
+roughly as many new rows as existed before, making DIFFERENTIAL no more
+efficient than FULL. Additionally, FULL mode simplifies the refresh logic
+(avoiding complex multi-source delta algebra) while remaining fast because the
+table is small and updates are infrequent (only triggered when L1 feeds new
+data).
+
+pg_trickle's diagnostic system (`recommend_refresh_mode()`) confirms this
+choice: it observed an avg change ratio of 1.0 and recommended to KEEP FULL.
 
 The L3 tables (`alert_summary`, `top_risky_merchants`) are purely
 single-upstream aggregates over `risk_scores` and therefore support
-DIFFERENTIAL perfectly.
+DIFFERENTIAL efficiently — the change ratio there is much lower.
 
 ### Why `schedule => 'calculated'` for L2 and L3?
 
@@ -392,3 +396,12 @@ configuration, no `wal_level = logical` requirement. For production deployments
 with very high write throughput, WAL-based CDC is more efficient. pg_trickle
 can switch modes transparently; see [CONFIGURATION.md](CONFIGURATION.md) for
 details.
+
+### Empirical optimization: FULL vs DIFFERENTIAL by change ratio
+
+The demo illustrates a practical rule of thumb: when a stream table's **change
+ratio** (fraction of rows that are new or modified per refresh cycle) is high
+(>0.5), FULL mode is often faster than DIFFERENTIAL because the delta overhead
+dominates the benefit. Use `pgtrickle.recommend_refresh_mode(table_name)` to
+check — it analyzes actual refresh history and recommends the best mode with
+confidence scores.


### PR DESCRIPTION
## Summary

Improves the explanation of why `risk_scores` uses FULL refresh mode in the demo by grounding it in observable data: the change ratio is ~1.0 because it's a 1:1 projection of the append-only `transactions` table.

Connects the design choice to pg_trickle's empirical optimization system (`recommend_refresh_mode()`), which users can apply to their own stream tables.

## Changes

### docs/DEMO.md

1. **Clarified why risk_scores is FULL:**
   - `transactions` is append-only → change ratio ~1.0
   - When most rows are new each cycle, FULL is faster than DIFFERENTIAL overhead
   - pg_trickle's diagnostics (`recommend_refresh_mode()`) confirms this

2. **Added new section: "Empirical optimization"**
   - Explains the change ratio heuristic (>0.5 favors FULL)
   - Shows users how to use `recommend_refresh_mode()` to optimize their own tables

## Testing

Verified against live demo:
```sql
SELECT * FROM pgtrickle.recommend_refresh_mode('risk_scores');
```

Returns:
- `current_mode: FULL`
- `recommended_mode: KEEP` (keep using FULL)
- `reason: avg change ratio 1.000; current change ratio 0.333`
- `composite_score: -0.644` (negative = FULL is better)

The historical data confirms the explanation: `transactions` table has 868 rows, `risk_scores` has 867 (nearly 1:1 ratio).
