### PR TITLE
fix(ci): fix SQLancer /dev/shm exhaustion

### DIFF
--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -346,7 +346,8 @@ async fn shared_container() -> &'static SharedContainer {
                 .with_env_var("POSTGRES_DB", "postgres")
                 .with_label("com.pgtrickle.test", "true")
                 .with_label("com.pgtrickle.suite", "full-e2e")
-                .with_label("com.pgtrickle.repo", "pg-stream");
+                .with_label("com.pgtrickle.repo", "pg-stream")
+                .with_shm_size(536_870_912); // 512 MB — prevents POSIX shm exhaustion when many databases accumulate
 
             if let Some(run_id) = run_id {
                 image = image.with_label("com.pgtrickle.run-id", run_id);

--- a/tests/e2e_sqlancer_tests.rs
+++ b/tests/e2e_sqlancer_tests.rs
@@ -369,10 +369,14 @@ async fn run_crash_oracle() {
     let mut structured_errors = 0usize;
     let mut successes = 0usize;
 
-    for (i, gq) in queries.iter().enumerate() {
-        // Use a fresh DB per query to avoid cross-test pollution.
-        let db = E2eDb::new().await.with_extension().await;
+    // One shared database for the entire oracle run.  Each iteration uses
+    // index-scoped table names (e.g. t_ss_0, t_ss_1, …) so there are no
+    // cross-iteration conflicts.  This avoids creating thousands of databases
+    // in the shared container, which exhausts its /dev/shm (POSIX shared
+    // memory used by PostgreSQL background workers).
+    let db = E2eDb::new().await.with_extension().await;
 
+    for (i, gq) in queries.iter().enumerate() {
         // Create tables and insert data.
         for tbl in &gq.tables {
             db.execute(&tbl.ddl()).await;
@@ -466,9 +470,10 @@ async fn run_equivalence_oracle() {
     let mut skipped = 0usize;
     let mut checked = 0usize;
 
-    for (i, gq) in queries.iter().enumerate() {
-        let db = E2eDb::new().await.with_extension().await;
+    // One shared database for the entire oracle run (see run_crash_oracle for rationale).
+    let db = E2eDb::new().await.with_extension().await;
 
+    for (i, gq) in queries.iter().enumerate() {
         // Create source tables.
         for tbl in &gq.tables {
             db.execute(&tbl.ddl()).await;
@@ -640,9 +645,10 @@ async fn run_diff_vs_full_oracle() {
     let mut skipped = 0usize;
     let mut checked = 0usize;
 
-    for (i, gq) in queries.iter().enumerate() {
-        let db = E2eDb::new().await.with_extension().await;
+    // One shared database for the entire oracle run (see run_crash_oracle for rationale).
+    let db = E2eDb::new().await.with_extension().await;
 
+    for (i, gq) in queries.iter().enumerate() {
         for tbl in &gq.tables {
             db.execute(&tbl.ddl()).await;
             let mut rng = Lcg::new(gq.seed ^ (i as u64).wrapping_mul(0x1234567890abcdef));


### PR DESCRIPTION
## Summary

Fixed the weekly SQLancer CI failure caused by POSIX shared memory exhaustion. The test harness was creating thousands of databases in a single container, causing pg_trickle background workers to allocate shared memory segments that eventually exceeded the container's capacity.

## Changes

- **tests/e2e/mod.rs**: Added `.with_shm_size(512 MB)` to the shared container for defense-in-depth against DSM-related out-of-memory errors
- **tests/e2e_sqlancer_tests.rs**: Refactored three oracle functions (`run_crash_oracle`, `run_equivalence_oracle`, `run_diff_vs_full_oracle`) to use a single database per oracle run instead of one per case, reducing database creation from ~6,000 to 3

## Root Cause

The test created `E2eDb::new()` per iteration, resulting in 2,000 cases × 3 oracle passes = 6,000 databases. Each database with pg_trickle enabled spawned background workers that allocated POSIX shared memory (`/dev/shm`), exhausting the container's default 64 MB limit:

```
could not resize shared memory segment "/PostgreSQL.1394343112" to 33554432 bytes: No space left on device
```

## Solution

Moved `E2eDb::new()` outside the for-loop in each oracle function. Since each iteration uses index-scoped table names (e.g. `t_ss_0`, `t_ss_1`, …), there are no conflicts within a single oracle run. This reduces memory pressure while maintaining test isolation at the oracle level.

## Testing

- `just fmt && just lint` — passes with zero warnings
- All affected code paths (E2E test harness and SQLancer tests) verified to compile and pass style checks
- The fix maintains existing test behavior; only changes database lifecycle management

## Notes

This is a CI stability fix with no changes to extension code or user-facing APIs. The shared memory size increase (64 MB → 512 MB) matches the configuration already in use for benchmark containers, ensuring consistency across the test suite.
