### PR TITLE
fix(security): resolve 13 open code-scanning alerts (dynamic SQL + panic-in-sql-path)

### DIFF
--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -434,6 +434,7 @@ pub fn rebuild_publication_for_partitioned_source(
     // Drop and recreate to ensure publish_via_partition_root is set.
     // Both identifiers are properly quoted above before interpolation.
     Spi::run(&format!(
+        // nosemgrep: rust.spi.run.dynamic-format — DDL cannot be parameterized; both identifiers are quoted via quote_ident before interpolation
         "DROP PUBLICATION IF EXISTS {pub_name_quoted}; \
          CREATE PUBLICATION {pub_name_quoted} FOR TABLE {table_name} \
          WITH (publish_via_partition_root = true)"

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1793,9 +1793,13 @@ impl ExecutionUnitDag {
         );
 
         // Collect external downstream edges of the LAST unit in the chain.
-        let last_id = *chain
-            .last() // nosemgrep: rust.panic-in-sql-path — chain is always non-empty by construction in build_execution_units
-            .expect("chain is always non-empty by construction in build_execution_units");
+        let last_id = match chain.last() {
+            Some(&id) => id,
+            // SAFETY: chain is always non-empty by construction in build_execution_units
+            None => pgrx::error!(
+                "unreachable: chain is always non-empty by construction in build_execution_units"
+            ),
+        };
         let external_downstream: Vec<ExecutionUnitId> =
             self.edges.get(&last_id).cloned().unwrap_or_default();
 

--- a/src/refresh/mod.rs
+++ b/src/refresh/mod.rs
@@ -942,6 +942,7 @@ fn apply_planner_hints(estimated_delta: i64, st_relid: pg_sys::Oid, scan_count: 
             );
         }
         if let Err(e) = Spi::run(&format!("SET LOCAL work_mem = '{mb}MB'")) {
+            // nosemgrep: rust.spi.run.dynamic-format — mb is a numeric GUC value, not user input; SET LOCAL GUC cannot be parameterized
             pgrx::debug1!("[pg_trickle] D-1: failed to SET LOCAL work_mem: {}", e);
         }
     } else if estimated_delta >= PLANNER_HINT_NESTLOOP_THRESHOLD {
@@ -1783,12 +1784,13 @@ fn deallocate_prepared_merge_statement(_pgt_id: i64) {
         let pgt_id = _pgt_id;
         let stmt = format!("__pgt_merge_{pgt_id}");
         let exists = Spi::get_one::<bool>(&format!(
+            // nosemgrep: rust.spi.query.dynamic-format — stmt is derived from numeric pgt_id, not user input
             "SELECT EXISTS(SELECT 1 FROM pg_prepared_statements WHERE name = '{stmt}')"
         ))
         .unwrap_or(Some(false))
         .unwrap_or(false);
         if exists {
-            let _ = Spi::run(&format!("DEALLOCATE {stmt}"));
+            let _ = Spi::run(&format!("DEALLOCATE {stmt}")); // nosemgrep: rust.spi.run.dynamic-format — stmt is derived from numeric pgt_id, not user input
         }
     }
 }
@@ -2746,7 +2748,7 @@ pub fn execute_full_refresh(st: &StreamTableMeta) -> Result<(i64, i64), PgTrickl
     // Suppress user triggers during TRUNCATE + INSERT to prevent
     // spurious trigger invocations with wrong semantics.
     if has_triggers {
-        Spi::run(&format!("ALTER TABLE {quoted_table} DISABLE TRIGGER USER"))
+        Spi::run(&format!("ALTER TABLE {quoted_table} DISABLE TRIGGER USER")) // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
     }
 
@@ -2816,7 +2818,7 @@ pub fn execute_full_refresh(st: &StreamTableMeta) -> Result<(i64, i64), PgTrickl
     };
 
     // Truncate
-    Spi::run(&format!("TRUNCATE {quoted_table}"))
+    Spi::run(&format!("TRUNCATE {quoted_table}")) // nosemgrep: rust.spi.run.dynamic-format — TRUNCATE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
 
     // Compute row_id using the same hash formula as the delta query so
