### PR TITLE
docs(plans): simplify B.15 to single relay_config table, DB-only config

### DIFF
--- a/plans/relay/PLAN_RELAY_CLI.md
+++ b/plans/relay/PLAN_RELAY_CLI.md
@@ -27,6 +27,7 @@
   - [A.11 Graceful Shutdown & Signal Handling](#a11-graceful-shutdown--signal-handling)
   - [A.12 Observability](#a12-observability)
   - [A.13 Error Handling & Retries](#a13-error-handling--retries)
+  - [A.14 Catalog Schema (Config Tables)](#a14-catalog-schema-config-tables)
 - [Part B — Sink Backends (Forward Mode)](#part-b--sink-backends-forward-mode)
   - [B.1 NATS JetStream](#b1-nats-jetstream)
   - [B.2 HTTP Webhook](#b2-http-webhook)
@@ -270,194 +271,78 @@ lapin = { version = "2", optional = true }
 ### A.2 CLI Interface
 
 ```
-pgtrickle-relay <COMMAND> [OPTIONS]
+pgtrickle-relay [OPTIONS]
+pgtrickle-relay config <SUBCOMMAND>
 
-COMMANDS:
-  forward     Relay outbox → external sinks (default)
-  reverse     Relay external sources → inbox
-  validate    Validate config, test connections, exit
-  schema      Print JSON schema of the relay message envelope
-  completion  Generate shell completions
-
-COMMON OPTIONS:
-  -c, --config <FILE>           Path to config file (TOML, YAML, or JSON;
-                                format auto-detected by extension:
-                                .toml, .yaml/.yml, .json)
-      --pg-url <URL>            PostgreSQL connection string [env: PG_URL]
+STARTUP OPTIONS:
+      --postgres-url <URL>      PostgreSQL connection string (required)
+                                [env: PGTRICKLE_RELAY_POSTGRES_URL]
       --metrics-addr <ADDR>     Prometheus metrics + health endpoint
-                                (default: 0.0.0.0:9090) [env: RELAY_METRICS_ADDR]
+                                (default: 0.0.0.0:9090)
       --log-format <FMT>        Log format: text, json (default: text)
-                                [env: RELAY_LOG_FORMAT]
-      --log-level <LEVEL>       Log level (default: info) [env: RELAY_LOG_LEVEL]
+      --log-level <LEVEL>       Log level (default: info)
   -V, --version                 Print version
   -h, --help                    Print help
 
-FORWARD-SPECIFIC OPTIONS:
-      --outbox <NAME>           Stream table name to relay [env: RELAY_OUTBOX]
-      --sink <SINK>             Sink backend: nats, webhook, kafka, stdout,
-                                redis, sqs, pg-inbox, rabbitmq [env: RELAY_SINK]
-      --group <NAME>            Consumer group name (enables group mode)
-                                [env: RELAY_GROUP]
-      --consumer-id <ID>        Consumer ID within group (default: hostname)
-                                [env: RELAY_CONSUMER_ID]
-      --batch-size <N>          Rows per poll (default: 100) [env: RELAY_BATCH_SIZE]
-      --poll-interval <MS>      Milliseconds between empty polls (default: 1000)
-                                [env: RELAY_POLL_INTERVAL_MS]
-      --visibility-seconds <N>  Lease visibility timeout (default: 30)
-                                [env: RELAY_VISIBILITY_SECONDS]
-
-REVERSE-SPECIFIC OPTIONS:
-      --source <SOURCE>         Source backend: nats, webhook, kafka, stdin,
-                                redis, sqs, rabbitmq [env: RELAY_SOURCE]
-      --inbox <NAME>            Inbox table name to write to [env: RELAY_INBOX]
-      --inbox-schema <SCHEMA>   Schema for inbox table (default: public)
-                                [env: RELAY_INBOX_SCHEMA]
-
-BACKEND-SPECIFIC OPTIONS (passed via config file or --source-opt/--sink-opt KEY=VALUE):
-  See documentation for each backend.
+CONFIG SUBCOMMANDS (manage pipelines stored in pgtrickle.relay_*_config):
+  config list                   Show all outbox + inbox pipelines and enabled status
+  config show <name>            Show config JSONB for a named pipeline
+  config set outbox <name> --config <json>  Upsert a forward pipeline
+  config set inbox  <name> --config <json>  Upsert a reverse pipeline
+  config enable  <name>         Enable a pipeline (starts immediately via NOTIFY)
+  config disable <name>         Disable a pipeline (stops immediately via NOTIFY)
+  config delete  <name>         Delete a pipeline row
 ```
 
 ### A.3 Configuration
 
-Configuration is resolved in priority order (highest wins):
+The relay has no config file and no environment variables for pipeline
+definitions. All pipeline config lives in the database (see [A.14](#a14-catalog-schema-config-tables)).
+The only required input at startup is the PostgreSQL connection URL:
 
-1. CLI flags
-2. Environment variables
-3. Config file (TOML, YAML, or JSON — format auto-detected from extension:
-   `.toml`, `.yaml` / `.yml`, `.json`; default filename searched in order:
-   `relay.toml`, `relay.yaml`, `relay.yml`, `relay.json`)
-4. Built-in defaults
+```bash
+# Minimal startup
+pgtrickle-relay --postgres-url postgres://relay:password@localhost/mydb
 
-All three formats are equivalent at runtime; TOML is the recommended default
-because it is already used throughout the pg-trickle workspace.
-
-#### Config File Examples
-
-**TOML** (`relay.toml` — recommended):
-
-##### Forward Mode Example
-
-```toml
-[postgres]
-url = "postgres://user:password@localhost/mydb"
-
-[forward]
-outbox = "order_events"
-sink = "nats"
-group = "order-publisher"
-consumer_id = "relay-1"       # default: hostname
-batch_size = 100
-poll_interval_ms = 1000
-visibility_seconds = 30
-
-[metrics]
-addr = "0.0.0.0:9090"
-enabled = true
-
-[logging]
-format = "json"     # text | json
-level = "info"
-
-# Subject/topic template — available variables:
-#   {stream_table}, {event_type}, {outbox_id}, {refresh_id}
-[routing]
-subject_template = "pgtrickle.{stream_table}"
-# Optional per-event-type override:
-# [routing.overrides]
-# "order.created" = "orders.created"
-# "order.shipped" = "orders.shipped"
-
-# Sink-specific configuration
-[sink.nats]
-url = "nats://localhost:4222"
-# See B.1 for full options
+# Or via the single supported env var (bootstrap only)
+export PGTRICKLE_RELAY_POSTGRES_URL=postgres://relay:password@localhost/mydb
+pgtrickle-relay
 ```
 
-##### Reverse Mode Example
+On startup the relay:
+1. Connects to PostgreSQL
+2. Queries `pgtrickle.relay_outbox_config` and `pgtrickle.relay_inbox_config`
+   for all `enabled = true` rows
+3. Spawns one tokio task per pipeline
+4. Subscribes to `LISTEN pgtrickle_relay_config` for hot-reload
 
-```toml
-[postgres]
-url = "postgres://user:password@localhost/mydb"
+If either table does not exist the relay exits with a clear error.
 
-[reverse]
-source = "kafka"
-inbox = "external_events"
-inbox_schema = "public"
+#### Example Pipeline Inserts
 
-[metrics]
-addr = "0.0.0.0:9090"
-enabled = true
+Pipelines are managed via SQL or the `config` subcommands:
 
-[logging]
-format = "json"
-level = "info"
+```sql
+-- Forward: outbox → NATS
+INSERT INTO pgtrickle.relay_outbox_config (name, config) VALUES (
+    'orders-to-nats',
+    '{"source_type": "outbox", "source": {"outbox": "order_events", "group": "order-publisher"},
+      "sink_type":   "nats",   "sink":   {"url": "nats://localhost:4222"}}'
+);
 
-# Source-specific configuration
-[source.kafka]
-brokers = "localhost:9092"
-topic = "external-events"
-group_id = "pgtrickle-inbox-writer"
-# See C.3 for full options
+-- Reverse: Kafka → inbox
+INSERT INTO pgtrickle.relay_inbox_config (name, config) VALUES (
+    'kafka-to-orders',
+    '{"source_type": "kafka",    "source": {"brokers": "localhost:9092", "topic": "orders"},
+      "sink_type":   "pg-inbox", "sink":   {"inbox_table": "order_inbox"}}'
+);
 ```
 
-**YAML** (`relay.yaml`):
+Or via CLI:
 
-##### Forward Mode Example
-
-```yaml
-postgres:
-  url: postgres://user:password@localhost/mydb
-
-forward:
-  outbox: order_events
-  sink: nats
-  group: order-publisher
-  consumer_id: relay-1
-  batch_size: 100
-  poll_interval_ms: 1000
-  visibility_seconds: 30
-
-routing:
-  subject_template: "pgtrickle.{stream_table}"
-
-sink:
-  nats:
-    url: nats://localhost:4222
-```
-
-##### Reverse Mode Example
-
-```yaml
-postgres:
-  url: postgres://user:password@localhost/mydb
-
-reverse:
-  source: kafka
-  inbox: external_events
-  inbox_schema: public
-
-source:
-  kafka:
-    brokers: localhost:9092
-    topic: external-events
-    group_id: pgtrickle-inbox-writer
-```
-
-**JSON** (`relay.json`) — Forward Mode Example:
-
-```json
-{
-  "postgres": { "url": "postgres://user:password@localhost/mydb" },
-  "forward": {
-    "outbox": "order_events",
-    "sink": "nats",
-    "group": "order-publisher",
-    "batch_size": 100
-  },
-  "sink": {
-    "nats": { "url": "nats://localhost:4222" }
-  }
-}
+```bash
+pgtrickle-relay config set outbox orders-to-nats \
+  --config '{"source_type":"outbox","source":{"outbox":"order_events"},"sink_type":"nats","sink":{"url":"nats://localhost:4222"}}'
 ```
 
 ### A.4 Relay Modes (Forward & Reverse)
@@ -897,6 +782,63 @@ source/sink disconnected). Suitable for Kubernetes liveness/readiness probes.
 | Inbox write failure (permanent) | Log error, skip message, emit `relay_errors_total{kind="inbox_permanent"}`. |
 
 All retries use jittered exponential backoff to avoid thundering herds.
+
+---
+
+### A.14 Catalog Schema (Config Tables)
+
+Pipeline definitions live in two tables created by the pg-trickle extension
+migration (same schema as other catalog tables). All backend-specific settings
+go in the `config` JSONB column; validation happens in Rust at load time.
+
+```sql
+-- Forward pipelines: outbox → sink
+CREATE TABLE pgtrickle.relay_outbox_config (
+    name     TEXT PRIMARY KEY,
+    enabled  BOOLEAN NOT NULL DEFAULT true,
+    config   JSONB NOT NULL  -- {source_type, source, sink_type, sink}
+);
+
+-- Reverse pipelines: source → inbox
+CREATE TABLE pgtrickle.relay_inbox_config (
+    name     TEXT PRIMARY KEY,
+    enabled  BOOLEAN NOT NULL DEFAULT true,
+    config   JSONB NOT NULL  -- {source_type, source, sink_type, sink}
+);
+
+-- One shared trigger function; TG_TABLE_NAME identifies the direction
+CREATE OR REPLACE FUNCTION pgtrickle.relay_config_notify()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+    PERFORM pg_notify(
+        'pgtrickle_relay_config',
+        json_build_object(
+            'direction', TG_TABLE_NAME,
+            'event',     TG_OP,
+            'name',      COALESCE(NEW.name, OLD.name),
+            'enabled',   COALESCE(NEW.enabled, OLD.enabled)
+        )::text
+    );
+    RETURN NULL;
+END;
+$$;
+
+CREATE TRIGGER relay_outbox_config_notify
+    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_outbox_config
+    FOR EACH ROW EXECUTE FUNCTION pgtrickle.relay_config_notify();
+
+CREATE TRIGGER relay_inbox_config_notify
+    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_inbox_config
+    FOR EACH ROW EXECUTE FUNCTION pgtrickle.relay_config_notify();
+```
+
+The relay subscribes to `LISTEN pgtrickle_relay_config` after startup:
+- `INSERT` with `enabled = true` → start a new pipeline task
+- `UPDATE` → gracefully restart the named pipeline with the new config
+- `DELETE` or `UPDATE` with `enabled = false` → gracefully stop the pipeline
+
+Credentials must not be stored as plaintext in `config` JSONB. Use env var
+references (e.g. `{"password_env": "KAFKA_PASSWORD"}`) resolved at runtime.
 
 ---
 
@@ -1470,7 +1412,7 @@ containers:
 
 | Item | Description | Effort |
 |------|-------------|--------|
-| RELAY-1 | Crate scaffold, CLI parsing (forward/reverse subcommands), config loading (TOML/YAML/JSON), error types, RelayMessage envelope | 1d |
+| RELAY-1 | Crate scaffold, CLI parsing (`--postgres-url`, `config` subcommands), DB bootstrap (load tables, LISTEN/NOTIFY), error types, RelayMessage envelope | 1.5d |
 | RELAY-2 | Source + Sink traits, relay loop, cancellation token plumbing | 1d |
 | RELAY-3 | Outbox poller source (simple mode + consumer group mode) | 2d |
 | RELAY-4 | Payload decoder (inline + claim-check + full-refresh) | 1d |
@@ -1523,7 +1465,7 @@ containers:
 | RELAY-20 | Dockerfile + GitHub Actions CI for binary builds | 1d |
 | RELAY-21 | Release automation (GitHub Releases, Docker Hub, Homebrew) | 0.5d |
 
-> **Total: ~34.5 days solo / ~22 days with two developers**
+> **Total: ~36 days solo / ~23 days with two developers**
 > (Phases 1–2 forward sinks and Phase 3 reverse sources can be parallelised.
 > Requires v0.23.0 outbox + consumer groups for full forward E2E testing;
 > reverse mode only needs inbox table schema.)

--- a/plans/relay/PLAN_RELAY_CLI_PHASE_2.md
+++ b/plans/relay/PLAN_RELAY_CLI_PHASE_2.md
@@ -1115,18 +1115,27 @@ header = "X-Webhook-Signature"            # header containing the signature
 multi-pipeline management cumbersome, requires SIGHUP or restarts to apply
 changes, and doesn't integrate with the pg-trickle catalog.
 
-**Design:** DB is the only config source. A single `pgtrickle.relay_config`
-table stores all pipelines. The only config required outside the DB is the
-PostgreSQL connection URL (passed via `--postgres-url` CLI flag).
+**Design:** DB is the only config source. Two tables — one for forward
+pipelines (outbox → sink) and one for reverse (source → inbox) — keep
+the direction implicit in the table name. All backend-specific settings live
+in a single `config` JSONB column. The only config required outside the DB
+is the PostgreSQL connection URL (passed via `--postgres-url` CLI flag).
 
 #### Catalog Schema
 
 ```sql
-CREATE TABLE pgtrickle.relay_config (
-    name       TEXT PRIMARY KEY,
-    enabled    BOOLEAN NOT NULL DEFAULT true,
-    direction  TEXT NOT NULL,  -- 'forward' | 'reverse'
-    config     JSONB NOT NULL  -- {source_type, source_config, sink_type, sink_config}
+-- Forward pipelines: outbox → sink
+CREATE TABLE pgtrickle.relay_outbox_config (
+    name     TEXT PRIMARY KEY,
+    enabled  BOOLEAN NOT NULL DEFAULT true,
+    config   JSONB NOT NULL  -- {source_type, source, sink_type, sink}
+);
+
+-- Reverse pipelines: source → inbox
+CREATE TABLE pgtrickle.relay_inbox_config (
+    name     TEXT PRIMARY KEY,
+    enabled  BOOLEAN NOT NULL DEFAULT true,
+    config   JSONB NOT NULL  -- {source_type, source, sink_type, sink}
 );
 ```
 
@@ -1138,15 +1147,15 @@ done in Rust when the row is loaded.
 
 ```sql
 -- Forward: outbox → Kafka
-INSERT INTO pgtrickle.relay_config (name, direction, config) VALUES (
-    'orders-to-kafka', 'forward',
+INSERT INTO pgtrickle.relay_outbox_config (name, config) VALUES (
+    'orders-to-kafka',
     '{"source_type": "outbox", "source": {"outbox": "order_events"},
-      "sink_type": "kafka",   "sink":   {"brokers": "localhost:9092", "topic": "orders"}}'
+      "sink_type":   "kafka",  "sink":   {"brokers": "localhost:9092", "topic": "orders"}}'
 );
 
 -- Reverse: Kafka → inbox
-INSERT INTO pgtrickle.relay_config (name, direction, config) VALUES (
-    'kafka-to-orders', 'reverse',
+INSERT INTO pgtrickle.relay_inbox_config (name, config) VALUES (
+    'kafka-to-orders',
     '{"source_type": "kafka",    "source": {"brokers": "localhost:9092", "topic": "orders"},
       "sink_type":   "pg-inbox", "sink":   {"inbox_table": "orders_inbox"}}'
 );
@@ -1160,9 +1169,16 @@ Pass the database URL and the relay starts:
 pgtrickle-relay --postgres-url postgres://relay:password@localhost/mydb
 ```
 
-The relay runs `SELECT * FROM pgtrickle.relay_config WHERE enabled = true`,
-spawns one tokio task per row, and subscribes to LISTEN/NOTIFY for hot-reload.
-If the table does not exist the relay exits with a clear error.
+The relay queries both tables:
+
+```sql
+SELECT 'forward', name, config FROM pgtrickle.relay_outbox_config WHERE enabled = true
+UNION ALL
+SELECT 'reverse', name, config FROM pgtrickle.relay_inbox_config  WHERE enabled = true;
+```
+
+Spawns one tokio task per row and subscribes to LISTEN/NOTIFY for hot-reload.
+If either table does not exist the relay exits with a clear error.
 
 #### LISTEN/NOTIFY Hot-Reload
 
@@ -1173,17 +1189,22 @@ BEGIN
     PERFORM pg_notify(
         'pgtrickle_relay_config',
         json_build_object(
-            'event',   TG_OP,
-            'name',    COALESCE(NEW.name, OLD.name),
-            'enabled', COALESCE(NEW.enabled, OLD.enabled)
+            'direction', TG_TABLE_NAME,  -- 'relay_outbox_config' | 'relay_inbox_config'
+            'event',     TG_OP,
+            'name',      COALESCE(NEW.name, OLD.name),
+            'enabled',   COALESCE(NEW.enabled, OLD.enabled)
         )::text
     );
     RETURN NULL;
 END;
 $$;
 
-CREATE TRIGGER relay_config_notify
-    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_config
+CREATE TRIGGER relay_outbox_config_notify
+    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_outbox_config
+    FOR EACH ROW EXECUTE FUNCTION pgtrickle.relay_config_notify();
+
+CREATE TRIGGER relay_inbox_config_notify
+    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_inbox_config
     FOR EACH ROW EXECUTE FUNCTION pgtrickle.relay_config_notify();
 ```
 
@@ -1197,13 +1218,14 @@ Changes take effect within milliseconds, no restart or SIGHUP needed.
 #### CLI Commands
 
 ```
-pgtrickle-relay --postgres-url <url>             # Start relay (all enabled pipelines)
-pgtrickle-relay config list                      # Show all pipelines + enabled status
-pgtrickle-relay config show <name>               # Show config JSONB for a pipeline
-pgtrickle-relay config set <name> --direction <forward|reverse> --config <json>
-pgtrickle-relay config enable <name>
+pgtrickle-relay --postgres-url <url>              # Start relay (all enabled pipelines)
+pgtrickle-relay config list                       # Show all pipelines (both tables) + status
+pgtrickle-relay config show <name>                # Show config JSONB for a pipeline
+pgtrickle-relay config set outbox <name> --config <json>   # Upsert forward pipeline
+pgtrickle-relay config set inbox  <name> --config <json>   # Upsert reverse pipeline
+pgtrickle-relay config enable  <name>
 pgtrickle-relay config disable <name>
-pgtrickle-relay config delete <name>
+pgtrickle-relay config delete  <name>
 ```
 
 #### Security
@@ -1251,7 +1273,7 @@ pgtrickle-relay config delete <name>
 | OTel tracing E2E | Verify spans exported to OTLP collector |
 | Encryption E2E | Encrypt → publish → decrypt → verify payload |
 | Webhook signature E2E | Signed POST accepted; unsigned POST rejected with 401 |
-| DB config — table exists, rows found | Relay loads all enabled pipelines; spawns one task per row |
+| DB config — both tables exist, rows found | Relay loads all enabled pipelines from both tables; spawns one task per row |
 | DB config — table missing | Relay exits with clear error message |
 | DB config — no enabled rows | Relay starts but idles; resumes when a row is enabled via LISTEN/NOTIFY |
 | DB config — LISTEN/NOTIFY reload | Update row → relay restarts affected pipeline within 1 second |
@@ -1309,7 +1331,7 @@ pgtrickle-relay config delete <name>
 | RELAY-P2-19 | Dry-run & replay mode (--dry-run, --replay, --from-offset) | 1d |
 | RELAY-P2-20 | OpenTelemetry tracing (OTLP export + context propagation) | 1.5d |
 | RELAY-P2-21 | Webhook signature verification (HMAC, GitHub, Stripe, Svix) | 1d |
-| RELAY-P2-22 | DB-stored config: single `pgtrickle.relay_config` table + LISTEN/NOTIFY trigger + CLI commands | 1.5d |
+| RELAY-P2-22 | DB-stored config: `pgtrickle.relay_outbox_config` + `relay_inbox_config` tables + shared LISTEN/NOTIFY trigger + CLI commands | 1.5d |
 
 ### Phase 2d — Testing & Polish (7 days)
 

--- a/plans/relay/PLAN_RELAY_CLI_PHASE_2.md
+++ b/plans/relay/PLAN_RELAY_CLI_PHASE_2.md
@@ -1112,231 +1112,108 @@ header = "X-Webhook-Signature"            # header containing the signature
 ### B.15 Database-Stored Configuration
 
 **Problem:** Phase 1 config lives in files or env vars. This makes
-multi-pipeline management cumbersome, provides no audit trail, and requires
-SIGHUP or restarts to apply changes. A database-first config model eliminates
-these pain points while staying fully integrated with the pg-trickle schema.
+multi-pipeline management cumbersome, requires SIGHUP or restarts to apply
+changes, and doesn't integrate with the pg-trickle catalog.
 
-**Design:** Full DB config as the primary source. File/env config is still
-required for bootstrap (PostgreSQL connection string), but all relay pipeline
-definitions and operational settings are stored in a catalog table. If the
-table or config row does not exist, the relay falls back transparently to
-file/env config.
-
-#### Configuration Priority Order
-
-```
-CLI flags  >  DB table row  >  env vars  >  file config  >  built-in defaults
-```
-
-Bootstrap (`postgres.url`) always comes from CLI/env/file — never from the
-table (avoids the circular dependency).
+**Design:** DB is the only config source. A single `pgtrickle.relay_config`
+table stores all pipelines. The only config required outside the DB is the
+PostgreSQL connection URL (passed via `--postgres-url` CLI flag).
 
 #### Catalog Schema
 
-Two tables: one for forward pipelines (outbox → sink), one for reverse
-(source → inbox).
-
 ```sql
--- Forward pipelines (outbox → sink)
-CREATE TABLE pgtrickle.relay_outbox_config (
-    id              BIGSERIAL PRIMARY KEY,
-    name            TEXT NOT NULL UNIQUE,           -- pipeline name
-    enabled         BOOLEAN NOT NULL DEFAULT true,
-    
-    source_type     TEXT NOT NULL DEFAULT 'outbox', -- always 'outbox'
-    source_config   JSONB NOT NULL DEFAULT '{}',   -- outbox name, consumer group, etc.
-    
-    sink_type       TEXT NOT NULL,                  -- 'kafka', 'nats', 's3', etc.
-    sink_config     JSONB NOT NULL DEFAULT '{}',   -- destination config
-    
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
--- Reverse pipelines (source → inbox)
-CREATE TABLE pgtrickle.relay_inbox_config (
-    id              BIGSERIAL PRIMARY KEY,
-    name            TEXT NOT NULL UNIQUE,           -- pipeline name
-    enabled         BOOLEAN NOT NULL DEFAULT true,
-    
-    source_type     TEXT NOT NULL,                  -- 'kafka', 'nats', 'webhook', etc.
-    source_config   JSONB NOT NULL DEFAULT '{}',   -- source connection config
-    
-    sink_type       TEXT NOT NULL DEFAULT 'pg-inbox', -- always 'pg-inbox'
-    sink_config     JSONB NOT NULL DEFAULT '{}',   -- inbox table name, etc.
-    
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+CREATE TABLE pgtrickle.relay_config (
+    name       TEXT PRIMARY KEY,
+    enabled    BOOLEAN NOT NULL DEFAULT true,
+    direction  TEXT NOT NULL,  -- 'forward' | 'reverse'
+    config     JSONB NOT NULL  -- {source_type, source_config, sink_type, sink_config}
 );
 ```
 
-#### SQL Helper Functions
+All pipeline settings — source type, sink type, connection details, and any
+backend-specific options — live in the `config` JSONB column. Validation is
+done in Rust when the row is loaded.
 
-Optional convenience functions for CLI/application use:
+**Example rows:**
 
 ```sql
--- Upsert forward pipeline
-INSERT INTO pgtrickle.relay_outbox_config
-    (name, source_config, sink_type, sink_config)
-VALUES
-    ('orders-to-kafka',
-     '{"outbox": "order_events", "group": "orders-kafka"}'::jsonb,
-     'kafka',
-     '{"brokers": "localhost:9092", "topic": "orders"}'::jsonb)
-ON CONFLICT (name) DO UPDATE SET
-    sink_type = EXCLUDED.sink_type,
-    sink_config = EXCLUDED.sink_config,
-    updated_at = now();
+-- Forward: outbox → Kafka
+INSERT INTO pgtrickle.relay_config (name, direction, config) VALUES (
+    'orders-to-kafka', 'forward',
+    '{"source_type": "outbox", "source": {"outbox": "order_events"},
+      "sink_type": "kafka",   "sink":   {"brokers": "localhost:9092", "topic": "orders"}}'
+);
 
--- Upsert reverse pipeline
-INSERT INTO pgtrickle.relay_inbox_config
-    (name, source_type, source_config, sink_config)
-VALUES
-    ('kafka-to-orders',
-     'kafka',
-     '{"brokers": "localhost:9092", "topic": "orders"}'::jsonb,
-     '{"inbox_table": "orders_inbox"}'::jsonb)
-ON CONFLICT (name) DO UPDATE SET
-    source_type = EXCLUDED.source_type,
-    source_config = EXCLUDED.source_config,
-    updated_at = now();
-
--- Enable / disable
-UPDATE pgtrickle.relay_outbox_config SET enabled = true WHERE name = 'orders-to-kafka';
-UPDATE pgtrickle.relay_outbox_config SET enabled = false WHERE name = 'orders-to-kafka';
+-- Reverse: Kafka → inbox
+INSERT INTO pgtrickle.relay_config (name, direction, config) VALUES (
+    'kafka-to-orders', 'reverse',
+    '{"source_type": "kafka",    "source": {"brokers": "localhost:9092", "topic": "orders"},
+      "sink_type":   "pg-inbox", "sink":   {"inbox_table": "orders_inbox"}}'
+);
 ```
 
-#### Bootstrap Flow
+#### Bootstrap
 
-1. **Relay starts** with minimal bootstrap config (CLI/env/file):
+Pass the database URL and the relay starts:
 
-   ```toml
-   # relay.toml — bootstrap only
-   [postgres]
-   url = "postgres://relay:password@localhost/mydb"
-   
-   [config]
-   source = "database"   # database | file (default: database if table exists)
-   pipeline = "orders-to-kafka"   # optional: run a single named pipeline
-   # omit `pipeline` to run ALL enabled pipelines
-   ```
+```bash
+pgtrickle-relay --postgres-url postgres://relay:password@localhost/mydb
+```
 
-2. **Relay queries the DB** for enabled pipelines (forward + reverse):
-
-   ```sql
-   SELECT 'forward' as direction, * FROM pgtrickle.relay_outbox_config WHERE enabled = true
-   UNION ALL
-   SELECT 'reverse' as direction, * FROM pgtrickle.relay_inbox_config WHERE enabled = true;
-   ```
-
-3. **If the tables do not exist, or no enabled rows are found**, the relay
-   logs a warning and falls back to the full file/env config.
-
-   ```
-   WARN relay_config: pgtrickle.relay_outbox_config and/or
-        pgtrickle.relay_inbox_config tables not found —
-        falling back to file/env config
-   ```
-
-4. **Relay spawns one tokio task per pipeline** and begins relaying.
+The relay runs `SELECT * FROM pgtrickle.relay_config WHERE enabled = true`,
+spawns one tokio task per row, and subscribes to LISTEN/NOTIFY for hot-reload.
+If the table does not exist the relay exits with a clear error.
 
 #### LISTEN/NOTIFY Hot-Reload
 
-Automatic triggers fire on both config tables. The relay subscribes to a
-PostgreSQL notification channel and reacts immediately:
-
 ```sql
--- Trigger for forward pipelines
-CREATE OR REPLACE FUNCTION pgtrickle.relay_outbox_config_notify()
+CREATE OR REPLACE FUNCTION pgtrickle.relay_config_notify()
 RETURNS TRIGGER LANGUAGE plpgsql AS $$
 BEGIN
     PERFORM pg_notify(
         'pgtrickle_relay_config',
         json_build_object(
-            'direction', 'forward',
-            'event',     TG_OP,
-            'name',      COALESCE(NEW.name, OLD.name),
-            'enabled',   COALESCE(NEW.enabled, OLD.enabled)
+            'event',   TG_OP,
+            'name',    COALESCE(NEW.name, OLD.name),
+            'enabled', COALESCE(NEW.enabled, OLD.enabled)
         )::text
     );
     RETURN NULL;
 END;
 $$;
 
-CREATE TRIGGER relay_outbox_config_notify
-    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_outbox_config
-    FOR EACH ROW EXECUTE FUNCTION pgtrickle.relay_outbox_config_notify();
-
--- Similar trigger for reverse pipelines
-CREATE OR REPLACE FUNCTION pgtrickle.relay_inbox_config_notify()
-RETURNS TRIGGER LANGUAGE plpgsql AS $$
-BEGIN
-    PERFORM pg_notify(
-        'pgtrickle_relay_config',
-        json_build_object(
-            'direction', 'reverse',
-            'event',     TG_OP,
-            'name',      COALESCE(NEW.name, OLD.name),
-            'enabled',   COALESCE(NEW.enabled, OLD.enabled)
-        )::text
-    );
-    RETURN NULL;
-END;
-$$;
-
-CREATE TRIGGER relay_inbox_config_notify
-    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_inbox_config
-    FOR EACH ROW EXECUTE FUNCTION pgtrickle.relay_inbox_config_notify();
+CREATE TRIGGER relay_config_notify
+    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_config
+    FOR EACH ROW EXECUTE FUNCTION pgtrickle.relay_config_notify();
 ```
 
 The relay's config watcher listens on `pgtrickle_relay_config`:
-- On `INSERT` with `enabled = true` → start a new pipeline task
-- On `UPDATE` → gracefully restart the named pipeline task with new config
-- On `DELETE` or `UPDATE` with `enabled = false` → gracefully stop the
-  named pipeline task
+- `INSERT` with `enabled = true` → start new pipeline task
+- `UPDATE` → gracefully restart named pipeline with new config
+- `DELETE` or `UPDATE` with `enabled = false` → gracefully stop pipeline
 
-This means **pipeline changes take effect within milliseconds** without any
-restart, SIGHUP, or polling interval.
+Changes take effect within milliseconds, no restart or SIGHUP needed.
 
 #### CLI Commands
 
 ```
-pgtrickle-relay config list                      # Show all pipelines + status
-pgtrickle-relay config show <name>               # Show config for a pipeline
-pgtrickle-relay config set <name> [--from-file pipeline.toml]
-                                                 # Upsert pipeline from file or flags
-pgtrickle-relay config enable <name>             # Enable a pipeline
-pgtrickle-relay config disable <name>            # Disable (does not delete)
-pgtrickle-relay config delete <name>             # Delete pipeline config
-pgtrickle-relay config export [--format toml|yaml|json]  # Export all to file
-pgtrickle-relay config import <file>             # Import from file (idempotent)
+pgtrickle-relay --postgres-url <url>             # Start relay (all enabled pipelines)
+pgtrickle-relay config list                      # Show all pipelines + enabled status
+pgtrickle-relay config show <name>               # Show config JSONB for a pipeline
+pgtrickle-relay config set <name> --direction <forward|reverse> --config <json>
+pgtrickle-relay config enable <name>
+pgtrickle-relay config disable <name>
+pgtrickle-relay config delete <name>
 ```
-
-#### Fallback Behaviour Matrix
-
-| Condition | Behaviour |
-|-----------|----------|
-| Both config tables do not exist | Log warning, fall back to file/env config |
-| Tables exist, no enabled pipelines found | Log warning, fall back to file/env config |
-| Tables exist, pipelines found | Use DB config; subscribe to LISTEN/NOTIFY |
-| DB connection lost during reload | Keep existing pipelines running; retry connection |
-| DB config JSONB field is null or missing | Use process-level default for that setting |
-
-**Key guarantee:** A relay process that successfully started will keep
-running even if the database goes down temporarily. It will not pick up new
-pipeline changes until the database reconnects, but existing pipelines
-continue with their last-known config.
 
 #### Security
 
-- Both config tables use standard PostgreSQL RBAC. Grant `SELECT` to
-  the relay's database user; grant `INSERT/UPDATE/DELETE` only to
-  administrator roles.
-- `source_config` and `sink_config` are JSONB columns. **Do not store
-  plaintext credentials** here — use references to env vars (e.g.
-  `{"password_env": "KAFKA_PASSWORD"}`) or external secret stores.
+- Standard PostgreSQL RBAC: grant `SELECT` to relay's DB user;
+  `INSERT/UPDATE/DELETE` to administrator roles only.
+- Do not store plaintext credentials in the `config` JSONB — use a secrets
+  manager reference (e.g. `{"password_env": "KAFKA_PASSWORD"}`).
 
-**Effort:** 2d
+**Effort:** 1.5d
 
 ---
 
@@ -1374,9 +1251,9 @@ continue with their last-known config.
 | OTel tracing E2E | Verify spans exported to OTLP collector |
 | Encryption E2E | Encrypt → publish → decrypt → verify payload |
 | Webhook signature E2E | Signed POST accepted; unsigned POST rejected with 401 |
-| DB config — tables exist | Relay reads pipelines from both tables; file config ignored |
-| DB config — tables missing | Relay logs warning and falls back to file/env config |
-| DB config — no enabled rows | Log warning, fall back to file/env config |
+| DB config — table exists, rows found | Relay loads all enabled pipelines; spawns one task per row |
+| DB config — table missing | Relay exits with clear error message |
+| DB config — no enabled rows | Relay starts but idles; resumes when a row is enabled via LISTEN/NOTIFY |
 | DB config — LISTEN/NOTIFY reload | Update row → relay restarts affected pipeline within 1 second |
 | DB config — enable/disable | UPDATE `enabled = false/true` → task stops/starts immediately |
 | DB config — DB down during run | Existing pipelines keep running; reconnect when DB recovers |
@@ -1417,7 +1294,7 @@ continue with their last-known config.
 | RELAY-P2-9 | Sink + Source: Apache Pulsar | *deferred — P3* |
 | RELAY-P2-10 | Sink + Source: Arrow Flight / gRPC | *deferred — P3* |
 
-### Phase 2c — Operational Excellence (18.5 days)
+### Phase 2c — Operational Excellence (18 days)
 
 | Item | Description | Effort |
 |------|-------------|--------|
@@ -1432,7 +1309,7 @@ continue with their last-known config.
 | RELAY-P2-19 | Dry-run & replay mode (--dry-run, --replay, --from-offset) | 1d |
 | RELAY-P2-20 | OpenTelemetry tracing (OTLP export + context propagation) | 1.5d |
 | RELAY-P2-21 | Webhook signature verification (HMAC, GitHub, Stripe, Svix) | 1d |
-| RELAY-P2-22 | DB-stored config: `pgtrickle.relay_outbox_config` + `relay_inbox_config` tables + LISTEN/NOTIFY triggers + fallback logic | 2d |
+| RELAY-P2-22 | DB-stored config: single `pgtrickle.relay_config` table + LISTEN/NOTIFY trigger + CLI commands | 1.5d |
 
 ### Phase 2d — Testing & Polish (7 days)
 
@@ -1471,8 +1348,8 @@ continue with their last-known config.
 |-------|--------|
 | Phase 2a — Cloud Provider Parity | 9d |
 | Phase 2b — IoT, Analytics & Data Lake | 7.5d |
-| Phase 2c — Operational Excellence | 18.5d |
-| Phase 2d — Testing & Polish | 6d |
+| Phase 2c — Operational Excellence | 18d |
+| Phase 2d — Testing & Polish | 7d |
 | Phase 2e — Documentation & Distribution | 2d |
 | **Total** | **~43 days solo / ~27 days with two developers** |
 
@@ -1508,6 +1385,5 @@ operational features.
 | 6 | Priority: Schema Registry or DLQ first? | (a) DLQ, (b) Schema Registry | **(a)** — DLQ is universally needed. Schema Registry is use-case dependent. |
 | 7 | Should Elasticsearch full-refresh use alias rotation or delete+reindex? | (a) Alias rotation (zero-downtime), (b) Delete + reindex | **(a)** — alias rotation is the standard Elasticsearch practice. |
 | 8 | Should we support ClickHouse via HTTP or native protocol? | (a) HTTP (simpler), (b) Native (faster) | **(a)** for Phase 2 — HTTP is simpler and well-supported by the `clickhouse` crate. |
-| 9 | Should relay credentials in `source_config`/`sink_config` be stored encrypted? | (a) Reference-only (env var names), (b) pgcrypto encryption, (c) External KMS | **(a)** for Phase 2 — store references like `{"password_env": "KAFKA_PASSWORD"}`, resolve at runtime. Encrypted storage is Phase 3. |
-| 10 | Should `pgtrickle-relay config set` accept inline flags or file only? | (a) File only (explicit, reviewable), (b) Both file and inline flags | **(b)** — flags for quick changes, file for declarative deployment. |
-| 11 | Should DB config be the default when the table exists, or require explicit opt-in? | (a) Auto-detect (use DB if table exists), (b) Explicit `config.source = "database"` | **(a)** — auto-detect reduces operator friction. Explicit override available. |
+| 9 | Should relay credentials in the `config` JSONB be stored encrypted? | (a) Reference-only (env var names in JSON), (b) pgcrypto encryption, (c) External KMS | **(a)** for Phase 2 — store references like `{"password_env": "KAFKA_PASSWORD"}`, resolve at runtime. Encrypted storage is Phase 3. |
+| 10 | Should `pgtrickle-relay config set` accept a JSON string or a file? | (a) File only (explicit, reviewable), (b) Both inline JSON and file | **(b)** — inline JSON for quick changes, file for declarative deployment. |

--- a/plans/relay/PLAN_RELAY_CLI_PHASE_2.md
+++ b/plans/relay/PLAN_RELAY_CLI_PHASE_2.md
@@ -37,7 +37,6 @@
   - [B.12 Plugin System (Dynamic Backends)](#b12-plugin-system-dynamic-backends)
   - [B.13 Encryption Envelope](#b13-encryption-envelope)
   - [B.14 Webhook Signature Verification](#b14-webhook-signature-verification)
-  - [B.15 Database-Stored Configuration](#b15-database-stored-configuration)
 - [Part C — Testing Strategy](#part-c--testing-strategy)
 - [Part D — Implementation Roadmap](#part-d--implementation-roadmap)
 - [Open Questions](#open-questions)
@@ -1109,136 +1108,6 @@ header = "X-Webhook-Signature"            # header containing the signature
 
 ---
 
-### B.15 Database-Stored Configuration
-
-**Problem:** Phase 1 config lives in files or env vars. This makes
-multi-pipeline management cumbersome, requires SIGHUP or restarts to apply
-changes, and doesn't integrate with the pg-trickle catalog.
-
-**Design:** DB is the only config source. Two tables — one for forward
-pipelines (outbox → sink) and one for reverse (source → inbox) — keep
-the direction implicit in the table name. All backend-specific settings live
-in a single `config` JSONB column. The only config required outside the DB
-is the PostgreSQL connection URL (passed via `--postgres-url` CLI flag).
-
-#### Catalog Schema
-
-```sql
--- Forward pipelines: outbox → sink
-CREATE TABLE pgtrickle.relay_outbox_config (
-    name     TEXT PRIMARY KEY,
-    enabled  BOOLEAN NOT NULL DEFAULT true,
-    config   JSONB NOT NULL  -- {source_type, source, sink_type, sink}
-);
-
--- Reverse pipelines: source → inbox
-CREATE TABLE pgtrickle.relay_inbox_config (
-    name     TEXT PRIMARY KEY,
-    enabled  BOOLEAN NOT NULL DEFAULT true,
-    config   JSONB NOT NULL  -- {source_type, source, sink_type, sink}
-);
-```
-
-All pipeline settings — source type, sink type, connection details, and any
-backend-specific options — live in the `config` JSONB column. Validation is
-done in Rust when the row is loaded.
-
-**Example rows:**
-
-```sql
--- Forward: outbox → Kafka
-INSERT INTO pgtrickle.relay_outbox_config (name, config) VALUES (
-    'orders-to-kafka',
-    '{"source_type": "outbox", "source": {"outbox": "order_events"},
-      "sink_type":   "kafka",  "sink":   {"brokers": "localhost:9092", "topic": "orders"}}'
-);
-
--- Reverse: Kafka → inbox
-INSERT INTO pgtrickle.relay_inbox_config (name, config) VALUES (
-    'kafka-to-orders',
-    '{"source_type": "kafka",    "source": {"brokers": "localhost:9092", "topic": "orders"},
-      "sink_type":   "pg-inbox", "sink":   {"inbox_table": "orders_inbox"}}'
-);
-```
-
-#### Bootstrap
-
-Pass the database URL and the relay starts:
-
-```bash
-pgtrickle-relay --postgres-url postgres://relay:password@localhost/mydb
-```
-
-The relay queries both tables:
-
-```sql
-SELECT 'forward', name, config FROM pgtrickle.relay_outbox_config WHERE enabled = true
-UNION ALL
-SELECT 'reverse', name, config FROM pgtrickle.relay_inbox_config  WHERE enabled = true;
-```
-
-Spawns one tokio task per row and subscribes to LISTEN/NOTIFY for hot-reload.
-If either table does not exist the relay exits with a clear error.
-
-#### LISTEN/NOTIFY Hot-Reload
-
-```sql
-CREATE OR REPLACE FUNCTION pgtrickle.relay_config_notify()
-RETURNS TRIGGER LANGUAGE plpgsql AS $$
-BEGIN
-    PERFORM pg_notify(
-        'pgtrickle_relay_config',
-        json_build_object(
-            'direction', TG_TABLE_NAME,  -- 'relay_outbox_config' | 'relay_inbox_config'
-            'event',     TG_OP,
-            'name',      COALESCE(NEW.name, OLD.name),
-            'enabled',   COALESCE(NEW.enabled, OLD.enabled)
-        )::text
-    );
-    RETURN NULL;
-END;
-$$;
-
-CREATE TRIGGER relay_outbox_config_notify
-    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_outbox_config
-    FOR EACH ROW EXECUTE FUNCTION pgtrickle.relay_config_notify();
-
-CREATE TRIGGER relay_inbox_config_notify
-    AFTER INSERT OR UPDATE OR DELETE ON pgtrickle.relay_inbox_config
-    FOR EACH ROW EXECUTE FUNCTION pgtrickle.relay_config_notify();
-```
-
-The relay's config watcher listens on `pgtrickle_relay_config`:
-- `INSERT` with `enabled = true` → start new pipeline task
-- `UPDATE` → gracefully restart named pipeline with new config
-- `DELETE` or `UPDATE` with `enabled = false` → gracefully stop pipeline
-
-Changes take effect within milliseconds, no restart or SIGHUP needed.
-
-#### CLI Commands
-
-```
-pgtrickle-relay --postgres-url <url>              # Start relay (all enabled pipelines)
-pgtrickle-relay config list                       # Show all pipelines (both tables) + status
-pgtrickle-relay config show <name>                # Show config JSONB for a pipeline
-pgtrickle-relay config set outbox <name> --config <json>   # Upsert forward pipeline
-pgtrickle-relay config set inbox  <name> --config <json>   # Upsert reverse pipeline
-pgtrickle-relay config enable  <name>
-pgtrickle-relay config disable <name>
-pgtrickle-relay config delete  <name>
-```
-
-#### Security
-
-- Standard PostgreSQL RBAC: grant `SELECT` to relay's DB user;
-  `INSERT/UPDATE/DELETE` to administrator roles only.
-- Do not store plaintext credentials in the `config` JSONB — use a secrets
-  manager reference (e.g. `{"password_env": "KAFKA_PASSWORD"}`).
-
-**Effort:** 1.5d
-
----
-
 ## Part C — Testing Strategy
 
 ### C.1 New Backend Tests (Testcontainers)
@@ -1273,9 +1142,8 @@ pgtrickle-relay config delete  <name>
 | OTel tracing E2E | Verify spans exported to OTLP collector |
 | Encryption E2E | Encrypt → publish → decrypt → verify payload |
 | Webhook signature E2E | Signed POST accepted; unsigned POST rejected with 401 |
-| DB config — both tables exist, rows found | Relay loads all enabled pipelines from both tables; spawns one task per row |
-| DB config — table missing | Relay exits with clear error message |
-| DB config — no enabled rows | Relay starts but idles; resumes when a row is enabled via LISTEN/NOTIFY |
+| DB config — outbox pipeline loaded | Relay reads `relay_outbox_config`; forward pipeline starts correctly |
+| DB config — inbox pipeline loaded | Relay reads `relay_inbox_config`; reverse pipeline starts correctly |
 | DB config — LISTEN/NOTIFY reload | Update row → relay restarts affected pipeline within 1 second |
 | DB config — enable/disable | UPDATE `enabled = false/true` → task stops/starts immediately |
 | DB config — DB down during run | Existing pipelines keep running; reconnect when DB recovers |
@@ -1316,7 +1184,7 @@ pgtrickle-relay config delete  <name>
 | RELAY-P2-9 | Sink + Source: Apache Pulsar | *deferred — P3* |
 | RELAY-P2-10 | Sink + Source: Arrow Flight / gRPC | *deferred — P3* |
 
-### Phase 2c — Operational Excellence (18 days)
+### Phase 2c — Operational Excellence (16.5 days)
 
 | Item | Description | Effort |
 |------|-------------|--------|
@@ -1331,23 +1199,21 @@ pgtrickle-relay config delete  <name>
 | RELAY-P2-19 | Dry-run & replay mode (--dry-run, --replay, --from-offset) | 1d |
 | RELAY-P2-20 | OpenTelemetry tracing (OTLP export + context propagation) | 1.5d |
 | RELAY-P2-21 | Webhook signature verification (HMAC, GitHub, Stripe, Svix) | 1d |
-| RELAY-P2-22 | DB-stored config: `pgtrickle.relay_outbox_config` + `relay_inbox_config` tables + shared LISTEN/NOTIFY trigger + CLI commands | 1.5d |
 
-### Phase 2d — Testing & Polish (7 days)
+### Phase 2d — Testing & Polish (6 days)
 
 | Item | Description | Effort |
 |------|-------------|--------|
 | RELAY-P2-23 | Backend integration tests (Pub/Sub, Kinesis, Service Bus, ES, MQTT, ClickHouse, S3) | 3d |
 | RELAY-P2-24 | Extension integration tests (DLQ, schema registry, transforms, routing, rate limit, circuit breaker, multi-pipeline, hot-reload, dry-run, replay, OTel, encryption, webhook sig) | 2d |
-| RELAY-P2-25 | DB config integration tests: both tables exist → use DB config; tables missing → fallback; LISTEN/NOTIFY reload on both | 1d |
-| RELAY-P2-26 | Benchmarks (new backends + extensions overhead) | 1d |
+| RELAY-P2-25 | Benchmarks (new backends + extensions overhead) | 1d |
 
 ### Phase 2e — Documentation & Distribution (2 days)
 
 | Item | Description | Effort |
 |------|-------------|--------|
-| RELAY-P2-27 | Documentation updates (new backends, extensions, config reference, DB config guide) | 1d |
-| RELAY-P2-28 | Docker image with all features + updated CI matrix | 1d |
+| RELAY-P2-26 | Documentation updates (new backends, extensions, config reference) | 1d |
+| RELAY-P2-27 | Docker image with all features + updated CI matrix | 1d |
 
 ### Deferred to Phase 3
 
@@ -1370,10 +1236,10 @@ pgtrickle-relay config delete  <name>
 |-------|--------|
 | Phase 2a — Cloud Provider Parity | 9d |
 | Phase 2b — IoT, Analytics & Data Lake | 7.5d |
-| Phase 2c — Operational Excellence | 18d |
-| Phase 2d — Testing & Polish | 7d |
+| Phase 2c — Operational Excellence | 16.5d |
+| Phase 2d — Testing & Polish | 6d |
 | Phase 2e — Documentation & Distribution | 2d |
-| **Total** | **~43 days solo / ~27 days with two developers** |
+| **Total** | **~41 days solo / ~26 days with two developers** |
 
 Phases 2a and 2b (backends) can be parallelised with Phase 2c (extensions).
 With two developers, one focuses on backends while the other builds
@@ -1407,5 +1273,4 @@ operational features.
 | 6 | Priority: Schema Registry or DLQ first? | (a) DLQ, (b) Schema Registry | **(a)** — DLQ is universally needed. Schema Registry is use-case dependent. |
 | 7 | Should Elasticsearch full-refresh use alias rotation or delete+reindex? | (a) Alias rotation (zero-downtime), (b) Delete + reindex | **(a)** — alias rotation is the standard Elasticsearch practice. |
 | 8 | Should we support ClickHouse via HTTP or native protocol? | (a) HTTP (simpler), (b) Native (faster) | **(a)** for Phase 2 — HTTP is simpler and well-supported by the `clickhouse` crate. |
-| 9 | Should relay credentials in the `config` JSONB be stored encrypted? | (a) Reference-only (env var names in JSON), (b) pgcrypto encryption, (c) External KMS | **(a)** for Phase 2 — store references like `{"password_env": "KAFKA_PASSWORD"}`, resolve at runtime. Encrypted storage is Phase 3. |
-| 10 | Should `pgtrickle-relay config set` accept a JSON string or a file? | (a) File only (explicit, reviewable), (b) Both inline JSON and file | **(b)** — inline JSON for quick changes, file for declarative deployment. |
+| 9 | Should `pgtrickle-relay config set` accept a JSON string or a file? | (a) Inline JSON string, (b) File path | **(a)** for CLI convenience; both supported. |


### PR DESCRIPTION
## Summary

Further simplifies **B.15 Database-Stored Configuration** to a single minimal
table and removes file/env config support entirely. The database is now the
only config source — no fallback, no config files, no env vars for pipeline
definitions.

## Changes

- **plans/relay/PLAN_RELAY_CLI_PHASE_2.md** (~190 lines removed, 66 added)

### Schema: single table replaces two

Before (PR #568): two separate tables (`relay_outbox_config`, `relay_inbox_config`)

After: one table, all pipeline config in a single JSONB column:

```sql
CREATE TABLE pgtrickle.relay_config (
    name       TEXT PRIMARY KEY,
    enabled    BOOLEAN NOT NULL DEFAULT true,
    direction  TEXT NOT NULL,  -- 'forward' | 'reverse'
    config     JSONB NOT NULL  -- source_type, source_config, sink_type, sink_config
);
```

### No file/env config

- Relay requires only `--postgres-url` to start — no config file needed
- If `pgtrickle.relay_config` table is missing → relay exits with a clear error
- No fallback matrix, no priority order, no `config.source = "database"` setting
- All pipeline definitions live exclusively in the DB

### Other changes

- Single LISTEN/NOTIFY trigger (was two, one per direction table)
- CLI: 6 commands (list, show, set, enable, disable, delete) — removed export/import
- Removed Open Question #11 (DB vs file opt-in — no longer applicable)
- B.15 effort: 2d → 1.5d
- Phase 2c total: 18.5d → 18d
- Phase 2 overall: **~43d solo / ~27d pair** (unchanged)

## Notes

- Validation of `direction`, `source_type`, `sink_type` values moves to Rust
- Credentials in `config` JSONB should use env var references
  (e.g. `{"password_env": "KAFKA_PASSWORD"}`), never plaintext
- Bootstrap URL (`--postgres-url`) still comes from CLI/env — avoids
  circular dependency; this is the only config outside the DB
