### PR TITLE
fix(tests): cast to bigint to prevent integer overflow in RF1 TPC-H refresh

### DIFF
--- a/tests/tpch/rf1.sql
+++ b/tests/tpch/rf1.sql
@@ -8,7 +8,7 @@ INSERT INTO orders (o_orderkey, o_custkey, o_orderstatus, o_totalprice, o_orderd
                     o_orderpriority, o_clerk, o_shippriority, o_comment)
 SELECT
     __NEXT_ORDERKEY__ + i AS o_orderkey,
-    1 + ((__NEXT_ORDERKEY__ + i) * 1013 % __SF_CUSTOMERS__) AS o_custkey,
+    1 + ((__NEXT_ORDERKEY__::bigint + i) * 1013 % __SF_CUSTOMERS__) AS o_custkey,
     (ARRAY['O','F','P'])[1 + i % 3] AS o_orderstatus,
     round((10000 + (i * 7919) % 500000)::numeric / 100, 2) AS o_totalprice,
     DATE '1995-01-01' + (i % 1000)::int AS o_orderdate,


### PR DESCRIPTION
## Summary

Fix integer overflow in TPC-H RF1 refresh that causes "integer out of range" errors during bulk INSERT at high scale factors (SF-10). The o_custkey computation multiplies a large order key (>2M) by 1013, which exceeds a 32-bit integer's capacity.

## Root Cause

The RF1 (refresh function 1) SQL template computes customer key as:
```sql
1 + ((__NEXT_ORDERKEY__ + i) * 1013 % __SF_CUSTOMERS__) AS o_custkey
```

At SF-10 with `__NEXT_ORDERKEY__ = 2,115,042` and `i = 15,000`:
- `(2,115,042 + 15,000) * 1013 = 2,157,752,546`
- This exceeds `max(int32) = 2,147,483,647`
- Result: `integer out of range` error during INSERT

## Solution

Cast `__NEXT_ORDERKEY__` to `bigint` before multiplication to perform arithmetic in 64-bit, reducing to 32-bit only via modulo:
```sql
1 + ((__NEXT_ORDERKEY__::bigint + i) * 1013 % __SF_CUSTOMERS__) AS o_custkey
```

This preserves the deterministic hash behaviour while preventing overflow.

## Testing

- Fixes TPC-H nightly run 24552284258 (SF-10 failure on q19 cycle 2)
- No changes to query semantics or refresh logic
- Modular arithmetic is mathematically equivalent

## Related

Fixes: https://github.com/grove/pg-trickle/actions/runs/24552284258
