### PR TITLE
docs(roadmap): inject v0.22.0 — Production Scalability & Downstream Integration

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,12 +38,13 @@ coverage, all in plain language.
 - [v0.19.0 — Production Gap Closure & Distribution](#v0190--production-gap-closure--distribution)
 - [v0.20.0 — Dog-Feeding](#v0200--dog-feeding-pg_trickle-monitors-itself)
 - [v0.21.0 — Correctness, Safety & Test Hardening](#v0210--correctness-safety--test-hardening)
-- [v0.22.0 — TUI Dog-Feeding Integration](#v0220--tui-dog-feeding-integration)
-- [v0.23.0 — PostgreSQL 17 Support](#v0230--postgresql-17-support)
-- [v0.24.0 — PGlite Proof of Concept](#v0240--pglite-proof-of-concept)
-- [v0.25.0 — Core Extraction (`pg_trickle_core`)](#v0250--core-extraction-pg_trickle_core)
-- [v0.26.0 — PGlite WASM Extension](#v0260--pglite-wasm-extension)
-- [v0.27.0 — PGlite Reactive Integration](#v0270--pglite-reactive-integration)
+- [v0.22.0 — Production Scalability & Downstream Integration](#v0220--production-scalability--downstream-integration)
+- [v0.23.0 — TUI Dog-Feeding Integration](#v0230--tui-dog-feeding-integration)
+- [v0.24.0 — PostgreSQL 17 Support](#v0240--postgresql-17-support)
+- [v0.25.0 — PGlite Proof of Concept](#v0250--pglite-proof-of-concept)
+- [v0.26.0 — Core Extraction (`pg_trickle_core`)](#v0260--core-extraction-pg_trickle_core)
+- [v0.27.0 — PGlite WASM Extension](#v0270--pglite-wasm-extension)
+- [v0.28.0 — PGlite Reactive Integration](#v0280--pglite-reactive-integration)
 - [v1.0.0 — Stable Release](#v100--stable-release)
 - [Post-1.0 — Scale, Ecosystem & Platform Expansion](#post-10--scale-ecosystem--platform-expansion)
 - [Effort Summary](#effort-summary)
@@ -87,12 +88,13 @@ from the v0.1.x series to 1.0 and beyond.
 | **v0.19.0** | **Production gap closure & distribution** | **✅ Released** |
 | **v0.20.0** | **Dog-feeding (pg_trickle monitors itself)** | **✅ Released** |
 | v0.21.0 | Correctness, safety & test hardening | Planned |
-| v0.22.0 | TUI dog-feeding integration | Planned |
-| v0.23.0 | PostgreSQL 17 support | Planned |
-| v0.24.0 | PGlite proof of concept | Planned |
-| v0.25.0 | Core extraction (`pg_trickle_core`) | Planned |
-| v0.26.0 | PGlite WASM extension | Planned |
-| v0.27.0 | PGlite reactive integration | Planned |
+| v0.22.0 | Production scalability & downstream integration | Planned |
+| v0.23.0 | TUI dog-feeding integration | Planned |
+| v0.24.0 | PostgreSQL 17 support | Planned |
+| v0.25.0 | PGlite proof of concept | Planned |
+| v0.26.0 | Core extraction (`pg_trickle_core`) | Planned |
+| v0.27.0 | PGlite WASM extension | Planned |
+| v0.28.0 | PGlite reactive integration | Planned |
 | v1.0.0 | Stable release (incl. PG 19 compatibility) | Planned |
 
 ---
@@ -6116,7 +6118,141 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 
 ---
 
-## v0.22.0 — TUI Dog-Feeding Integration
+## v0.22.0 — Production Scalability & Downstream Integration
+
+**Status: Planned.** Driven by [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) P1 items not addressed in v0.21.0 and the highest-value P2 items.
+
+> **Release Theme**
+> This release delivers the two highest-impact items from the overall
+> assessment deferred from v0.21.0: a minimal-viable in-database parallel
+> refresh worker pool (the single largest scalability unlock) and a downstream
+> CDC publication so stream table changes can drive Kafka, Debezium, and
+> event-sourcing pipelines without a second replication slot. Three P2 items
+> ship alongside: a predictive cost model for adaptive refresh, SLA-driven
+> tier auto-assignment, and a transactional outbox helper for zero-copy
+> dual-write elimination.
+
+### Downstream CDC Publication (P1 — §9.2)
+
+> **In plain terms:** pg_trickle consumes CDC from source tables but cannot
+> *emit* changes downstream. This adds `stream_table_to_publication()` — a
+> helper that exposes every row applied to a stream table as a PostgreSQL
+> logical replication publication so Kafka Connect, Debezium, and
+> event-sourcing pipelines can subscribe with zero code and no second
+> replication slot.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| CDC-PUB-1 | **`stream_table_to_publication(name TEXT)` SQL function.** Creates a logical replication publication for the target stream table using `pgt_inserted_rows`/`pgt_deleted_rows` output from the MERGE step. Catalog column `downstream_publication_name` tracks the association. | 2–3d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.2 |
+| CDC-PUB-2 | **Lifecycle management.** `drop_stream_table_publication(name)`, auto-drop on `drop_stream_table()`, recreation on schema-change rebuild. | 1d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.2 |
+| CDC-PUB-3 | **`pg_stat_stream_tables` — `downstream_publication` column.** Surface publication name (or NULL) in the monitoring view. | 0.5d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.2 |
+| CDC-PUB-4 | **E2E tests.** Create publication; verify subscriber receives insert/update/delete events; drop and verify cleanup. | 1d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.2 |
+| CDC-PUB-5 | **Documentation.** `docs/SQL_REFERENCE.md` section on downstream publications; tutorial showing Kafka Connect integration pattern. | 1d | — |
+
+> **Downstream CDC publication subtotal: ~1–1.5 weeks**
+
+### In-Database Parallel Refresh Worker Pool — Minimal Viable Slice (P1 — §3.1)
+
+> **In plain terms:** The scheduler today runs one refresh at a time per
+> tick. This installs a dynamic bgworker pool — a coordinator owns the DAG,
+> workers execute refreshes — so independent stream tables at the same DAG
+> level refresh simultaneously. Deployments with 200+ STs or long refresh
+> queues get immediate throughput gains. Opt-in via `max_parallel_workers`;
+> default 0 preserves existing serial behaviour.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| PAR-1 | **Coordinator / worker process split.** Coordinator BGW manages the tick; dispatches ready-to-run STs to a `PgLwLock`-protected shared work queue; worker BGWs pop entries and execute refresh transactions. | 1.5–2wk | [plans/sql/PLAN_PARALLELISM.md](plans/sql/PLAN_PARALLELISM.md) §3 |
+| PAR-2 | **`pg_trickle.max_parallel_workers` GUC** (default 0 = serial, range 0–32). Gate the entire parallel path so deployments can opt in incrementally. | 1d | [plans/sql/PLAN_PARALLELISM.md](plans/sql/PLAN_PARALLELISM.md) §4 |
+| PAR-3 | **DAG level extraction.** Re-use `topological_levels()` already in `dag.rs` to identify STs that can run concurrently (same level, no intra-level edges). | 0.5d | [plans/sql/PLAN_PARALLELISM.md](plans/sql/PLAN_PARALLELISM.md) §3 |
+| PAR-4 | **Worker crash recovery.** Coordinator marks the ST `ERROR` in `pgt_refresh_history` on worker crash (same behaviour as serial crash); respawns the worker slot. | 1d | [plans/sql/PLAN_PARALLELISM.md](plans/sql/PLAN_PARALLELISM.md) §5 |
+| PAR-5 | **E2E tests: correctness + throughput.** Diamond DAG with concurrent same-level refreshes; verify no partial-consistency window. Benchmark: wall-clock tick latency vs serial at 50-ST scale. | 1d | [plans/sql/PLAN_PARALLELISM.md](plans/sql/PLAN_PARALLELISM.md) §6 |
+
+> **Parallel refresh subtotal: ~3–4 weeks**
+
+### Predictive Refresh Cost Model (P2 — §9.3)
+
+> **In plain terms:** The current adaptive threshold reacts *after* a slow
+> differential refresh. This extends dog-feeding to *predict* `duration_ms`
+> from `rows_inserted + rows_deleted` via linear regression over the last
+> hour. When the forecast exceeds `last_full_ms × 1.5`, pg_trickle switches
+> to FULL pre-emptively — eliminating the one-bad-cycle latency spike entirely.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| PRED-1 | **Linear regression forecaster.** Fit `duration_ms ~ delta_rows` over `pg_trickle.prediction_window` minutes of `pgt_refresh_history` per ST. Expose fitted slope and intercept as columns in `df_threshold_advice`. | 1–2d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.3 |
+| PRED-2 | **Pre-emptive FULL switch.** If `predicted_diff_ms > last_full_ms × pg_trickle.prediction_ratio` (default 1.5), override strategy to FULL; log `refresh_reason = 'predicted_cost_exceeds_full'`. | 1d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.3 |
+| PRED-3 | **Cold-start fallback.** When fewer than `pg_trickle.prediction_min_samples` (default 5) history rows exist, fall back to the existing fixed-threshold logic. | 0.5d | — |
+| PRED-4 | **E2E test + proptest.** Verify pre-emptive switch fires under synthetic cost spike; proptest checks cold-start fallback boundary (0–4 samples). | 1d | — |
+
+> **Predictive cost model subtotal: ~1 week**
+
+### SLA-Driven Tier Auto-Assignment (P2 — §9.7)
+
+> **In plain terms:** `alter_stream_table(name, sla => interval '30 seconds')`
+> lets the scheduler pick the right tier automatically — no manual tier
+> tuning required. Removes the expert-knowledge barrier to tiered scheduling.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| SLA-1 | **`sla` parameter on `create_stream_table` / `alter_stream_table`.** Accepts an `INTERVAL`; stored as `freshness_deadline_ms` in `pgt_stream_tables`. | 0.5d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.7 |
+| SLA-2 | **Initial tier assignment.** On creation or `alter_stream_table` with `sla` set, assign to the tier whose `dispatch_gap ≤ sla`, considering current queue depth. | 1d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.7 |
+| SLA-3 | **Dynamic re-assignment.** After each tick, check whether the ST's tier still meets the SLA given measured queue depth; bump one tier up or down if the gap is consistently exceeded or under-utilised by >2×. | 1d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.7 |
+| SLA-4 | **E2E test.** Create ST with 30 s SLA; inject artificial tick delay; verify tier promotion within 3 cycles. | 0.5d | — |
+
+> **SLA-driven tier subtotal: ~3–4 days**
+
+### Transactional Outbox Helper (P2 — §9.12)
+
+> **In plain terms:** After each refresh cycle, pg_trickle writes a row to
+> `pgtrickle.outbox_<st>` with a JSON payload `{inserted:[…], deleted:[…]}`.
+> Eliminates the dual-write problem for downstream event buses without a
+> CDC connector or external replication slot.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| OUTBOX-1 | **`enable_outbox(name TEXT)` / `disable_outbox(name TEXT)`.** Create/drop `pgtrickle.outbox_<st>` table (`id BIGSERIAL`, `pgt_id`, `created_at`, `payload JSONB`). | 0.5d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.12 |
+| OUTBOX-2 | **Refresh-path outbox write.** After successful MERGE, if outbox is enabled, INSERT into `outbox_<st>` within the same transaction with `{inserted:[…], deleted:[…]}`. | 1d | [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.12 |
+| OUTBOX-3 | **Retention management.** `pg_trickle.outbox_retention_hours` GUC (default 24); scheduler drains expired outbox rows during the cleanup phase. | 0.5d | — |
+| OUTBOX-4 | **E2E test.** Enable outbox; trigger refresh; verify payload rows; test retention drain. | 0.5d | — |
+
+> **Transactional outbox subtotal: ~2–3 days**
+
+### Implementation Phases
+
+| Phase | Description | Duration |
+|-------|-------------|----------|
+| CDC-PUB | Downstream CDC publication: SQL function, lifecycle, monitoring, tests, docs | Days 1–8 |
+| PAR | Parallel refresh: coordinator/worker split, GUC, DAG levels, recovery, tests | Days 9–28 |
+| PRED | Predictive cost model: regression, pre-emptive switch, cold-start fallback, tests | Days 29–33 |
+| SLA | SLA-driven tier: `sla` param, initial assignment, dynamic re-assignment, tests | Days 34–37 |
+| OUTBOX | Transactional outbox: SQL functions, refresh-path write, retention, tests | Days 38–40 |
+
+> **v0.22.0 total: ~5–6 weeks** (downstream CDC + parallel refresh + predictive cost + SLA tier + outbox)
+
+**Exit criteria:**
+- [ ] CDC-PUB-1: `stream_table_to_publication(name)` creates a working logical publication
+- [ ] CDC-PUB-2: Publication is dropped automatically when the stream table is dropped
+- [ ] CDC-PUB-3: `downstream_publication` column visible in `pg_stat_stream_tables`
+- [ ] CDC-PUB-4: Subscriber receives correct insert/update/delete events; E2E test passes
+- [ ] PAR-2: `max_parallel_workers = 0` (default) produces identical results to serial mode
+- [ ] PAR-1/PAR-3: `max_parallel_workers ≥ 1` dispatches independent same-level STs concurrently
+- [ ] PAR-4: Worker crash marks ST `ERROR`; coordinator respawns worker slot
+- [ ] PAR-5: Diamond DAG concurrent correctness test passes; throughput improvement benchmarked
+- [ ] PRED-1: Fitted coefficients visible in `df_threshold_advice`
+- [ ] PRED-2: Pre-emptive FULL switch fires under synthetic spike; `refresh_reason = 'predicted_cost_exceeds_full'` logged
+- [ ] PRED-3: Cold-start fallback active when fewer than `prediction_min_samples` history rows exist
+- [ ] SLA-1: `create_stream_table(..., sla => '30 seconds')` stores `freshness_deadline_ms`
+- [ ] SLA-2: Initial tier assignment matches SLA requirement on creation
+- [ ] SLA-3: Tier auto-adjusts within 3 cycles when queue depth breaches SLA
+- [ ] OUTBOX-1/2: `enable_outbox()` creates table; refresh populates payload within same transaction
+- [ ] OUTBOX-3: Retention drain removes rows older than `outbox_retention_hours`
+- [ ] Extension upgrade path tested (`0.21.0 → 0.22.0`)
+- [ ] `just check-version-sync` passes
+
+---
+
+## v0.23.0 — TUI Dog-Feeding Integration
 
 **Status: Planned.** See [plans/ui/PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) for the full design.
 
@@ -6233,12 +6369,12 @@ TUI/CLI visualization enhancement for the dog-feeding views. Recommended from [P
 - [ ] CLI-1: `pgtrickle dog-feeding enable/disable/status` functional
 - [ ] CLI-2: `pgtrickle graph --format mermaid` outputs valid Mermaid
 - [ ] TUI-D1/DOC-21/DOC-22: Documentation updated
-- [ ] Extension upgrade path tested (`0.21.0 → 0.22.0`)
+- [ ] Extension upgrade path tested (`0.22.0 → 0.23.0`)
 - [ ] `just check-version-sync` passes
 
 ---
 
-## v0.23.0 — PostgreSQL 17 Support
+## v0.24.0 — PostgreSQL 17 Support
 
 > **Release Theme**
 > This release adds PostgreSQL 17 as a supported target alongside
@@ -6331,12 +6467,12 @@ Low-hanging PostgreSQL feature opportunities identified in [plans/sql/PLAN_POSTG
 - [ ] PGFEAT-7: Skip scan index optimization evaluated; benchmarks quantify benefit; indexes created if beneficial
 - [ ] PGFEAT-8: `MERGE ... RETURNING OLD.*, NEW.*` integrated in `build_merge_sql()`; ST-to-ST change buffer performance improved
 - [ ] PGFEAT-9: Virtual generated columns correctly excluded from CDC change buffer schemas; E2E tests pass with virtual column sources
-- [ ] Extension upgrade path tested (`0.22.0 → 0.23.0`)
+- [ ] Extension upgrade path tested (`0.23.0 → 0.24.0`)
 - [ ] `just check-version-sync` passes
 
 ---
 
-## v0.24.0 — PGlite Proof of Concept
+## v0.25.0 — PGlite Proof of Concept
 
 > **Release Theme**
 > This release validates whether PGlite users want real incremental view
@@ -6728,12 +6864,12 @@ Dependencies: None. Schema change: No (PG extension unchanged).
 - [ ] UX-4: TypeScript type definitions ship with strict-mode compatibility
 - [ ] TEST-1: > 50 correctness test cases pass on PGlite latest
 - [ ] TEST-2: CI tests pass against PGlite N, N-1, N-2
-- [ ] TEST-5: Extension upgrade path tested (`0.23.0 -> 0.24.0`)
+- [ ] TEST-5: Extension upgrade path tested (`0.24.0 -> 0.25.0`)
 - [ ] `just check-version-sync` passes
 
 ---
 
-## v0.25.0 — Core Extraction (`pg_trickle_core`)
+## v0.26.0 — Core Extraction (`pg_trickle_core`)
 
 > **Release Theme**
 > This release surgically separates pg_trickle's "brain" — the DVM engine,
@@ -7144,7 +7280,7 @@ Dependencies: PGL-1-1. Schema change: No.
 - [ ] STAB-1: Zero `pg_sys::` references in `pg_trickle_core/src/`
 - [ ] STAB-2: `cargo build -p pg_trickle_core --no-default-features` passes in CI
 - [ ] STAB-3: `cargo pgrx package` and `cargo pgrx test` succeed with workspace layout
-- [ ] STAB-4: Extension upgrade path tested (`0.23.0 -> 0.24.0`)
+- [ ] STAB-4: Extension upgrade path tested (`0.25.0 -> 0.26.0`)
 - [ ] STAB-5: WASM target builds in CI
 - [ ] PERF-1: Criterion shows < 1% regression on `diff_operators` benchmark
 - [ ] PERF-2: Full benchmark suite passes with < 5% regression threshold
@@ -7159,7 +7295,7 @@ Dependencies: PGL-1-1. Schema change: No.
 
 ---
 
-## v0.26.0 — PGlite WASM Extension
+## v0.27.0 — PGlite WASM Extension
 
 > **Release Theme**
 > This release delivers the first working PGlite extension — the moment
@@ -7611,7 +7747,7 @@ Dependencies: PGL-2-3, PERF-2. Schema change: No.
 - [ ] STAB-1: OOM stress test: PGlite survives with actionable error
 - [ ] STAB-2: Panic from invalid SQL returns SQL error, not WASM trap
 - [ ] STAB-3: Load/unload/reload lifecycle test: zero leaked allocations
-- [ ] STAB-4: Extension upgrade path tested (`0.24.0 -> 0.25.0`)
+- [ ] STAB-4: Extension upgrade path tested (`0.26.0 -> 0.27.0`)
 - [ ] PERF-1: WASM vs native benchmark report published (≤ 3× overhead)
 - [ ] PERF-2: WASM bundle ≤ 2 MB (CI gated)
 - [ ] PERF-3: Cold-start load time < 500 ms browser, < 200 ms Node.js
@@ -7627,7 +7763,7 @@ Dependencies: PGL-2-3, PERF-2. Schema change: No.
 
 ---
 
-## v0.27.0 — PGlite Reactive Integration
+## v0.28.0 — PGlite Reactive Integration
 
 > **Release Theme**
 > This release completes the PGlite story by bridging the gap between
@@ -8077,7 +8213,7 @@ Dependencies: STAB-1, PGL-3-2. Schema change: No.
 - [ ] STAB-1: 4-hour soak test: heap growth < 10%
 - [ ] STAB-2: 100 mount/unmount cycles: zero leaked subscriptions
 - [ ] STAB-3: Stream table dropped while hook active: error boundary catches
-- [ ] STAB-4: Extension upgrade path tested (`0.24.0 -> 0.25.0`)
+- [ ] STAB-4: Extension upgrade path tested (`0.27.0 -> 0.28.0`)
 - [ ] STAB-5: CI matrix passes for React 18, React 19, Vue 3.4+
 - [ ] PERF-1: INSERT-to-render latency < 50% of `live.incrementalQuery()` at 10K rows
 - [ ] PERF-2: Render count = 1 for bulk DML (1, 10, 100, 1000 rows)
@@ -8302,12 +8438,13 @@ to keep the pre-1.0 milestones focused on performance and correctness.
 | v0.19.0 — Production Gap Closure & Distribution | ~4–5 weeks | — | |
 | v0.20.0 — Dog-Feeding (pg_trickle monitors itself) | ~3–4wk | — | |
 | v0.21.0 — Correctness, Safety & Test Hardening | ~6–8wk | — | |
-| v0.22.0 — TUI Dog-Feeding Integration | ~3–4wk (TUI + architecture + backend + CLI) | — | |
-| v0.23.0 — PostgreSQL 17 Support | ~2–4d | — | |
-| v0.24.0 — PGlite Proof of Concept | ~2–3wk (plugin) + ~1–2d (version bump) | — | |
-| v0.25.0 — Core Extraction (`pg_trickle_core`) | ~3–4wk (extraction) + ~1–2wk (abstraction + testing) | — | |
-| v0.26.0 — PGlite WASM Extension | ~5–7wk (WASM build) + ~2–3wk (testing + polish) | — | |
-| v0.27.0 — PGlite Reactive Integration | ~2–3wk (bridge + hooks) + ~1–2wk (examples + testing + polish) | — | |
+| v0.22.0 — Production Scalability & Downstream Integration | ~5–6wk (parallel refresh + downstream CDC + predictive cost + SLA tier + outbox) | — | |
+| v0.23.0 — TUI Dog-Feeding Integration | ~3–4wk (TUI + architecture + backend + CLI) | — | |
+| v0.24.0 — PostgreSQL 17 Support | ~2–4d | — | |
+| v0.25.0 — PGlite Proof of Concept | ~2–3wk (plugin) + ~1–2d (version bump) | — | |
+| v0.26.0 — Core Extraction (`pg_trickle_core`) | ~3–4wk (extraction) + ~1–2wk (abstraction + testing) | — | |
+| v0.27.0 — PGlite WASM Extension | ~5–7wk (WASM build) + ~2–3wk (testing + polish) | — | |
+| v0.28.0 — PGlite Reactive Integration | ~2–3wk (bridge + hooks) + ~1–2wk (examples + testing + polish) | — | |
 | v1.0.0 — Stable release (incl. PG 19 compat) | ~36–66h | — | |
 | Post-1.0 (PG compat + Native DDL) | ~38–56h (PG 16–18) + ~13–21d (Native DDL) | — | |
 | Post-1.0 (ecosystem) | 88–134h | — | |

--- a/plans/PLAN_OVERALL_ASSESSMENT.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT.md
@@ -6,6 +6,12 @@
 **Scope:** Repository-wide review of pg_trickle at v0.20.0 (main @ `cfacdc0`)
 **Target audience:** Maintainers planning v0.21+ and v1.0
 
+> **Roadmap cross-reference:** All items from §10 (Prioritised Action Plan) have been
+> assigned to milestones in [ROADMAP.md](../ROADMAP.md). P0 items land in **v0.21.0**;
+> P1 #8 and #11 land in **v0.22.0** (Production Scalability & Downstream Integration);
+> remaining P1 items and selected P2 items are distributed across **v0.21.0** and
+> **v0.22.0**. P3 items are tracked in Post-1.0. See §10 for per-item milestone tags.
+
 ---
 
 ## Executive Summary
@@ -118,6 +124,8 @@ pre-image columns already captured by the CDC trigger (see EC-01
 [PLAN_EDGE_CASES.md](PLAN_EDGE_CASES.md)). Either approach keeps the
 EXCEPT ALL snapshot logic that ships today.
 
+> **→ Roadmap:** [v0.21.0 §EC-01 Fix](../ROADMAP.md#ec-01-fix--join-delta-phantom-rows) — items EC01-0 through EC01-4.
+
 ### 2.2 HIGH — `.unwrap()` in production parser hot paths
 
 `src/` contains 513 `.unwrap()` calls total. Most are in `#[cfg(test)]`
@@ -138,6 +146,8 @@ wrapper per site; do it opportunistically when touching each function.
 Add a clippy `deny(clippy::unwrap_used)` lint gate outside of test
 modules, with an `allow` on `dag.rs` invariant-justified lines.
 
+> **→ Roadmap:** [v0.21.0 §Safety & Code Quality](../ROADMAP.md#safety--code-quality) — items SAF-1 and SAF-3.
+
 ### 2.3 HIGH — 547 `unsafe` blocks, reduction plan still "Proposed"
 
 [plans/safety/PLAN_REDUCED_UNSAFE.md](safety/PLAN_REDUCED_UNSAFE.md) has
@@ -153,6 +163,8 @@ the counter. A targeted pass to:
    safe façades in `src/dvm/parser/types.rs`.
 
 would likely halve the count and create a reviewable audit unit.
+
+> **→ Roadmap:** [v0.21.0 §Safety & Code Quality](../ROADMAP.md#safety--code-quality) — item SAF-2.
 
 ### 2.4 MEDIUM — Monolithic modules invite silent coupling
 
@@ -173,6 +185,8 @@ more. Splitting them into focused submodules (e.g. `refresh/{merge.rs,
 phd1.rs, codegen.rs, orchestrator.rs}`) reduces reviewer cognitive load
 and merge-conflict friction.
 
+> **→ Roadmap:** [v0.21.0 §Architecture](../ROADMAP.md#architecture) — item ARCH-1 (`refresh.rs` split into 4 sub-modules).
+
 ### 2.5 MEDIUM — Incremental recursive CTE refresh falls back to FULL
 
 [plans/PLAN.md](PLAN.md) records P2-1 (Recursive CTE DRed for
@@ -185,6 +199,8 @@ latency death for transitive closures over anything nontrivial.
 the recomputation cost in `EXPLAIN` output and add a Prometheus metric
 tagged `refresh_reason="recursive_cte_fallback"` so operators can see
 what is happening.
+
+> **→ Roadmap:** [v0.21.0 §Architecture](../ROADMAP.md#architecture) — item ARCH-2 (recursive CTE fallback observability).
 
 ### 2.6 MEDIUM — `PLAN_NON_DETERMINISM.md` is still "Not started"
 
@@ -199,6 +215,8 @@ would. This is a data-correctness footgun.
 `pg_proc.provolatile = 'v'` and either (a) reject with a clear error
 or (b) emit a `WARNING` and force `FULL` mode unless the user passes
 `non_deterministic => true`.
+
+> **→ Roadmap:** [v0.21.0 §Safety & Code Quality](../ROADMAP.md#safety--code-quality) — item OP-6.
 
 ### 2.7 LOW — One `FIXME`, zero `TODO`/`HACK`/`XXX`
 
@@ -229,6 +247,8 @@ can provide. Deployments with 200+ stream tables see serialised tails.
 Minimal viable slice: dynamic bgworker pool per database, with
 coordinator owning the DAG and the pool owning refresh execution.
 
+> **→ Roadmap:** [v0.22.0 §In-Database Parallel Refresh Worker Pool](../ROADMAP.md#in-database-parallel-refresh-worker-pool--minimal-viable-slice-p1--31) — items PAR-1 through PAR-5.
+
 ### 3.2 Gap — No downstream CDC emitter
 
 pg_trickle consumes CDC (trigger or WAL) but cannot *emit* changes to
@@ -242,12 +262,16 @@ Redis Streams, or event sourcing without a separate replication slot.
 
 **Recommendation:** see §9.2 (feature proposal "ST→logical publication").
 
+> **→ Roadmap:** [v0.22.0 §Downstream CDC Publication](../ROADMAP.md#downstream-cdc-publication-p1--92) — items CDC-PUB-1 through CDC-PUB-5.
+
 ### 3.3 Gap — Multi-database / multi-tenant isolation
 
 [plans/infra/PLAN_MULTI_DATABASE.md](infra/PLAN_MULTI_DATABASE.md) is
 *Draft*. The shmem state (`src/shmem.rs`) currently tracks stream
 tables globally; the bgworker attaches per-database but cross-DB
 accounting is absent. For managed offerings this is a blocker.
+
+> **→ Roadmap:** Post-1.0 — [Scale §S3](../ROADMAP.md#scale) (deferred; scope is large).
 
 ### 3.4 Gap — Cost model does not include network/disk pressure
 
@@ -272,6 +296,8 @@ v0.20's self-monitoring identifies anomalies *after* they occur (3×
 baseline duration spike, error burst). A predictive model — linear
 regression on the last hour of delta sizes vs. duration — could preempt
 spills and recommend mode switches before a single bad refresh fires.
+
+> **→ Roadmap:** [v0.22.0 §Predictive Refresh Cost Model](../ROADMAP.md#predictive-refresh-cost-model-p2--93) — items PRED-1 through PRED-4.
 
 ### 3.7 Strength — Hybrid CDC is well separated
 
@@ -398,12 +424,16 @@ covering each rewrite pass (view inlining, DISTINCT ON, GROUPING SETS,
 scalar subquery in WHERE, correlated SSQ in SELECT, SubLinks in OR,
 multi-PARTITION BY windows).
 
+> **→ Roadmap:** [v0.21.0 §Test Coverage](../ROADMAP.md#test-coverage) — items TEST-1, TEST-2, TEST-3.
+
 ### 6.2 Gap — No fuzz target for the parser
 
 `cargo-fuzz` is not configured. Given that `PLAN_NON_DETERMINISM` is
 *Not started* and the parser is 18k LOC, a week of differential
 fuzzing (pg_trickle parser vs. plain `SELECT`) would likely uncover
 rejection bugs and panic-on-malformed cases.
+
+> **→ Roadmap:** [v0.21.0 §Test Coverage](../ROADMAP.md#test-coverage) — item TEST-4.
 
 ### 6.3 Gap — No kill-switch / crash-recovery test for bgworker
 
@@ -416,6 +446,8 @@ rejection bugs and panic-on-malformed cases.
 
 …would close a class of "what happens if…" questions.
 
+> **→ Roadmap:** [v0.21.0 §Test Coverage](../ROADMAP.md#test-coverage) — item TEST-5.
+
 ### 6.4 Gap — TPC-H IMMEDIATE mode correctness still gated by allowlist
 
 The skip-allowlist in
@@ -423,6 +455,8 @@ The skip-allowlist in
 excludes q05/q07/q08/q09 (join size). Repo memory identifies q15 as
 *also* failing under IMMEDIATE mode but *not* in the allowlist — either
 add it (test hygiene) or fix the underlying EC-01 issue (correctness).
+
+> **→ Roadmap:** [v0.21.0 §EC-01 Fix](../ROADMAP.md#ec-01-fix--join-delta-phantom-rows) — item EC01-0 (Q15 stop-gap) and EC01-3 (permanent fix).
 
 ### 6.5 Strength — Property tests + TPC-H nightly + SQLancer
 
@@ -448,6 +482,8 @@ upgrading / benchmarking guides.
 *symptom → likely cause → GUC to tune → measurement* rows would round
 out the operator experience. Most of the content already exists
 distributed across FAQ / TROUBLESHOOTING.
+
+> **→ Roadmap:** [v0.21.0 §Documentation](../ROADMAP.md#documentation) — item DOC-1.
 
 ### 7.3 Gap — Dog-feeding recipes are new; examples light
 
@@ -488,6 +524,8 @@ dashboard, but Prometheus consumes metrics either via
 HTTP endpoint on a bgworker exposing OpenMetrics
 (`/metrics`) would remove the "bring your own exporter" hurdle.
 
+> **→ Roadmap:** [v0.21.0 §Operational Features](../ROADMAP.md#operational-features) — item OP-2.
+
 ### 8.4 Gap — No canary / shadow mode
 
 When changing a defining query via `alter_stream_table`, the stream
@@ -495,12 +533,16 @@ table is rebuilt and exposed immediately. A "shadow" mode that writes
 to a hidden sibling table and diffs against the live table would make
 migrations of critical STs safer.
 
+> **→ Roadmap:** [v0.21.0 §Operational Features](../ROADMAP.md#operational-features) — item OPS-1.
+
 ### 8.5 Gap — `explain_dag()` is Mermaid/DOT; no runtime profile
 
 v0.20 renders the DAG topology. The natural next step is to overlay
 per-node *refresh latency* and *change volume* so operators can see
 where time is being spent at a glance. Data already exists in
 `pgt_refresh_history`.
+
+> **→ Roadmap:** [v0.23.0 §TUI/CLI Visualization Polish](../ROADMAP.md#phase-6--tuicli-visualization-polish) — item OP-1.
 
 ---
 
@@ -515,6 +557,8 @@ Trivial wrapper on existing building blocks. Unblocks every
 application that wants "refresh-on-read with a grace period" semantics
 without writing their own procedural code. Also useful in dbt hooks.
 
+> **→ Roadmap:** [v0.21.0 §Operational Features](../ROADMAP.md#operational-features) — item OP-4.
+
 ### 9.2 Downstream CDC publication — `stream_table_to_publication()` (M effort — 1–2 weeks)
 
 Emit changes applied to each stream table as a PostgreSQL logical
@@ -526,6 +570,8 @@ capture layer needed.
 **Value:** unlocks streaming-to-Kafka / event sourcing use cases that
 are currently blocked on users setting up a second slot.
 
+> **→ Roadmap:** [v0.22.0 §Downstream CDC Publication](../ROADMAP.md#downstream-cdc-publication-p1--92) — items CDC-PUB-1 through CDC-PUB-5.
+
 ### 9.3 Predictive refresh cost model (M effort — 1–2 weeks)
 
 Extend dog-feeding to forecast `duration_ms` from
@@ -533,6 +579,8 @@ Extend dog-feeding to forecast `duration_ms` from
 hour. When the forecast exceeds `last_full_ms × 1.5`, pre-emptively
 switch to FULL. Keeps adaptive fallback from *reacting* to a slow
 diff and instead *predicts* it.
+
+> **→ Roadmap:** [v0.22.0 §Predictive Refresh Cost Model](../ROADMAP.md#predictive-refresh-cost-model-p2--93) — items PRED-1 through PRED-4.
 
 ### 9.4 Stream-table checkpoint / snapshot restore (M effort — 2–3 weeks)
 
@@ -548,11 +596,15 @@ is materialised into `pgt_shadow_<name>` on the same schedule; a
 diff function (`pgtrickle.canary_diff(name)`) compares against the
 live table. Flip atomically when confident.
 
+> **→ Roadmap:** [v0.21.0 §Operational Features](../ROADMAP.md#operational-features) — item OPS-1.
+
 ### 9.6 Prometheus HTTP endpoint in bgworker (S effort — 1 week)
 
 Tiny `tiny_http` (or `hyper`) server bound to a port configured via
 `pg_trickle.metrics_port` (default `0` = off). Emits all existing
 monitor metrics in OpenMetrics format. No sidecar needed.
+
+> **→ Roadmap:** [v0.21.0 §Operational Features](../ROADMAP.md#operational-features) — item OP-2.
 
 ### 9.7 SLA-driven tier auto-assignment (M effort — 1–2 weeks)
 
@@ -561,11 +613,15 @@ scheduler assigns the ST to the tier whose worst-case dispatch gap is
 ≤ SLA, considering current queue depth. Makes the tiered scheduler
 usable without operator expertise.
 
+> **→ Roadmap:** [v0.22.0 §SLA-Driven Tier Auto-Assignment](../ROADMAP.md#sla-driven-tier-auto-assignment-p2--97) — items SLA-1 through SLA-4.
+
 ### 9.8 Native streaming SQL dialect — `CREATE STREAM TABLE … WATERMARK …` (L effort — 4–6 weeks)
 
 Already drafted in [PLAN_NATIVE_SYNTAX.md](sql/PLAN_NATIVE_SYNTAX.md).
 Customers asking for "Materialize-compatible syntax" get a familiar
 API; the function layer remains as a compatibility shim.
+
+> **→ Roadmap:** Post-1.0 — [PG Backward Compatibility & Native DDL](../ROADMAP.md#pg-backward-compatibility-pg-16-18) (deferred; large scope).
 
 ### 9.9 pgvector stream-table operator (M effort — 2–3 weeks)
 
@@ -586,6 +642,8 @@ Colour each node by *p95 latency* and width by *rows per refresh*
 using existing `pgt_refresh_history` data. One SQL aggregate plus a
 Mermaid template tweak.
 
+> **→ Roadmap:** [v0.23.0 §TUI/CLI Visualization Polish](../ROADMAP.md#phase-6--tuicli-visualization-polish) — item OP-1.
+
 ### 9.12 Transactional outbox helper (S effort — 1 week)
 
 Already planned in
@@ -593,6 +651,8 @@ Already planned in
 `pgtrickle.outbox_<st>` receives a row per refresh cycle with JSON
 payload `{inserted:[…], deleted:[…]}`. Eliminates the dual-write
 problem for downstream event buses.
+
+> **→ Roadmap:** [v0.22.0 §Transactional Outbox Helper](../ROADMAP.md#transactional-outbox-helper-p2--912) — items OUTBOX-1 through OUTBOX-4.
 
 ---
 
@@ -602,50 +662,50 @@ problem for downstream event buses.
 
 ### P0 — Land before v1.0
 
-| # | Item | Kind | Impact | Effort | Notes |
-|---|---|---|---|---|---|
-| 1 | Fix EC-01 Part 1 row-id hash (single-left-pk hash OR pre-image reconstruction) | Bug | 5 | L | §2.1 — correctness gate for TPC-H Q07/Q15 |
-| 2 | Reject or warn on volatile functions in defining query | Bug | 4 | S | §2.6 — silent wrong-answer risk |
-| 3 | Add Q15 to `IMMEDIATE_SKIP_ALLOWLIST` (interim) | Test | 3 | XS | §6.4 — until #1 ships |
-| 4 | Convert remaining production `.unwrap()` sites in `sublinks.rs` to `?` | Bug | 3 | S | §2.2 — 28 sites |
+| # | Item | Kind | Impact | Effort | Notes | Milestone |
+|---|---|---|---|---|---|---|
+| 1 | Fix EC-01 Part 1 row-id hash (single-left-pk hash OR pre-image reconstruction) | Bug | 5 | L | §2.1 — correctness gate for TPC-H Q07/Q15 | [v0.21.0 EC01-1/2](../ROADMAP.md#ec-01-fix--join-delta-phantom-rows) |
+| 2 | Reject or warn on volatile functions in defining query | Bug | 4 | S | §2.6 — silent wrong-answer risk | [v0.21.0 OP-6](../ROADMAP.md#safety--code-quality) |
+| 3 | Add Q15 to `IMMEDIATE_SKIP_ALLOWLIST` (interim) | Test | 3 | XS | §6.4 — until #1 ships | [v0.21.0 EC01-0](../ROADMAP.md#ec-01-fix--join-delta-phantom-rows) |
+| 4 | Convert remaining production `.unwrap()` sites in `sublinks.rs` to `?` | Bug | 3 | S | §2.2 — 28 sites | [v0.21.0 SAF-1](../ROADMAP.md#safety--code-quality) |
 
 ### P1 — Next two releases
 
-| # | Item | Kind | Impact | Effort | Notes |
-|---|---|---|---|---|---|
-| 5 | Shard `refresh.rs` (8.4k LOC) into 4 submodules | Arch | 4 | M | §2.4 |
-| 6 | `PLAN_REDUCED_UNSAFE` half-pass (list helpers + façades) | Safety | 4 | M | §2.3 |
-| 7 | Prometheus HTTP endpoint in bgworker | Ops | 4 | S | §9.6 |
-| 8 | Downstream CDC publication (`stream_table_to_publication`) | Feature | 5 | M | §9.2 |
-| 9 | Unit-test campaign for `parser/rewrites.rs` + `api/helpers.rs` + `api/diagnostics.rs` | Test | 3 | M | §6.1 |
-| 10 | Parser fuzz target (`cargo-fuzz`) | Test | 3 | S | §6.2 |
-| 11 | In-database parallel refresh pool (PLAN_PARALLELISM minimal slice) | Arch | 5 | L | §3.1 |
+| # | Item | Kind | Impact | Effort | Notes | Milestone |
+|---|---|---|---|---|---|---|
+| 5 | Shard `refresh.rs` (8.4k LOC) into 4 submodules | Arch | 4 | M | §2.4 | [v0.21.0 ARCH-1](../ROADMAP.md#architecture) |
+| 6 | `PLAN_REDUCED_UNSAFE` half-pass (list helpers + façades) | Safety | 4 | M | §2.3 | [v0.21.0 SAF-2](../ROADMAP.md#safety--code-quality) |
+| 7 | Prometheus HTTP endpoint in bgworker | Ops | 4 | S | §9.6 | [v0.21.0 OP-2](../ROADMAP.md#operational-features) |
+| 8 | Downstream CDC publication (`stream_table_to_publication`) | Feature | 5 | M | §9.2 | [v0.22.0 CDC-PUB](../ROADMAP.md#downstream-cdc-publication-p1--92) |
+| 9 | Unit-test campaign for `parser/rewrites.rs` + `api/helpers.rs` + `api/diagnostics.rs` | Test | 3 | M | §6.1 | [v0.21.0 TEST-1/2/3](../ROADMAP.md#test-coverage) |
+| 10 | Parser fuzz target (`cargo-fuzz`) | Test | 3 | S | §6.2 | [v0.21.0 TEST-4](../ROADMAP.md#test-coverage) |
+| 11 | In-database parallel refresh pool (PLAN_PARALLELISM minimal slice) | Arch | 5 | L | §3.1 | [v0.22.0 PAR](../ROADMAP.md#in-database-parallel-refresh-worker-pool--minimal-viable-slice-p1--31) |
 
 ### P2 — Opportunistic
 
-| # | Item | Kind | Impact | Effort |
-|---|---|---|---|---|
-| 12 | `refresh_if_stale`, `pause_all`, `resume_all`, `stream_table_definition` | API | 2 | XS |
-| 13 | Predictive refresh cost model | Feature | 3 | M |
-| 14 | Shared-memory template cache | Perf | 3 | M |
-| 15 | Shadow/canary `alter_stream_table` | Ops | 3 | S |
-| 16 | DAG runtime overlay in `explain_dag()` | Ops | 2 | XS |
-| 17 | SLA-driven tier assignment | Feature | 3 | M |
-| 18 | Stream-table checkpoint | Feature | 3 | M |
-| 19 | Native `CREATE STREAM TABLE` syntax | Feature | 4 | L |
-| 20 | pgvector TopK support | Feature | 3 | M |
-| 21 | Auto-denormalisation advisor | Feature | 2 | M |
-| 22 | Transactional outbox helper | Feature | 3 | S |
-| 23 | Performance Tuning Cookbook doc | Docs | 2 | S |
-| 24 | Chaos/crash-recovery test for bgworker | Test | 3 | M |
+| # | Item | Kind | Impact | Effort | Milestone |
+|---|---|---|---|---|---|
+| 12 | `refresh_if_stale`, `pause_all`, `resume_all`, `stream_table_definition` | API | 2 | XS | [v0.21.0 OP-3/4/5](../ROADMAP.md#operational-features) |
+| 13 | Predictive refresh cost model | Feature | 3 | M | [v0.22.0 PRED](../ROADMAP.md#predictive-refresh-cost-model-p2--93) |
+| 14 | Shared-memory template cache | Perf | 3 | M | Post-1.0 |
+| 15 | Shadow/canary `alter_stream_table` | Ops | 3 | S | [v0.21.0 OPS-1](../ROADMAP.md#operational-features) |
+| 16 | DAG runtime overlay in `explain_dag()` | Ops | 2 | XS | [v0.23.0 OP-1](../ROADMAP.md#phase-6--tuicli-visualization-polish) |
+| 17 | SLA-driven tier assignment | Feature | 3 | M | [v0.22.0 SLA](../ROADMAP.md#sla-driven-tier-auto-assignment-p2--97) |
+| 18 | Stream-table checkpoint | Feature | 3 | M | Post-1.0 |
+| 19 | Native `CREATE STREAM TABLE` syntax | Feature | 4 | L | Post-1.0 |
+| 20 | pgvector TopK support | Feature | 3 | M | Post-1.0 |
+| 21 | Auto-denormalisation advisor | Feature | 2 | M | Post-1.0 |
+| 22 | Transactional outbox helper | Feature | 3 | S | [v0.22.0 OUTBOX](../ROADMAP.md#transactional-outbox-helper-p2--912) |
+| 23 | Performance Tuning Cookbook doc | Docs | 2 | S | [v0.21.0 DOC-1](../ROADMAP.md#documentation) |
+| 24 | Chaos/crash-recovery test for bgworker | Test | 3 | M | [v0.21.0 TEST-5](../ROADMAP.md#test-coverage) |
 
 ### P3 — Track, don't build yet
 
-| # | Item | Notes |
-|---|---|---|
-| 25 | Multi-database support (PLAN_MULTI_DATABASE Draft) | Scope is large; stays Draft until a customer demand forces prioritisation |
-| 26 | Recursive CTE DRed (P2-1 from PLAN.md) | Documented fallback; instrument, don't build |
-| 27 | Downgrade SQL scripts | Policy decision first (support forward-only?) |
+| # | Item | Notes | Milestone |
+|---|---|---|---|
+| 25 | Multi-database support (PLAN_MULTI_DATABASE Draft) | Scope is large; stays Draft until a customer demand forces prioritisation | Post-1.0 S3 |
+| 26 | Recursive CTE DRed (P2-1 from PLAN.md) | Documented fallback; instrument, don't build | [v0.21.0 ARCH-2](../ROADMAP.md#architecture) (observability only) |
+| 27 | Downgrade SQL scripts | Policy decision first (support forward-only?) | Post-1.0 |
 
 ---
 


### PR DESCRIPTION
## Summary

Inserts a new **v0.22.0 — Production Scalability & Downstream Integration** milestone into the roadmap, covering the P1 and highest-value P2 items from [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) that were not addressed in v0.21.0 (Correctness, Safety & Test Hardening).

All subsequent planned versions are shifted up by one (v0.22→v0.23 … v0.27→v0.28) and their upgrade path exit criteria updated to match.

## New v0.22.0 Contents

Items sourced from PLAN_OVERALL_ASSESSMENT.md priority table:

| Feature | Priority | Impact | Effort |
|---------|----------|--------|--------|
| Downstream CDC publication (`stream_table_to_publication()`) | P1 #8 | 5 | M |
| In-database parallel refresh worker pool (minimal viable slice) | P1 #11 | 5 | L |
| Predictive refresh cost model (linear regression, pre-emptive FULL switch) | P2 #13 | 3 | M |
| SLA-driven tier auto-assignment (`sla =>` param on `create/alter_stream_table`) | P2 #17 | 3 | M |
| Transactional outbox helper (`enable_outbox()` / `disable_outbox()`) | P2 #22 | 3 | S |

Estimated release effort: **~5–6 weeks**

## Version Renumbering

| Was | Now |
|-----|-----|
| v0.22.0 — TUI Dog-Feeding Integration | v0.23.0 |
| v0.23.0 — PostgreSQL 17 Support | v0.24.0 |
| v0.24.0 — PGlite Proof of Concept | v0.25.0 |
| v0.25.0 — Core Extraction (`pg_trickle_core`) | v0.26.0 |
| v0.26.0 — PGlite WASM Extension | v0.27.0 |
| v0.27.0 — PGlite Reactive Integration | v0.28.0 |

## Changes

- TOC: added v0.22.0 entry; v0.22–v0.27 → v0.23–v0.28
- Overview table: same renumbering + new row
- New v0.22.0 section with 5 feature tracks, implementation phases, and exit criteria
- Renamed 6 section headings
- Updated all 7 upgrade path references in exit criteria
- Effort Summary table updated with new row and renamed rows

## Notes

The two highest-impact P1 items (downstream CDC and parallel refresh) were the main motivation — these are the ones the assessment flags as missing from v0.21.0 before any of the PGlite/platform work proceeds. The three P2 items were added because they complement the same scalability theme and are relatively small in isolation.

Items from the assessment deferred to Post-1.0 or later milestones: stream-table checkpoint, pgvector TopK, native `CREATE STREAM TABLE` syntax, auto-denormalisation advisor, multi-database support.