@@ -2892,7 +2894,7 @@ pub fn execute_full_refresh(st: &StreamTableMeta) -> Result<(i64, i64), PgTrickl
     // Re-enable user triggers and emit NOTIFY so listeners know a FULL
     // refresh occurred.
     if has_triggers {
-        Spi::run(&format!("ALTER TABLE {quoted_table} ENABLE TRIGGER USER"))
+        Spi::run(&format!("ALTER TABLE {quoted_table} ENABLE TRIGGER USER")) // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
 
         // PB2/STAB-1: Skip NOTIFY when pooler compatibility mode is enabled.
@@ -5114,7 +5116,7 @@ pub fn execute_differential_refresh(
             schema.replace('"', "\"\""),
             name.replace('"', "\"\""),
         );
-        Spi::run(&format!("ALTER TABLE {quoted_table} DISABLE TRIGGER USER"))
+        Spi::run(&format!("ALTER TABLE {quoted_table} DISABLE TRIGGER USER")) // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
     }
 
@@ -5642,14 +5644,16 @@ pub fn execute_differential_refresh(
             // Note: DEALLOCATE does not support IF EXISTS in PostgreSQL.
             // Check pg_prepared_statements first to avoid an error.
             let stale_exists = Spi::get_one::<bool>(&format!(
+                // nosemgrep: rust.spi.query.dynamic-format — stmt_name is derived from numeric pgt_id, not user input
                 "SELECT EXISTS(SELECT 1 FROM pg_prepared_statements WHERE name = '{stmt_name}')"
             ))
             .unwrap_or(Some(false))
             .unwrap_or(false);
             if stale_exists {
-                let _ = Spi::run(&format!("DEALLOCATE {stmt_name}"));
+                let _ = Spi::run(&format!("DEALLOCATE {stmt_name}")); // nosemgrep: rust.spi.run.dynamic-format — stmt_name is derived from numeric pgt_id, not user input
             }
             Spi::run(&format!(
+                // nosemgrep: rust.spi.run.dynamic-format — stmt_name and type_list are derived from numeric IDs; parameterized_merge_sql is an internal template
                 "PREPARE {stmt_name} ({type_list}) AS {}",
                 resolved.parameterized_merge_sql
             ))
@@ -5688,7 +5692,7 @@ pub fn execute_differential_refresh(
             schema.replace('"', "\"\""),
             name.replace('"', "\"\""),
         );
-        Spi::run(&format!("ALTER TABLE {quoted_table} ENABLE TRIGGER USER"))
+        Spi::run(&format!("ALTER TABLE {quoted_table} ENABLE TRIGGER USER")) // nosemgrep: rust.spi.run.dynamic-format — ALTER TABLE DDL cannot be parameterized; quoted_table is a PostgreSQL-quoted identifier
             .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
     }
 


### PR DESCRIPTION
## Summary

Resolves all 13 open GitHub code-scanning alerts (Semgrep) reported at
`/security/code-scanning`. Changes fall into two categories:

1. **panic-in-sql-path** — replace `.expect()` with a `match` + `pgrx::error!()`
   so PostgreSQL can perform an orderly session cleanup instead of a hard backend
   abort on the (unreachable) error branch.

2. **dynamic-format SPI calls** — add `// nosemgrep` annotations with clear
   justifications at each safe dynamic-SQL site. Every annotated call is either:
   - PostgreSQL DDL that cannot be parameterised (`ALTER TABLE`, `TRUNCATE`,
     `DROP PUBLICATION`, `PREPARE`, `DEALLOCATE`), or
   - Identifiers already double-quote–escaped or produced by `quote_ident()`, or
   - Numeric values (`pgt_id`, `mb`) that are not reachable via user input.

## Changes

- **`src/cdc.rs`** — annotate `CREATE PUBLICATION` dynamic SQL; both identifiers
  are quoted via `quote_ident` before interpolation.
- **`src/dag.rs`** — replace `.expect()` on `chain.last()` with
  `match … { None => pgrx::error!("unreachable: …") }`.
- **`src/refresh/mod.rs`** — annotate 11 dynamic-SQL call sites:
  - `SET LOCAL work_mem` (numeric GUC, non-parameterisable)
  - `DEALLOCATE` / `PREPARE` for prepared-statement lifecycle (`stmt` derived
    from numeric `pgt_id`)
  - `pg_prepared_statements` catalog checks (`stmt` derived from numeric `pgt_id`)
  - `ALTER TABLE … DISABLE/ENABLE TRIGGER USER` (DDL, `quoted_table` uses
    PostgreSQL double-quote escaping) — FULL refresh path (×2) and DIFF
    refresh path (×2)
  - `TRUNCATE` (DDL, `quoted_table` is properly quoted)

## Testing

- `just fmt` — passes
- `just lint` — passes (zero warnings)

## Notes

No behaviour changes. These are annotation-only fixes (plus the `pgrx::error!`
replacement which preserves the same runtime behaviour while being backend-safe).
Once merged, GitHub should automatically close all 13 open alerts on the next
code-scanning run.
