### PR TITLE
fix(cdc): document BIGSERIAL CACHE 1 as hard correctness invariant

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -33,6 +33,7 @@ pg_trickle in production.
   - [12. Worker Pool Exhaustion](#12-worker-pool-exhaustion)
   - [13. Fuse Tripped (Circuit Breaker)](#13-fuse-tripped-circuit-breaker)
   - [14. Stream Table Appears Stuck Behind a Long Transaction](#14-stream-table-appears-stuck-behind-a-long-transaction)
+  - [15. Stale Data After High-Concurrency Writes (Sequence Cache Inversion)](#15-stale-data-after-high-concurrency-writes-sequence-cache-inversion)
 
 ---
 
@@ -654,6 +655,80 @@ ORDER BY prepared;
    Then restart the pg_trickle scheduler (or reload PostgreSQL) so the new
    privilege takes effect.
 
+
+---
+
+### 15. Stale Data After High-Concurrency Writes (Sequence Cache Inversion)
+
+**Symptoms:**
+- A stream table consistently shows an outdated value for a row that is
+  being updated frequently by concurrent sessions.
+- The issue is reproducible under high write concurrency but not with a
+  single writer.
+- `pgtrickle.check_cdc_health()` returns a `CRITICAL: change buffer
+  sequence(s) have CACHE > 1` alert.
+
+**Cause:**
+Someone manually altered a change buffer sequence to use `CACHE > 1` (e.g.
+to reduce sequence LWLock contention). The change buffer BIGSERIAL sequence
+**must** use `CACHE 1` — this is a hard correctness invariant, not a
+performance knob.
+
+With `CACHE > 1`, PostgreSQL backends pre-allocate blocks of sequence
+values. Two concurrent transactions modifying the same row can commit in an
+order that inverts their pre-cached `change_id` values:
+
+1. **Backend A** caches `[16, 31]` and starts updating row `id=1`.
+2. **Backend B** caches `[33, 64]`, updates the same row with
+   `change_id=33`, and commits first.
+3. **Backend A** commits last (true final state), but its `change_id=16`.
+4. The compaction/delta pipeline uses `ORDER BY change_id DESC` to find the
+   final state → picks `change_id=33` (Backend B's **stale** data).
+
+Silent data corruption. See [issue #536](https://github.com/grove/pg-trickle/issues/536)
+for full analysis.
+
+**Diagnosis:**
+
+```sql
+-- check_cdc_health() surfaces the problem:
+SELECT source_table, cdc_mode, alert
+FROM pgtrickle.check_cdc_health()
+WHERE alert IS NOT NULL;
+
+-- Directly inspect all change buffer sequences:
+SELECT schemaname, sequencename, cache_size
+FROM pg_sequences
+WHERE schemaname = 'pgtrickle_changes'
+  AND (sequencename LIKE 'changes_%_change_id_seq'
+    OR sequencename LIKE 'changes_pgt_%_change_id_seq')
+  AND cache_size > 1;
+```
+
+**Resolution:**
+
+1. Reset every affected sequence back to `CACHE 1`:
+
+   ```sql
+   -- Replace <seq_name> with the sequencename from the query above.
+   ALTER SEQUENCE pgtrickle_changes.<seq_name> CACHE 1;
+   ```
+
+2. Verify the alert is gone:
+
+   ```sql
+   SELECT alert FROM pgtrickle.check_cdc_health() WHERE alert IS NOT NULL;
+   -- Should return zero rows.
+   ```
+
+3. **Do NOT increase CACHE to reduce LWLock contention.** The only
+   structural solution for high-concurrency `change_id` contention is to
+   switch to the WAL/logical-decoding CDC backend, which uses commit-LSN
+   ordering and has no sequence at all:
+
+   ```sql
+   SELECT pgtrickle.alter_stream_table('my_st', cdc_mode => 'wal');
+   ```
 
 ---
 

--- a/plans/safety/PLAN_FRONTIER_VISIBILITY_HOLDBACK.md
+++ b/plans/safety/PLAN_FRONTIER_VISIBILITY_HOLDBACK.md
@@ -213,8 +213,17 @@ known-clean OLTP workloads.
 
 ## 7. Out-of-scope follow-ups (separate issues)
 
-1. **Sequence cache contention on `change_id`** — evaluate `CACHE 32+`
-   default; document that gaps are harmless.
+1. ~~**Sequence cache contention on `change_id`** — evaluate `CACHE 32+`
+   default; document that gaps are harmless.~~
+   **Retracted (2026-04-20):** Increasing `CACHE` above 1 is **unsafe**.
+   With `CACHE > 1`, concurrent transactions modifying the same row can
+   commit in an order that inverts their pre-cached sequence values,
+   causing compaction/delta pipelines (`ORDER BY change_id`) to pick stale
+   data as the final state — silent data corruption.  `CACHE 1` is a hard
+   correctness requirement for the trigger-based CDC path; the throughput
+   ceiling this imposes is a fundamental limitation that only the
+   WAL/logical-decoding backend can eliminate.  See issue #536 (last
+   comment by @Teletele-Lin) for the full analysis.
 2. **Atomic frontier+buffer commit** — covered by
    [PLAN_OVERALL_ASSESSMENT_2.md](../PLAN_OVERALL_ASSESSMENT_2.md).
 3. **WAL/logical-decoding CDC as default** — already on roadmap; this fix

--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -410,6 +410,23 @@ pub fn create_change_buffer_table(
         ""
     };
 
+    // INVARIANT: change_id uses BIGSERIAL which defaults to CACHE 1.
+    // CACHE 1 is a **hard correctness requirement** — do NOT increase it.
+    //
+    // With CACHE > 1, backends pre-allocate sequence blocks. Two concurrent
+    // transactions modifying the same row can commit in an order that
+    // inverts their cached sequence values (Tx B commits first with
+    // change_id=33, Tx A commits last with change_id=16). The compaction
+    // and delta pipelines use ORDER BY change_id to determine first/last
+    // state per PK — a cache inversion causes them to pick the stale row
+    // as the final state (silent data corruption).
+    //
+    // With CACHE 1, nextval() is called at trigger fire time while the
+    // row lock is held, so change_id order matches row-lock serialization
+    // order for same-row modifications.
+    //
+    // The WAL/logical-decoding CDC backend is immune (uses commit-LSN
+    // ordering). See: https://github.com/grove/pg-trickle/issues/536
     let sql = format!(
         "CREATE {unlogged_kw}TABLE IF NOT EXISTS {schema}.changes_{oid} (\
             change_id   BIGSERIAL,\
@@ -511,6 +528,10 @@ pub fn create_st_change_buffer_table(
         ""
     };
 
+    // INVARIANT: change_id BIGSERIAL must use CACHE 1 (the default).
+    // See the base-table change buffer comment above for the full
+    // rationale — increasing CACHE causes sequence-cache inversion that
+    // silently corrupts compaction and delta ordering. Ref: issue #536.
     let sql = format!(
         "CREATE {unlogged_kw}TABLE IF NOT EXISTS {schema}.changes_pgt_{id} (\
             change_id   BIGSERIAL,\

--- a/src/dvm/operators/scan.rs
+++ b/src/dvm/operators/scan.rs
@@ -3,7 +3,7 @@
 //! ΔI(Scan(T)) reads from the change buffer table for T.
 //!
 //! The change buffer table `pgtrickle_changes.changes_<oid>` contains:
-//! - change_id BIGSERIAL — insertion ordering (no PK index)
+//! - change_id BIGSERIAL — insertion ordering (CACHE 1 invariant, see cdc.rs)
 //! - lsn PG_LSN
 //! - action CHAR(1) — 'I', 'U', 'D'
 //! - pk_hash BIGINT — pre-computed PK hash (optional)

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1701,6 +1701,57 @@ fn check_cdc_health() -> TableIterator<
         }
     }
 
+    // INV-CACHE1: Check that no change buffer sequence has been manually altered
+    // to CACHE > 1. This would silently corrupt compaction and delta ordering
+    // (sequence-cache inversion — see issue #536). The check queries pg_sequences
+    // for any sequence whose name matches the change buffer pattern and whose
+    // cache_size > 1.
+    let corrupted_seqs: Vec<String> = Spi::connect(|client| {
+        let result = match client.select(
+            "SELECT sequencename::text \
+             FROM pg_sequences \
+             WHERE (sequencename LIKE 'changes_%_change_id_seq' \
+                 OR sequencename LIKE 'changes_pgt_%_change_id_seq') \
+               AND cache_size > 1 \
+               AND schemaname = 'pgtrickle_changes'",
+            None,
+            &[],
+        ) {
+            Ok(r) => r,
+            Err(_) => return Vec::new(),
+        };
+        result
+            .map(|row| row.get::<String>(1).unwrap_or(None).unwrap_or_default())
+            .filter(|s| !s.is_empty())
+            .collect()
+    });
+
+    if !corrupted_seqs.is_empty() {
+        let seq_list = corrupted_seqs.join(", ");
+        let cache_alert = format!(
+            "CRITICAL: change buffer sequence(s) have CACHE > 1 — \
+             this causes silent data corruption via sequence-cache inversion. \
+             Run: ALTER SEQUENCE pgtrickle_changes.<name> CACHE 1; \
+             Affected: {}",
+            seq_list
+        );
+        // Attach the alert to every trigger-mode row (the sequence belongs to
+        // the trigger path; WAL-mode rows are unaffected but the operator
+        // should still see the warning).
+        for row in &mut rows {
+            row.6 = Some(match &row.6 {
+                Some(existing) => format!("{}; {}", existing, cache_alert),
+                None => cache_alert.clone(),
+            });
+        }
+        pgrx::warning!(
+            "[pg_trickle] INV-CACHE1: change buffer sequence(s) with CACHE > 1 detected ({}). \
+             This causes silent data corruption. Reset with: \
+             ALTER SEQUENCE pgtrickle_changes.<name> CACHE 1",
+            seq_list
+        );
+    }
+
     TableIterator::new(rows)
 }
 

--- a/tests/e2e_cdc_tests.rs
+++ b/tests/e2e_cdc_tests.rs
@@ -1030,3 +1030,84 @@ async fn test_sec2_unprivileged_dml_captured_by_immediate_cdc() {
         .await;
     assert!(!gone, "deleted row must not appear in stream table");
 }
+
+// ── INV-CACHE1: Change buffer sequence invariant ───────────────────────
+
+/// INV-CACHE1: The change buffer BIGSERIAL sequence must have CACHE = 1.
+///
+/// With CACHE > 1 backends pre-allocate sequence blocks, decoupling
+/// assignment order from row-lock serialization order. This causes the
+/// compaction and delta pipelines (ORDER BY change_id) to silently pick
+/// stale data as the final state for a row — silent data corruption.
+///
+/// This test verifies:
+/// 1. A freshly created change buffer has CACHE = 1.
+/// 2. Manually altering the sequence to CACHE > 1 causes check_cdc_health()
+///    to emit a CRITICAL alert string.
+/// 3. Restoring CACHE = 1 clears the alert.
+#[tokio::test]
+async fn test_inv_cache1_change_buffer_sequence_cache_is_one() {
+    let db = E2eDb::new().await.with_extension().await;
+
+    db.execute("CREATE TABLE cache1_src (id INT PRIMARY KEY, val TEXT)")
+        .await;
+    db.execute("INSERT INTO cache1_src VALUES (1, 'a')").await;
+    db.create_st(
+        "cache1_st",
+        "SELECT id, val FROM cache1_src",
+        "1m",
+        "DIFFERENTIAL",
+    )
+    .await;
+    db.refresh_st("cache1_st").await;
+
+    let source_oid = db.table_oid("cache1_src").await;
+    let seq_name = format!("pgtrickle_changes.changes_{}_change_id_seq", source_oid);
+
+    // 1. Fresh sequence must have CACHE = 1.
+    let cache_size: i64 = db
+        .query_scalar(&format!(
+            "SELECT cache_size FROM pg_sequences \
+             WHERE schemaname = 'pgtrickle_changes' \
+               AND sequencename = 'changes_{}_change_id_seq'",
+            source_oid
+        ))
+        .await;
+    assert_eq!(
+        cache_size, 1,
+        "change buffer sequence must have CACHE = 1 (INV-CACHE1)"
+    );
+
+    // 2. Manually corrupt: set CACHE = 32. check_cdc_health() must alert.
+    db.execute(&format!("ALTER SEQUENCE {} CACHE 32", seq_name))
+        .await;
+
+    let alert: Option<String> = db
+        .query_scalar_opt(
+            "SELECT alert FROM pgtrickle.check_cdc_health() WHERE alert IS NOT NULL LIMIT 1",
+        )
+        .await;
+    assert!(
+        alert.is_some(),
+        "check_cdc_health() must return an alert when sequence CACHE > 1"
+    );
+    let alert_text = alert.unwrap();
+    assert!(
+        alert_text.contains("CACHE > 1") || alert_text.contains("cache_size"),
+        "alert must mention CACHE > 1, got: {alert_text}"
+    );
+
+    // 3. Restore CACHE = 1. check_cdc_health() must clear the alert.
+    db.execute(&format!("ALTER SEQUENCE {} CACHE 1", seq_name))
+        .await;
+
+    let alert_after_fix: Option<String> = db
+        .query_scalar_opt(
+            "SELECT alert FROM pgtrickle.check_cdc_health() WHERE alert LIKE '%CACHE%' LIMIT 1",
+        )
+        .await;
+    assert!(
+        alert_after_fix.is_none(),
+        "check_cdc_health() must not alert after CACHE is restored to 1"
+    );
+}


### PR DESCRIPTION
## Summary

Documents `BIGSERIAL CACHE 1` as a **hard correctness invariant** for the
trigger-based CDC path, adds a runtime guard that detects violations, an E2E
test that regression-locks the invariant, and a TROUBLESHOOTING guide entry.

Follows up on [#536](https://github.com/grove/pg-trickle/issues/536) — specifically
the final comment by @Teletele-Lin, which demonstrated that the previously
suggested `CACHE 32+` tuning would cause silent data corruption via
sequence-cache inversion.

## Problem

The compaction and delta pipelines use `ORDER BY change_id` to identify first
and last state per primary key. With `CACHE > 1`:

1. Backend A caches `[16, 31]`, starts updating row `id=1`
2. Backend B caches `[33, 64]`, updates the same row with `change_id=33`, commits first
3. Backend A commits last (true final state) with `change_id=16`
4. Pipeline sees `33 > 16` → silently picks Backend B's stale data as the final row state

With `CACHE 1`, `nextval()` is called at trigger fire time while the row lock
is held, so `change_id` order always matches the row-lock serialization order.

## Changes

**Commit 1 — Code invariant comments**
- `src/cdc.rs`: `INVARIANT` comments near both `BIGSERIAL` definitions (base-table
  and stream-table change buffers) explaining why `CACHE 1` must not be increased
- `src/dvm/operators/scan.rs`: module doc updated to reference the invariant
- `plans/safety/PLAN_FRONTIER_VISIBILITY_HOLDBACK.md`: retracted the
  "evaluate CACHE 32+" follow-up item with explanation

**Commit 2 — Runtime guard, test, docs**
- `src/monitor.rs`: `check_cdc_health()` now queries `pg_sequences` for any
  change buffer sequence with `cache_size > 1` and appends a `CRITICAL` alert
  to every output row plus emits a `WARNING`-level log. Catches operators who
  manually tuned the sequence.
- `tests/e2e_cdc_tests.rs`: `test_inv_cache1_change_buffer_sequence_cache_is_one`
  verifies a fresh buffer has `CACHE=1`, that `CACHE=32` triggers the health
  alert, and that restoring `CACHE=1` clears it.
- `docs/TROUBLESHOOTING.md`: New scenario 15 "Stale Data After High-Concurrency
  Writes (Sequence Cache Inversion)" with symptoms, cause, diagnostic queries,
  and resolution steps including a pointer to the WAL backend as the only
  structural fix for the underlying LWLock contention.

## Testing

- `just fmt` — passes
- `just lint` — passes (zero warnings)
- New E2E test: `test_inv_cache1_change_buffer_sequence_cache_is_one`

## Notes

The `CACHE 1` LWLock contention is a fundamental limitation of the trigger-based
CDC path. The only structural fix is the WAL/logical-decoding backend, which
uses commit-LSN ordering and sidesteps `BIGSERIAL` entirely. This is already
on the roadmap.
