### PR TITLE
fix(demo): use pgt_schema||pgt_name in refresh_history queries

### DIFF
--- a/demo/dashboard/app.py
+++ b/demo/dashboard/app.py
@@ -789,8 +789,8 @@ def api_internals():
         """)
 
         latest_ref = safe_query(conn, """
-            SELECT DISTINCT ON (st.name)
-                st.name,
+            SELECT DISTINCT ON (st.pgt_schema, st.pgt_name)
+                st.pgt_schema || '.' || st.pgt_name AS name,
                 h.start_time  AS last_refresh,
                 ROUND(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000)::bigint
                               AS duration_ms,
@@ -798,7 +798,7 @@ def api_internals():
             FROM pgtrickle.pgt_refresh_history h
             JOIN pgtrickle.pgt_stream_tables   st ON st.pgt_id = h.pgt_id
             WHERE h.status = 'COMPLETED'
-            ORDER BY st.name, h.start_time DESC
+            ORDER BY st.pgt_schema, st.pgt_name, h.start_time DESC
         """)
 
         dep_tree = safe_query(conn, """
@@ -806,7 +806,7 @@ def api_internals():
         """)
 
         refresh_hist = safe_query(conn, """
-            SELECT st.name,
+            SELECT st.pgt_schema || '.' || st.pgt_name AS name,
                    h.action          AS refresh_mode,
                    h.start_time,
                    ROUND(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000)::bigint


### PR DESCRIPTION
## Summary

Fix the empty Refresh History and Last Refresh columns in the Internals tab dashboard panel. The dashboard queries were referencing a non-existent `st.name` column in `pgt_stream_tables`. The correct approach is to concatenate `pgt_schema || '.' || pgt_name` to form the fully qualified stream table name.

## Changes

- Fixed `latest_ref` query: use `pgt_schema || '.' || pgt_name` instead of `st.name`
- Fixed `DISTINCT ON` clause to use both `pgt_schema` and `pgt_name` for proper grouping
- Fixed `ORDER BY` to use `pgt_schema, pgt_name` instead of just `st.name`
- Fixed `refresh_hist` query to concatenate columns for the name display

## Testing

- Dashboard Internals tab now displays refresh history and last refresh times correctly
- Query no longer silently fails in `safe_query()` error handling

## Related

- Addresses the empty panels reported in PR #547 (fix empty Refresh History panel in Internals tab)
