### PR TITLE
fix(ci): increase e2e benchmark refresh job timeout to 120 minutes

### DIFF
--- a/.github/workflows/e2e-benchmarks.yml
+++ b/.github/workflows/e2e-benchmarks.yml
@@ -57,7 +57,7 @@ jobs:
       github.event_name == 'schedule' ||
       inputs.job == 'all' ||
       inputs.job == 'refresh'
-    timeout-minutes: 60
+    timeout-minutes: 120
     continue-on-error: true
     steps:
       - name: Free up disk space


### PR DESCRIPTION
## Summary

The `bench-refresh` job in the E2E benchmarks workflow was timing out after 60 minutes. The refresh matrix benchmark is comprehensive and tests many combinations of scan/filter/agg/join operations with varying data sizes and change ratios. Increasing the timeout to 120 minutes allows the benchmark to complete successfully.

## Changes

- Increased `timeout-minutes` from 60 to 120 for the `bench-refresh` job in `.github/workflows/e2e-benchmarks.yml`

## Testing

- This is a workflow configuration change that affects CI infrastructure
- The benchmark will now have sufficient time to complete without hitting the timeout wall

## Notes

The refresh matrix benchmark runs a comprehensive test matrix across multiple dimension combinations (scan/filter/agg/join operators × 10K/100K rows × 1%/10%/50% change ratios), which requires roughly 90-120 minutes of execution time. The previous 60-minute timeout was causing the job to be cancelled before completion.
