### PR TITLE
fix(tests): use wrapping_mul for seed arithmetic in sqlancer tests

### DIFF
--- a/tests/e2e_sqlancer_tests.rs
+++ b/tests/e2e_sqlancer_tests.rs
@@ -125,7 +125,7 @@ fn generate_queries(base_seed: u64, count: usize) -> Vec<GeneratedQuery> {
     let mut queries = Vec::with_capacity(count);
 
     for idx in 0..count {
-        let seed = base_seed.wrapping_add(idx as u64 * 0x9e3779b97f4a7c15);
+        let seed = base_seed.wrapping_add((idx as u64).wrapping_mul(0x9e3779b97f4a7c15));
         let mut rng = Lcg::new(seed);
 
         let query = generate_one_query(&mut rng, idx);
@@ -376,7 +376,7 @@ async fn run_crash_oracle() {
         // Create tables and insert data.
         for tbl in &gq.tables {
             db.execute(&tbl.ddl()).await;
-            let mut rng = Lcg::new(gq.seed ^ (i as u64 * 0x1234567890abcdef));
+            let mut rng = Lcg::new(gq.seed ^ (i as u64).wrapping_mul(0x1234567890abcdef));
             db.execute(&tbl.insert_dml(&mut rng)).await;
         }
 
@@ -472,7 +472,7 @@ async fn run_equivalence_oracle() {
         // Create source tables.
         for tbl in &gq.tables {
             db.execute(&tbl.ddl()).await;
-            let mut rng = Lcg::new(gq.seed ^ (i as u64 * 0x1234567890abcdef));
+            let mut rng = Lcg::new(gq.seed ^ (i as u64).wrapping_mul(0x1234567890abcdef));
             db.execute(&tbl.insert_dml(&mut rng)).await;
         }
 


### PR DESCRIPTION
## Summary

Fix integer overflow panic that caused all SQLancer tests (`test_sqlancer_stateful_dml` and `test_sqlancer_ci_combined`) to fail immediately in debug builds. The seed diversification arithmetic used plain `*` on `u64` with large hex constants, which panics on overflow in debug mode (Rust's default).

## Root Cause

Three sites in `tests/e2e_sqlancer_tests.rs` computed per-iteration seeds using plain multiplication:

```rust
// Line 128: overflows for idx >= 2 (0x9e3779b97f4a7c15 > u64::MAX/2)
let seed = base_seed.wrapping_add(idx as u64 * 0x9e3779b97f4a7c15);

// Lines 379, 475: overflows for i >= 15
let mut rng = Lcg::new(gq.seed ^ (i as u64 * 0x1234567890abcdef));
```

In release builds the overflow wraps silently; in debug builds (used by `cargo nextest` in CI) it panics immediately, before any database work is done.

## Changes

- Replace all three raw `*` multiplications with `.wrapping_mul()` in `tests/e2e_sqlancer_tests.rs`
- No logic change — wrapping modular arithmetic is the intended behaviour for hash/seed diversification

## Testing

- `just lint` passes (clippy + fmt-check, zero warnings)
- Fixes: https://github.com/grove/pg-trickle/actions/runs/24298819786
