### PR TITLE
refactor: rename dog_feeding → self_monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ For future plans and upcoming features, see [ROADMAP.md](ROADMAP.md).
 - [0.23.0 — Performance Tuning & Diagnostics](#0230--performance-tuning--diagnostics)
 - [0.22.0 — Downstream CDC, Parallel Refresh & Predictive Cost Model](#0220--downstream-cdc-parallel-refresh--predictive-cost-model)
 - [0.21.0 — Reliability, Safety & Operational Tools](#0210--reliability-safety--operational-tools)
-- [0.20.0 — Dog Feeding](#0200--dog-feeding)
+- [0.20.0 — Self Monitoring](#0200--self-monitoring)
 - [0.19.0 — Security, Scheduler Performance & Operator Convenience](#0190--security-scheduler-performance--operator-convenience)
 - [0.18.0 — Hardening & Delta Performance](#0180--hardening--delta-performance)
 - [0.17.0 — Query Intelligence & Stability](#0170--query-intelligence--stability)
@@ -312,7 +312,7 @@ ALTER EXTENSION pg_trickle UPDATE TO '0.21.0';
 
 ---
 
-## [0.20.0] — Dog Feeding
+## [0.20.0] — Self Monitoring
 
 **pg_trickle now monitors itself.** Instead of you having to check on
 pg_trickle's health manually, this release lets pg_trickle watch its own
@@ -321,18 +321,18 @@ new stream tables sit in the `pgtrickle` schema and continuously analyse
 refresh history — the same technology you use for your own data, pointed
 inward. One SQL call sets everything up; one call tears it down.
 
-We call this *dog feeding* — pg_trickle uses its own stream-table technology
+We call this *self monitoring* — pg_trickle uses its own stream-table technology
 to keep an eye on itself, just like it keeps your data views up to date.
 
 ### What's new
 
-- **One-click self-monitoring** — run `SELECT pgtrickle.setup_dog_feeding()`
+- **One-click self-monitoring** — run `SELECT pgtrickle.setup_self_monitoring()`
   and pg_trickle creates five monitoring stream tables that continuously track
-  how well it is performing. Run `teardown_dog_feeding()` to remove them.
+  how well it is performing. Run `teardown_self_monitoring()` to remove them.
   Both are idempotent — safe to call as many times as you like, even during
   rolling upgrades.
 
-- **Health at a glance** — the new `dog_feeding_status()` function shows the
+- **Health at a glance** — the new `self_monitoring_status()` function shows the
   status of all five monitoring views in one query: whether each one exists,
   its refresh mode, and the last time it refreshed. Quick to run from a
   monitoring script or dashboard.
@@ -345,11 +345,11 @@ to keep an eye on itself, just like it keeps your data views up to date.
   `sla_headroom_pct` column shows exactly how much faster incremental refresh
   is versus full refresh for that table.
 
-- **Automatic tuning** — set `pg_trickle.dog_feeding_auto_apply = 'threshold_only'`
+- **Automatic tuning** — set `pg_trickle.self_monitoring_auto_apply = 'threshold_only'`
   and pg_trickle will apply HIGH-confidence threshold recommendations
   automatically. Changes are rate-limited to once per 10 minutes per stream
   table, and every adjustment is logged to `pgt_refresh_history` with
-  `initiated_by = 'DOG_FEED'` so you have a full audit trail.
+  `initiated_by = 'SELF_MONITOR'` so you have a full audit trail.
 
 - **Real-time alerts** — when pg_trickle detects an anomaly (duration spike
   exceeding 3× the baseline, or two or more recent failures), it sends a
@@ -364,12 +364,12 @@ to keep an eye on itself, just like it keeps your data views up to date.
 
 - **Visual dependency graph** — the new `explain_dag()` function renders
   your full refresh pipeline as a Mermaid or Graphviz DOT diagram. User
-  stream tables appear in blue, dog-feeding tables in green, suspended tables
+  stream tables appear in blue, self-monitoring tables in green, suspended tables
   in red. Paste the output into any Mermaid renderer or `dot` to see exactly
   how your tables depend on each other.
 
 - **Scheduler overhead report** — `scheduler_overhead()` returns metrics
-  for the last hour: total refreshes, how many were dog-feeding, the
+  for the last hour: total refreshes, how many were self-monitoring, the
   fraction they represent, and average durations. Useful for confirming that
   self-monitoring adds negligible cost.
 
@@ -386,7 +386,7 @@ to keep an eye on itself, just like it keeps your data views up to date.
 ### Faster and more reliable
 
 - A new index on `pgt_refresh_history(pgt_id, start_time)` speeds up all
-  dog-feeding queries and general history lookups. Applied automatically
+  self-monitoring queries and general history lookups. Applied automatically
   during the 0.19.0 → 0.20.0 upgrade.
 - Old history records are now pruned in batches of 1,000 rows per transaction
   (previously one large DELETE), which avoids long lock holds on
@@ -394,26 +394,26 @@ to keep an eye on itself, just like it keeps your data views up to date.
 - `check_cdc_health()` is enriched with spill-risk alerts: if a source
   table's max burst delta exceeds 10× its average, you get an early warning
   before the buffer fills.
-- `explain_st()` now shows two new properties: `dog_feeding_coverage`
+- `explain_st()` now shows two new properties: `self_monitoring_coverage`
   (none / partial / full) and `recommended_refresh_mode`, so diagnostics
   automatically surface self-monitoring data when it is available.
 
 ### New documentation and tooling
 
-- **SQL Reference** — a new "Dog Feeding — Self-Monitoring" section covers
-  all five stream tables, `setup_dog_feeding()`, `teardown_dog_feeding()`,
+- **SQL Reference** — a new "Self Monitoring — Self-Monitoring" section covers
+  all five stream tables, `setup_self_monitoring()`, `teardown_self_monitoring()`,
   confidence levels, and the `sla_headroom_pct` column.
 - **Getting Started** — a new "Day 2 Operations" section walks through
-  enabling dog-feeding, reading recommendations, enabling auto-apply, and
+  enabling self-monitoring, reading recommendations, enabling auto-apply, and
   visualising the DAG.
-- **Configuration** — `pg_trickle.dog_feeding_auto_apply` is fully
+- **Configuration** — `pg_trickle.self_monitoring_auto_apply` is fully
   documented with values, rate-limiting behaviour, and the audit trail.
-- A ready-made **Grafana dashboard** (`pg_trickle_dog_feeding.json`) with
+- A ready-made **Grafana dashboard** (`pg_trickle_self_monitoring.json`) with
   five panels covers refresh throughput, anomaly heatmap, threshold
   calibration, CDC buffer growth, and the scheduling interference matrix.
 - A **dbt macro** (`pgtrickle_enable_monitoring`) enables monitoring as a
   post-hook with one line in `dbt_project.yml`.
-- A **quick-start SQL script** at `sql/dog_feeding_setup.sql` walks through
+- A **quick-start SQL script** at `sql/self_monitoring_setup.sql` walks through
   setup, auto-apply, alert listening, and status verification in six steps.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ For future plans and upcoming features, see [ROADMAP.md](ROADMAP.md).
 ## Table of Contents
 
 <!-- TOC start -->
-- [0.24.0 — Join Correctness & Durability Hardening](#0240--join-correctness--durability-hardening)
 - [Unreleased](#unreleased)
 - [0.24.0 — Join Correctness & Durability Hardening](#0240--join-correctness--durability-hardening)
 - [0.23.0 — Performance Tuning & Diagnostics](#0230--performance-tuning--diagnostics)
@@ -42,83 +41,6 @@ For future plans and upcoming features, see [ROADMAP.md](ROADMAP.md).
 <!-- TOC end -->
 
 ---
-
-## [0.24.0] — Join Correctness & Durability Hardening
-
-### Join Correctness (EC-01)
-
-- **Row-id hash convergence** (EC01-1) — Part 1b (ΔL_D ⋈ R₀) now uses the
-  same canonical hash formula as Part 1a (ΔL_I ⋈ R₁), guaranteeing that
-  insert/delete pairs for the same logical row produce identical
-  `__pgt_row_id` values across refresh cycles. Prevents phantom row
-  accumulation in multi-table JOIN stream tables.
-
-- **Cross-cycle phantom cleanup** (EC01-2) — The PH-D1 delete path now
-  reconciles orphaned row IDs from prior cycles, not just the current delta.
-  After a differential refresh, any rows in the stream table that don't
-  exist in the full-refresh result set are detected and removed in batches.
-
-- **Q15 IMMEDIATE mode** (EC01-3) — TPC-H Q15 removed from the
-  `IMMEDIATE_SKIP_ALLOWLIST` after the EC-01 join fixes landed.
-
-- **Proptest harness** (EC01-4) — New 5,000-iteration property tests verify
-  that INSERT/UPDATE/DELETE sequences on multi-table JOINs converge to the
-  same result as a full refresh, regardless of change ordering.
-
-### Durability & Frontier Atomicity
-
-- **Two-phase frontier commit** (DUR-1) — The scheduler now writes a
-  tentative frontier before the MERGE, then promotes it after commit. On
-  crash recovery, tentative frontiers are reconciled based on change buffer
-  state, eliminating the window where a crash between TRUNCATE and frontier
-  store could replay or lose rows.
-
-  New catalog column: `tentative_frontier` on `pgt_stream_tables`.
-
-- **`pg_trickle.change_buffer_durability` GUC** (DUR-2) — New three-valued
-  GUC controlling change buffer WAL behavior:
-  - `unlogged` (default): UNLOGGED tables, maximum throughput, lost on crash.
-  - `logged`: WAL-logged, survives crash, replicated to standbys.
-  - `sync`: WAL-logged + synchronous commit, maximum durability.
-
-### CDC Hardening
-
-- **Zero `unwrap()` in production CDC code** (CDC-1) — All `unwrap()` calls
-  in `src/cdc.rs` are now confined to test code. New error variant
-  `ChangedColsBitmaskFailed` added for future safety.
-
-- **Partitioned-source publication rebuild** (CDC-2) — On scheduler tick,
-  partitioned source tables are checked for correct
-  `publish_via_partition_root` configuration. Mismatched publications are
-  automatically rebuilt with the correct setting.
-
-- **TOAST-aware CDC hashing** (CDC-3) — Columns with `attstorage IN ('e', 'x')`
-  (external/extended TOAST) now include `pg_column_size()` in the row-id hash,
-  detecting in-place TOAST rewrites that would otherwise be invisible to CDC.
-
-### Operational Improvements
-
-- **History retention pruning** (OPS-1) — The scheduler now prunes rows from
-  `pgt_refresh_history` older than `pg_trickle.history_retention_days` (default
-  90) in 1k-row batches during idle ticks. Previously, history grew unbounded.
-
-- **Frozen-stream-table detector** (OPS-2) — New dog-feeding view
-  `df_frozen_stream_tables` flags any stream table whose `last_refresh_at`
-  is older than 5× its refresh interval. Alerts via `pgtrickle_alert` NOTIFY.
-
-- **Internal catalog indexes** (OPS-3) — Added composite indexes on:
-  - `pgt_stream_tables(status, scc_id)`
-  - `pgt_refresh_history(pgt_id, action, data_timestamp)`
-  - `pgt_change_tracking(source_relid)`
-
-### Testing
-
-- **25+ unit tests** for `publication.rs` (TEST-6): SLA tier assignment
-  boundary cases, parse_qualified_name edge cases, quote_ident variations.
-- **20+ unit tests** for `diagnostics.rs` (TEST-7): Duration parsing,
-  version validation, format routing.
-- **10+ unit tests** for `metrics_server.rs` (TEST-8): HTTP request routing,
-  OpenMetrics content-type, port-zero disablement, health endpoints.
 
 ## [Unreleased]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ For future plans and upcoming features, see [ROADMAP.md](ROADMAP.md).
 ## Table of Contents
 
 <!-- TOC start -->
+- [0.24.0 — Join Correctness & Durability Hardening](#0240--join-correctness--durability-hardening)
 - [Unreleased](#unreleased)
 - [0.24.0 — Join Correctness & Durability Hardening](#0240--join-correctness--durability-hardening)
 - [0.23.0 — Performance Tuning & Diagnostics](#0230--performance-tuning--diagnostics)
@@ -41,6 +42,83 @@ For future plans and upcoming features, see [ROADMAP.md](ROADMAP.md).
 <!-- TOC end -->
 
 ---
+
+## [0.24.0] — Join Correctness & Durability Hardening
+
+### Join Correctness (EC-01)
+
+- **Row-id hash convergence** (EC01-1) — Part 1b (ΔL_D ⋈ R₀) now uses the
+  same canonical hash formula as Part 1a (ΔL_I ⋈ R₁), guaranteeing that
+  insert/delete pairs for the same logical row produce identical
+  `__pgt_row_id` values across refresh cycles. Prevents phantom row
+  accumulation in multi-table JOIN stream tables.
+
+- **Cross-cycle phantom cleanup** (EC01-2) — The PH-D1 delete path now
+  reconciles orphaned row IDs from prior cycles, not just the current delta.
+  After a differential refresh, any rows in the stream table that don't
+  exist in the full-refresh result set are detected and removed in batches.
+
+- **Q15 IMMEDIATE mode** (EC01-3) — TPC-H Q15 removed from the
+  `IMMEDIATE_SKIP_ALLOWLIST` after the EC-01 join fixes landed.
+
+- **Proptest harness** (EC01-4) — New 5,000-iteration property tests verify
+  that INSERT/UPDATE/DELETE sequences on multi-table JOINs converge to the
+  same result as a full refresh, regardless of change ordering.
+
+### Durability & Frontier Atomicity
+
+- **Two-phase frontier commit** (DUR-1) — The scheduler now writes a
+  tentative frontier before the MERGE, then promotes it after commit. On
+  crash recovery, tentative frontiers are reconciled based on change buffer
+  state, eliminating the window where a crash between TRUNCATE and frontier
+  store could replay or lose rows.
+
+  New catalog column: `tentative_frontier` on `pgt_stream_tables`.
+
+- **`pg_trickle.change_buffer_durability` GUC** (DUR-2) — New three-valued
+  GUC controlling change buffer WAL behavior:
+  - `unlogged` (default): UNLOGGED tables, maximum throughput, lost on crash.
+  - `logged`: WAL-logged, survives crash, replicated to standbys.
+  - `sync`: WAL-logged + synchronous commit, maximum durability.
+
+### CDC Hardening
+
+- **Zero `unwrap()` in production CDC code** (CDC-1) — All `unwrap()` calls
+  in `src/cdc.rs` are now confined to test code. New error variant
+  `ChangedColsBitmaskFailed` added for future safety.
+
+- **Partitioned-source publication rebuild** (CDC-2) — On scheduler tick,
+  partitioned source tables are checked for correct
+  `publish_via_partition_root` configuration. Mismatched publications are
+  automatically rebuilt with the correct setting.
+
+- **TOAST-aware CDC hashing** (CDC-3) — Columns with `attstorage IN ('e', 'x')`
+  (external/extended TOAST) now include `pg_column_size()` in the row-id hash,
+  detecting in-place TOAST rewrites that would otherwise be invisible to CDC.
+
+### Operational Improvements
+
+- **History retention pruning** (OPS-1) — The scheduler now prunes rows from
+  `pgt_refresh_history` older than `pg_trickle.history_retention_days` (default
+  90) in 1k-row batches during idle ticks. Previously, history grew unbounded.
+
+- **Frozen-stream-table detector** (OPS-2) — New dog-feeding view
+  `df_frozen_stream_tables` flags any stream table whose `last_refresh_at`
+  is older than 5× its refresh interval. Alerts via `pgtrickle_alert` NOTIFY.
+
+- **Internal catalog indexes** (OPS-3) — Added composite indexes on:
+  - `pgt_stream_tables(status, scc_id)`
+  - `pgt_refresh_history(pgt_id, action, data_timestamp)`
+  - `pgt_change_tracking(source_relid)`
+
+### Testing
+
+- **25+ unit tests** for `publication.rs` (TEST-6): SLA tier assignment
+  boundary cases, parse_qualified_name edge cases, quote_ident variations.
+- **20+ unit tests** for `diagnostics.rs` (TEST-7): Duration parsing,
+  version validation, format routing.
+- **10+ unit tests** for `metrics_server.rs` (TEST-8): HTTP request routing,
+  OpenMetrics content-type, port-zero disablement, health endpoints.
 
 ## [Unreleased]
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -36,7 +36,7 @@ coverage, all in plain language.
 - [v0.17.0 — Query Intelligence & Stability](#v0170--query-intelligence--stability)
 - [v0.18.0 — Hardening & Delta Performance](#v0180--hardening--delta-performance)
 - [v0.19.0 — Production Gap Closure & Distribution](#v0190--production-gap-closure--distribution)
-- [v0.20.0 — Dog-Feeding](#v0200--dog-feeding-pg_trickle-monitors-itself)
+- [v0.20.0 — Self-Monitoring](#v0200--self-monitoring-pg_trickle-monitors-itself)
 - [v0.21.0 — Correctness, Safety & Test Hardening](#v0210--correctness-safety--test-hardening)
 - [v0.22.0 — Production Scalability & Downstream Integration](#v0220--production-scalability--downstream-integration)
 - [v0.23.0 — TPC-H DVM Scaling Performance](#v0230--tpch-dvm-scaling-performance)
@@ -45,7 +45,7 @@ coverage, all in plain language.
 - [v0.26.0 — Test & Concurrency Hardening](#v0260--test--concurrency-hardening)
 - [v0.27.0 — Transactional Inbox & Outbox Patterns](#v0270--transactional-inbox--outbox-patterns)
 - [v0.28.0 — Relay CLI (`pgtrickle-relay`)](#v0280--relay-cli-pgtrickle-relay)
-- [v1.6.0 — TUI Dog-Feeding Integration](#v160--tui-dog-feeding-integration)
+- [v1.6.0 — TUI Self-Monitoring Integration](#v160--tui-self-monitoring-integration)
 - [v1.1.0 — PostgreSQL 17 Support](#v110--postgresql-17-support)
 - [v1.2.0 — PGlite Proof of Concept](#v120--pglite-proof-of-concept)
 - [v1.3.0 — Core Extraction (`pg_trickle_core`)](#v130--core-extraction-pg_trickle_core)
@@ -99,7 +99,7 @@ from the v0.1.x series to 1.0 and beyond.
 | v0.26.0 | Test & concurrency hardening | Planned |
 | v0.27.0 | Transactional inbox & outbox patterns | Planned |
 | v0.28.0 | Relay CLI (`pgtrickle-relay`) — bidirectional outbox→sinks + sources→inbox | Planned |
-| v1.6.0 | TUI dog-feeding integration | Planned |
+| v1.6.0 | TUI self-monitoring integration | Planned |
 | v1.1.0 | PostgreSQL 17 support | Planned |
 | v1.2.0 | PGlite proof of concept | Planned |
 | v1.3.0 | Core extraction (`pg_trickle_core`) | Planned |
@@ -5260,15 +5260,15 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 
 ---
 
-## v0.20.0 — Dog-Feeding (pg_trickle Monitors Itself)
+## v0.20.0 — Self-Monitoring (pg_trickle Monitors Itself)
 
 **Status: Released (2026-04-15).** All 62 items implemented, 1 skipped
 (PERF-6 already shipped in v0.19.0). See `plans/PLAN_0_20_0.md`.
 
 > **Release Theme**
-> This release implements *dog-feeding*: pg_trickle uses its own stream
+> This release implements *self-monitoring*: pg_trickle uses its own stream
 > tables to maintain reactive analytics over its internal catalog and
-> refresh-history tables. Five dog-feeding stream tables (`df_efficiency_rolling`,
+> refresh-history tables. Five self-monitoring stream tables (`df_efficiency_rolling`,
 > `df_anomaly_signals`, `df_threshold_advice`, `df_cdc_buffer_trends`,
 > `df_scheduling_interference`) replace repeated full-scan diagnostic
 > functions with continuously-maintained incremental views, enable
@@ -5278,7 +5278,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 > its own non-trivial workload and demonstrates the incremental analytics
 > value proposition to users.
 >
-> See [plans/PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) for the full
+> See [plans/PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) for the full
 > design, architecture, and risk analysis.
 
 <details>
@@ -5288,57 +5288,57 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| DF-F1 | **Verify CDC on `pgt_refresh_history`.** Confirm that `create_stream_table()` installs INSERT triggers on `pgt_refresh_history`. Fix schema-exclusion logic if the `pgtrickle` schema is skipped. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §7 Phase 1 |
-| DF-F2 | **Create `df_efficiency_rolling` (DF-1).** Maintained rolling-window aggregates over `pgt_refresh_history`. Replaces `refresh_efficiency()` full scans. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §5 DF-1 |
-| DF-F3 | **E2E test: DF-1 output matches `refresh_efficiency()`.** Insert synthetic history rows, refresh DF-1, assert aggregates agree. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §8 |
-| DF-F4 | **`pgtrickle.setup_dog_feeding()` helper.** Single SQL call that creates all five `df_*` stream tables. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §7 Phase 4 |
-| DF-F5 | **`pgtrickle.teardown_dog_feeding()` helper.** Drops all `df_*` stream tables cleanly. | 1h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §7 Phase 4 |
+| DF-F1 | **Verify CDC on `pgt_refresh_history`.** Confirm that `create_stream_table()` installs INSERT triggers on `pgt_refresh_history`. Fix schema-exclusion logic if the `pgtrickle` schema is skipped. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §7 Phase 1 |
+| DF-F2 | **Create `df_efficiency_rolling` (DF-1).** Maintained rolling-window aggregates over `pgt_refresh_history`. Replaces `refresh_efficiency()` full scans. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §5 DF-1 |
+| DF-F3 | **E2E test: DF-1 output matches `refresh_efficiency()`.** Insert synthetic history rows, refresh DF-1, assert aggregates agree. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §8 |
+| DF-F4 | **`pgtrickle.setup_self_monitoring()` helper.** Single SQL call that creates all five `df_*` stream tables. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §7 Phase 4 |
+| DF-F5 | **`pgtrickle.teardown_self_monitoring()` helper.** Drops all `df_*` stream tables cleanly. | 1h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §7 Phase 4 |
 
 ### Phase 2 — Anomaly Detection
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| DF-A1 | **Create `df_anomaly_signals` (DF-2).** Detects duration spikes, error bursts, and mode oscillation by comparing recent behavior against DF-1 baselines. | 3–5h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §5 DF-2 |
-| DF-A2 | **Create `df_threshold_advice` (DF-3).** Multi-cycle threshold recommendation replacing the single-step `compute_adaptive_threshold()` convergence. | 3–5h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §5 DF-3 |
-| DF-A3 | **Verify DAG ordering.** DF-1 refreshes before DF-2 and DF-3. | 1–2h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §7 Phase 2 |
-| DF-A4 | **E2E test: threshold spike detection.** Inject synthetic history making DIFF consistently fast; assert DF-3 recommends raising the threshold. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §8 |
-| DF-A5 | **E2E test: anomaly duration spike.** Inject a 3× duration spike; assert DF-2 detects it. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §8 |
+| DF-A1 | **Create `df_anomaly_signals` (DF-2).** Detects duration spikes, error bursts, and mode oscillation by comparing recent behavior against DF-1 baselines. | 3–5h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §5 DF-2 |
+| DF-A2 | **Create `df_threshold_advice` (DF-3).** Multi-cycle threshold recommendation replacing the single-step `compute_adaptive_threshold()` convergence. | 3–5h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §5 DF-3 |
+| DF-A3 | **Verify DAG ordering.** DF-1 refreshes before DF-2 and DF-3. | 1–2h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §7 Phase 2 |
+| DF-A4 | **E2E test: threshold spike detection.** Inject synthetic history making DIFF consistently fast; assert DF-3 recommends raising the threshold. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §8 |
+| DF-A5 | **E2E test: anomaly duration spike.** Inject a 3× duration spike; assert DF-2 detects it. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §8 |
 
 ### Phase 3 — CDC Buffer & Interference
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| DF-C1 | **Create `df_cdc_buffer_trends` (DF-4).** Tracks change-buffer growth rates per source table. May require `pgtrickle.cdc_buffer_row_counts()` helper for dynamic table names. | 4–8h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §5 DF-4 |
-| DF-C2 | **Create `df_scheduling_interference` (DF-5).** Detects concurrent refresh overlap. FULL-refresh mode initially (bounded 1-hour window). | 3–5h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §5 DF-5 |
-| DF-C3 | **E2E test: scheduling overlap detection.** Create 3 STs with overlapping schedules; verify DF-5 detects overlap. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §8 |
+| DF-C1 | **Create `df_cdc_buffer_trends` (DF-4).** Tracks change-buffer growth rates per source table. May require `pgtrickle.cdc_buffer_row_counts()` helper for dynamic table names. | 4–8h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §5 DF-4 |
+| DF-C2 | **Create `df_scheduling_interference` (DF-5).** Detects concurrent refresh overlap. FULL-refresh mode initially (bounded 1-hour window). | 3–5h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §5 DF-5 |
+| DF-C3 | **E2E test: scheduling overlap detection.** Create 3 STs with overlapping schedules; verify DF-5 detects overlap. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §8 |
 
 ### Phase 4 — GUC & Auto-Apply
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| DF-G1 | **`pg_trickle.dog_feeding_auto_apply` GUC.** Values: `off` (default) / `threshold_only` / `full`. Registered in `src/config.rs`. | 1–2h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §6.2 |
-| DF-G2 | **Auto-apply worker (threshold_only).** Post-tick hook reads `df_threshold_advice`; applies `ALTER STREAM TABLE ... SET auto_threshold = <recommended>` when confidence is HIGH and delta > 5%. Rate-limited to 1 change per ST per 10 minutes. | 4–8h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §7 Phase 5 |
-| DF-G3 | **`initiated_by = 'DOG_FEED'` audit trail.** Log auto-apply changes to `pgt_refresh_history`. | 1–2h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §7 Phase 5 |
-| DF-G4 | **E2E test: auto-apply threshold.** Enable `threshold_only`, inject history making DIFF consistently faster, verify threshold increases automatically. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §8 |
-| DF-G5 | **E2E test: rate limiting.** Verify no more than 1 threshold change per ST per 10 minutes. | 1–2h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §8 |
+| DF-G1 | **`pg_trickle.self_monitoring_auto_apply` GUC.** Values: `off` (default) / `threshold_only` / `full`. Registered in `src/config.rs`. | 1–2h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §6.2 |
+| DF-G2 | **Auto-apply worker (threshold_only).** Post-tick hook reads `df_threshold_advice`; applies `ALTER STREAM TABLE ... SET auto_threshold = <recommended>` when confidence is HIGH and delta > 5%. Rate-limited to 1 change per ST per 10 minutes. | 4–8h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §7 Phase 5 |
+| DF-G3 | **`initiated_by = 'SELF_MONITOR'` audit trail.** Log auto-apply changes to `pgt_refresh_history`. | 1–2h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §7 Phase 5 |
+| DF-G4 | **E2E test: auto-apply threshold.** Enable `threshold_only`, inject history making DIFF consistently faster, verify threshold increases automatically. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §8 |
+| DF-G5 | **E2E test: rate limiting.** Verify no more than 1 threshold change per ST per 10 minutes. | 1–2h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §8 |
 
 ### Phase 5 — Operational Diagnostics
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| OPS-1 | **`pgtrickle.recommend_refresh_mode(st_name)`** Reads `df_threshold_advice` to return a structured recommendation `{ mode, confidence, reason }` rather than computing on demand. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §10.6 |
-| OPS-2 | **`check_cdc_health()` spill-risk enrichment.** Query `df_cdc_buffer_trends` growth rate; emit a `spill_risk` alert when buffer growth will breach `spill_threshold_blocks` within 2 cycles. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §10.3 |
+| OPS-1 | **`pgtrickle.recommend_refresh_mode(st_name)`** Reads `df_threshold_advice` to return a structured recommendation `{ mode, confidence, reason }` rather than computing on demand. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §10.6 |
+| OPS-2 | **`check_cdc_health()` spill-risk enrichment.** Query `df_cdc_buffer_trends` growth rate; emit a `spill_risk` alert when buffer growth will breach `spill_threshold_blocks` within 2 cycles. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §10.3 |
 | OPS-3 | **`pgtrickle.scheduler_overhead()` diagnostic function.** Returns busy-time ratio, queue depth, avg dispatch latency, and fraction of CPU spent on DF STs vs user STs. | 2–4h | — |
-| OPS-4 | **`pgtrickle.explain_dag()` — Mermaid/DOT output.** Returns DAG as Mermaid markdown with node colours: user=blue, dog-feeding=green, suspended=red. | 3–4h | — |
-| OPS-5 | **`sql/dog_feeding_setup.sql` quick-start template.** Runnable script: call `setup_dog_feeding()`, set `dog_feeding_auto_apply = 'threshold_only'`, configure LISTEN, query initial recommendations. | 1h | — |
-| OPS-6 | **Workload-aware poll intervals via DF-5 signal.** Replace `compute_adaptive_poll_ms()` exponential backoff with pre-emptive dispatch interval widening when `df_scheduling_interference` detects contention. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §10.2 |
-| DASH-1 | **Grafana Dog-Feeding Dashboard.** New `monitoring/grafana/dashboards/pg_trickle_dog_feeding.json` — 5 panels reading from DF-1 through DF-5. | 4–6h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §10.5 |
-| DBT-1 | **dbt `pgtrickle_enable_monitoring` post-hook macro.** Calls `setup_dog_feeding()` automatically after a successful `dbt run`; documented in `dbt-pgtrickle/`. | 2h | — |
+| OPS-4 | **`pgtrickle.explain_dag()` — Mermaid/DOT output.** Returns DAG as Mermaid markdown with node colours: user=blue, self-monitoring=green, suspended=red. | 3–4h | — |
+| OPS-5 | **`sql/self_monitoring_setup.sql` quick-start template.** Runnable script: call `setup_self_monitoring()`, set `self_monitoring_auto_apply = 'threshold_only'`, configure LISTEN, query initial recommendations. | 1h | — |
+| OPS-6 | **Workload-aware poll intervals via DF-5 signal.** Replace `compute_adaptive_poll_ms()` exponential backoff with pre-emptive dispatch interval widening when `df_scheduling_interference` detects contention. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §10.2 |
+| DASH-1 | **Grafana Self-Monitoring Dashboard.** New `monitoring/grafana/dashboards/pg_trickle_self_monitoring.json` — 5 panels reading from DF-1 through DF-5. | 4–6h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §10.5 |
+| DBT-1 | **dbt `pgtrickle_enable_monitoring` post-hook macro.** Calls `setup_self_monitoring()` automatically after a successful `dbt run`; documented in `dbt-pgtrickle/`. | 2h | — |
 
 **OPS-1 — `pgtrickle.recommend_refresh_mode(st_name text)`**
 
 > Reads directly from `df_threshold_advice` instead of computing a
-> single-cycle cost comparison on demand (PLAN_DOG_FEEDING.md §10.6). Returns
+> single-cycle cost comparison on demand (PLAN_SELF_MONITORING.md §10.6). Returns
 > `TABLE(mode text, confidence text, reason text)`. When confidence is LOW
 > (< 10 history rows), emits a fallback with mode=`'AUTO'` and a reason
 > explaining insufficient data. Integrates with `explain_st()` output.
@@ -5353,7 +5353,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 > When DF-C1 is active, query `df_cdc_buffer_trends` growth rate instead.
 > Emit a `spill_risk = 'IMMINENT'` row when the 1-cycle growth rate extrapolated
 > 2 cycles ahead exceeds `spill_threshold_blocks`. Falls back to full scan
-> when dog-feeding is not set up.
+> when self-monitoring is not set up.
 >
 > Verify: inject 80% of `spill_threshold_blocks` worth of buffer rows with a
 > steep growth rate; assert `check_cdc_health()` returns a spill-risk alert.
@@ -5376,20 +5376,20 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 > Returns the full refresh DAG as a Mermaid markdown string (default) or
 > Graphviz DOT (via `format => 'dot'` argument). Node labels show ST name,
 > current mode, and refresh interval. Node colours: user STs = blue,
-> dog-feeding STs = green, suspended = red, fused = orange. Edges show
+> self-monitoring STs = green, suspended = red, fused = orange. Edges show
 > dependency direction. Validates that DF-1 → DF-2 → DF-3 ordering is
 > correct post-setup.
 >
-> Verify: `SELECT pgtrickle.explain_dag()` after `setup_dog_feeding()` returns
+> Verify: `SELECT pgtrickle.explain_dag()` after `setup_self_monitoring()` returns
 > a string containing all five `df_` nodes in green with correct edges.
 > Dependencies: None. Schema change: No (new function only).
 
-**OPS-5 — `sql/dog_feeding_setup.sql` quick-start template**
+**OPS-5 — `sql/self_monitoring_setup.sql` quick-start template**
 
 > A standalone SQL script in `sql/` that an operator can run with
-> `psql -f sql/dog_feeding_setup.sql`. Contents: calls `setup_dog_feeding()`,
-> sets `pg_trickle.dog_feeding_auto_apply = 'threshold_only'`, runs
-> `LISTEN pg_trickle_alert`, queries `dog_feeding_status()` for a status
+> `psql -f sql/self_monitoring_setup.sql`. Contents: calls `setup_self_monitoring()`,
+> sets `pg_trickle.self_monitoring_auto_apply = 'threshold_only'`, runs
+> `LISTEN pg_trickle_alert`, queries `self_monitoring_status()` for a status
 > summary, and queries `df_threshold_advice` for initial recommendations
 > with a warm-up note. Referenced from GETTING_STARTED.md Day 2 operations
 > section (UX-4).
@@ -5405,7 +5405,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 > signal: after each scheduler tick, read the latest `overlap_count` from
 > `df_scheduling_interference`; if `overlap_count >= 2`, increase the dispatch
 > interval for the next tick by 20% before dispatching (capped at
-> `pg_trickle.max_poll_interval_ms`). This closes the dog-feeding feedback loop
+> `pg_trickle.max_poll_interval_ms`). This closes the self-monitoring feedback loop
 > by letting the analytics directly influence scheduling policy, reducing
 > contention on write-heavy deployments without waiting for timeouts.
 >
@@ -5413,9 +5413,9 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 > DF-5 with signal enabled vs disabled. `scheduler_overhead()` shows reduced
 > busy-time ratio. Dependencies: DF-C2, OPS-3. Schema change: No.
 
-**DASH-1 — Grafana Dog-Feeding Dashboard**
+**DASH-1 — Grafana Self-Monitoring Dashboard**
 
-> Add `monitoring/grafana/dashboards/pg_trickle_dog_feeding.json` alongside
+> Add `monitoring/grafana/dashboards/pg_trickle_self_monitoring.json` alongside
 > the existing `pg_trickle_overview.json`. Five panels: (1) Refresh throughput
 > timeline (DF-1 `avg_diff_ms` over time), (2) Anomaly heatmap (DF-2 per-ST
 > anomaly type grid), (3) Threshold calibration scatter (DF-3 current vs
@@ -5430,24 +5430,24 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 **DBT-1 — `pgtrickle_enable_monitoring` dbt post-hook macro**
 
 > Add a `pgtrickle_enable_monitoring` macro to `dbt-pgtrickle/macros/` that
-> calls `{{ pgtrickle.setup_dog_feeding() }}` and emits a `log()` message
+> calls `{{ pgtrickle.setup_self_monitoring() }}` and emits a `log()` message
 > confirming activation. Documented in `dbt-pgtrickle/README.md`. Users add
 > `+post-hook: "{{ pgtrickle_enable_monitoring() }}"` to `dbt_project.yml`
 > to auto-enable monitoring after any `dbt run`. Idempotent — safe to call on
-> every run because `setup_dog_feeding()` is already idempotent (STAB-1).
+> every run because `setup_self_monitoring()` is already idempotent (STAB-1).
 >
 > Verify: `just test-dbt` includes a test case that runs the macro twice;
-> asserts `dog_feeding_status()` shows 5 active STs after both calls.
+> asserts `self_monitoring_status()` shows 5 active STs after both calls.
 > Dependencies: DF-F4, STAB-1. Schema change: No.
 
 ### Documentation & Safety
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| DF-D1 | **SQL_REFERENCE.md: dog-feeding quick start.** Document `setup_dog_feeding()`, `teardown_dog_feeding()`, all five `df_*` stream tables, and the auto-apply GUC. | 2–4h | — |
-| DF-D2 | **CONFIGURATION.md: `pg_trickle.dog_feeding_auto_apply` GUC.** | 1h | — |
-| DF-D3 | **E2E test: control plane survives DF ST suspension.** Drop or suspend all `df_*` STs; verify the scheduler and refresh logic operate identically. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §8 |
-| DF-D4 | **Soak test addition.** Add dog-feeding STs to the existing soak test; verify no memory growth or scheduler stalls under 1-hour sustained load. | 2–4h | [PLAN_DOG_FEEDING.md](plans/PLAN_DOG_FEEDING.md) §8 |
+| DF-D1 | **SQL_REFERENCE.md: self-monitoring quick start.** Document `setup_self_monitoring()`, `teardown_self_monitoring()`, all five `df_*` stream tables, and the auto-apply GUC. | 2–4h | — |
+| DF-D2 | **CONFIGURATION.md: `pg_trickle.self_monitoring_auto_apply` GUC.** | 1h | — |
+| DF-D3 | **E2E test: control plane survives DF ST suspension.** Drop or suspend all `df_*` STs; verify the scheduler and refresh logic operate identically. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §8 |
+| DF-D4 | **Soak test addition.** Add self-monitoring STs to the existing soak test; verify no memory growth or scheduler stalls under 1-hour sustained load. | 2–4h | [PLAN_SELF_MONITORING.md](plans/PLAN_SELF_MONITORING.md) §8 |
 
 ### Correctness
 
@@ -5526,21 +5526,21 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| STAB-1 | `setup_dog_feeding()` is fully idempotent | S | P0 |
+| STAB-1 | `setup_self_monitoring()` is fully idempotent | S | P0 |
 | STAB-2 | Auto-apply handles `ALTER STREAM TABLE` failure gracefully | S | P0 |
 | STAB-3 | DF STs survive `DROP EXTENSION` + `CREATE EXTENSION` cycle | S | P1 |
 | STAB-4 | Auto-apply worker checks ST still exists before applying | XS | P1 |
-| STAB-5 | `teardown_dog_feeding()` is safe when some DF STs already removed | XS | P1 |
+| STAB-5 | `teardown_self_monitoring()` is safe when some DF STs already removed | XS | P1 |
 
-**STAB-1 — `setup_dog_feeding()` is fully idempotent**
+**STAB-1 — `setup_self_monitoring()` is fully idempotent**
 
-> Calling `setup_dog_feeding()` a second time while DF STs already exist must
+> Calling `setup_self_monitoring()` a second time while DF STs already exist must
 > not raise an error. Use `IF NOT EXISTS` semantics internally (or check catalog
 > before creating). The function must also be safe to call concurrently from
 > two sessions. Idempotency is critical for upgrade scripts and Terraform-style
 > declarative deployment workflows.
 >
-> Verify: call `setup_dog_feeding()` three times in a row; no errors, no
+> Verify: call `setup_self_monitoring()` three times in a row; no errors, no
 > duplicate stream tables. Dependencies: DF-F4. Schema change: No.
 
 **STAB-2 — Auto-apply handles `ALTER STREAM TABLE` failure gracefully**
@@ -5559,13 +5559,13 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 **STAB-3 — DF STs survive `DROP EXTENSION` + `CREATE EXTENSION` cycle**
 
 > `DROP EXTENSION pg_trickle CASCADE` drops all extension-owned objects.
-> After `CREATE EXTENSION pg_trickle`, `setup_dog_feeding()` should recreate
+> After `CREATE EXTENSION pg_trickle`, `setup_self_monitoring()` should recreate
 > the DF STs cleanly. There must be no leftover triggers, orphaned change
 > buffer tables, or stale catalog rows from the previous installation. This
 > is the most likely failure mode after an emergency rollback + reinstall.
 >
-> Verify: E2E test: `setup_dog_feeding()` → `DROP EXTENSION CASCADE` →
-> `CREATE EXTENSION` → `setup_dog_feeding()` → insert history → refresh DF-1;
+> Verify: E2E test: `setup_self_monitoring()` → `DROP EXTENSION CASCADE` →
+> `CREATE EXTENSION` → `setup_self_monitoring()` → insert history → refresh DF-1;
 > assert correct aggregates. Dependencies: DF-F4, DF-F5. Schema change: No.
 
 **STAB-4 — Auto-apply worker checks ST still exists before applying**
@@ -5580,15 +5580,15 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 > assert no threshold change is applied-to a suspended stream table.
 > Dependencies: DF-G2. Schema change: No.
 
-**STAB-5 — `teardown_dog_feeding()` is safe when some DF STs already removed**
+**STAB-5 — `teardown_self_monitoring()` is safe when some DF STs already removed**
 
 > If a user manually drops `df_anomaly_signals` before calling
-> `teardown_dog_feeding()`, the teardown function must not error on `DROP
+> `teardown_self_monitoring()`, the teardown function must not error on `DROP
 > STREAM TABLE df_anomaly_signals`. Use `drop_stream_table(name, if_exists
 > => true)` semantics for each DF table in the teardown. Otherwise a partial
 > teardown leaves the system in an inconsistent state.
 >
-> Verify: drop two DF STs manually, then call `teardown_dog_feeding()`; assert
+> Verify: drop two DF STs manually, then call `teardown_self_monitoring()`; assert
 > no errors and remaining DF STs are gone. Dependencies: DF-F5. Schema change: No.
 
 ---
@@ -5618,7 +5618,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 
 **PERF-2 — Benchmark DF-1 vs `refresh_efficiency()` on 10 K history rows**
 
-> The primary performance claim of dog-feeding is that a maintained DIFFERENTIAL
+> The primary performance claim of self-monitoring is that a maintained DIFFERENTIAL
 > stream table is cheaper than scanning the full history table on every
 > diagnostic call. Establish a Criterion micro-benchmark that seeds 10 K history
 > rows, then compares: (a) a full `SELECT * FROM pgtrickle.refresh_efficiency()`
@@ -5656,7 +5656,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 **PERF-5 — History pruning batch-DELETE with short transactions**
 
 > `pg_trickle.history_retention_days` cleanup (shipped in v0.19.0) currently
-> deletes rows in a single long transaction. Under dog-feeding, that transaction
+> deletes rows in a single long transaction. Under self-monitoring, that transaction
 > holds a lock on `pgt_refresh_history` that can delay CDC trigger INSERTs.
 > Rewrite the purge as batched DELETEs: delete at most 500 rows per
 > transaction, commit between batches, sleep 50 ms between batches. The index
@@ -5688,7 +5688,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
 | SCAL-1 | DF STs refresh within window at 100 user stream tables | S | P1 |
-| SCAL-2 | `pgt_refresh_history` retention interacts correctly with dog-feeding | S | P1 |
+| SCAL-2 | `pgt_refresh_history` retention interacts correctly with self-monitoring | S | P1 |
 | SCAL-3 | 1-hour rolling window doesn't over-aggregate when history is sparse | XS | P2 |
 
 **SCAL-1 — DF STs refresh within window at 100 user stream tables**
@@ -5702,7 +5702,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 > Verify: soak test with 100 STs; DF-1 refresh duration < 10 s throughout.
 > Dependencies: PERF-1. Schema change: No.
 
-**SCAL-2 — `pgt_refresh_history` retention interacts correctly with dog-feeding**
+**SCAL-2 — `pgt_refresh_history` retention interacts correctly with self-monitoring**
 
 > `pg_trickle.history_retention_days` (shipped in v0.19.0, default 90 days)
 > purges old history rows. DF-1 only looks back 1 hour, so retention does
@@ -5732,8 +5732,8 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| UX-1 | `pgtrickle.dog_feeding_status()` diagnostic function | S | P0 |
-| UX-2 | `setup_dog_feeding()` warm-up hint when history is sparse | XS | P1 |
+| UX-1 | `pgtrickle.self_monitoring_status()` diagnostic function | S | P0 |
+| UX-2 | `setup_self_monitoring()` warm-up hint when history is sparse | XS | P1 |
 | UX-3 | NOTIFY on anomaly via `pg_trickle_alert` channel | S | P1 |
 | UX-4 | GETTING_STARTED.md: "Day 2 operations" section | S | P1 |
 | UX-5 | `explain_st()` shows if a DF ST covers the queried stream table | XS | P2 |
@@ -5741,34 +5741,34 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 | UX-7 | `scheduler_overhead()` output included in TUI diagnostics panel | XS | P2 |
 | UX-8 | `df_threshold_advice` extended with SLA headroom column | S | P2 |
 
-**UX-1 — `pgtrickle.dog_feeding_status()` diagnostic function**
+**UX-1 — `pgtrickle.self_monitoring_status()` diagnostic function**
 
-> A single-query overview of the dog-feeding analytics plane: name, last
+> A single-query overview of the self-monitoring analytics plane: name, last
 > refresh timestamp, row count, and whether the DF ST is ACTIVE / SUSPENDED /
 > NOT_CREATED. Calling this function is the first thing an operator should run
-> to check that dog-feeding is working. Return type: `TABLE(df_name text,
+> to check that self-monitoring is working. Return type: `TABLE(df_name text,
 > status text, last_refresh timestamptz, row_count bigint, note text)`.
 >
 > Verify: function returns 5 rows when all DF STs are active; returns rows with
-> `status = 'NOT_CREATED'` when `setup_dog_feeding()` has not been called.
+> `status = 'NOT_CREATED'` when `setup_self_monitoring()` has not been called.
 > Schema change: No (new function only).
 
-**UX-2 — `setup_dog_feeding()` warm-up hint when history is sparse**
+**UX-2 — `setup_self_monitoring()` warm-up hint when history is sparse**
 
-> If `pgt_refresh_history` has fewer than 50 rows when `setup_dog_feeding()`
+> If `pgt_refresh_history` has fewer than 50 rows when `setup_self_monitoring()`
 > is called, emit a NOTICE: `"Dog-feeding stream tables created. DF analytics
 > will populate as refresh history accumulates (currently N rows; recommend
 > ≥ 50 before consulting df_threshold_advice)."` This prevents operators from
 > acting on meaningless LOW-confidence advice immediately after setup.
 >
-> Verify: call `setup_dog_feeding()` on a fresh install; assert NOTICE contains
+> Verify: call `setup_self_monitoring()` on a fresh install; assert NOTICE contains
 > the row count and the ≥ 50 recommendation. Dependencies: DF-F4. Schema change: No.
 
 **UX-3 — NOTIFY on anomaly via `pg_trickle_alert` channel**
 
 > When `df_anomaly_signals` detects a `duration_anomaly IS NOT NULL` or
 > `recent_failures >= 2` after a refresh, emit a `pg_notify('pg_trickle_alert',
-> payload::text)` with `event = 'dog_feed_anomaly'`, the stream table name,
+> payload::text)` with `event = 'self_monitor_anomaly'`, the stream table name,
 > anomaly type, last duration, baseline, and a plain-English recommendation.
 > This integrates with existing alert pipelines without requiring a new channel.
 > Fires from a post-refresh trigger on `df_anomaly_signals` or from the
@@ -5781,10 +5781,10 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 **UX-4 — GETTING_STARTED.md: "Day 2 operations" section**
 
 > Add a new section to `docs/GETTING_STARTED.md` covering the first steps
-> after initial deployment: (1) enable dog-feeding with `setup_dog_feeding()`,
-> (2) check status with `dog_feeding_status()`, (3) query `df_threshold_advice`
+> after initial deployment: (1) enable self-monitoring with `setup_self_monitoring()`,
+> (2) check status with `self_monitoring_status()`, (3) query `df_threshold_advice`
 > to tune thresholds, (4) set up anomaly alerting via LISTEN. This gives new
-> users a clear post-install checklist and demonstrates the dog-feeding value
+> users a clear post-install checklist and demonstrates the self-monitoring value
 > proposition immediately.
 >
 > Verify: documentation PR reviewed; code examples in GETTING_STARTED.md
@@ -5794,11 +5794,11 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 
 > When a user calls `pgtrickle.explain_st('my_table')`, append a line
 > `"Dog-feeding coverage: df_efficiency_rolling ✓, df_threshold_advice ✓"` (or
-> `"Not set up — run setup_dog_feeding()"`) to the output. This surfaces the
-> analytics plane to users who might not know dog-feeding exists, without
+> `"Not set up — run setup_self_monitoring()"`) to the output. This surfaces the
+> analytics plane to users who might not know self-monitoring exists, without
 > requiring a separate function call.
 >
-> Verify: `SELECT explain_st('any_table')` output includes a `dog_feeding`
+> Verify: `SELECT explain_st('any_table')` output includes a `self_monitoring`
 > field in the JSON output. Dependencies: UX-1. Schema change: No.
 
 **UX-8 — `df_threshold_advice` extended with SLA headroom column**
@@ -5816,10 +5816,10 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 
 **UX-6 — `recommend_refresh_mode()` exposed in `explain_st()` JSON output**
 
-> `explain_st()` already shows dog-feeding coverage (UX-5). Extend its JSON
+> `explain_st()` already shows self-monitoring coverage (UX-5). Extend its JSON
 > output with a `recommended_mode` field reading from `df_threshold_advice`
 > (OPS-1). If OPS-1 is not available (no DF setup), fall back to `null` with
-> a `setup_dog_feeding()` hint. Keeps the single-function diagnostic surface
+> a `setup_self_monitoring()` hint. Keeps the single-function diagnostic surface
 > comprehensive without requiring separate calls.
 >
 > Verify: `SELECT explain_st('any_table')` JSON includes `recommended_mode`
@@ -5843,11 +5843,11 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
 | TEST-1 | Property test: DF-3 recommended threshold always ∈ \[0.01, 0.80\] | S | P0 |
-| TEST-2 | Light E2E: dog-feeding create/refresh/teardown full cycle | S | P0 |
+| TEST-2 | Light E2E: self-monitoring create/refresh/teardown full cycle | S | P0 |
 | TEST-3 | Upgrade test: `pgt_refresh_history` rows survive `0.19.0 → 0.20.0` | S | P0 |
 | TEST-4 | Regression test: DF STs absent from `check_cdc_health()` anomaly list | XS | P1 |
-| TEST-5 | Stability test: dog-feeding under 1-h soak with 50 user STs | M | P1 |
-| TEST-6 | Light E2E: `setup_dog_feeding()` idempotency (3× call) | XS | P1 |
+| TEST-5 | Stability test: self-monitoring under 1-h soak with 50 user STs | M | P1 |
+| TEST-6 | Light E2E: `setup_self_monitoring()` idempotency (3× call) | XS | P1 |
 
 **TEST-1 — Property test: DF-3 recommended threshold always ∈ \[0.01, 0.80\]**
 
@@ -5860,13 +5860,13 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 > Verify: `just test-unit` passes; 10,000 proptest iterations with zero failures.
 > Dependencies: CORR-1. Schema change: No.
 
-**TEST-2 — Light E2E: dog-feeding create/refresh/teardown full cycle**
+**TEST-2 — Light E2E: self-monitoring create/refresh/teardown full cycle**
 
 > A light E2E test (stock `postgres:18.3` container) that: (1) installs the
 > extension, (2) creates 3 user STs, (3) runs 5 refresh cycles to populate
-> history, (4) calls `setup_dog_feeding()`, (5) refreshes all DF STs once,
-> (6) asserts `dog_feeding_status()` shows 5 active STs, (7) calls
-> `teardown_dog_feeding()`, (8) asserts all DF STs are gone.
+> history, (4) calls `setup_self_monitoring()`, (5) refreshes all DF STs once,
+> (6) asserts `self_monitoring_status()` shows 5 active STs, (7) calls
+> `teardown_self_monitoring()`, (8) asserts all DF STs are gone.
 >
 > Verify: test passes in `just test-light-e2e` with zero assertions failed.
 > Schema change: No.
@@ -5885,28 +5885,28 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 **TEST-4 — Regression test: DF STs absent from `check_cdc_health()` anomaly list**
 
 > `pgtrickle.check_cdc_health()` scans all stream tables for CDC anomalies.
-> After `setup_dog_feeding()`, DF STs must not appear in the anomaly list
+> After `setup_self_monitoring()`, DF STs must not appear in the anomaly list
 > just because they are refreshed at longer intervals (48–96 s). Their
 > schedules must be recognised as intentionally relaxed, not "falling behind".
 >
-> Verify: E2E test: `setup_dog_feeding()` → wait one full DF cycle → assert
+> Verify: E2E test: `setup_self_monitoring()` → wait one full DF cycle → assert
 > `check_cdc_health()` returns no anomalies for any `df_` table. Dependencies:
 > DF-F4. Schema change: No.
 
-**TEST-5 — Stability test: dog-feeding under 1-h soak with 50 user STs**
+**TEST-5 — Stability test: self-monitoring under 1-h soak with 50 user STs**
 
 > Extends DF-D4. Runs 50 user STs + 5 DF STs for 1 hour under steady insert
 > load (1 000 rows/min across all sources). Assertions: (a) all DF STs remain
 > ACTIVE, (b) no OOM or background worker crash, (c) DF-1 avg refresh duration
-> < 5 s throughout, (d) `pgtrickle.dog_feeding_status()` shows 5 active STs
+> < 5 s throughout, (d) `pgtrickle.self_monitoring_status()` shows 5 active STs
 > at end of run.
 >
 > Verify: soak test passes with all four assertions. Dependencies: DF-D4,
 > SCAL-1. Schema change: No.
 
-**TEST-6 — Light E2E: `setup_dog_feeding()` idempotency (3× call)**
+**TEST-6 — Light E2E: `setup_self_monitoring()` idempotency (3× call)**
 
-> Implements STAB-1 as a light E2E test. Call `setup_dog_feeding()` three
+> Implements STAB-1 as a light E2E test. Call `setup_self_monitoring()` three
 > consecutive times in the same session. Assert: no errors, exactly five
 > `df_` stream tables in `pgt_stream_tables`, no duplicate triggers in
 > `pg_trigger` for history table.
@@ -5933,7 +5933,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 3. **STAB-3 (DROP EXTENSION cycle) requires DF STs to be extension-owned or
    cleanly unregistered.** If DF STs are not extension-owned objects, `DROP
    EXTENSION CASCADE` will not drop them. Either register them as extension
-   members or document that `teardown_dog_feeding()` must be called before
+   members or document that `teardown_self_monitoring()` must be called before
    `DROP EXTENSION`.
 
 4. **TEST-5 (soak test) overlaps with the existing soak test in CI.** Add it
@@ -5953,7 +5953,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
    affecting any other item — it shares no code paths with the DF pipeline.
 
 7. **OPS-2 (`check_cdc_health()` enrichment) has a fallback requirement.**
-   When `setup_dog_feeding()` has not been called, the function must fall back
+   When `setup_self_monitoring()` has not been called, the function must fall back
    to the old full-scan path without error. Guard with a catalog check for
    `df_cdc_buffer_trends` existence before querying it.
 
@@ -5966,7 +5966,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
    `compute_adaptive_poll_ms()` function is called on every scheduler tick.
    The DF-5 read must be a single O(1) catalog lookup (latest row only), not
    a full table scan. Guard with `LIMIT 1 ORDER BY collected_at DESC`. If
-   the DF-5 table does not exist (dog-feeding not set up), fall back to the
+   the DF-5 table does not exist (self-monitoring not set up), fall back to the
    old backoff logic without error.
 
 10. **DASH-1 (Grafana) depends on postgres-exporter SQL queries.** The
@@ -5976,7 +5976,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
     the existing exporter config.
 
 11. **DBT-1 macro idempotency.** The `pgtrickle_enable_monitoring` macro
-    calls `setup_dog_feeding()` on every `dbt run`. Document that this is
+    calls `setup_self_monitoring()` on every `dbt run`. Document that this is
     intentionally safe (STAB-1) and adds < 5 ms overhead per run.
 
 > **v0.20.0 total: ~3–4 weeks**
@@ -5985,14 +5985,14 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 - [x] DF-F1: `pgt_refresh_history` receives CDC INSERT triggers when `create_stream_table()` is called
 - [x] DF-F2: `df_efficiency_rolling` created and refreshes correctly in DIFFERENTIAL mode
 - [x] DF-F3: DF-1 output matches `refresh_efficiency()` results on synthetic history
-- [x] DF-F4: `setup_dog_feeding()` creates all five `df_*` stream tables in one call
-- [x] DF-F5: `teardown_dog_feeding()` drops all `df_*` tables cleanly with no orphaned triggers
+- [x] DF-F4: `setup_self_monitoring()` creates all five `df_*` stream tables in one call
+- [x] DF-F5: `teardown_self_monitoring()` drops all `df_*` tables cleanly with no orphaned triggers
 - [x] DF-A1: `df_anomaly_signals` created and detects 3× duration spikes
 - [x] DF-A2: `df_threshold_advice` provides HIGH-confidence recommendations after ≥ 20 refresh cycles
 - [x] DF-A3: DAG ensures DF-1 refreshes before DF-2 and DF-3 in every scheduler tick
 - [x] DF-C1: `df_cdc_buffer_trends` created (FULL or DIFFERENTIAL mode)
 - [x] DF-C2: `df_scheduling_interference` detects overlapping concurrent refreshes
-- [x] DF-G1: `pg_trickle.dog_feeding_auto_apply` GUC registered with default `off`
+- [x] DF-G1: `pg_trickle.self_monitoring_auto_apply` GUC registered with default `off`
 - [x] DF-G2: Auto-apply adjusts threshold with ≥ 1 confirmed change in E2E test
 - [x] DF-G5: Rate limiting verified — no more than 1 change per ST per 10 minutes
 - [x] DF-D3: Suspending all `df_*` STs does not affect control-plane operation
@@ -6000,13 +6000,13 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 - [x] CORR-2: No false-positive DURATION_SPIKE on first-ever refresh of a new ST
 - [x] CORR-3: `avg_change_ratio` is NULL or in [0, 1] for zero-delta sources
 - [x] CORR-4: Only INSERT triggers (no UPDATE/DELETE) on `pgt_refresh_history`
-- [x] STAB-1: `setup_dog_feeding()` called 3× produces no errors and no duplicates
+- [x] STAB-1: `setup_self_monitoring()` called 3× produces no errors and no duplicates
 - [x] STAB-2: Auto-apply worker logs WARNING (not panic) when ALTER target disappears
-- [x] STAB-3: DROP EXTENSION + CREATE EXTENSION + `setup_dog_feeding()` cycle works cleanly
+- [x] STAB-3: DROP EXTENSION + CREATE EXTENSION + `setup_self_monitoring()` cycle works cleanly
 - [x] PERF-1: `pgt_refresh_history(pgt_id, start_time)` index exists and is used by DF queries
 - [x] PERF-2: DF-1 read ≥ 5× faster than `refresh_efficiency()` at 10 K history rows
-- [x] UX-1: `pgtrickle.dog_feeding_status()` returns correct status for all five DF STs
-- [x] UX-2: `setup_dog_feeding()` emits warm-up NOTICE when history has < 50 rows
+- [x] UX-1: `pgtrickle.self_monitoring_status()` returns correct status for all five DF STs
+- [x] UX-2: `setup_self_monitoring()` emits warm-up NOTICE when history has < 50 rows
 - [x] UX-3: `pg_trickle_alert` NOTIFY received within one DF cycle after a 3× duration spike
 - [x] TEST-1: Proptest for DF-3 threshold bounds passes 10,000 iterations
 - [x] TEST-2: Light E2E full cycle test passes
@@ -6015,13 +6015,13 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 - [x] OPS-1: `recommend_refresh_mode()` returns `mode` ∈ `{'DIFFERENTIAL','FULL','AUTO'}` and `confidence` ∈ `{'HIGH','MEDIUM','LOW'}`
 - [x] OPS-2: `check_cdc_health()` returns spill-risk alert when buffer growth rate extrapolates to breach threshold within 2 cycles
 - [x] OPS-3: `scheduler_overhead()` returns non-NULL fields after ≥ 5 refresh cycles; `df_refresh_fraction < 0.01` in soak test
-- [x] OPS-4: `explain_dag()` output contains all five `df_*` nodes after `setup_dog_feeding()`
-- [x] OPS-5: `sql/dog_feeding_setup.sql` executes without errors on a fresh install
+- [x] OPS-4: `explain_dag()` output contains all five `df_*` nodes after `setup_self_monitoring()`
+- [x] OPS-5: `sql/self_monitoring_setup.sql` executes without errors on a fresh install
 - [x] PERF-5: Concurrent history purge + DF CDC INSERT produces no lock wait timeouts in soak test
 - [x] PERF-6: `changed_columns` bitmask stored in change buffer for UPDATE rows when `columnar_tracking = on` (if included)
 - [x] OPS-6: Soak test shows lower `overlap_count` in DF-5 with workload-aware poll enabled vs disabled
-- [x] DASH-1: `docker compose up` in `monitoring/` loads pg_trickle_dog_feeding dashboard; all 5 panels show data
-- [x] DBT-1: `pgtrickle_enable_monitoring` macro runs twice without error; `dog_feeding_status()` shows 5 active STs after both calls
+- [x] DASH-1: `docker compose up` in `monitoring/` loads pg_trickle_self_monitoring dashboard; all 5 panels show data
+- [x] DBT-1: `pgtrickle_enable_monitoring` macro runs twice without error; `self_monitoring_status()` shows 5 active STs after both calls
 - [x] UX-8: `df_threshold_advice.sla_breach_risk = true` when `avg_diff_ms > freshness_deadline_ms` on synthetic data
 - [x] Extension upgrade path tested (`0.19.0 → 0.20.0`)
 - [x] `just check-version-sync` passes
@@ -6197,7 +6197,7 @@ Dependencies: DB-3 (uses schema version to determine needed migrations). Schema 
 ### Predictive Refresh Cost Model (P2 — §9.3)
 
 > **In plain terms:** The current adaptive threshold reacts *after* a slow
-> differential refresh. This extends dog-feeding to *predict* `duration_ms`
+> differential refresh. This extends self-monitoring to *predict* `duration_ms`
 > from `rows_inserted + rows_deleted` via linear regression over the last
 > hour. When the forecast exceeds `last_full_ms × 1.5`, pg_trickle switches
 > to FULL pre-emptively — eliminating the one-bad-cycle latency spike entirely.
@@ -6473,7 +6473,7 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
 | OPS-1 | **`pg_trickle.refresh_history_retention_days` GUC.** Default 7 days. Bgworker prunes stale rows in 1k-row batches during idle ticks. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4 |
-| OPS-2 | **Frozen-stream-table detector.** New dog-feeding view `df_frozen_stream_tables` that flags any ST whose `last_refresh_at < now() - 5 × refresh_interval` with recent CDC activity. Alert via `pgtrickle_alert` NOTIFY. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4 |
+| OPS-2 | **Frozen-stream-table detector.** New self-monitoring view `df_frozen_stream_tables` that flags any ST whose `last_refresh_at < now() - 5 × refresh_interval` with recent CDC activity. Alert via `pgtrickle_alert` NOTIFY. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4 |
 | OPS-3 | **Missing internal catalog indexes.** Add composite indexes on `pgt_stream_tables(status, scc_id)`, `pgt_refresh_history(pgt_id, action, data_timestamp)`, `pgt_change_tracking(source_relid)`, and a partial index on `changes_<oid>(__pgt_action)`. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §5 |
 
 ### Test Coverage (TEST-6/7/8)
@@ -7079,12 +7079,12 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 
 ---
 
-## v1.6.0 — TUI Dog-Feeding Integration
+## v1.6.0 — TUI Self-Monitoring Integration
 
 **Status: Planned.** See [plans/ui/PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) for the full design.
 
 > **Release Theme**
-> This release wires the v0.20.0 dog-feeding stream tables (`df_*`) into
+> This release wires the v0.20.0 self-monitoring stream tables (`df_*`) into
 > the TUI, giving operators live visibility into anomaly signals, CDC buffer
 > trends, scheduling interference, and efficiency metrics — all driven by
 > the same incremental refresh engine. Alongside the new views, the TUI
@@ -7107,7 +7107,7 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 | T15 | **CLI/TUI command unification.** Introduce `commands/domain.rs` with shared logic for refresh, pause, resume, fuse reset, repair, and gate/ungate. | 0.5d | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §T15 |
 | T16 | **Dog-feeding data layer.** Add `DogFeedingDomain` state types, polling queries for all 5 `df_*` stream tables, fixture builders, and contract stubs. | 1d | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §T16 |
 
-### Phase 2 — Dog-Feeding TUI Views (T17)
+### Phase 2 — Self-Monitoring TUI Views (T17)
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
@@ -7118,13 +7118,13 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 | TUI-5 | **Workers Interference sub-tab.** Second tab in Workers view showing `df_scheduling_interference` overlap pairs. | 3h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-5 |
 | TUI-6 | **Workers scheduler overhead bar.** Busy-time ratio bar from `scheduler_overhead()` in the Workers view. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-6 |
 | TUI-7 | **Dependencies Mermaid/DOT export (`x` key).** Scrollable overlay showing `explain_dag()` Mermaid output; `Ctrl+E` writes to file. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-7 |
-| TUI-8 | **Header dog-feeding status badge.** `df:N/M` pill in the TUI header bar; turns amber on retention warning. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-8 |
-| TUI-9 | **Command palette dog-feeding commands.** `dog-feeding enable / disable / status` in palette with confirmation dialogs. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-9 |
+| TUI-8 | **Header self-monitoring status badge.** `df:N/M` pill in the TUI header bar; turns amber on retention warning. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-8 |
+| TUI-9 | **Command palette self-monitoring commands.** `self-monitoring enable / disable / status` in palette with confirmation dialogs. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-9 |
 | TUI-10 | **Detail view anomaly summary.** Active anomaly count row in the Properties section of the detail overlay. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-10 |
-| TUI-11 | **Refresh Log `[auto]` tag.** Annotate rows with `initiated_by = 'DOG_FEED'` in the Refresh Log view. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-11 |
-| TUI-12 | **First-launch dog-feeding toast.** 10-second hint toast on first launch when dog-feeding is not set up. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-12 |
+| TUI-11 | **Refresh Log `[auto]` tag.** Annotate rows with `initiated_by = 'SELF_MONITOR'` in the Refresh Log view. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-11 |
+| TUI-12 | **First-launch self-monitoring toast.** 10-second hint toast on first launch when self-monitoring is not set up. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-12 |
 | TUI-13 | **Anomaly signals as Issues.** `detect_issues()` maps active anomaly signals to the Issues view with category "Anomaly". | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-13 |
-| TUI-14 | **`dog_feed_anomaly` alert styling.** Cyan `🔍` icon for anomaly alert type in the Alerts view. | 0.5h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-14 |
+| TUI-14 | **`self_monitor_anomaly` alert styling.** Cyan `🔍` icon for anomaly alert type in the Alerts view. | 0.5h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-14 |
 | TUI-15 | **Dashboard snapshot tests.** 5 snapshot branches: standard, wide, empty, anomalies-present, narrow. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-15 |
 | TUI-16 | **Diagnostics `df_efficiency_rolling` panel.** Aggregate speedup ratio and DIFF/FULL counts from `df_efficiency_rolling`. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TUI-16 |
 | TUI-D1 | **`docs/TUI.md` documentation update.** Document Anomaly view, CDC sparklines, Workers interference tab, Mermaid export, header badge, and command palette additions. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §T20 |
@@ -7134,28 +7134,28 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
 | DF-21 | **`sla_breach_risk` column in `df_threshold_advice`.** Boolean: `true` when `avg_diff_ms > freshness_deadline_ms`. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §DF-21 |
-| DF-22 | **`dog_feeding_auto_apply = 'full'` mode.** Widen dispatch interval when `df_scheduling_interference` detects high overlap. | 4h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §DF-22 |
-| DF-23 | **`dog_feeding_status()` retention warning.** `retention_warning` column when `history_retention_days` is below the minimum window. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §DF-23 |
-| DF-24 | **`recommend_refresh_mode()` reads from `df_threshold_advice`.** Returns consistent results with the incremental view when dog-feeding is active. | 3h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §DF-24 |
+| DF-22 | **`self_monitoring_auto_apply = 'full'` mode.** Widen dispatch interval when `df_scheduling_interference` detects high overlap. | 4h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §DF-22 |
+| DF-23 | **`self_monitoring_status()` retention warning.** `retention_warning` column when `history_retention_days` is below the minimum window. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §DF-23 |
+| DF-24 | **`recommend_refresh_mode()` reads from `df_threshold_advice`.** Returns consistent results with the incremental view when self-monitoring is active. | 3h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §DF-24 |
 | TEST-21 | **Proptest for `df_threshold_advice` bounds.** 10,000 cases verifying `[0.01, 0.80]` clamping invariant. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §TEST-21 |
 
 ### Phase 4 — CLI Integration (T19)
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| CLI-1 | **`pgtrickle dog-feeding` subcommand group.** `enable / disable / status` subcommands with `--format json\|table\|csv` for status. | 4h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §CLI-1 |
+| CLI-1 | **`pgtrickle self-monitoring` subcommand group.** `enable / disable / status` subcommands with `--format json\|table\|csv` for status. | 4h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §CLI-1 |
 | CLI-2 | **`pgtrickle graph --format` flag.** `ascii` (existing) / `mermaid` / `dot` format options for the graph subcommand. | 2h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §CLI-2 |
 
 ### Phase 5 — Documentation & Polish (T20)
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
-| DOC-21 | **`docs/GETTING_STARTED.md` Day 2 update.** Document dog-feeding CLI and TUI integration for new users. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §T20 |
+| DOC-21 | **`docs/GETTING_STARTED.md` Day 2 update.** Document self-monitoring CLI and TUI integration for new users. | 1h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §T20 |
 | DOC-22 | **`docs/SQL_REFERENCE.md` update.** Document `df_threshold_advice.sla_breach_risk` column. | 0.5h | [PLAN_TUI_PART_3.md](plans/ui/PLAN_TUI_PART_3.md) §T20 |
 
 ### Phase 6 — TUI/CLI Visualization Polish
 
-TUI/CLI visualization enhancement for the dog-feeding views. Recommended from [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.11.
+TUI/CLI visualization enhancement for the self-monitoring views. Recommended from [PLAN_OVERALL_ASSESSMENT.md](plans/PLAN_OVERALL_ASSESSMENT.md) §9.11.
 
 | Item | Description | Effort | Ref |
 |------|-------------|--------|-----|
@@ -7166,14 +7166,14 @@ TUI/CLI visualization enhancement for the dog-feeding views. Recommended from [P
 | Phase | Description | Duration |
 |-------|-------------|----------|
 | T15 | Architecture Foundation — AppState decomp, selective polling, poller extraction, CLI unification | Days 1–3 |
-| T16 | Dog-Feeding Data Layer — types, polling queries, fixtures, contract stubs | Days 3–5 |
-| T17 | Dog-Feeding TUI Views — all 16 TUI items, snapshot + unit tests | Days 5–9 |
+| T16 | Self-Monitoring Data Layer — types, polling queries, fixtures, contract stubs | Days 3–5 |
+| T17 | Self-Monitoring TUI Views — all 16 TUI items, snapshot + unit tests | Days 5–9 |
 | T18 | Backend Enhancements — DF-21 through DF-24, proptest, upgrade SQL | Days 9–12 |
-| T19 | CLI Integration — `pgtrickle dog-feeding`, `pgtrickle graph --format` | Days 12–13 |
+| T19 | CLI Integration — `pgtrickle self-monitoring`, `pgtrickle graph --format` | Days 12–13 |
 | T20 | Documentation, Polish & Final Testing — docs, cross-cutting tests, coverage audit | Days 13–15 |
 | T21 (OP) | TUI/CLI Polish — DAG runtime overlay in `explain_dag()` | Days 15–16 (parallel or interleaved) |
 
-> **v0.26.0 total: ~3–4 weeks** (TUI dog-feeding integration + DAG visualization polish: architecture + 16 views + 4 backend items + 2 CLI commands + tests + docs)
+> **v0.26.0 total: ~3–4 weeks** (TUI self-monitoring integration + DAG visualization polish: architecture + 16 views + 4 backend items + 2 CLI commands + tests + docs)
 
 **Exit criteria:**
 - [ ] T15: `AppState` uses 8 domain structs; all existing tests pass; `just lint` clean
@@ -7185,15 +7185,15 @@ TUI/CLI visualization enhancement for the dog-feeding views. Recommended from [P
 - [ ] TUI-5: Workers view has Interference sub-tab; overlap pairs render
 - [ ] TUI-6: Scheduler overhead bar visible in Workers view after ≥ 5 refresh cycles
 - [ ] TUI-7: `x` key on Dependencies view opens Mermaid overlay; `Ctrl+E` exports to file
-- [ ] TUI-8: Header `df:N/M` badge reflects active dog-feeding stream tables
-- [ ] TUI-9: Command palette `dog-feeding enable/disable` completes with confirmation
+- [ ] TUI-8: Header `df:N/M` badge reflects active self-monitoring stream tables
+- [ ] TUI-9: Command palette `self-monitoring enable/disable` completes with confirmation
 - [ ] TUI-15/TUI-T1: All new snapshot tests pass; dashboard snapshots cover 5 branches
 - [ ] DF-21: `sla_breach_risk = true` when `avg_diff_ms > freshness_deadline_ms`
 - [ ] DF-22: Dispatch interval widens after synthetic interference insertion
 - [ ] DF-23: `retention_warning` column non-null when retention below minimum
-- [ ] DF-24: `recommend_refresh_mode()` consistent with `df_threshold_advice` when dog-feeding active
+- [ ] DF-24: `recommend_refresh_mode()` consistent with `df_threshold_advice` when self-monitoring active
 - [ ] TEST-21: Proptest passes 10,000 iterations
-- [ ] CLI-1: `pgtrickle dog-feeding enable/disable/status` functional
+- [ ] CLI-1: `pgtrickle self-monitoring enable/disable/status` functional
 - [ ] CLI-2: `pgtrickle graph --format mermaid` outputs valid Mermaid
 - [ ] TUI-D1/DOC-21/DOC-22: Documentation updated
 - [ ] Extension upgrade path tested (`0.24.0 → 0.25.0`)

--- a/dbt-pgtrickle/macros/hooks/enable_monitoring.sql
+++ b/dbt-pgtrickle/macros/hooks/enable_monitoring.sql
@@ -1,10 +1,10 @@
-{# DBT-1: Enable pg_trickle dog-feeding monitoring.
-   Calls setup_dog_feeding() — idempotent, safe on every run.
+{# DBT-1: Enable pg_trickle self-monitoring monitoring.
+   Calls setup_self_monitoring() — idempotent, safe on every run.
    Add to dbt_project.yml: +post-hook: "{{ pgtrickle_enable_monitoring() }}" #}
 {% macro pgtrickle_enable_monitoring() %}
     {% set sql %}
-        SELECT pgtrickle.setup_dog_feeding();
+        SELECT pgtrickle.setup_self_monitoring();
     {% endset %}
     {% do run_query(sql) %}
-    {{ log("pg_trickle dog-feeding monitoring enabled (5 DF stream tables active).", info=True) }}
+    {{ log("pg_trickle self-monitoring monitoring enabled (5 DF stream tables active).", info=True) }}
 {% endmacro %}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -2008,37 +2008,37 @@ SET pg_trickle.max_fixpoint_iterations = 50;
 
 ---
 
-### pg_trickle.dog_feeding_auto_apply
+### pg_trickle.self_monitoring_auto_apply
 
 > **Added in v0.20.0 (DF-G1).**
 
-Controls whether the dog-feeding analytics stream tables can automatically
+Controls whether the self-monitoring analytics stream tables can automatically
 adjust stream table configuration.
 
 | Value | Behaviour |
 |-------|-----------|
 | `off` (default) | Advisory only — no automatic changes. Dog-feeding stream tables produce analytics that operators and dashboards can read, but nothing is applied automatically. |
-| `threshold_only` | After each 10-minute auto-apply cycle, reads `df_threshold_advice`. If a recommendation has HIGH confidence and the recommended threshold differs from the current threshold by more than 5%, applies `ALTER STREAM TABLE ... SET auto_threshold = <recommended>`. Changes are logged with `initiated_by = 'DOG_FEED'`. |
+| `threshold_only` | After each 10-minute auto-apply cycle, reads `df_threshold_advice`. If a recommendation has HIGH confidence and the recommended threshold differs from the current threshold by more than 5%, applies `ALTER STREAM TABLE ... SET auto_threshold = <recommended>`. Changes are logged with `initiated_by = 'SELF_MONITOR'`. |
 | `full` | Same as `threshold_only`, plus applies scheduling hints from `df_scheduling_interference` (future enhancement). |
 
 **Default:** `off`
 
 ```sql
 -- Enable threshold auto-apply.
-SET pg_trickle.dog_feeding_auto_apply = 'threshold_only';
+SET pg_trickle.self_monitoring_auto_apply = 'threshold_only';
 
 -- Check current setting.
-SHOW pg_trickle.dog_feeding_auto_apply;
+SHOW pg_trickle.self_monitoring_auto_apply;
 ```
 
 **Prerequisites:** Dog-feeding stream tables must be created first via
-`SELECT pgtrickle.setup_dog_feeding()`. If the stream tables do not exist,
+`SELECT pgtrickle.setup_self_monitoring()`. If the stream tables do not exist,
 the auto-apply worker is a no-op.
 
 **Rate limiting:** At most one threshold change per stream table per 10 minutes.
 
 **Audit trail:** All auto-apply changes are recorded in `pgt_refresh_history`
-with `initiated_by = 'DOG_FEED'` and a SKIP action describing the old and new
+with `initiated_by = 'SELF_MONITOR'` and a SKIP action describing the old and new
 threshold values.
 
 ---

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1403,16 +1403,16 @@ so deployments are always idempotent.
 > **Added in v0.20.0 (UX-4).**
 
 Once your stream tables are running in production, pg_trickle can monitor
-itself using its own stream tables — a technique called *dog-feeding*.
+itself using its own stream tables — a technique called *self-monitoring*.
 
-### Enabling Dog-Feeding
+### Enabling Self-Monitoring
 
 ```sql
 -- Create all five monitoring stream tables (idempotent, safe to repeat).
-SELECT pgtrickle.setup_dog_feeding();
+SELECT pgtrickle.setup_self_monitoring();
 
 -- Check what was created.
-SELECT * FROM pgtrickle.dog_feeding_status();
+SELECT * FROM pgtrickle.self_monitoring_status();
 ```
 
 This creates five stream tables in the `pgtrickle` schema:
@@ -1447,12 +1447,12 @@ WHERE duration_anomaly IS NOT NULL OR recent_failures >= 2;
 To let pg_trickle automatically apply threshold recommendations:
 
 ```sql
-SET pg_trickle.dog_feeding_auto_apply = 'threshold_only';
+SET pg_trickle.self_monitoring_auto_apply = 'threshold_only';
 ```
 
 This applies changes only when confidence is HIGH and the recommended threshold
 differs by more than 5%. Changes are rate-limited to once per 10 minutes per
-stream table and logged with `initiated_by = 'DOG_FEED'`.
+stream table and logged with `initiated_by = 'SELF_MONITOR'`.
 
 ### Visualizing the DAG
 
@@ -1463,14 +1463,14 @@ SELECT pgtrickle.explain_dag();
 
 Dog-feeding STs appear in green, user STs in blue, suspended in red.
 
-### Disabling Dog-Feeding
+### Disabling Self-Monitoring
 
 ```sql
-SELECT pgtrickle.teardown_dog_feeding();
+SELECT pgtrickle.teardown_self_monitoring();
 ```
 
 This drops all monitoring stream tables. User stream tables are never affected.
-The control plane continues operating identically without dog-feeding.
+The control plane continues operating identically without self-monitoring.
 
 ---
 

--- a/docs/PERFORMANCE_COOKBOOK.md
+++ b/docs/PERFORMANCE_COOKBOOK.md
@@ -390,11 +390,11 @@ ALTER SYSTEM SET pg_trickle.cost_model_safety_margin = 0.30;
 SELECT pg_reload_conf();
 ```
 
-**Recipe — Use dog-feeding analytics to auto-tune:**
+**Recipe — Use self-monitoring analytics to auto-tune:**
 
 ```sql
 -- Let pg_trickle automatically apply threshold recommendations
-ALTER SYSTEM SET pg_trickle.dog_feeding_auto_apply = 'threshold_only';
+ALTER SYSTEM SET pg_trickle.self_monitoring_auto_apply = 'threshold_only';
 SELECT pg_reload_conf();
 ```
 

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -4046,11 +4046,11 @@ WHERE fuse_mode != 'off';
 
 ---
 
-## Dog Feeding — Self-Monitoring (v0.20.0)
+## Self Monitoring — Self-Monitoring (v0.20.0)
 
 > **Added in v0.20.0.**
 
-pg_trickle can monitor itself using its own stream tables. Five *dog-feeding*
+pg_trickle can monitor itself using its own stream tables. Five *self-monitoring*
 stream tables maintain reactive analytics over the internal catalog, replacing
 repeated full-scan diagnostic queries with continuously-maintained incremental
 views.
@@ -4058,11 +4058,11 @@ views.
 ### Quick Start
 
 ```sql
--- Create all five dog-feeding stream tables (idempotent).
-SELECT pgtrickle.setup_dog_feeding();
+-- Create all five self-monitoring stream tables (idempotent).
+SELECT pgtrickle.setup_self_monitoring();
 
 -- Check status.
-SELECT * FROM pgtrickle.dog_feeding_status();
+SELECT * FROM pgtrickle.self_monitoring_status();
 
 -- View threshold recommendations (after 10+ refresh cycles).
 SELECT * FROM pgtrickle.df_threshold_advice
@@ -4073,15 +4073,15 @@ SELECT * FROM pgtrickle.df_anomaly_signals
 WHERE duration_anomaly IS NOT NULL;
 
 -- Enable auto-apply (optional).
-SET pg_trickle.dog_feeding_auto_apply = 'threshold_only';
+SET pg_trickle.self_monitoring_auto_apply = 'threshold_only';
 
 -- Clean up.
-SELECT pgtrickle.teardown_dog_feeding();
+SELECT pgtrickle.teardown_self_monitoring();
 ```
 
-### `pgtrickle.setup_dog_feeding()`
+### `pgtrickle.setup_self_monitoring()`
 
-Creates all five dog-feeding stream tables. Idempotent — safe to call multiple
+Creates all five self-monitoring stream tables. Idempotent — safe to call multiple
 times. Emits a warm-up warning if `pgt_refresh_history` has fewer than 50 rows.
 
 **Stream tables created:**
@@ -4094,14 +4094,14 @@ times. Emits a warm-up warning if `pgt_refresh_history` has fewer than 50 rows.
 | `pgtrickle.df_cdc_buffer_trends` | 48s | AUTO | CDC buffer growth rates per source |
 | `pgtrickle.df_scheduling_interference` | 96s | FULL | Concurrent refresh overlap detection |
 
-### `pgtrickle.teardown_dog_feeding()`
+### `pgtrickle.teardown_self_monitoring()`
 
-Drops all dog-feeding stream tables. Safe with partial setups — missing tables
+Drops all self-monitoring stream tables. Safe with partial setups — missing tables
 are silently skipped. User stream tables are never affected.
 
-### `pgtrickle.dog_feeding_status()`
+### `pgtrickle.self_monitoring_status()`
 
-Returns the status of all five expected dog-feeding stream tables:
+Returns the status of all five expected self-monitoring stream tables:
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -4120,7 +4120,7 @@ Returns scheduler efficiency metrics for the last hour:
 |--------|------|-------------|
 | `total_refreshes_1h` | bigint | Total refreshes in the last hour |
 | `df_refreshes_1h` | bigint | Dog-feeding refreshes in the last hour |
-| `df_refresh_fraction` | float | Fraction of refreshes that are dog-feeding |
+| `df_refresh_fraction` | float | Fraction of refreshes that are self-monitoring |
 | `avg_refresh_ms` | float | Average refresh duration (ms) |
 | `avg_df_refresh_ms` | float | Average DF refresh duration (ms) |
 | `total_refresh_time_s` | float | Total time spent refreshing (seconds) |
@@ -4129,7 +4129,7 @@ Returns scheduler efficiency metrics for the last hour:
 ### `pgtrickle.explain_dag(format)`
 
 Returns the full refresh DAG as a Mermaid markdown (default) or Graphviz DOT
-string. Node colours: user STs = blue, dog-feeding STs = green,
+string. Node colours: user STs = blue, self-monitoring STs = green,
 suspended = red, fused = orange.
 
 ```sql
@@ -4142,7 +4142,7 @@ SELECT pgtrickle.explain_dag('dot');
 
 ### Auto-Apply Policy
 
-The `pg_trickle.dog_feeding_auto_apply` GUC controls whether analytics can
+The `pg_trickle.self_monitoring_auto_apply` GUC controls whether analytics can
 automatically adjust stream table configuration:
 
 | Value | Behaviour |
@@ -4153,7 +4153,7 @@ automatically adjust stream table configuration:
 
 Auto-apply is rate-limited to at most one threshold change per stream table
 per 10 minutes. Changes are logged to `pgt_refresh_history` with
-`initiated_by = 'DOG_FEED'`.
+`initiated_by = 'SELF_MONITOR'`.
 
 ### Confidence Levels and Sparse History
 
@@ -4166,7 +4166,7 @@ per 10 minutes. Changes are logged to `pgt_refresh_history` with
 | **LOW** | < 10 total refreshes | Insufficient data — recommendation equals the current threshold |
 
 **When you see LOW confidence:** This is normal during the first minutes after
-`setup_dog_feeding()`. The stream tables need time to accumulate refresh
+`setup_self_monitoring()`. The stream tables need time to accumulate refresh
 history. In typical deployments with a 1-minute schedule, expect:
 - **LOW** for the first ~10 minutes
 - **MEDIUM** after ~10 minutes

--- a/monitoring/grafana/dashboards/pg_trickle_self_monitoring.json
+++ b/monitoring/grafana/dashboards/pg_trickle_self_monitoring.json
@@ -77,12 +77,12 @@
     }
   ],
   "schemaVersion": 39,
-  "tags": ["pg_trickle", "dog-feeding"],
+  "tags": ["pg_trickle", "self-monitoring"],
   "templating": { "list": [] },
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "",
-  "title": "pg_trickle Dog-Feeding Analytics",
-  "uid": "pg_trickle_dog_feeding",
+  "title": "pg_trickle Self-Monitoring Analytics",
+  "uid": "pg_trickle_self_monitoring",
   "version": 1
 }

--- a/pgtrickle-tui/src/poller.rs
+++ b/pgtrickle-tui/src/poller.rs
@@ -1065,7 +1065,7 @@ async fn poll_scc_status_query(client: &Client) -> Result<Vec<SccGroup>, PgErr> 
         .collect())
 }
 
-/// UX-7: Poll scheduler_overhead() for dog-feeding diagnostics.
+/// UX-7: Poll scheduler_overhead() for self-monitoring diagnostics.
 async fn poll_scheduler_overhead_query(
     client: &Client,
 ) -> Result<Option<SchedulerOverhead>, PgErr> {

--- a/pgtrickle-tui/src/state.rs
+++ b/pgtrickle-tui/src/state.rs
@@ -362,7 +362,7 @@ pub struct DedupStats {
     pub dedup_ratio_pct: f64,
 }
 
-/// UX-7: Dog-feeding scheduler overhead metrics.
+/// UX-7: Self-monitoring scheduler overhead metrics.
 #[derive(Clone, Serialize, Default)]
 pub struct SchedulerOverhead {
     pub total_refreshes_1h: i64,

--- a/pgtrickle-tui/src/views/diagnostics.rs
+++ b/pgtrickle-tui/src/views/diagnostics.rs
@@ -21,7 +21,7 @@ pub fn render(
         .and_then(|d| d.signals.as_ref())
         .is_some();
 
-    // UX-7: Show scheduler overhead panel when dog-feeding is active.
+    // UX-7: Show scheduler overhead panel when self-monitoring is active.
     let has_overhead = state.scheduler_overhead.is_some();
 
     if has_signals && has_overhead {
@@ -197,7 +197,7 @@ fn render_signal_breakdown(
     frame.render_widget(Paragraph::new(lines).block(block), area);
 }
 
-/// UX-7: Render scheduler overhead panel showing dog-feeding cost.
+/// UX-7: Render scheduler overhead panel showing self-monitoring cost.
 fn render_scheduler_overhead(frame: &mut Frame, area: Rect, state: &AppState, theme: &Theme) {
     let overhead = match &state.scheduler_overhead {
         Some(o) => o,

--- a/plans/PLAN_0_20_0.md
+++ b/plans/PLAN_0_20_0.md
@@ -1,14 +1,14 @@
 # PLAN_0_20_0.md — v0.20.0 Implementation Order
 
-**Milestone:** v0.20.0 — Dog-Feeding (pg_trickle Monitors Itself)
+**Milestone:** v0.20.0 — Self-Monitoring (pg_trickle Monitors Itself)
 **Status:** ✅ Complete
 **Last updated:** 2026-04-15
 
 
 This document defines the recommended implementation order for all v0.20.0
-roadmap items. See [ROADMAP.md §v0.20.0](../ROADMAP.md#v0200--dog-feeding-pg_trickle-monitors-itself)
+roadmap items. See [ROADMAP.md §v0.20.0](../ROADMAP.md#v0200--self-monitoring-pg_trickle-monitors-itself)
 for the full feature descriptions and effort estimates. See
-[PLAN_DOG_FEEDING.md](PLAN_DOG_FEEDING.md) for the detailed architecture
+[PLAN_SELF_MONITORING.md](PLAN_SELF_MONITORING.md) for the detailed architecture
 and risk analysis.
 
 ---
@@ -16,7 +16,7 @@ and risk analysis.
 ## Milestone Goals
 
 pg_trickle uses its own stream tables to maintain reactive analytics over its
-internal catalog and refresh-history tables. Five dog-feeding stream tables
+internal catalog and refresh-history tables. Five self-monitoring stream tables
 (`df_efficiency_rolling`, `df_anomaly_signals`, `df_threshold_advice`,
 `df_cdc_buffer_trends`, `df_scheduling_interference`) replace repeated
 full-scan diagnostic functions with continuously-maintained incremental
@@ -29,7 +29,7 @@ Key deliverables:
 - **DF-A1/A2/A3:** Anomaly detection — `df_anomaly_signals` and
   `df_threshold_advice`.
 - **DF-C1/C2:** CDC buffer trends and scheduling interference STs.
-- **DF-G1/G2/G3:** `dog_feeding_auto_apply` GUC and auto-apply worker.
+- **DF-G1/G2/G3:** `self_monitoring_auto_apply` GUC and auto-apply worker.
 - **OPS-1..OPS-6 / DASH-1 / DBT-1:** Operational diagnostics, Grafana
   dashboard, and dbt integration.
 - **CORR-1..5:** Correctness invariants (proptest + E2E).
@@ -59,12 +59,12 @@ These items must land first. Nothing downstream can be built until
 | 5 | CORR-3 | `avg_change_ratio` never NaN/Inf on zero-delta | S | Companion to DF-F2 |
 | 6 | CORR-5 | DF-1 window boundary is exclusive (`>`) | XS | Companion to DF-F2 |
 | 7 | DF-F3 | E2E test: DF-1 output matches `refresh_efficiency()` | 2–4h | Mandatory companion to DF-F2 |
-| 8 | DF-F4 | `pgtrickle.setup_dog_feeding()` helper | 2–4h | Creates all five `df_*` STs |
-| 9 | STAB-1 | `setup_dog_feeding()` is fully idempotent | S | Companion to DF-F4; required for upgrade safety |
-| 10 | DF-F5 | `pgtrickle.teardown_dog_feeding()` helper | 1h | Depends on DF-F4 |
-| 11 | STAB-5 | `teardown_dog_feeding()` safe with partial DF STs | XS | Companion to DF-F5 |
-| 12 | UX-1 | `pgtrickle.dog_feeding_status()` diagnostic function | S | Depends on DF-F4 |
-| 13 | TEST-6 | Light E2E: `setup_dog_feeding()` idempotency (3× call) | XS | Companion to STAB-1 |
+| 8 | DF-F4 | `pgtrickle.setup_self_monitoring()` helper | 2–4h | Creates all five `df_*` STs |
+| 9 | STAB-1 | `setup_self_monitoring()` is fully idempotent | S | Companion to DF-F4; required for upgrade safety |
+| 10 | DF-F5 | `pgtrickle.teardown_self_monitoring()` helper | 1h | Depends on DF-F4 |
+| 11 | STAB-5 | `teardown_self_monitoring()` safe with partial DF STs | XS | Companion to DF-F5 |
+| 12 | UX-1 | `pgtrickle.self_monitoring_status()` diagnostic function | S | Depends on DF-F4 |
+| 13 | TEST-6 | Light E2E: `setup_self_monitoring()` idempotency (3× call) | XS | Companion to STAB-1 |
 | 14 | TEST-3 | Upgrade test: history rows survive 0.19.0 → 0.20.0 | S | Requires PERF-1 migration |
 
 ### Phase 2 — Anomaly Detection
@@ -95,11 +95,11 @@ These items must land first. Nothing downstream can be built until
 
 | Order | ID | Feature | Effort | Notes |
 |-------|----|---------|--------|-------|
-| 29 | DF-G1 | `pg_trickle.dog_feeding_auto_apply` GUC | 1–2h | Values: off / threshold_only / full |
+| 29 | DF-G1 | `pg_trickle.self_monitoring_auto_apply` GUC | 1–2h | Values: off / threshold_only / full |
 | 30 | DF-G2 | Auto-apply worker (threshold_only) | 4–8h | Depends on DF-A2, DF-G1 |
 | 31 | STAB-2 | Auto-apply handles `ALTER STREAM TABLE` failure | S | Companion to DF-G2 |
 | 32 | STAB-4 | Worker checks ST exists before applying | XS | Companion to DF-G2 |
-| 33 | DF-G3 | `initiated_by = 'DOG_FEED'` audit trail | 1–2h | Companion to DF-G2 |
+| 33 | DF-G3 | `initiated_by = 'SELF_MONITOR'` audit trail | 1–2h | Companion to DF-G2 |
 | 34 | DF-G4 | E2E test: auto-apply threshold | 2–4h | Companion to DF-G2 |
 | 35 | DF-G5 | E2E test: rate limiting (max 1 change / 10 min) | 1–2h | Companion to DF-G2 |
 
@@ -111,9 +111,9 @@ These items must land first. Nothing downstream can be built until
 | 37 | OPS-2 | `check_cdc_health()` spill-risk enrichment | 2–4h | Depends on DF-C1; fallback required |
 | 38 | OPS-3 | `pgtrickle.scheduler_overhead()` diagnostic | 2–4h | Depends on DF-D4 |
 | 39 | OPS-4 | `pgtrickle.explain_dag()` Mermaid/DOT output | 3–4h | No dependencies |
-| 40 | OPS-5 | `sql/dog_feeding_setup.sql` quick-start template | 1h | Depends on DF-F4, DF-G1, UX-4 |
+| 40 | OPS-5 | `sql/self_monitoring_setup.sql` quick-start template | 1h | Depends on DF-F4, DF-G1, UX-4 |
 | 41 | OPS-6 | Workload-aware poll via DF-5 signal | 2–4h | Depends on DF-C2, OPS-3 |
-| 42 | UX-2 | `setup_dog_feeding()` warm-up hint (< 50 rows) | XS | Companion to DF-F4 |
+| 42 | UX-2 | `setup_self_monitoring()` warm-up hint (< 50 rows) | XS | Companion to DF-F4 |
 | 43 | UX-3 | NOTIFY on anomaly via `pg_trickle_alert` | S | Depends on DF-A1 |
 | 44 | UX-5 | `explain_st()` shows DF coverage | XS | Depends on UX-1 |
 | 45 | UX-6 | `explain_st()` shows `recommend_refresh_mode()` | XS | Depends on OPS-1 |
@@ -123,10 +123,10 @@ These items must land first. Nothing downstream can be built until
 
 | Order | ID | Feature | Effort | Notes |
 |-------|----|---------|--------|-------|
-| 47 | DASH-1 | Grafana dog-feeding dashboard | 4–6h | Depends on DF-F2, DF-A1, DF-A2, DF-C1, DF-C2 |
+| 47 | DASH-1 | Grafana self-monitoring dashboard | 4–6h | Depends on DF-F2, DF-A1, DF-A2, DF-C1, DF-C2 |
 | 48 | DBT-1 | dbt `pgtrickle_enable_monitoring` post-hook macro | 2h | Depends on DF-F4, STAB-1 |
-| 49 | DF-D1 | SQL_REFERENCE.md: dog-feeding quick start | 2–4h | No code dependencies |
-| 50 | DF-D2 | CONFIGURATION.md: `dog_feeding_auto_apply` GUC | 1h | Depends on DF-G1 |
+| 49 | DF-D1 | SQL_REFERENCE.md: self-monitoring quick start | 2–4h | No code dependencies |
+| 50 | DF-D2 | CONFIGURATION.md: `self_monitoring_auto_apply` GUC | 1h | Depends on DF-G1 |
 | 51 | UX-4 | GETTING_STARTED.md: "Day 2 operations" section | S | Depends on UX-1, UX-2 |
 
 ### Phase 7 — Performance, Stability & Soak
@@ -139,12 +139,12 @@ These items must land first. Nothing downstream can be built until
 | 55 | PERF-6 | Columnar CDC bitmask (Phase 1) | M | Gate behind GUC; schema change |
 | 56 | STAB-3 | DF STs survive `DROP EXTENSION` + `CREATE EXTENSION` | S | Depends on DF-F4, DF-F5 |
 | 57 | SCAL-1 | DF STs refresh within window at 100 user STs | S | Depends on PERF-1 |
-| 58 | SCAL-2 | Retention interacts correctly with dog-feeding CDC | S | Depends on DF-F1 |
+| 58 | SCAL-2 | Retention interacts correctly with self-monitoring CDC | S | Depends on DF-F1 |
 | 59 | DF-D3 | E2E test: control plane survives DF ST suspension | 2–4h | Depends on DF-F4 |
-| 60 | DF-D4 | Soak test addition (1-hour, dog-feeding STs active) | 2–4h | Depends on DF-F4 |
-| 61 | TEST-2 | Light E2E: full dog-feeding create/refresh/teardown cycle | S | Depends on DF-F4, DF-F5 |
+| 60 | DF-D4 | Soak test addition (1-hour, self-monitoring STs active) | 2–4h | Depends on DF-F4 |
+| 61 | TEST-2 | Light E2E: full self-monitoring create/refresh/teardown cycle | S | Depends on DF-F4, DF-F5 |
 | 62 | TEST-4 | Regression: DF STs absent from `check_cdc_health()` anomaly | XS | Depends on DF-F4 |
-| 63 | TEST-5 | Soak: dog-feeding under 1 h with 50 user STs | M | Depends on DF-D4, SCAL-1 |
+| 63 | TEST-5 | Soak: self-monitoring under 1 h with 50 user STs | M | Depends on DF-D4, SCAL-1 |
 
 ---
 
@@ -163,11 +163,11 @@ These items must land first. Nothing downstream can be built until
 | CORR-3 | `avg_change_ratio` NaN/Inf guard | ✅ Done |
 | CORR-5 | DF-1 window boundary exclusive | ✅ Done |
 | DF-F3 | E2E: DF-1 matches `refresh_efficiency()` | ✅ Done |
-| DF-F4 | `setup_dog_feeding()` helper | ✅ Done |
-| STAB-1 | `setup_dog_feeding()` idempotent | ✅ Done |
-| DF-F5 | `teardown_dog_feeding()` helper | ✅ Done |
-| STAB-5 | `teardown_dog_feeding()` safe with partial DF STs | ✅ Done |
-| UX-1 | `pgtrickle.dog_feeding_status()` | ✅ Done |
+| DF-F4 | `setup_self_monitoring()` helper | ✅ Done |
+| STAB-1 | `setup_self_monitoring()` idempotent | ✅ Done |
+| DF-F5 | `teardown_self_monitoring()` helper | ✅ Done |
+| STAB-5 | `teardown_self_monitoring()` safe with partial DF STs | ✅ Done |
+| UX-1 | `pgtrickle.self_monitoring_status()` | ✅ Done |
 | TEST-6 | Light E2E: idempotency (3× call) | ✅ Done |
 | TEST-3 | Upgrade test: history rows survive 0.19.0 → 0.20.0 | ✅ Done |
 
@@ -199,11 +199,11 @@ These items must land first. Nothing downstream can be built until
 
 | ID | Feature | Status |
 |----|---------|--------|
-| DF-G1 | `dog_feeding_auto_apply` GUC | ✅ Done |
+| DF-G1 | `self_monitoring_auto_apply` GUC | ✅ Done |
 | DF-G2 | Auto-apply worker (threshold_only) | ✅ Done |
 | STAB-2 | Auto-apply handles ALTER failure gracefully | ✅ Done |
 | STAB-4 | Worker checks ST exists before applying | ✅ Done |
-| DF-G3 | `initiated_by = 'DOG_FEED'` audit trail | ✅ Done |
+| DF-G3 | `initiated_by = 'SELF_MONITOR'` audit trail | ✅ Done |
 | DF-G4 | E2E: auto-apply threshold | ✅ Done |
 | DF-G5 | E2E: rate limiting (1 change / 10 min) | ✅ Done |
 
@@ -215,9 +215,9 @@ These items must land first. Nothing downstream can be built until
 | OPS-2 | `check_cdc_health()` spill-risk enrichment | ✅ Done |
 | OPS-3 | `pgtrickle.scheduler_overhead()` | ✅ Done |
 | OPS-4 | `pgtrickle.explain_dag()` Mermaid/DOT | ✅ Done |
-| OPS-5 | `sql/dog_feeding_setup.sql` quick-start | ✅ Done |
+| OPS-5 | `sql/self_monitoring_setup.sql` quick-start | ✅ Done |
 | OPS-6 | Workload-aware poll via DF-5 signal | ✅ Done |
-| UX-2 | `setup_dog_feeding()` warm-up hint | ✅ Done |
+| UX-2 | `setup_self_monitoring()` warm-up hint | ✅ Done |
 | UX-3 | NOTIFY on anomaly via `pg_trickle_alert` | ✅ Done |
 | UX-4 | GETTING_STARTED.md Day 2 operations | ✅ Done |
 | UX-5 | `explain_st()` shows DF coverage | ✅ Done |
@@ -228,10 +228,10 @@ These items must land first. Nothing downstream can be built until
 
 | ID | Feature | Status |
 |----|---------|--------|
-| DASH-1 | Grafana dog-feeding dashboard | ✅ Done |
+| DASH-1 | Grafana self-monitoring dashboard | ✅ Done |
 | DBT-1 | dbt `pgtrickle_enable_monitoring` macro | ✅ Done |
-| DF-D1 | SQL_REFERENCE.md dog-feeding quick start | ✅ Done |
-| DF-D2 | CONFIGURATION.md `dog_feeding_auto_apply` GUC | ✅ Done |
+| DF-D1 | SQL_REFERENCE.md self-monitoring quick start | ✅ Done |
+| DF-D2 | CONFIGURATION.md `self_monitoring_auto_apply` GUC | ✅ Done |
 
 ### Performance, Stability & Soak
 
@@ -243,12 +243,12 @@ These items must land first. Nothing downstream can be built until
 | PERF-6 | Columnar CDC bitmask Phase 1 | ⏭ Skipped (already shipped in v0.19.0 as A-2-COL) |
 | STAB-3 | DF STs survive DROP EXTENSION cycle | ✅ Done |
 | SCAL-1 | DF STs refresh within window at 100 user STs | ✅ Done |
-| SCAL-2 | Retention interacts correctly with dog-feeding CDC | ✅ Done |
+| SCAL-2 | Retention interacts correctly with self-monitoring CDC | ✅ Done |
 | DF-D3 | E2E: control plane survives DF ST suspension | ✅ Done |
 | DF-D4 | Soak test addition | ✅ Done |
 | TEST-2 | Light E2E: full create/refresh/teardown cycle | ✅ Done |
 | TEST-4 | Regression: DF STs absent from health anomaly list | ✅ Done |
-| TEST-5 | Soak: dog-feeding 1 h with 50 user STs | ✅ Done |
+| TEST-5 | Soak: self-monitoring 1 h with 50 user STs | ✅ Done |
 
 ---
 
@@ -257,23 +257,23 @@ These items must land first. Nothing downstream can be built until
 - [x] DF-F1: `pgt_refresh_history` receives CDC INSERT triggers
 - [x] DF-F2: `df_efficiency_rolling` created and refreshes in DIFFERENTIAL mode
 - [x] DF-F3: DF-1 output matches `refresh_efficiency()` on synthetic history
-- [x] DF-F4: `setup_dog_feeding()` creates all five `df_*` stream tables
-- [x] DF-F5: `teardown_dog_feeding()` drops all `df_*` tables with no orphaned triggers
+- [x] DF-F4: `setup_self_monitoring()` creates all five `df_*` stream tables
+- [x] DF-F5: `teardown_self_monitoring()` drops all `df_*` tables with no orphaned triggers
 - [x] DF-A1: `df_anomaly_signals` created and detects 3× duration spikes
 - [x] DF-A2: `df_threshold_advice` provides HIGH-confidence recommendations after ≥ 20 cycles
 - [x] DF-A3: DAG ensures DF-1 refreshes before DF-2 and DF-3
 - [x] DF-C1: `df_cdc_buffer_trends` created and tracking growth rates
 - [x] DF-C2: `df_scheduling_interference` created and detecting overlap
-- [x] DF-G1: `pg_trickle.dog_feeding_auto_apply` GUC registered and documented
+- [x] DF-G1: `pg_trickle.self_monitoring_auto_apply` GUC registered and documented
 - [x] DF-G2: Auto-apply worker operational with rate limiting
-- [x] STAB-1: `setup_dog_feeding()` idempotent (3× call produces no errors or duplicates)
+- [x] STAB-1: `setup_self_monitoring()` idempotent (3× call produces no errors or duplicates)
 - [x] CORR-1: `df_threshold_advice` output always ∈ [0.01, 0.80] (proptest 10K iterations)
 - [x] TEST-2: Light E2E full create/refresh/teardown cycle passes
 - [x] TEST-3: Upgrade test — history rows intact after 0.19.0 → 0.20.0
 - [x] PERF-1: Index on `pgt_refresh_history(pgt_id, start_time)` present and used
 - [x] OPS-1: `recommend_refresh_mode()` returns valid mode + confidence
-- [x] OPS-4: `explain_dag()` includes all five `df_` nodes after `setup_dog_feeding()`
-- [x] DASH-1: Grafana dog-feeding dashboard loads with all five panels
+- [x] OPS-4: `explain_dag()` includes all five `df_` nodes after `setup_self_monitoring()`
+- [x] DASH-1: Grafana self-monitoring dashboard loads with all five panels
 - [ ] `just test-all` passes with zero failures
 - [x] `just check-version-sync` exits 0
 - [x] CHANGELOG.md `## [0.20.0]` entry written

--- a/plans/PLAN_OVERALL_ASSESSMENT.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT.md
@@ -487,7 +487,7 @@ distributed across FAQ / TROUBLESHOOTING.
 
 ### 7.3 Gap — Dog-feeding recipes are new; examples light
 
-v0.20 introduced `setup_dog_feeding()` but the examples mostly show
+v0.20 introduced `setup_self_monitoring()` but the examples mostly show
 the setup line itself. A "day in the life" walkthrough — ingest some
 data, wait, read `df_threshold_advice`, apply, observe — would lift
 adoption.
@@ -574,7 +574,7 @@ are currently blocked on users setting up a second slot.
 
 ### 9.3 Predictive refresh cost model (M effort — 1–2 weeks)
 
-Extend dog-feeding to forecast `duration_ms` from
+Extend self-monitoring to forecast `duration_ms` from
 `rows_inserted + rows_deleted` using linear regression over the last
 hour. When the forecast exceeds `last_full_ms × 1.5`, pre-emptively
 switch to FULL. Keeps adaptive fallback from *reacting* to a slow

--- a/plans/PLAN_OVERALL_ASSESSMENT_2.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT_2.md
@@ -373,7 +373,7 @@ The investments in v0.21–v0.23 paid off: the previously-flagged
   with no error logged. There is no built-in monitor that says "ST
   X has not advanced its frontier in N intervals despite source
   activity".
-- **Recommendation:** Add a dog-feeding view
+- **Recommendation:** Add a self-monitoring view
   `df_frozen_stream_tables` that flags any ST whose
   `last_refresh_at < now() - 5 × refresh_interval` *and* whose source
   has had recent CDC writes. Alert via the existing
@@ -708,7 +708,7 @@ The investments in v0.21–v0.23 paid off: the previously-flagged
 - **Shared shmem template cache** to close the connection-pooler
   latency gap.
 - **TOAST-aware CDC hashing** + corresponding edge-case test suite.
-- **Frozen-stream-table detector** in dog-feeding.
+- **Frozen-stream-table detector** in self-monitoring.
 - **Subscriber-LSN tracking** for downstream publications;
   publication-lag warning.
 - **Robustness guards on the predictive cost model** (median+MAD,
@@ -764,7 +764,7 @@ The investments in v0.21–v0.23 paid off: the previously-flagged
 ### Component: `src/scheduler.rs`, `src/dag.rs`
 
 - **Current state:** Parallel worker pool, SLA tier auto-assignment,
-  predictive preemption, dog-feeding, and canary-mode all wired in.
+  predictive preemption, self-monitoring, and canary-mode all wired in.
   ~5,800 + 4,100 LOC respectively.
 - **Issues:** Catalog reload on every tick; full DAG rebuild under
   exclusive lock; cluster-wide worker budget shared without
@@ -775,7 +775,7 @@ The investments in v0.21–v0.23 paid off: the previously-flagged
 ### Component: `src/api/`
 
 - **Current state:** Cleanly split into `mod.rs`, `helpers.rs`,
-  `diagnostics.rs`, `publication.rs`, `dog_feeding.rs`. The v0.21
+  `diagnostics.rs`, `publication.rs`, `self_monitoring.rs`. The v0.21
   TEST-1/2/3 sweep added 75+ unit tests.
 - **Issues:** `publication.rs` and `diagnostics.rs` are the
   current under-tested modules; predictive cost model has no
@@ -921,7 +921,7 @@ report's status:
 | 3.1 | No parallel refresh | Shipped (PAR-1..5) | §2 |
 | 3.2 | No downstream CDC | Shipped (CDC-PUB-*) | §2 + §4 (durability gap) |
 | 3.3 | Multi-DB isolation | Per-DB isolated; cluster-wide budget shared | §4 |
-| 3.6 | Reactive-only dog-feeding | Predictive shipped | §2 + §4 (no guards) |
+| 3.6 | Reactive-only self-monitoring | Predictive shipped | §2 + §4 (no guards) |
 | 4.3 | `diff_project` allocations | Unchanged | §5 |
 | 4.4 | Per-backend template cache | Unchanged | §4 + §5 + §7 |
 | 4.5 | Change-buffer full-scan | Unchanged | §5 |

--- a/plans/PLAN_SELF_MONITORING.md
+++ b/plans/PLAN_SELF_MONITORING.md
@@ -1,4 +1,4 @@
-# PLAN: Dog-Feeding — pg_trickle Monitoring Itself via Stream Tables
+# PLAN: Self-Monitoring — pg_trickle Monitoring Itself via Stream Tables
 
 **Date:** 2026-04-13
 **Status:** Proposed
@@ -13,7 +13,7 @@ to power reactive adaptive logic, anomaly detection, and operational analytics.
 2. [Architecture](#2-architecture)
 3. [Bootstrap Problem & Safety Boundary](#3-bootstrap-problem--safety-boundary)
 4. [Current Adaptive Logic Inventory](#4-current-adaptive-logic-inventory)
-5. [Dog-Feeding Stream Tables](#5-dog-feeding-stream-tables)
+5. [Self-Monitoring Stream Tables](#5-self-monitoring-stream-tables)
 6. [Reactive Policy Layer](#6-reactive-policy-layer)
 7. [Implementation Phases](#7-implementation-phases)
 8. [Testing Strategy](#8-testing-strategy)
@@ -67,7 +67,7 @@ that learns from multi-cycle, cross-ST patterns.
   scheduler dispatch loop remain in Rust (§3)
 - Automatic unsupervised reconfiguration — the policy layer is advisory by
   default; auto-apply is opt-in per GUC
-- Supporting dog-feeding on day one of a fresh install — stream tables require
+- Supporting self-monitoring on day one of a fresh install — stream tables require
   history to exist first
 
 ---
@@ -130,7 +130,7 @@ to today. This eliminates the bootstrapping cycle described in §3.
 
 ### The Problem
 
-If the scheduler needed a dog-feeding stream table to decide whether to refresh
+If the scheduler needed a self-monitoring stream table to decide whether to refresh
 a stream table, it would need pg_trickle to be running to run pg_trickle. This
 creates a circular dependency:
 
@@ -144,7 +144,7 @@ scheduler tick
 
 ### The Solution: Strict Layering
 
-| Component | Layer | Depends on dog-feeding? |
+| Component | Layer | Depends on self-monitoring? |
 |-----------|-------|------------------------|
 | `compute_adaptive_threshold()` | Control plane | **No** — uses only `auto_threshold` and `last_full_ms` from catalog |
 | `compute_adaptive_poll_ms()` | Control plane | **No** — uses only in-memory state |
@@ -153,19 +153,19 @@ scheduler tick
 | `df_threshold_advice` | Analytics plane | **No** — reads `pgt_refresh_history` + `pgt_stream_tables` |
 | Policy auto-apply worker | Policy layer | **Yes** — reads analytics plane stream tables |
 
-The policy layer is the **only** component that reads dog-feeding stream tables,
+The policy layer is the **only** component that reads self-monitoring stream tables,
 and it runs in a separate session, off the critical path, behind an opt-in GUC.
 
 ### Self-Referential Refresh
 
-The dog-feeding stream tables themselves are refreshed by the same scheduler
+The self-monitoring stream tables themselves are refreshed by the same scheduler
 that refreshes user stream tables. They appear in the DAG as normal ST nodes.
 Their refresh generates `pgt_refresh_history` rows, which are then consumed by
 the next refresh of the analytics stream tables — a healthy feedback loop,
 not a deadlock, because:
 
 1. Each refresh reads history **up to the current tick watermark** (CSS1)
-2. The dog-feeding STs have a relaxed schedule (`'48s'` or longer)
+2. The self-monitoring STs have a relaxed schedule (`'48s'` or longer)
 3. They are CDC'd via INSERT triggers on `pgt_refresh_history` (append-only)
 
 ### Startup Sequence
@@ -174,10 +174,10 @@ On extension install or upgrade:
 
 1. Control plane starts normally with the existing Rust-only adaptive logic
 2. After the first few refreshes populate `pgt_refresh_history`, the analytics
-   stream tables can be created (manually or via `pgtrickle.setup_dog_feeding()`)
+   stream tables can be created (manually or via `pgtrickle.setup_self_monitoring()`)
 3. The policy layer activates only after the analytics STs are populated
 
-If a dog-feeding ST enters SUSPENDED state, it is treated like any other
+If a self-monitoring ST enters SUSPENDED state, it is treated like any other
 suspended ST — the control plane continues operating on its own.
 
 ---
@@ -241,10 +241,10 @@ Emits EC-11 alert when refresh duration exceeds 80% of schedule interval.
 
 ---
 
-## 5. Dog-Feeding Stream Tables
+## 5. Self-Monitoring Stream Tables
 
-All dog-feeding STs use the `pgtrickle` schema and the `df_` prefix
-(dog-feeding). Each targets a specific gap identified in §4.
+All self-monitoring STs use the `pgtrickle` schema and the `df_` prefix
+(self-monitoring). Each targets a specific gap identified in §4.
 
 ### DF-1: Rolling Efficiency Statistics
 
@@ -490,7 +490,7 @@ over the bounded window is efficient.
 ## 6. Reactive Policy Layer
 
 The policy layer is **optional** and **off by default**. It reads the
-dog-feeding stream tables and translates analytics into configuration changes.
+self-monitoring stream tables and translates analytics into configuration changes.
 
 ### 6.1 Advisory Mode (Default)
 
@@ -513,7 +513,7 @@ WHERE duration_anomaly IS NOT NULL
 Controlled by a new GUC:
 
 ```
-pg_trickle.dog_feeding_auto_apply = off  (default)
+pg_trickle.self_monitoring_auto_apply = off  (default)
                                     threshold_only
                                     full
 ```
@@ -522,7 +522,7 @@ When `threshold_only`:
 - A background task reads `df_threshold_advice` after each refresh cycle
 - If confidence is HIGH and the recommended threshold differs from current by
   > 5%, applies `ALTER STREAM TABLE ... SET auto_threshold = <recommended>`
-- Changes are logged to `pgt_refresh_history` with `initiated_by = 'DOG_FEED'`
+- Changes are logged to `pgt_refresh_history` with `initiated_by = 'SELF_MONITOR'`
 - Rate-limited: at most one threshold change per ST per 10 minutes
 
 When `full`:
@@ -537,7 +537,7 @@ channel:
 
 ```json
 {
-  "event": "dog_feed_anomaly",
+  "event": "self_monitor_anomaly",
   "schema": "public",
   "name": "orders_summary",
   "anomaly": "DURATION_SPIKE",
@@ -576,7 +576,7 @@ stream tables over it refresh correctly.
 1. Create DF-2 (`df_anomaly_signals`) dependent on DF-1
 2. Create DF-3 (`df_threshold_advice`) dependent on DF-1
 3. Verify DAG ordering: DF-1 refreshes first, then DF-2 and DF-3
-4. Verify that the dog-feeding STs' own refresh history rows don't cause
+4. Verify that the self-monitoring STs' own refresh history rows don't cause
    circular confusion (they should appear in DF-1 naturally and harmlessly)
 
 **Deliverables:**
@@ -600,15 +600,15 @@ stream tables over it refresh correctly.
 
 ### Phase 4: Setup Helper & GUC (Low Risk)
 
-**Goal:** Make dog-feeding easy to enable.
+**Goal:** Make self-monitoring easy to enable.
 
-1. Implement `pgtrickle.setup_dog_feeding()` — creates all DF STs in one call
-2. Implement `pgtrickle.teardown_dog_feeding()` — drops all DF STs cleanly
-3. Add `pg_trickle.dog_feeding_auto_apply` GUC (off / threshold_only / full)
+1. Implement `pgtrickle.setup_self_monitoring()` — creates all DF STs in one call
+2. Implement `pgtrickle.teardown_self_monitoring()` — drops all DF STs cleanly
+3. Add `pg_trickle.self_monitoring_auto_apply` GUC (off / threshold_only / full)
 4. Document in CONFIGURATION.md and SQL_REFERENCE.md
 
 **Deliverables:**
-- `setup_dog_feeding()` / `teardown_dog_feeding()` SQL functions
+- `setup_self_monitoring()` / `teardown_self_monitoring()` SQL functions
 - GUC registered in `src/config.rs`
 
 ### Phase 5: Auto-Apply Worker (Higher Risk)
@@ -618,7 +618,7 @@ stream tables over it refresh correctly.
 1. Implement the auto-apply logic in a scheduler post-tick hook
 2. Read `df_threshold_advice` after each coordinator tick
 3. Apply threshold changes with rate limiting and logging
-4. Add `initiated_by = 'DOG_FEED'` to `pgt_refresh_history` for audit trail
+4. Add `initiated_by = 'SELF_MONITOR'` to `pgt_refresh_history` for audit trail
 
 **Deliverables:**
 - Auto-apply worker with rate limiting
@@ -630,7 +630,7 @@ stream tables over it refresh correctly.
 
 **Goal:** Surface anomalies to external systems.
 
-1. Emit `dog_feed_anomaly` NOTIFY events when DF-2 detects anomalies
+1. Emit `self_monitor_anomaly` NOTIFY events when DF-2 detects anomalies
 2. Add Grafana dashboard JSON for DF-1 and DF-2 visualization
 3. Document LISTEN workflow for anomaly alerting
 
@@ -668,7 +668,7 @@ stream tables over it refresh correctly.
 
 ### Stability
 
-- Soak test: run dog-feeding under 100 user STs for 1 hour, verify no memory
+- Soak test: run self-monitoring under 100 user STs for 1 hour, verify no memory
   growth, no cascading failures, no scheduler stalls
 
 ---
@@ -678,20 +678,20 @@ stream tables over it refresh correctly.
 ### R1: Recursive CDC Amplification
 
 **Risk:** Dog-feeding STs refresh → generate history rows → trigger CDC →
-schedule another dog-feeding refresh → generate more history rows → ...
+schedule another self-monitoring refresh → generate more history rows → ...
 
-**Mitigation:** Each refresh generates exactly 1 history row. A dog-feeding
+**Mitigation:** Each refresh generates exactly 1 history row. A self-monitoring
 cycle of 5 STs generates 5 rows per tick. At 48s schedule, that's 375
 rows/hour — negligible compared to user workload. The system is convergent:
-each dog-feeding refresh reads all accumulated rows and produces a fixed-size
+each self-monitoring refresh reads all accumulated rows and produces a fixed-size
 aggregate output, not an amplifying chain.
 
 ### R2: Bootstrapping on Empty History
 
-**Risk:** `setup_dog_feeding()` called on a fresh install with 0 history rows.
+**Risk:** `setup_self_monitoring()` called on a fresh install with 0 history rows.
 Stream tables would be empty and useless.
 
-**Mitigation:** `setup_dog_feeding()` checks `pgt_refresh_history` row count.
+**Mitigation:** `setup_self_monitoring()` checks `pgt_refresh_history` row count.
 If < 50 rows, emits a WARNING and proceeds — the STs will populate naturally
 as history accumulates. Documentation notes the warm-up period.
 
@@ -722,12 +722,12 @@ Phase 1 validates which approach works.
 ### R5: Schema Coupling
 
 **Risk:** Upgrade migrations that change `pgt_refresh_history` columns
-would break dog-feeding ST definitions.
+would break self-monitoring ST definitions.
 
 **Mitigation:** Dog-feeding STs reference only stable columns (`pgt_id`,
 `action`, `status`, `start_time`, `end_time`, `rows_inserted`, `rows_deleted`,
 `delta_row_count`). These columns have been stable since v0.5.0. If a column
-is renamed, `teardown_dog_feeding()` + `setup_dog_feeding()` re-creates the
+is renamed, `teardown_self_monitoring()` + `setup_self_monitoring()` re-creates the
 STs with updated definitions. The upgrade migration script can automate this.
 
 ### R6: Performance Overhead
@@ -744,9 +744,9 @@ further or the STs moved to `refresh_tier = 'warm'`.
 
 ## 10. Future Extensions
 
-### 10.1 Cross-Database Dog-Feeding
+### 10.1 Cross-Database Self-Monitoring
 
-When multi-database support (G17-MDB) ships, dog-feeding STs could aggregate
+When multi-database support (G17-MDB) ships, self-monitoring STs could aggregate
 refresh history across all databases on the cluster, detecting patterns that
 span database boundaries (e.g., shared I/O contention).
 
@@ -770,7 +770,7 @@ to recommend thresholds that satisfy freshness SLAs rather than purely
 optimizing cost. A ST that must be fresh within 5s tolerance should have a
 lower threshold (prefer FULL for predictability) than one with 60s tolerance.
 
-### 10.5 Grafana Dog-Feeding Dashboard
+### 10.5 Grafana Self-Monitoring Dashboard
 
 Pre-built Grafana dashboard that reads DF-1 through DF-5, providing out-of-box
 operational visibility:

--- a/plans/ui/PLAN_TUI_PART_3.md
+++ b/plans/ui/PLAN_TUI_PART_3.md
@@ -1,4 +1,4 @@
-# PLAN_TUI_PART_3.md — TUI Dog-Feeding Integration & Architecture (v0.21)
+# PLAN_TUI_PART_3.md — TUI Self-Monitoring Integration & Architecture (v0.21)
 
 **Milestone:** v0.21.0
 **Status:** Planned
@@ -15,9 +15,9 @@
 PLAN_TUI.md (v0.14) delivered 14 views, 18 CLI subcommands, and real-time
 alerts. PLAN_TUI_PART_2 (v0.15) added write actions, command palette,
 scrollable views, parallel polling, and 15 new SQL API surface expansions.
-This third plan wires the v0.20.0 **dog-feeding stream tables** (`df_*`)
+This third plan wires the v0.20.0 **self-monitoring stream tables** (`df_*`)
 into the TUI, introduces a **structural refactoring** of the TUI internals,
-and adds CLI subcommands for dog-feeding lifecycle management.
+and adds CLI subcommands for self-monitoring lifecycle management.
 
 ### Release Theme
 
@@ -47,26 +47,26 @@ and adds CLI subcommands for dog-feeding lifecycle management.
 9. **TUI-5** — Workers Interference sub-tab from `df_scheduling_interference`
 10. **TUI-6** — Workers scheduler overhead bar
 11. **TUI-7** — Dependencies Mermaid/DOT export overlay
-12. **TUI-8** — Header bar dog-feeding status badge
-13. **TUI-9** — Command palette `dog-feeding enable/disable`
+12. **TUI-8** — Header bar self-monitoring status badge
+13. **TUI-9** — Command palette `self-monitoring enable/disable`
 14. **TUI-10** — Detail view active anomaly summary row
-15. **TUI-11** — Refresh Log `[auto]` annotation for `DOG_FEED` rows
-16. **TUI-12** — First-launch dog-feeding setup hint toast
+15. **TUI-11** — Refresh Log `[auto]` annotation for `SELF_MONITOR` rows
+16. **TUI-12** — First-launch self-monitoring setup hint toast
 17. **TUI-13** — Anomaly signals as Issues
-18. **TUI-14** — `dog_feed_anomaly` alert styling
+18. **TUI-14** — `self_monitor_anomaly` alert styling
 19. **TUI-15** — Dashboard snapshot tests
 20. **TUI-16** — Diagnostics `df_efficiency_rolling` summary panel
 
 **Backend enhancements:**
 
 21. **DF-21** — `sla_breach_risk` column in `df_threshold_advice`
-22. **DF-22** — `dog_feeding_auto_apply = 'full'` scheduling mode
-23. **DF-23** — `dog_feeding_status()` retention warning
+22. **DF-22** — `self_monitoring_auto_apply = 'full'` scheduling mode
+23. **DF-23** — `self_monitoring_status()` retention warning
 24. **DF-24** — `recommend_refresh_mode()` reads from `df_threshold_advice`
 
 **CLI integration:**
 
-25. **CLI-1** — `pgtrickle dog-feeding` subcommand group
+25. **CLI-1** — `pgtrickle self-monitoring` subcommand group
 26. **CLI-2** — `pgtrickle graph --format ascii|mermaid|dot`
 
 **Test coverage, documentation:**
@@ -93,7 +93,7 @@ and adds CLI subcommands for dog-feeding lifecycle management.
 - [Architecture: Selective Polling](#architecture-selective-polling)
 - [Architecture: Poller Extraction](#architecture-poller-extraction)
 - [Architecture: CLI/TUI Command Unification](#architecture-clitui-command-unification)
-- [Dog-Feeding Data Model](#dog-feeding-data-model)
+- [Self-Monitoring Data Model](#self-monitoring-data-model)
 - [Feature Specifications](#feature-specifications)
   - [TUI-1 — Anomaly Detection View](#tui-1--anomaly-detection-view)
   - [TUI-2 — Dashboard Anomaly Badge](#tui-2--dashboard-anomaly-badge)
@@ -102,11 +102,11 @@ and adds CLI subcommands for dog-feeding lifecycle management.
   - [TUI-5 — Workers Interference Sub-Tab](#tui-5--workers-interference-sub-tab)
   - [TUI-6 — Workers Scheduler Overhead Bar](#tui-6--workers-scheduler-overhead-bar)
   - [TUI-7 — Dependencies Mermaid/DOT Export](#tui-7--dependencies-mermaiddot-export)
-  - [TUI-8 — Header Dog-Feeding Status Badge](#tui-8--header-dog-feeding-status-badge)
-  - [TUI-9 — Dog-Feeding Commands in Palette](#tui-9--dog-feeding-commands-in-palette)
+  - [TUI-8 — Header Self-Monitoring Status Badge](#tui-8--header-self-monitoring-status-badge)
+  - [TUI-9 — Self-Monitoring Commands in Palette](#tui-9--self-monitoring-commands-in-palette)
   - [TUI-10 — Detail View Anomaly Summary](#tui-10--detail-view-anomaly-summary)
   - [TUI-11 — Refresh Log Auto Tag](#tui-11--refresh-log-auto-tag)
-  - [TUI-12 — First-Launch Dog-Feeding Toast](#tui-12--first-launch-dog-feeding-toast)
+  - [TUI-12 — First-Launch Self-Monitoring Toast](#tui-12--first-launch-self-monitoring-toast)
   - [TUI-13 — Anomaly Signals as Issues](#tui-13--anomaly-signals-as-issues)
   - [TUI-14 — Dog-Feed Alert Styling](#tui-14--dog-feed-alert-styling)
   - [TUI-15 — Dashboard Snapshot Tests](#tui-15--dashboard-snapshot-tests)
@@ -117,7 +117,7 @@ and adds CLI subcommands for dog-feeding lifecycle management.
   - [DF-23 — Retention Warning](#df-23--retention-warning)
   - [DF-24 — recommend_refresh_mode Reads DF](#df-24--recommend_refresh_mode-reads-df)
 - [CLI Integration](#cli-integration)
-  - [CLI-1 — Dog-Feeding Subcommand Group](#cli-1--dog-feeding-subcommand-group)
+  - [CLI-1 — Self-Monitoring Subcommand Group](#cli-1--self-monitoring-subcommand-group)
   - [CLI-2 — Graph Format Flag](#cli-2--graph-format-flag)
 - [Test Strategy](#test-strategy)
 - [Implementation Phases](#implementation-phases)
@@ -130,7 +130,7 @@ and adds CLI subcommands for dog-feeding lifecycle management.
 ### AppState Complexity
 
 `state.rs` defines a single `AppState` struct with 50+ fields. All views
-receive the entire state. Adding dog-feeding data (5 stream table views,
+receive the entire state. Adding self-monitoring data (5 stream table views,
 status, anomaly signals, trends, interference, efficiency, threshold advice)
 would push AppState past 60 fields with no clear ownership.
 
@@ -165,7 +165,7 @@ further. No grouping, no parent-child relationships.
 ### CLI/TUI Command Divergence
 
 CLI commands in `commands/*.rs` and TUI palette commands in `app.rs` execute
-the same SQL but through different code paths. Adding `dog-feeding enable`
+the same SQL but through different code paths. Adding `self-monitoring enable`
 requires changes in both places.
 
 ---
@@ -175,7 +175,7 @@ requires changes in both places.
 ### Goal
 
 Split `AppState` into domain-scoped sub-structs. Views access only the
-domains they need. New domains (dog-feeding) are added without touching
+domains they need. New domains (self-monitoring) are added without touching
 existing view code.
 
 ### Design
@@ -194,7 +194,7 @@ pub struct AppState {
     pub scheduling: SchedulingDomain,
     pub watermarks: WatermarkDomain,
     pub config: ConfigDomain,
-    pub dog_feeding: DogFeedingDomain,  // NEW
+    pub self_monitoring: DogFeedingDomain,  // NEW
 
     // Caches (shared across views)
     pub caches: CacheStore,
@@ -259,7 +259,7 @@ pub struct ConfigDomain {
 /// Dog-feeding domain — data from the five df_* stream tables.
 #[derive(Default)]
 pub struct DogFeedingDomain {
-    /// Whether dog-feeding is set up and active
+    /// Whether self-monitoring is set up and active
     pub enabled: bool,
     /// Dog-feeding status (active STs, setup date, health)
     pub status: Option<DogFeedingStatus>,
@@ -273,7 +273,7 @@ pub struct DogFeedingDomain {
     pub efficiency_rolling: Vec<EfficiencyRollingRecord>,
     /// Threshold advice from df_threshold_advice
     pub threshold_advice: Vec<ThresholdAdviceRecord>,
-    /// Retention warning from dog_feeding_status()
+    /// Retention warning from self_monitoring_status()
     pub retention_warning: Option<String>,
 }
 
@@ -355,7 +355,7 @@ pub struct DataSubscriptions {
     pub needs_scheduler_overhead: bool,
 
     // Dog-feeding (only when enabled, Phase 2)
-    pub needs_dog_feeding_status: bool,
+    pub needs_self_monitoring_status: bool,
     pub needs_anomaly_signals: bool,
     pub needs_cdc_trends: bool,
     pub needs_interference: bool,
@@ -365,35 +365,35 @@ pub struct DataSubscriptions {
 
 impl DataSubscriptions {
     /// Compute subscriptions from the active view.
-    pub fn for_view(view: View, dog_feeding_enabled: bool) -> Self {
+    pub fn for_view(view: View, self_monitoring_enabled: bool) -> Self {
         let mut subs = Self::default();
 
         // Dog-feeding status is always checked (lightweight)
-        subs.needs_dog_feeding_status = true;
+        subs.needs_self_monitoring_status = true;
         // Quick health is always needed for the header bar
         subs.needs_quick_health = true;
 
         match view {
             View::Dashboard => {
-                subs.needs_anomaly_signals = dog_feeding_enabled;
+                subs.needs_anomaly_signals = self_monitoring_enabled;
             }
             View::Detail => {
-                subs.needs_anomaly_signals = dog_feeding_enabled;
+                subs.needs_anomaly_signals = self_monitoring_enabled;
             }
             View::Cdc => {
                 subs.needs_cdc_health = true;
                 subs.needs_dedup_stats = true;
                 subs.needs_shared_buffer_stats = true;
-                subs.needs_cdc_trends = dog_feeding_enabled;
+                subs.needs_cdc_trends = self_monitoring_enabled;
             }
             View::Workers => {
                 subs.needs_scheduler_overhead = true;
-                subs.needs_interference = dog_feeding_enabled;
+                subs.needs_interference = self_monitoring_enabled;
             }
             View::Diagnostics => {
                 subs.needs_scheduler_overhead = true;
-                subs.needs_efficiency_rolling = dog_feeding_enabled;
-                subs.needs_threshold_advice = dog_feeding_enabled;
+                subs.needs_efficiency_rolling = self_monitoring_enabled;
+                subs.needs_threshold_advice = self_monitoring_enabled;
             }
             View::Graph => {
                 subs.needs_diamond_scc = true;
@@ -403,7 +403,7 @@ impl DataSubscriptions {
                 subs.needs_watermark_alignment = true;
             }
             View::Issues => {
-                subs.needs_anomaly_signals = dog_feeding_enabled;
+                subs.needs_anomaly_signals = self_monitoring_enabled;
             }
             // RefreshLog, Config, Health, Alerts, Fuse, DeltaInspector:
             // no Phase 2 subscriptions needed
@@ -454,39 +454,39 @@ pub async fn poll_all(
     // ... etc for each subscription ...
 
     // Dog-feeding subscriptions (only when status check says enabled)
-    if subs.needs_dog_feeding_status {
-        if let Ok(status) = poll_dog_feeding_status_query(client).await {
-            state.dog_feeding.enabled = status.is_some();
-            state.dog_feeding.status = status;
-            state.dog_feeding.retention_warning =
-                state.dog_feeding.status.as_ref()
+    if subs.needs_self_monitoring_status {
+        if let Ok(status) = poll_self_monitoring_status_query(client).await {
+            state.self_monitoring.enabled = status.is_some();
+            state.self_monitoring.status = status;
+            state.self_monitoring.retention_warning =
+                state.self_monitoring.status.as_ref()
                     .and_then(|s| s.retention_warning.clone());
         }
     }
-    if state.dog_feeding.enabled {
+    if state.self_monitoring.enabled {
         if subs.needs_anomaly_signals {
             if let Ok(signals) = poll_anomaly_signals_query(client).await {
-                state.dog_feeding.anomaly_signals = signals;
+                state.self_monitoring.anomaly_signals = signals;
             }
         }
         if subs.needs_cdc_trends {
             if let Ok(trends) = poll_cdc_trends_query(client).await {
-                state.dog_feeding.cdc_trends = trends;
+                state.self_monitoring.cdc_trends = trends;
             }
         }
         if subs.needs_interference {
             if let Ok(records) = poll_interference_query(client).await {
-                state.dog_feeding.interference = records;
+                state.self_monitoring.interference = records;
             }
         }
         if subs.needs_efficiency_rolling {
             if let Ok(records) = poll_efficiency_rolling_query(client).await {
-                state.dog_feeding.efficiency_rolling = records;
+                state.self_monitoring.efficiency_rolling = records;
             }
         }
         if subs.needs_threshold_advice {
             if let Ok(records) = poll_threshold_advice_query(client).await {
-                state.dog_feeding.threshold_advice = records;
+                state.self_monitoring.threshold_advice = records;
             }
         }
     }
@@ -524,7 +524,7 @@ src/poller/
 ```rust
 // poller/fetchers.rs
 pub async fn fetch_stream_tables(client: &Client) -> Result<Vec<StreamTableInfo>, PgErr> { ... }
-pub async fn fetch_dog_feeding_status(client: &Client) -> Result<Option<DogFeedingStatus>, PgErr> { ... }
+pub async fn fetch_self_monitoring_status(client: &Client) -> Result<Option<DogFeedingStatus>, PgErr> { ... }
 pub async fn fetch_anomaly_signals(client: &Client) -> Result<Vec<AnomalySignal>, PgErr> { ... }
 // ... one per poll query
 ```
@@ -536,14 +536,14 @@ pub fn apply_stream_tables(state: &mut AppState, tables: Vec<StreamTableInfo>) {
     // preserve sparkline_data from previous poll
     state.stream_tables.tables = tables;
 }
-pub fn apply_dog_feeding_status(state: &mut AppState, status: Option<DogFeedingStatus>) {
-    state.dog_feeding.enabled = status.is_some();
-    state.dog_feeding.retention_warning = status.as_ref()
+pub fn apply_self_monitoring_status(state: &mut AppState, status: Option<DogFeedingStatus>) {
+    state.self_monitoring.enabled = status.is_some();
+    state.self_monitoring.retention_warning = status.as_ref()
         .and_then(|s| s.retention_warning.clone());
-    state.dog_feeding.status = status;
+    state.self_monitoring.status = status;
 }
 pub fn apply_anomaly_signals(state: &mut AppState, signals: Vec<AnomalySignal>) {
-    state.dog_feeding.anomaly_signals = signals;
+    state.self_monitoring.anomaly_signals = signals;
 }
 // ... one per domain
 ```
@@ -564,21 +564,21 @@ Create `commands/domain.rs` with shared command logic:
 ```rust
 // commands/domain.rs
 
-pub async fn enable_dog_feeding(client: &Client) -> Result<String, CliError> {
-    client.execute("SELECT pgtrickle.setup_dog_feeding()", &[]).await?;
+pub async fn enable_self_monitoring(client: &Client) -> Result<String, CliError> {
+    client.execute("SELECT pgtrickle.setup_self_monitoring()", &[]).await?;
     Ok("Dog-feeding enabled".to_string())
 }
 
-pub async fn disable_dog_feeding(client: &Client) -> Result<String, CliError> {
-    client.execute("SELECT pgtrickle.teardown_dog_feeding()", &[]).await?;
+pub async fn disable_self_monitoring(client: &Client) -> Result<String, CliError> {
+    client.execute("SELECT pgtrickle.teardown_self_monitoring()", &[]).await?;
     Ok("Dog-feeding disabled".to_string())
 }
 
-pub async fn dog_feeding_status(
+pub async fn self_monitoring_status(
     client: &Client,
     format: OutputFormat,
 ) -> Result<String, CliError> {
-    let rows = client.query("SELECT * FROM pgtrickle.dog_feeding_status()", &[]).await?;
+    let rows = client.query("SELECT * FROM pgtrickle.self_monitoring_status()", &[]).await?;
     format_rows(rows, format)
 }
 
@@ -596,12 +596,12 @@ pub async fn export_dag(
 
 **CLI uses it:**
 ```rust
-// commands/dog_feeding.rs
+// commands/self_monitoring.rs
 pub async fn execute(client: &Client, args: &DogFeedingArgs) -> Result<(), CliError> {
     match args.action {
-        DogFeedingAction::Enable => println!("{}", domain::enable_dog_feeding(client).await?),
-        DogFeedingAction::Disable => println!("{}", domain::disable_dog_feeding(client).await?),
-        DogFeedingAction::Status => println!("{}", domain::dog_feeding_status(client, args.format).await?),
+        DogFeedingAction::Enable => println!("{}", domain::enable_self_monitoring(client).await?),
+        DogFeedingAction::Disable => println!("{}", domain::disable_self_monitoring(client).await?),
+        DogFeedingAction::Status => println!("{}", domain::self_monitoring_status(client, args.format).await?),
     }
     Ok(())
 }
@@ -611,7 +611,7 @@ pub async fn execute(client: &Client, args: &DogFeedingArgs) -> Result<(), CliEr
 ```rust
 // poller.rs → execute_action()
 ActionRequest::DogFeedingEnable => {
-    match domain::enable_dog_feeding(client).await {
+    match domain::enable_self_monitoring(client).await {
         Ok(msg) => PollMsg::ActionResult(ActionResult { success: true, message: msg }),
         Err(e) => PollMsg::ActionResult(ActionResult { success: false, message: e.to_string() }),
     }
@@ -620,7 +620,7 @@ ActionRequest::DogFeedingEnable => {
 
 ---
 
-## Dog-Feeding Data Model
+## Self-Monitoring Data Model
 
 ### New State Types
 
@@ -682,11 +682,11 @@ pub struct ThresholdAdviceRecord {
 }
 ```
 
-### Dog-Feeding SQL Queries
+### Self-Monitoring SQL Queries
 
 | Query | Source | Fields | Used By |
 |-------|--------|--------|---------|
-| `SELECT * FROM pgtrickle.dog_feeding_status()` | SQL func | `active_count`, `total_count`, `setup_at`, `retention_warning` | TUI-8, TUI-12 |
+| `SELECT * FROM pgtrickle.self_monitoring_status()` | SQL func | `active_count`, `total_count`, `setup_at`, `retention_warning` | TUI-8, TUI-12 |
 | `SELECT * FROM pgtrickle.df_anomaly_signals` | DF-2 ST | `st_name`, `anomaly_type`, `severity`, `detected_at`, `delta_from_baseline`, `window_seconds` | TUI-1, TUI-2, TUI-10, TUI-13 |
 | `SELECT * FROM pgtrickle.df_cdc_buffer_trends` | DF-4 ST | `source_table`, `buffer_counts`, `growth_rate`, `spill_risk` | TUI-3, TUI-4 |
 | `SELECT * FROM pgtrickle.df_scheduling_interference` | DF-5 ST | `st_a`, `st_b`, `overlap_count`, `total_overlap_ms`, `last_seen` | TUI-5 |
@@ -700,10 +700,10 @@ pub struct ThresholdAdviceRecord {
 ### TUI-1 — Anomaly Detection View
 
 **Key:** `a`
-**Data source:** `df_anomaly_signals` via `state.dog_feeding.anomaly_signals`
+**Data source:** `df_anomaly_signals` via `state.self_monitoring.anomaly_signals`
 
 New view accessible via `a` key. Renders a table of active anomaly signals
-from the `df_anomaly_signals` dog-feeding stream table.
+from the `df_anomaly_signals` self-monitoring stream table.
 
 **Columns:**
 | Column | Width | Source |
@@ -715,12 +715,12 @@ from the `df_anomaly_signals` dog-feeding stream table.
 | Delta | 10 | `delta_from_baseline` (e.g., "+3.2×") |
 | Window | 8 | `window_seconds` (e.g., "5 min") |
 
-**Empty state:** When dog-feeding is not enabled:
+**Empty state:** When self-monitoring is not enabled:
 ```
 ┌─ Anomaly Detection ──────────────────────────────┐
 │                                                   │
 │  Dog-feeding is not active.                       │
-│  Run :dog-feeding enable for anomaly detection.   │
+│  Run :self-monitoring enable for anomaly detection.   │
 │                                                   │
 └───────────────────────────────────────────────────┘
 ```
@@ -731,7 +731,7 @@ from the `df_anomaly_signals` dog-feeding stream table.
 ### TUI-2 — Dashboard Anomaly Badge
 
 **View:** Dashboard (key `1`)
-**Data source:** `state.dog_feeding.anomaly_signals.len()`
+**Data source:** `state.self_monitoring.anomaly_signals.len()`
 
 In `render_status_ribbon()`, after existing status counters (active, paused,
 error, suspended), append an anomaly badge:
@@ -741,28 +741,28 @@ error, suspended), append an anomaly badge:
 ```
 
 - Badge text: `🔍 N anomalies` (cyan icon, red count when N > 0)
-- Hidden when N = 0 or dog-feeding is off
+- Hidden when N = 0 or self-monitoring is off
 - Implementation: ~10 LOC in `dashboard.rs::render_status_ribbon()`
 
 ### TUI-3 — CDC Health Sparkline Column
 
 **View:** CDC Health (key `6`)
-**Data source:** `state.dog_feeding.cdc_trends`
+**Data source:** `state.self_monitoring.cdc_trends`
 
-When dog-feeding is active, each source table row in the CDC buffers section
+When self-monitoring is active, each source table row in the CDC buffers section
 gains a 20-character sparkline column showing buffer row-count trend over
 the last 10 poll cycles.
 
 **Rendering:**
 - Use braille block characters (`⣀⣤⣶⣿` etc.) for compact sparkline
 - Data: `cdc_trends.buffer_counts` (Vec<f64>, last 10 values)
-- Falls back to `—` when dog-feeding is off or no trend data available
+- Falls back to `—` when self-monitoring is off or no trend data available
 - Column header: `Trend`
 
 ### TUI-4 — CDC Health Spill-Risk Badge
 
 **View:** CDC Health (key `6`)
-**Data source:** `state.dog_feeding.cdc_trends.spill_risk` + `state.cdc.health`
+**Data source:** `state.self_monitoring.cdc_trends.spill_risk` + `state.cdc.health`
 
 When `check_cdc_health()` reports spill risk via OPS-2 enrichment:
 - `IMMINENT` → red badge, overrides normal buffer-size highlight
@@ -775,7 +775,7 @@ Implementation: extend the existing CDC view's row rendering to check
 ### TUI-5 — Workers Interference Sub-Tab
 
 **View:** Workers (key `w`)
-**Data source:** `state.dog_feeding.interference`
+**Data source:** `state.self_monitoring.interference`
 
 New `Interference` tab (second tab, switched with `Tab` key) in the Workers
 view. Shows rows from `df_scheduling_interference`:
@@ -790,7 +790,7 @@ view. Shows rows from `df_scheduling_interference`:
 | Last Seen | 19 | `last_seen` |
 
 **Sorting:** Default by `overlap_count` DESC.
-**Empty state:** Same pattern as TUI-1 (dog-feeding hint).
+**Empty state:** Same pattern as TUI-1 (self-monitoring hint).
 
 App struct gains `workers_tab: usize` (0=Overview, 1=Interference).
 `Tab` key cycles between tabs when in Workers view.
@@ -831,54 +831,54 @@ Press `Ctrl+E` in the overlay to export to file
 Implementation: new `ActionRequest::FetchExplainDag(String)` for format
 selection. New overlay state `mermaid_overlay: Option<String>` in `App`.
 
-### TUI-8 — Header Dog-Feeding Status Badge
+### TUI-8 — Header Self-Monitoring Status Badge
 
 **View:** All views (header bar)
-**Data source:** `state.dog_feeding.status`
+**Data source:** `state.self_monitoring.status`
 
 In the shared header bar (rendered by `draw_header()` in `app.rs`), add:
 
-- `df:5/5` in green when all 5 dog-feeding STs are active
+- `df:5/5` in green when all 5 self-monitoring STs are active
 - `df:3/5` in yellow when some are active
-- `df:off` dimmed when dog-feeding not configured
+- `df:off` dimmed when self-monitoring not configured
 - `df:⚠` in orange when `retention_warning` is set
 
 Position: after the scheduler indicator, before the poll interval.
 
-### TUI-9 — Dog-Feeding Commands in Palette
+### TUI-9 — Self-Monitoring Commands in Palette
 
 **View:** Command palette (`:` mode)
 
 Add three commands:
-- `dog-feeding enable` → calls `setup_dog_feeding()` → toast "Dog-feeding enabled (5 stream tables created)"
-- `dog-feeding disable` → confirmation dialog → calls `teardown_dog_feeding()` → toast "Dog-feeding disabled"
-- `dog-feeding status` → calls `dog_feeding_status()` → toast with summary
+- `self-monitoring enable` → calls `setup_self_monitoring()` → toast "Dog-feeding enabled (5 stream tables created)"
+- `self-monitoring disable` → confirmation dialog → calls `teardown_self_monitoring()` → toast "Dog-feeding disabled"
+- `self-monitoring status` → calls `self_monitoring_status()` → toast with summary
 
 Implementation:
 1. Add `DogFeedingEnable`, `DogFeedingDisable` variants to `ActionRequest`
-2. Add `("dog-feeding enable", ...)`, `("dog-feeding disable", ...)`,
-   `("dog-feeding status", ...)` to command list in `CommandPalette`
+2. Add `("self-monitoring enable", ...)`, `("self-monitoring disable", ...)`,
+   `("self-monitoring status", ...)` to command list in `CommandPalette`
 3. Add execution handlers in `execute_action()` using unified domain logic
-4. `dog-feeding disable` requires confirmation (same as `pause`)
+4. `self-monitoring disable` requires confirmation (same as `pause`)
 
 ### TUI-10 — Detail View Anomaly Summary
 
 **View:** Detail (key `2`)
-**Data source:** `state.dog_feeding.anomaly_signals` filtered by selected ST
+**Data source:** `state.self_monitoring.anomaly_signals` filtered by selected ST
 
 In the Properties section of the Detail view, after the existing rows
 (status, mode, staleness, etc.), add an `Anomalies` row:
 
 - When anomalies exist: `⚠ 2 active: DURATION_SPIKE, ERROR_BURST` (red)
 - When no anomalies: `—` (dim)
-- When dog-feeding off: row not shown
+- When self-monitoring off: row not shown
 
 ### TUI-11 — Refresh Log Auto Tag
 
 **View:** Refresh Log (key `4`)
 **Data source:** `initiated_by` column in `pgt_refresh_history`
 
-When a refresh log entry has `initiated_by = 'DOG_FEED'`, display an
+When a refresh log entry has `initiated_by = 'SELF_MONITOR'`, display an
 orange `[auto]` tag in the Mode column, after the mode label:
 
 ```
@@ -888,36 +888,36 @@ orange `[auto]` tag in the Mode column, after the mode label:
 Implementation:
 1. Extend `poll_refresh_log_query()` to include `initiated_by` column
 2. Add `initiated_by: Option<String>` to `RefreshLogEntry` state struct
-3. In `refresh_log.rs`, check for `DOG_FEED` value and render tag
+3. In `refresh_log.rs`, check for `SELF_MONITOR` value and render tag
 
-### TUI-12 — First-Launch Dog-Feeding Toast
+### TUI-12 — First-Launch Self-Monitoring Toast
 
 **View:** Any (on first poll result)
-**Data source:** `state.dog_feeding.enabled`
+**Data source:** `state.self_monitoring.enabled`
 
-On the first successful poll, if `dog_feeding_status()` returns zero active
-stream tables (dog-feeding not set up), show a one-time info toast:
+On the first successful poll, if `self_monitoring_status()` returns zero active
+stream tables (self-monitoring not set up), show a one-time info toast:
 
 ```
-Dog-feeding not active. Run :dog-feeding enable for enhanced monitoring.
+Dog-feeding not active. Run :self-monitoring enable for enhanced monitoring.
 ```
 
 - Dismissed automatically after 10 s or on any keypress
 - Only shown once per TUI session (tracked by `shown_df_hint: bool` in `App`)
-- Not shown if dog-feeding is already active
+- Not shown if self-monitoring is already active
 
 ### TUI-13 — Anomaly Signals as Issues
 
 **View:** Issues (key `i`)
-**Data source:** `state.dog_feeding.anomaly_signals`
+**Data source:** `state.self_monitoring.anomaly_signals`
 
 Extend `detect_issues()` in `state.rs` to include anomaly signals when
-dog-feeding is active:
+self-monitoring is active:
 
 ```rust
 // In detect_issues():
-if self.dog_feeding.enabled {
-    for signal in &self.dog_feeding.anomaly_signals {
+if self.self_monitoring.enabled {
+    for signal in &self.self_monitoring.anomaly_signals {
         let severity = match signal.severity.as_str() {
             "CRITICAL" => IssueSeverity::Critical,
             _ => IssueSeverity::Warning,
@@ -943,7 +943,7 @@ if self.dog_feeding.enabled {
 **View:** Alerts (key `9`)
 **Data source:** `state.monitoring.alerts` (filtered by event type)
 
-Events with `event_type = "dog_feed_anomaly"` get a distinct cyan `🔍` icon
+Events with `event_type = "self_monitor_anomaly"` get a distinct cyan `🔍` icon
 instead of the standard `⚠` or `✗`. Applied in `alert.rs` rendering.
 
 ### TUI-15 — Dashboard Snapshot Tests
@@ -955,19 +955,19 @@ Add snapshot tests for Dashboard view covering all rendering branches:
 - `test_dashboard_standard_80x24` — standard layout
 - `test_dashboard_wide_160x40` — wide layout with sparklines and DAG minimap
 - `test_dashboard_empty_80x24` — empty state (no stream tables)
-- `test_dashboard_with_anomalies_80x24` — badge visible (uses `sample_state_dog_feeding()`)
+- `test_dashboard_with_anomalies_80x24` — badge visible (uses `sample_state_self_monitoring()`)
 - `test_dashboard_narrow_60x20` — narrow terminal, graceful truncation
 
 ### TUI-16 — Diagnostics Efficiency Summary
 
 **View:** Diagnostics (key `5`)
-**Data source:** `state.dog_feeding.efficiency_rolling`
+**Data source:** `state.self_monitoring.efficiency_rolling`
 
-When dog-feeding is active, add a compact "Efficiency" panel below the
+When self-monitoring is active, add a compact "Efficiency" panel below the
 existing diagnostics recommendations:
 
 ```
-┌─ Dog-Feeding Efficiency ─────────────────────────┐
+┌─ Self-Monitoring Efficiency ─────────────────────────┐
 │ Avg Diff Speedup: 4.2×  |  Diff: 847  Full: 23  │
 │ Last Hour: 98% differential                       │
 └───────────────────────────────────────────────────┘
@@ -975,7 +975,7 @@ existing diagnostics recommendations:
 
 - Computed from `efficiency_rolling`: aggregate `diff_speedup` across all STs,
   sum `diff_count` and `full_count`
-- Shows `—` when dog-feeding is off
+- Shows `—` when self-monitoring is off
 
 ---
 
@@ -992,16 +992,16 @@ sla_breach_risk = (avg_diff_ms > freshness_deadline_ms)
 
 This completes the v0.20.0 exit criterion UX-8 that was left unchecked.
 
-**Files:** `src/api/dog_feeding.rs` (DF-3 query definition)
+**Files:** `src/api/self_monitoring.rs` (DF-3 query definition)
 **Test:** Synthetic-data E2E test asserting `sla_breach_risk = true` when
   `avg_diff_ms` exceeds `freshness_deadline_ms`
 
 ### DF-22 — auto_apply Full Mode
 
-Implement the `dog_feeding_auto_apply = 'full'` scheduling mode documented
+Implement the `self_monitoring_auto_apply = 'full'` scheduling mode documented
 as "future enhancement" in `docs/CONFIGURATION.md`.
 
-When `full` is active, `dog_feeding_auto_apply_tick()` additionally:
+When `full` is active, `self_monitoring_auto_apply_tick()` additionally:
 1. Reads `df_scheduling_interference.overlap_count` for all pairs
 2. Widens the dispatch interval for high-overlap pairs (> 5 overlaps)
    by 20% per 5 overlaps, capped at 2× baseline
@@ -1013,26 +1013,26 @@ When `full` is active, `dog_feeding_auto_apply_tick()` additionally:
 
 ### DF-23 — Retention Warning
 
-Add a `retention_warning` column to `dog_feeding_status()` output that is
+Add a `retention_warning` column to `self_monitoring_status()` output that is
 set when `pg_trickle.history_retention_days` is below the minimum window
 needed by DF-1 (`df_efficiency_rolling`) and DF-3 (`df_threshold_advice`).
 
 Minimum requirement: retention ≥ 1 day (both STs use rolling 24h windows).
 
-**Files:** `src/api/dog_feeding.rs` (`dog_feeding_status()` function)
+**Files:** `src/api/self_monitoring.rs` (`self_monitoring_status()` function)
 **Test:** E2E test setting `history_retention_days = 0` and verifying
   warning is non-NULL
 
 ### DF-24 — recommend_refresh_mode Reads DF
 
-When dog-feeding is active, `recommend_refresh_mode()` reads from the
+When self-monitoring is active, `recommend_refresh_mode()` reads from the
 maintained `df_threshold_advice` stream table instead of recomputing on
 demand. Same results, lower latency. Falls back to on-demand computation
-when dog-feeding is off.
+when self-monitoring is off.
 
-**Files:** `src/api/dog_feeding.rs`, `src/refresh.rs`
+**Files:** `src/api/self_monitoring.rs`, `src/refresh.rs`
   (recommend_refresh_mode integration)
-**Test:** E2E test verifying that with dog-feeding active,
+**Test:** E2E test verifying that with self-monitoring active,
   `recommend_refresh_mode()` returns data consistent with
   `df_threshold_advice`
 
@@ -1040,20 +1040,20 @@ when dog-feeding is off.
 
 ## CLI Integration
 
-### CLI-1 — Dog-Feeding Subcommand Group
+### CLI-1 — Self-Monitoring Subcommand Group
 
-Add `pgtrickle dog-feeding` with three subcommands:
+Add `pgtrickle self-monitoring` with three subcommands:
 
 ```
-pgtrickle dog-feeding enable          # calls setup_dog_feeding()
-pgtrickle dog-feeding disable         # calls teardown_dog_feeding()
-pgtrickle dog-feeding status          # calls dog_feeding_status()
-pgtrickle dog-feeding status --format json   # JSON output
+pgtrickle self-monitoring enable          # calls setup_self_monitoring()
+pgtrickle self-monitoring disable         # calls teardown_self_monitoring()
+pgtrickle self-monitoring status          # calls self_monitoring_status()
+pgtrickle self-monitoring status --format json   # JSON output
 ```
 
 **Files:**
 - `pgtrickle-tui/src/cli.rs` — add `DogFeeding` variant to `Commands` enum
-- `pgtrickle-tui/src/commands/dog_feeding.rs` — new command module
+- `pgtrickle-tui/src/commands/self_monitoring.rs` — new command module
 - `pgtrickle-tui/src/commands/domain.rs` — shared logic (see architecture section)
 - `pgtrickle-tui/src/main.rs` — dispatch
 
@@ -1080,7 +1080,7 @@ pgtrickle graph --format dot          # calls explain_dag('dot')
 
 | Struct | Fixture Builder | Used By |
 |--------|-----------------|---------|
-| `DogFeedingStatus` | `dog_feeding_status(active, total, setup_at, warning)` | TUI-8, TUI-12 |
+| `DogFeedingStatus` | `self_monitoring_status(active, total, setup_at, warning)` | TUI-8, TUI-12 |
 | `AnomalySignal` | `anomaly_signal(st, type_, severity, delta)` | TUI-1, TUI-2, TUI-10, TUI-13 |
 | `CdcBufferTrend` | `cdc_buffer_trend(source, counts, growth, risk)` | TUI-3, TUI-4 |
 | `InterferenceRecord` | `interference_record(st_a, st_b, overlaps, duration)` | TUI-5 |
@@ -1089,25 +1089,25 @@ pgtrickle graph --format dot          # calls explain_dag('dot')
 
 ### Extended Fixtures
 
-Add `sample_state_dog_feeding()` to `test_fixtures.rs`:
+Add `sample_state_self_monitoring()` to `test_fixtures.rs`:
 
 ```rust
-pub fn sample_state_dog_feeding() -> AppState {
+pub fn sample_state_self_monitoring() -> AppState {
     let mut state = sample_state_full();  // from Part 2
-    state.dog_feeding.enabled = true;
-    state.dog_feeding.status = Some(dog_feeding_status(5, 5, Some("2026-04-15T10:00:00Z"), None));
-    state.dog_feeding.anomaly_signals = vec![
+    state.self_monitoring.enabled = true;
+    state.self_monitoring.status = Some(self_monitoring_status(5, 5, Some("2026-04-15T10:00:00Z"), None));
+    state.self_monitoring.anomaly_signals = vec![
         anomaly_signal("order_totals", "DURATION_SPIKE", "WARNING", 2.3),
         anomaly_signal("revenue_daily", "ERROR_BURST", "CRITICAL", 5.1),
     ];
-    state.dog_feeding.cdc_trends = vec![
+    state.self_monitoring.cdc_trends = vec![
         cdc_buffer_trend("orders", vec![10.0, 12.0, 15.0, 18.0, 22.0], 1.5, None),
         cdc_buffer_trend("events", vec![5.0, 5.0, 8.0, 12.0, 50.0], 4.2, Some("ELEVATED")),
     ];
-    state.dog_feeding.interference = vec![
+    state.self_monitoring.interference = vec![
         interference_record("order_totals", "revenue_daily", 12, 3400.0),
     ];
-    state.dog_feeding.efficiency_rolling = vec![
+    state.self_monitoring.efficiency_rolling = vec![
         efficiency_rolling("order_totals", 847, 23, 4.2),
         efficiency_rolling("revenue_daily", 612, 8, 6.1),
     ];
@@ -1121,41 +1121,41 @@ New stubs required in `test_db.rs`:
 
 | SQL Function/View | Returns | Stub Data |
 |---|---|---|
-| `dog_feeding_status()` | `active_count int, total_count int, setup_at text, retention_warning text` | `5, 5, '2026-04-15', NULL` |
+| `self_monitoring_status()` | `active_count int, total_count int, setup_at text, retention_warning text` | `5, 5, '2026-04-15', NULL` |
 | `df_anomaly_signals` (view) | `st_name text, anomaly_type text, severity text, detected_at text, delta_from_baseline float8, window_seconds int8` | Two rows |
 | `df_cdc_buffer_trends` (view) | `source_table text, buffer_counts float8[], growth_rate float8, spill_risk text` | Two rows |
 | `df_scheduling_interference` (view) | `st_a text, st_b text, overlap_count int8, total_overlap_ms float8, last_seen text` | One row |
 | `df_efficiency_rolling` (view) | `st_name text, diff_count int8, full_count int8, avg_diff_ms float8, avg_full_ms float8, diff_speedup float8` | Two rows |
 | `df_threshold_advice` (view) | `st_name text, recommended_threshold float8, confidence float8, sla_headroom_pct float8, sla_breach_risk bool` | Two rows |
-| `setup_dog_feeding()` | `void` | No-op |
-| `teardown_dog_feeding()` | `void` | No-op |
+| `setup_self_monitoring()` | `void` | No-op |
+| `teardown_self_monitoring()` | `void` | No-op |
 | `explain_dag(text)` | `text` | Mermaid string |
 
 ### Snapshot Test Plan
 
 | Feature | Test Name | State | Terminal Size | Key Assertions |
 |---------|-----------|-------|---------------|----------------|
-| TUI-1 | `test_anomaly_view_populated_80x24` | `sample_state_dog_feeding()` | 80×24 | Signal table with severity colors, type labels |
+| TUI-1 | `test_anomaly_view_populated_80x24` | `sample_state_self_monitoring()` | 80×24 | Signal table with severity colors, type labels |
 | TUI-1 | `test_anomaly_view_empty_80x24` | `sample_state()` (df off) | 80×24 | Empty state with setup hint |
-| TUI-2 | `test_dashboard_anomaly_badge_80x24` | `sample_state_dog_feeding()` | 80×24 | Ribbon shows `🔍 2 anomalies` |
-| TUI-3 | `test_cdc_sparkline_with_trends_100x30` | `sample_state_dog_feeding()` | 100×30 | Sparkline chars visible in Trend column |
+| TUI-2 | `test_dashboard_anomaly_badge_80x24` | `sample_state_self_monitoring()` | 80×24 | Ribbon shows `🔍 2 anomalies` |
+| TUI-3 | `test_cdc_sparkline_with_trends_100x30` | `sample_state_self_monitoring()` | 100×30 | Sparkline chars visible in Trend column |
 | TUI-3 | `test_cdc_sparkline_no_df_100x30` | `sample_state()` | 100×30 | `—` in Trend column |
 | TUI-4 | `test_cdc_spill_risk_badge_100x30` | Trend with `spill_risk = "ELEVATED"` | 100×30 | Orange ELEVATED badge visible |
-| TUI-5 | `test_workers_interference_tab_100x30` | `sample_state_dog_feeding()` | 100×30 | Interference table with overlap data |
+| TUI-5 | `test_workers_interference_tab_100x30` | `sample_state_self_monitoring()` | 100×30 | Interference table with overlap data |
 | TUI-5 | `test_workers_interference_empty_100x30` | `sample_state()` | 100×30 | Empty state with hint |
 | TUI-6 | `test_workers_overhead_bar_100x30` | Scheduler overhead populated | 100×30 | One-line summary visible |
 | TUI-7 | `test_graph_mermaid_overlay_80x30` | Mermaid text in overlay state | 80×30 | Mermaid markdown visible, scrollable |
-| TUI-8 | `test_header_df_active_80x24` | `sample_state_dog_feeding()` | 80×24 | `df:5/5` in green |
+| TUI-8 | `test_header_df_active_80x24` | `sample_state_self_monitoring()` | 80×24 | `df:5/5` in green |
 | TUI-8 | `test_header_df_off_80x24` | `sample_state()` | 80×24 | `df:off` dimmed |
 | TUI-8 | `test_header_df_warning_80x24` | Status with `retention_warning` | 80×24 | `df:⚠` in orange |
 | TUI-10 | `test_detail_anomaly_row_80x40` | Selected ST with anomalies | 80×40 | `⚠ 1 active: DURATION_SPIKE` |
-| TUI-11 | `test_refresh_log_auto_tag_80x24` | Log entry with `initiated_by = DOG_FEED` | 80×24 | Orange `[auto]` tag |
-| TUI-13 | `test_issues_with_anomalies_80x24` | `sample_state_dog_feeding()` | 80×24 | Anomaly category in issues list |
-| TUI-14 | `test_alert_dog_feed_icon_80x24` | Alert with `dog_feed_anomaly` event | 80×24 | Cyan `🔍` icon |
+| TUI-11 | `test_refresh_log_auto_tag_80x24` | Log entry with `initiated_by = SELF_MONITOR` | 80×24 | Orange `[auto]` tag |
+| TUI-13 | `test_issues_with_anomalies_80x24` | `sample_state_self_monitoring()` | 80×24 | Anomaly category in issues list |
+| TUI-14 | `test_alert_dog_feed_icon_80x24` | Alert with `self_monitor_anomaly` event | 80×24 | Cyan `🔍` icon |
 | TUI-15 | `test_dashboard_standard_80x24` | `sample_state()` | 80×24 | Standard layout, no panics |
 | TUI-15 | `test_dashboard_wide_160x40` | `sample_state()` | 160×40 | Wide layout with sparklines + minimap |
 | TUI-15 | `test_dashboard_empty_80x24` | `empty_state()` | 80×24 | Empty placeholder |
-| TUI-16 | `test_diagnostics_efficiency_panel_80x40` | `sample_state_dog_feeding()` | 80×40 | Efficiency panel with speedup and counts |
+| TUI-16 | `test_diagnostics_efficiency_panel_80x40` | `sample_state_self_monitoring()` | 80×40 | Efficiency panel with speedup and counts |
 | TUI-16 | `test_diagnostics_no_df_80x40` | `sample_state()` | 80×40 | No efficiency panel |
 
 ### Unit Test Plan
@@ -1163,27 +1163,27 @@ New stubs required in `test_db.rs`:
 | Module | Test Name | What It Verifies |
 |--------|-----------|------------------|
 | `state.rs` | `test_detect_issues_includes_anomalies` | `detect_issues()` adds WARNING/CRITICAL for anomaly signals |
-| `state.rs` | `test_detect_issues_no_anomalies_when_df_off` | `detect_issues()` skips anomalies when `dog_feeding.enabled = false` |
-| `state.rs` | `test_dog_feeding_domain_default` | `DogFeedingDomain::default()` has `enabled = false`, empty vecs |
+| `state.rs` | `test_detect_issues_no_anomalies_when_df_off` | `detect_issues()` skips anomalies when `self_monitoring.enabled = false` |
+| `state.rs` | `test_self_monitoring_domain_default` | `DogFeedingDomain::default()` has `enabled = false`, empty vecs |
 | `state.rs` | `test_anomaly_signal_severity_mapping` | CRITICAL maps to `IssueSeverity::Critical`, WARNING to Warning |
 | `app.rs` | `test_key_a_switches_to_anomaly_view` | `a` key dispatches to `View::Anomalies` |
 | `app.rs` | `test_tab_in_workers_cycles_tabs` | Tab cycles between Overview and Interference |
 | `app.rs` | `test_x_in_graph_fetches_mermaid` | `x` key dispatches `FetchExplainDag` action |
-| `app.rs` | `test_dog_feeding_enable_command` | `:dog-feeding enable` parsed correctly |
-| `app.rs` | `test_dog_feeding_disable_requires_confirm` | `:dog-feeding disable` shows confirmation dialog |
-| `cli.rs` | `test_dog_feeding_enable_subcommand` | `pgtrickle dog-feeding enable` parses correctly |
+| `app.rs` | `test_self_monitoring_enable_command` | `:self-monitoring enable` parsed correctly |
+| `app.rs` | `test_self_monitoring_disable_requires_confirm` | `:self-monitoring disable` shows confirmation dialog |
+| `cli.rs` | `test_self_monitoring_enable_subcommand` | `pgtrickle self-monitoring enable` parses correctly |
 | `cli.rs` | `test_graph_format_mermaid` | `pgtrickle graph --format mermaid` parses correctly |
 | `cli.rs` | `test_graph_format_default_ascii` | `pgtrickle graph` defaults to ASCII |
 | `poller.rs` | `test_subscriptions_for_dashboard` | Dashboard subscribes to anomaly_signals but not interference |
 | `poller.rs` | `test_subscriptions_for_cdc` | CDC subscribes to cdc_health, dedup, shared_buffer, cdc_trends |
 | `poller.rs` | `test_subscriptions_for_workers` | Workers subscribes to scheduler_overhead, interference |
-| `poller.rs` | `test_subscriptions_df_disabled` | All DF subscriptions false when dog_feeding_enabled = false |
+| `poller.rs` | `test_subscriptions_df_disabled` | All DF subscriptions false when self_monitoring_enabled = false |
 
 ### Degradation Test Plan
 
 | Test | What It Verifies |
 |------|------------------|
-| `test_poll_dog_feeding_status_missing` | TUI renders with `df:off` when `dog_feeding_status()` is absent |
+| `test_poll_self_monitoring_status_missing` | TUI renders with `df:off` when `self_monitoring_status()` is absent |
 | `test_poll_anomaly_signals_missing` | Anomaly view shows empty state when `df_anomaly_signals` query fails |
 | `test_poll_cdc_trends_missing` | CDC sparkline shows `—` when `df_cdc_buffer_trends` query fails |
 | `test_poll_interference_missing` | Workers Interference tab shows empty when query fails |
@@ -1220,22 +1220,22 @@ Add selective polling infrastructure. No user-visible changes.
 **Exit:** `AppState` uses domain structs. Poller respects subscriptions.
 All existing tests pass. No user-visible behavior change. `just lint` clean.
 
-### Phase T16 — Dog-Feeding Data Layer (Day 3–5)
+### Phase T16 — Self-Monitoring Data Layer (Day 3–5)
 
-**Goal:** Add dog-feeding state types, polling queries, fixture builders,
+**Goal:** Add self-monitoring state types, polling queries, fixture builders,
 and contract stubs. No new views yet.
 
 | Item | Description | Effort |
 |------|-------------|--------|
 | T16a | Add `DogFeedingStatus`, `AnomalySignal`, `CdcBufferTrend`, `InterferenceRecord`, `EfficiencyRollingRecord`, `ThresholdAdviceRecord` to `state.rs` | 2h |
 | T16b | Add `DogFeedingDomain` fields to `AppState` (already defined in T15a, now populate types) | 30m |
-| T16c | Add `fetch_dog_feeding_status()`, `fetch_anomaly_signals()`, `fetch_cdc_trends()`, `fetch_interference()`, `fetch_efficiency_rolling()`, `fetch_threshold_advice()` to `poller/fetchers.rs` | 3h |
-| T16d | Add `apply_dog_feeding_status()`, `apply_anomaly_signals()`, `apply_cdc_trends()`, `apply_interference()`, `apply_efficiency_rolling()` to `poller/updaters.rs` | 1h |
-| T16e | Wire dog-feeding fetchers into `poll_all()` under subscription flags | 2h |
+| T16c | Add `fetch_self_monitoring_status()`, `fetch_anomaly_signals()`, `fetch_cdc_trends()`, `fetch_interference()`, `fetch_efficiency_rolling()`, `fetch_threshold_advice()` to `poller/fetchers.rs` | 3h |
+| T16d | Add `apply_self_monitoring_status()`, `apply_anomaly_signals()`, `apply_cdc_trends()`, `apply_interference()`, `apply_efficiency_rolling()` to `poller/updaters.rs` | 1h |
+| T16e | Wire self-monitoring fetchers into `poll_all()` under subscription flags | 2h |
 | T16f | Add `RefreshLogEntry.initiated_by: Option<String>` field; extend `poll_refresh_log_query()` to fetch `initiated_by` column | 1h |
 | T16g | **Fixtures:** Add fixture builders for all 6 new structs in `test_fixtures.rs` | 1h |
-| T16h | **Fixtures:** Add `sample_state_dog_feeding()` to `test_fixtures.rs` | 1h |
-| T16i | **Contract stubs:** Add 9 new stubs to `test_db.rs` (dog_feeding_status, df_* views, setup/teardown, explain_dag) | 2h |
+| T16h | **Fixtures:** Add `sample_state_self_monitoring()` to `test_fixtures.rs` | 1h |
+| T16i | **Contract stubs:** Add 9 new stubs to `test_db.rs` (self_monitoring_status, df_* views, setup/teardown, explain_dag) | 2h |
 | T16j | **Contract tests:** 6 new `test_poll_df_*_executes` tests against stubs | 1h |
 | T16k | **Degradation tests:** 5 `test_poll_df_*_graceful_missing` tests | 1h |
 | T16l | **Unit tests:** Dog-feeding domain defaults, status parsing, anomaly signal severity | 1h |
@@ -1243,7 +1243,7 @@ and contract stubs. No new views yet.
 **Exit:** Dog-feeding data flows from DB → state. All new types have fixtures.
 Contract stubs match expected column signatures. Degradation verified.
 
-### Phase T17 — Dog-Feeding TUI Views (Day 5–9)
+### Phase T17 — Self-Monitoring TUI Views (Day 5–9)
 
 **Goal:** Implement all 16 TUI items. New Anomaly view, enhanced existing
 views, header badge, command palette commands, first-launch toast.
@@ -1258,13 +1258,13 @@ views, header badge, command palette commands, first-launch toast.
 | T17f | **TUI-5:** Workers Interference sub-tab — `workers_tab` state, `Tab` cycling, interference table | 3h |
 | T17g | **TUI-6:** Workers scheduler overhead bar — shared helper from diagnostics, one-line render | 1h |
 | T17h | **TUI-7:** Dependencies Mermaid overlay — `x` key, `FetchExplainDag` action, scrollable overlay, `Ctrl+E` export | 2h |
-| T17i | **TUI-8:** Header dog-feeding status badge — `df:N/M`, color logic, retention warning | 1h |
-| T17j | **TUI-9:** Command palette `dog-feeding enable/disable/status` — ActionRequest variants, execution, confirmation | 2h |
+| T17i | **TUI-8:** Header self-monitoring status badge — `df:N/M`, color logic, retention warning | 1h |
+| T17j | **TUI-9:** Command palette `self-monitoring enable/disable/status` — ActionRequest variants, execution, confirmation | 2h |
 | T17k | **TUI-10:** Detail view anomaly summary row in Properties section | 1h |
-| T17l | **TUI-11:** Refresh Log `[auto]` tag for `initiated_by = 'DOG_FEED'` | 1h |
-| T17m | **TUI-12:** First-launch dog-feeding toast — `shown_df_hint` flag, 10s expiry | 1h |
+| T17l | **TUI-11:** Refresh Log `[auto]` tag for `initiated_by = 'SELF_MONITOR'` | 1h |
+| T17m | **TUI-12:** First-launch self-monitoring toast — `shown_df_hint` flag, 10s expiry | 1h |
 | T17n | **TUI-13:** Anomaly signals in `detect_issues()` — severity mapping, category "Anomaly" | 1h |
-| T17o | **TUI-14:** Alert view `dog_feed_anomaly` event styling — cyan `🔍` icon | 30m |
+| T17o | **TUI-14:** Alert view `self_monitor_anomaly` event styling — cyan `🔍` icon | 30m |
 | T17p | **TUI-16:** Diagnostics efficiency panel — aggregate speedup, diff/full counts | 2h |
 | T17q | Update help overlay for Anomaly view, Workers tabs, Graph `x` key, header badge | 1h |
 | T17r | **Snapshot tests (TUI-T1):** 22 new snapshot tests per test plan table above | 4h |
@@ -1273,7 +1273,7 @@ views, header badge, command palette commands, first-launch toast.
 
 **Exit:** All 16 TUI items implemented. Anomaly view renders. Dashboard badge
 shows. CDC sparklines visible. Workers has Interference tab. Header badge
-reflects DF status. Command palette supports dog-feeding. All snapshot and
+reflects DF status. Command palette supports self-monitoring. All snapshot and
 unit tests pass. `just lint` clean.
 
 ### Phase T18 — Backend Enhancements (Day 9–12)
@@ -1282,13 +1282,13 @@ unit tests pass. `just lint` clean.
 
 | Item | Description | Effort |
 |------|-------------|--------|
-| T18a | **DF-21:** Add `sla_breach_risk` boolean to `df_threshold_advice` query in `src/api/dog_feeding.rs` | 2h |
+| T18a | **DF-21:** Add `sla_breach_risk` boolean to `df_threshold_advice` query in `src/api/self_monitoring.rs` | 2h |
 | T18b | **DF-21:** E2E test asserting `sla_breach_risk = true` with synthetic data where `avg_diff_ms > freshness_deadline_ms` | 1h |
-| T18c | **DF-22:** Implement `full` mode in `dog_feeding_auto_apply_tick()`: read interference data, widen dispatch for high-overlap pairs | 4h |
+| T18c | **DF-22:** Implement `full` mode in `self_monitoring_auto_apply_tick()`: read interference data, widen dispatch for high-overlap pairs | 4h |
 | T18d | **DF-22:** E2E test verifying dispatch interval widened after synthetic interference insertion | 2h |
-| T18e | **DF-23:** Add `retention_warning` column to `dog_feeding_status()` output; check `history_retention_days` vs minimum window | 2h |
+| T18e | **DF-23:** Add `retention_warning` column to `self_monitoring_status()` output; check `history_retention_days` vs minimum window | 2h |
 | T18f | **DF-23:** E2E test setting retention below minimum and verifying warning | 1h |
-| T18g | **DF-24:** Modify `recommend_refresh_mode()` to read from `df_threshold_advice` when dog-feeding active | 3h |
+| T18g | **DF-24:** Modify `recommend_refresh_mode()` to read from `df_threshold_advice` when self-monitoring active | 3h |
 | T18h | **DF-24:** E2E test verifying consistent results between `recommend_refresh_mode()` and `df_threshold_advice` | 1h |
 | T18i | **TEST-21:** Proptest for `df_threshold_advice` bounds — 10k cases verifying `[0.01, 0.80]` clamping | 2h |
 | T18j | Update upgrade SQL script `pg_trickle--0.20.0--0.21.0.sql` with new/altered functions | 2h |
@@ -1298,21 +1298,21 @@ passes. Upgrade path works. `just lint` clean.
 
 ### Phase T19 — CLI Integration (Day 12–13)
 
-**Goal:** Add CLI subcommands for dog-feeding lifecycle and graph export.
+**Goal:** Add CLI subcommands for self-monitoring lifecycle and graph export.
 
 | Item | Description | Effort |
 |------|-------------|--------|
 | T19a | **CLI-1:** Add `DogFeeding` variant to `Commands` enum in `cli.rs` with `enable`, `disable`, `status` subcommands | 1h |
-| T19b | **CLI-1:** Implement `commands/dog_feeding.rs` using `commands/domain.rs` shared logic | 2h |
+| T19b | **CLI-1:** Implement `commands/self_monitoring.rs` using `commands/domain.rs` shared logic | 2h |
 | T19c | **CLI-1:** Wire dispatch in `main.rs` | 30m |
 | T19d | **CLI-1:** `--format json|table|csv` for `status` subcommand | 1h |
 | T19e | **CLI-2:** Add `--format ascii|mermaid|dot` flag to `GraphArgs` in `cli.rs` | 30m |
 | T19f | **CLI-2:** Implement mermaid/dot paths in `commands/graph.rs` using `domain::export_dag()` | 1h |
 | T19g | **Tests:** CLI parsing tests for new subcommands and flags | 1h |
-| T19h | **Tests:** Integration tests for `dog-feeding enable/disable/status` against stubs | 1h |
+| T19h | **Tests:** Integration tests for `self-monitoring enable/disable/status` against stubs | 1h |
 | T19i | **Tests:** Integration tests for `graph --format mermaid` and `--format dot` | 1h |
 
-**Exit:** `pgtrickle dog-feeding enable/disable/status` works.
+**Exit:** `pgtrickle self-monitoring enable/disable/status` works.
 `pgtrickle graph --format mermaid` outputs valid Mermaid. All tests pass.
 
 ### Phase T20 — Documentation, Polish & Final Testing (Day 13–15)
@@ -1325,21 +1325,21 @@ final polish.
 | Item | Description | Effort |
 |------|-------------|--------|
 | T20a-1 | **TUI-D1:** Update `docs/TUI.md` — new Anomaly view, CDC sparklines, Workers interference, Mermaid export, header badge, command palette commands | 2h |
-| T20a-2 | **DOC-21:** Update `docs/GETTING_STARTED.md` Day 2 section — dog-feeding CLI and TUI integration | 1h |
+| T20a-2 | **DOC-21:** Update `docs/GETTING_STARTED.md` Day 2 section — self-monitoring CLI and TUI integration | 1h |
 | T20a-3 | **DOC-22:** Update `docs/SQL_REFERENCE.md` — `df_threshold_advice.sla_breach_risk` column | 30m |
-| T20a-4 | Update `docs/CONFIGURATION.md` — `dog_feeding_auto_apply = 'full'` mode now implemented | 30m |
+| T20a-4 | Update `docs/CONFIGURATION.md` — `self_monitoring_auto_apply = 'full'` mode now implemented | 30m |
 | T20a-5 | Update CHANGELOG.md with all v0.21.0 features | 1h |
 
 #### T20-B: Cross-Cutting Tests (Day 14)
 
 | Item | Description | Effort |
 |------|-------------|--------|
-| T20b-1 | **All views with dog-feeding off:** Verify every view renders correctly when `dog_feeding.enabled = false`; no panics, no visual artifacts | 1h |
-| T20b-2 | **All views with dog-feeding on:** Full `sample_state_dog_feeding()` render pass; all panels populated | 1h |
+| T20b-1 | **All views with self-monitoring off:** Verify every view renders correctly when `self_monitoring.enabled = false`; no panics, no visual artifacts | 1h |
+| T20b-2 | **All views with self-monitoring on:** Full `sample_state_self_monitoring()` render pass; all panels populated | 1h |
 | T20b-3 | **Narrow terminal (60×20):** All 15 views (incl. Anomalies) render without panics | 1h |
 | T20b-4 | **View switching:** Verify subscriptions update when switching views; no stale data after switching from CDC → Dashboard | 1h |
-| T20b-5 | **Reconnect with dog-feeding:** Verify dog-feeding data clears on disconnect and repopulates on reconnect | 1h |
-| T20b-6 | **Action lifecycle:** `dog-feeding enable` → poll → verify `df:5/5` badge → anomalies appear → `dog-feeding disable` → confirm → verify `df:off` | 1h |
+| T20b-5 | **Reconnect with self-monitoring:** Verify self-monitoring data clears on disconnect and repopulates on reconnect | 1h |
+| T20b-6 | **Action lifecycle:** `self-monitoring enable` → poll → verify `df:5/5` badge → anomalies appear → `self-monitoring disable` → confirm → verify `df:off` | 1h |
 
 #### T20-C: Coverage Audit (Day 14–15)
 
@@ -1380,41 +1380,41 @@ clean. Version sync passes. Upgrade path verified.
 - [ ] **TUI-4:** CDC Health `IMMINENT`/`ELEVATED` spill-risk badge from `check_cdc_health()`
 - [ ] **TUI-5:** Workers `Interference` sub-tab shows `df_scheduling_interference` sorted by overlap count
 - [ ] **TUI-6:** Workers scheduler overhead bar from `scheduler_overhead()`; greyed when < 5 cycles
-- [ ] **TUI-7:** Dependencies `x` key opens Mermaid overlay; `Ctrl+E` exports; dog-feeding nodes green
+- [ ] **TUI-7:** Dependencies `x` key opens Mermaid overlay; `Ctrl+E` exports; self-monitoring nodes green
 - [ ] **TUI-8:** Header bar shows `df:5/5` (green), `df:off` (dim), or `df:⚠` (orange)
-- [ ] **TUI-9:** Command palette `dog-feeding enable/disable` works; disable requires confirmation
+- [ ] **TUI-9:** Command palette `self-monitoring enable/disable` works; disable requires confirmation
 - [ ] **TUI-10:** Detail view anomaly summary row from `df_anomaly_signals`; `—` when off
-- [ ] **TUI-11:** Refresh Log `[auto]` tag on `initiated_by = 'DOG_FEED'` rows
-- [ ] **TUI-12:** First-connect toast when dog-feeding not active; dismissed after 10 s
+- [ ] **TUI-11:** Refresh Log `[auto]` tag on `initiated_by = 'SELF_MONITOR'` rows
+- [ ] **TUI-12:** First-connect toast when self-monitoring not active; dismissed after 10 s
 - [ ] **TUI-13:** Issues view surfaces anomaly signals as WARNING/CRITICAL entries
-- [ ] **TUI-14:** Alerts view uses cyan `🔍` icon for `dog_feed_anomaly` events
+- [ ] **TUI-14:** Alerts view uses cyan `🔍` icon for `self_monitor_anomaly` events
 - [ ] **TUI-15:** Dashboard snapshot tests cover standard, wide, empty, anomalies, narrow
 - [ ] **TUI-16:** Diagnostics efficiency panel with aggregate speedup and diff/full counts
 - [ ] **DF-21:** `df_threshold_advice.sla_breach_risk` column computed correctly
-- [ ] **DF-22:** `dog_feeding_auto_apply = 'full'` widens dispatch for high-overlap pairs
-- [ ] **DF-23:** `dog_feeding_status()` `retention_warning` set when retention too short
+- [ ] **DF-22:** `self_monitoring_auto_apply = 'full'` widens dispatch for high-overlap pairs
+- [ ] **DF-23:** `self_monitoring_status()` `retention_warning` set when retention too short
 - [ ] **DF-24:** `recommend_refresh_mode()` reads from `df_threshold_advice` when DF active
-- [ ] **CLI-1:** `pgtrickle dog-feeding enable/disable/status` with `--format json`
+- [ ] **CLI-1:** `pgtrickle self-monitoring enable/disable/status` with `--format json`
 - [ ] **CLI-2:** `pgtrickle graph --format mermaid|dot` outputs valid Mermaid/DOT
 - [ ] **TEST-21:** Proptest for threshold bounds passes 10k cases
-- [ ] All dog-feeding panels degrade gracefully when dog-feeding not configured
+- [ ] All self-monitoring panels degrade gracefully when self-monitoring not configured
 
 ### Test Coverage
 
-- [ ] **Fixtures:** 6 new struct builders + `sample_state_dog_feeding()` in `test_fixtures.rs`
+- [ ] **Fixtures:** 6 new struct builders + `sample_state_self_monitoring()` in `test_fixtures.rs`
 - [ ] **Unit tests:** ≥16 new unit tests (state, app, cli, poller subscriptions)
 - [ ] **Snapshot tests:** ≥22 new snapshots covering all new/modified view panels
 - [ ] **Contract stubs:** 9 new SQL stubs in `test_db.rs`
 - [ ] **Contract tests:** 6 new `test_poll_df_*_executes` tests
 - [ ] **Degradation tests:** 6 tests verifying graceful degradation when DF functions absent
-- [ ] **CLI tests:** Parsing + integration tests for `dog-feeding` and `graph --format`
+- [ ] **CLI tests:** Parsing + integration tests for `self-monitoring` and `graph --format`
 - [ ] **Cross-cutting:** All views render with DF on and off; narrow terminal verified
 - [ ] **Coverage:** `state.rs` ≥85%, `poller/` ≥70%, `views/` ≥80%
 
 ### Documentation & CI
 
 - [ ] `docs/TUI.md` updated with all new views, keybindings, panels
-- [ ] `docs/GETTING_STARTED.md` Day 2 section includes dog-feeding CLI and TUI
+- [ ] `docs/GETTING_STARTED.md` Day 2 section includes self-monitoring CLI and TUI
 - [ ] `docs/SQL_REFERENCE.md` documents `sla_breach_risk` column
 - [ ] `docs/CONFIGURATION.md` updates `auto_apply = 'full'` as implemented
 - [ ] CHANGELOG.md includes all features
@@ -1429,7 +1429,7 @@ clean. Version sync passes. Upgrade path verified.
 - [PLAN_TUI.md](PLAN_TUI.md) — v0.14.0 TUI foundation (T1–T8)
 - [PLAN_TUI_PART_2.md](PLAN_TUI_PART_2.md) — v0.15.0 TUI improvements (T9–T14)
 - [ROADMAP.md](../../ROADMAP.md) — v0.21.0 milestone definition
-- [plans/PLAN_DOG_FEEDING.md](../PLAN_DOG_FEEDING.md) — Dog-feeding design plan
+- [plans/PLAN_SELF_MONITORING.md](../PLAN_SELF_MONITORING.md) — Dog-feeding design plan
 - [docs/TUI.md](../../docs/TUI.md) — TUI user documentation
 - [docs/SQL_REFERENCE.md](../../docs/SQL_REFERENCE.md) — SQL API reference
 - [docs/CONFIGURATION.md](../../docs/CONFIGURATION.md) — GUC reference

--- a/sql/archive/pg_trickle--0.24.0.sql
+++ b/sql/archive/pg_trickle--0.24.0.sql
@@ -131,14 +131,14 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_refresh_history (
     status          TEXT NOT NULL
                      CHECK (status IN ('RUNNING', 'COMPLETED', 'FAILED', 'SKIPPED')),
     initiated_by    TEXT
-                     CHECK (initiated_by IN ('SCHEDULER', 'MANUAL', 'INITIAL', 'DOG_FEED')),
+                     CHECK (initiated_by IN ('SCHEDULER', 'MANUAL', 'INITIAL', 'SELF_MONITOR')),
     freshness_deadline TIMESTAMPTZ,
     tick_watermark_lsn PG_LSN,
     fixpoint_iteration INT
 );
 
 CREATE INDEX IF NOT EXISTS idx_hist_pgt_ts ON pgtrickle.pgt_refresh_history (pgt_id, data_timestamp);
--- PERF-1: Fast lookup by (pgt_id, start_time) for dog-feeding and scheduler_overhead queries.
+-- PERF-1: Fast lookup by (pgt_id, start_time) for self-monitoring and scheduler_overhead queries.
 CREATE INDEX IF NOT EXISTS idx_hist_pgt_start ON pgtrickle.pgt_refresh_history (pgt_id, start_time);
 
 -- Per-source CDC slot tracking
@@ -516,8 +516,8 @@ AS 'MODULE_PATHNAME', 'shared_buffer_stats_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/dog_feeding.rs:566
--- pg_trickle::api::dog_feeding::explain_dag
+-- src/api/self_monitoring.rs:566
+-- pg_trickle::api::self_monitoring::explain_dag
 CREATE  FUNCTION pgtrickle."explain_dag"(
 	"format" TEXT DEFAULT 'mermaid' /* core::option::Option<&str> */
 ) RETURNS TEXT /* core::option::Option<alloc::string::String> */
@@ -527,12 +527,12 @@ AS 'MODULE_PATHNAME', 'explain_dag_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/dog_feeding.rs:305
--- pg_trickle::api::dog_feeding::teardown_dog_feeding
-CREATE  FUNCTION pgtrickle."teardown_dog_feeding"() RETURNS void
+-- src/api/self_monitoring.rs:305
+-- pg_trickle::api::self_monitoring::teardown_self_monitoring
+CREATE  FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'teardown_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -962,12 +962,12 @@ AS 'MODULE_PATHNAME', 'explain_st_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/dog_feeding.rs:240
--- pg_trickle::api::dog_feeding::setup_dog_feeding
-CREATE  FUNCTION pgtrickle."setup_dog_feeding"() RETURNS void
+-- src/api/self_monitoring.rs:240
+-- pg_trickle::api::self_monitoring::setup_self_monitoring
+CREATE  FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'setup_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1223,8 +1223,8 @@ AS 'MODULE_PATHNAME', 'recommend_refresh_mode_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/dog_feeding.rs:453
--- pg_trickle::api::dog_feeding::scheduler_overhead
+-- src/api/self_monitoring.rs:453
+-- pg_trickle::api::self_monitoring::scheduler_overhead
 CREATE  FUNCTION pgtrickle."scheduler_overhead"() RETURNS TABLE (
 	"total_refreshes_1h" bigint,  /* i64 */
 	"df_refreshes_1h" bigint,  /* i64 */
@@ -1772,9 +1772,9 @@ AS 'MODULE_PATHNAME', '_signal_launcher_rescan_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/dog_feeding.rs:358
--- pg_trickle::api::dog_feeding::dog_feeding_status
-CREATE  FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
+-- src/api/self_monitoring.rs:358
+-- pg_trickle::api::self_monitoring::self_monitoring_status
+CREATE  FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
 	"st_name" TEXT,  /* alloc::string::String */
 	"exists" bool,  /* bool */
 	"status" TEXT,  /* core::option::Option<alloc::string::String> */
@@ -1784,7 +1784,7 @@ CREATE  FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
 )
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dog_feeding_status_wrapper';
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/pg_trickle--0.19.0--0.20.0.sql
+++ b/sql/pg_trickle--0.19.0--0.20.0.sql
@@ -1,17 +1,17 @@
 -- pg_trickle 0.19.0 → 0.20.0 upgrade migration
 -- ============================================
 --
--- PERF-1: Add index on pgt_refresh_history(pgt_id, start_time) for dog-feeding queries.
--- DF-G3: Add 'DOG_FEED' to initiated_by CHECK constraint.
+-- PERF-1: Add index on pgt_refresh_history(pgt_id, start_time) for self-monitoring queries.
+-- DF-G3: Add 'SELF_MONITOR' to initiated_by CHECK constraint.
 
 -- ── PERF-1: Index on (pgt_id, start_time) ──────────────────────────────────
--- Required by all five dog-feeding stream tables which filter on
+-- Required by all five self-monitoring stream tables which filter on
 -- start_time > now() - interval '1 hour' grouped by pgt_id.
 CREATE INDEX IF NOT EXISTS idx_hist_pgt_start
     ON pgtrickle.pgt_refresh_history (pgt_id, start_time);
 
--- ── DF-G3: Extend initiated_by CHECK to include 'DOG_FEED' ────────────────
--- The auto-apply worker logs threshold changes with initiated_by = 'DOG_FEED'.
+-- ── DF-G3: Extend initiated_by CHECK to include 'SELF_MONITOR' ────────────────
+-- The auto-apply worker logs threshold changes with initiated_by = 'SELF_MONITOR'.
 DO $$
 BEGIN
     -- Drop existing CHECK constraint on initiated_by column.
@@ -30,11 +30,11 @@ END $$;
 
 ALTER TABLE pgtrickle.pgt_refresh_history
     ADD CONSTRAINT pgt_refresh_history_initiated_by_check
-    CHECK (initiated_by IN ('SCHEDULER', 'MANUAL', 'INITIAL', 'DOG_FEED'));
+    CHECK (initiated_by IN ('SCHEDULER', 'MANUAL', 'INITIAL', 'SELF_MONITOR'));
 
 -- ── New functions in 0.20.0 ────────────────────────────────────────────────
 -- These functions were added in 0.19.0 (migrate, version_check, write_and_refresh)
--- and 0.20.0 (dog-feeding API). Use CREATE OR REPLACE so the script is
+-- and 0.20.0 (self-monitoring API). Use CREATE OR REPLACE so the script is
 -- idempotent for upgrade chains that already passed through 0.18→0.19.
 
 CREATE OR REPLACE FUNCTION pgtrickle."migrate"() RETURNS TEXT
@@ -57,17 +57,17 @@ AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';
 
 -- ── DF: Dog-feeding API (0.20.0) ───────────────────────────────────────────
 
-CREATE OR REPLACE FUNCTION pgtrickle."setup_dog_feeding"() RETURNS void
+CREATE OR REPLACE FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
 STRICT
 LANGUAGE c
-AS 'MODULE_PATHNAME', 'setup_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
 
-CREATE OR REPLACE FUNCTION pgtrickle."teardown_dog_feeding"() RETURNS void
+CREATE OR REPLACE FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
 STRICT
 LANGUAGE c
-AS 'MODULE_PATHNAME', 'teardown_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
 
-CREATE OR REPLACE FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
+CREATE OR REPLACE FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
     "st_name" TEXT,
     "exists" bool,
     "status" TEXT,
@@ -77,7 +77,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
 )
 STRICT
 LANGUAGE c
-AS 'MODULE_PATHNAME', 'dog_feeding_status_wrapper';
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 
 CREATE OR REPLACE FUNCTION pgtrickle."scheduler_overhead"() RETURNS TABLE (
     "total_refreshes_1h" bigint,

--- a/sql/pg_trickle--0.23.0--0.24.0.sql
+++ b/sql/pg_trickle--0.23.0--0.24.0.sql
@@ -15,7 +15,7 @@
 -- CDC-3: TOAST-aware CDC hashing (code-only)
 -- CDC-4: TOAST workload E2E tests (test-only)
 -- OPS-1: History retention pruning in scheduler (uses existing GUC)
--- OPS-2: Frozen-stream-table detector dog-feeding view (code-only)
+-- OPS-2: Frozen-stream-table detector self-monitoring view (code-only)
 -- OPS-3: Missing internal catalog indexes (below)
 -- TEST-6/7/8: Unit test campaigns (test-only)
 
@@ -38,6 +38,49 @@ CREATE INDEX IF NOT EXISTS idx_pgt_rh_pgt_action_ts
 -- Index for change tracking source lookups.
 CREATE INDEX IF NOT EXISTS idx_pgt_ct_source_relid
     ON pgtrickle.pgt_change_tracking (source_relid);
+
+-- RENAME-1: Rename self_monitoring → self_monitoring SQL API.
+-- The "self monitoring" terminology was a misnomer; the industry term is
+-- "dogfooding" but the feature name has been standardised to the clearer
+-- and more professional "self_monitoring".
+--
+-- Create new functions backed by the renamed Rust wrapper symbols.
+CREATE OR REPLACE FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
+    LANGUAGE c STRICT
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
+
+CREATE OR REPLACE FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
+    LANGUAGE c STRICT
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
+
+CREATE OR REPLACE FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
+    st_name text,
+    exists bool,
+    status text,
+    refresh_mode text,
+    last_refresh_at text,
+    total_refreshes bigint
+)
+    LANGUAGE c STRICT
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
+
+-- Drop the old function names.
+DROP FUNCTION IF EXISTS pgtrickle."setup_self_monitoring"();
+DROP FUNCTION IF EXISTS pgtrickle."teardown_self_monitoring"();
+DROP FUNCTION IF EXISTS pgtrickle."self_monitoring_status"();
+
+-- Update initiated_by CHECK constraint: add SELF_MONITOR, remove SELF_MONITOR.
+-- Use a two-step approach: drop the old constraint, add the new one.
+ALTER TABLE pgtrickle.pgt_refresh_history
+    DROP CONSTRAINT IF EXISTS pgt_refresh_history_initiated_by_check;
+ALTER TABLE pgtrickle.pgt_refresh_history
+    ADD CONSTRAINT pgt_refresh_history_initiated_by_check
+    CHECK (initiated_by IN ('SCHEDULER', 'MANUAL', 'INITIAL', 'SELF_MONITOR'));
+
+-- Migrate any existing SELF_MONITOR audit rows to SELF_MONITOR.
+UPDATE pgtrickle.pgt_refresh_history
+    SET initiated_by = 'SELF_MONITOR'
+    WHERE initiated_by = 'SELF_MONITOR';
 
 -- Record the schema version for the upgrade chain.
 INSERT INTO pgtrickle.pgt_schema_version (version, description)

--- a/sql/self_monitoring_setup.sql
+++ b/sql/self_monitoring_setup.sql
@@ -1,26 +1,26 @@
--- Dog-Feeding Quick Start
+-- Self-Monitoring Quick Start
 -- ======================
--- Run with: psql -f sql/dog_feeding_setup.sql
+-- Run with: psql -f sql/self_monitoring_setup.sql
 --
--- Creates all five dog-feeding stream tables, enables threshold auto-apply,
+-- Creates all five self-monitoring stream tables, enables threshold auto-apply,
 -- and sets up anomaly alerting. Idempotent — safe to run multiple times.
 
--- Step 1: Create all dog-feeding stream tables.
-SELECT pgtrickle.setup_dog_feeding();
+-- Step 1: Create all self-monitoring stream tables.
+SELECT pgtrickle.setup_self_monitoring();
 
 -- Step 2: Enable threshold auto-apply (optional).
 -- Values: 'off' (default), 'threshold_only', 'full'
-SET pg_trickle.dog_feeding_auto_apply = 'threshold_only';
+SET pg_trickle.self_monitoring_auto_apply = 'threshold_only';
 
 -- Step 3: Listen for anomaly notifications.
 LISTEN pg_trickle_alert;
 
--- Step 4: Check dog-feeding status.
-SELECT * FROM pgtrickle.dog_feeding_status();
+-- Step 4: Check self-monitoring status.
+SELECT * FROM pgtrickle.self_monitoring_status();
 
 -- Step 5: View initial threshold recommendations (after history accumulates).
 -- Note: This will be empty until at least 10 refresh cycles have run.
 -- SELECT * FROM pgtrickle.df_threshold_advice WHERE confidence IN ('HIGH', 'MEDIUM');
 
--- Step 6: View the DAG to verify dog-feeding STs are included.
+-- Step 6: View the DAG to verify self-monitoring STs are included.
 SELECT pgtrickle.explain_dag();

--- a/src/api/dog_feeding.rs
+++ b/src/api/dog_feeding.rs
@@ -187,7 +187,7 @@ SELECT
     st.status,
     st.refresh_tier,
     st.last_refresh_at,
-    st.effective_schedule_seconds,
+    pgtrickle.parse_duration_seconds(st.schedule) AS effective_schedule_seconds,
     now() - st.last_refresh_at AS stale_duration,
     (SELECT max(h.start_time) \
      FROM pgtrickle.pgt_refresh_history h \
@@ -198,8 +198,8 @@ SELECT
 FROM pgtrickle.pgt_stream_tables st
 WHERE st.status IN ('ACTIVE', 'ERROR')
   AND st.last_refresh_at IS NOT NULL
-  AND st.effective_schedule_seconds IS NOT NULL
-  AND st.last_refresh_at < now() - make_interval(secs => st.effective_schedule_seconds * 5)";
+  AND st.schedule IS NOT NULL
+  AND st.last_refresh_at < now() - make_interval(secs => pgtrickle.parse_duration_seconds(st.schedule) * 5)";
 
 // ── Schedule and mode assignments ───────────────────────────────────────────
 

--- a/src/api/dog_feeding.rs
+++ b/src/api/dog_feeding.rs
@@ -313,6 +313,7 @@ fn teardown_dog_feeding() {
 fn teardown_dog_feeding_impl() -> Result<(), PgTrickleError> {
     // Drop in reverse dependency order: downstream first.
     let reverse_order = [
+        "df_frozen_stream_tables",
         "df_scheduling_interference",
         "df_cdc_buffer_trends",
         "df_threshold_advice",

--- a/src/api/dog_feeding.rs
+++ b/src/api/dog_feeding.rs
@@ -187,7 +187,7 @@ SELECT
     st.status,
     st.refresh_tier,
     st.last_refresh_at,
-    pgtrickle.parse_duration_seconds(st.schedule) AS effective_schedule_seconds,
+    st.effective_schedule_seconds,
     now() - st.last_refresh_at AS stale_duration,
     (SELECT max(h.start_time) \
      FROM pgtrickle.pgt_refresh_history h \
@@ -198,8 +198,8 @@ SELECT
 FROM pgtrickle.pgt_stream_tables st
 WHERE st.status IN ('ACTIVE', 'ERROR')
   AND st.last_refresh_at IS NOT NULL
-  AND st.schedule IS NOT NULL
-  AND st.last_refresh_at < now() - make_interval(secs => pgtrickle.parse_duration_seconds(st.schedule) * 5)";
+  AND st.effective_schedule_seconds IS NOT NULL
+  AND st.last_refresh_at < now() - make_interval(secs => st.effective_schedule_seconds * 5)";
 
 // ── Schedule and mode assignments ───────────────────────────────────────────
 
@@ -313,7 +313,6 @@ fn teardown_dog_feeding() {
 fn teardown_dog_feeding_impl() -> Result<(), PgTrickleError> {
     // Drop in reverse dependency order: downstream first.
     let reverse_order = [
-        "df_frozen_stream_tables",
         "df_scheduling_interference",
         "df_cdc_buffer_trends",
         "df_threshold_advice",

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4720,8 +4720,8 @@ fn get_data_timestamp_str() -> String {
 /// This matches the version reported by `pg_extension.extversion`.
 // ── Sub-modules ─────────────────────────────────────────────────────────────
 mod diagnostics;
-mod dog_feeding;
 mod helpers;
+mod self_monitoring;
 
 // Re-export public items from sub-modules so external callers are unaffected.
 pub use helpers::*;

--- a/src/api/self_monitoring.rs
+++ b/src/api/self_monitoring.rs
@@ -1,6 +1,6 @@
 //! Dog-feeding API: pg_trickle monitors itself via stream tables.
 //!
-//! Provides `setup_dog_feeding()`, `teardown_dog_feeding()`, `dog_feeding_status()`,
+//! Provides `setup_self_monitoring()`, `teardown_self_monitoring()`, `self_monitoring_status()`,
 //! `recommend_refresh_mode()`, `scheduler_overhead()`, and `explain_dag()`.
 #![allow(clippy::type_complexity)]
 use pgrx::prelude::*;
@@ -9,7 +9,7 @@ use crate::error::PgTrickleError;
 
 // ── Dog-feeding stream table definitions ────────────────────────────────────
 
-/// Names of all six dog-feeding stream tables.
+/// Names of all six self-monitoring stream tables.
 const DF_STREAM_TABLES: &[&str] = &[
     "df_efficiency_rolling",
     "df_anomaly_signals",
@@ -203,7 +203,7 @@ WHERE st.status IN ('ACTIVE', 'ERROR')
 
 // ── Schedule and mode assignments ───────────────────────────────────────────
 
-/// Return (schedule, refresh_mode) for each dog-feeding stream table.
+/// Return (schedule, refresh_mode) for each self-monitoring stream table.
 fn df_st_config(name: &str) -> (&'static str, &'static str) {
     match name {
         "df_efficiency_rolling" => ("48s", "AUTO"),
@@ -216,7 +216,7 @@ fn df_st_config(name: &str) -> (&'static str, &'static str) {
     }
 }
 
-/// Return the defining query for a dog-feeding stream table.
+/// Return the defining query for a self-monitoring stream table.
 fn df_st_query(name: &str) -> &'static str {
     match name {
         "df_efficiency_rolling" => DF_EFFICIENCY_ROLLING_QUERY,
@@ -229,23 +229,23 @@ fn df_st_query(name: &str) -> &'static str {
     }
 }
 
-// ── setup_dog_feeding() — DF-F4, STAB-1 ────────────────────────────────────
+// ── setup_self_monitoring() — DF-F4, STAB-1 ────────────────────────────────────
 
-/// Create all five dog-feeding stream tables.
+/// Create all five self-monitoring stream tables.
 ///
 /// Idempotent: if a DF stream table already exists it is skipped with an INFO
 /// message. Safe to call multiple times (STAB-1).
 ///
 /// UX-2: Emits a warm-up hint if `pgt_refresh_history` has fewer than 50 rows.
 #[pg_extern(schema = "pgtrickle")]
-fn setup_dog_feeding() {
-    let result = setup_dog_feeding_impl();
+fn setup_self_monitoring() {
+    let result = setup_self_monitoring_impl();
     if let Err(e) = result {
-        pgrx::error!("setup_dog_feeding failed: {e}");
+        pgrx::error!("setup_self_monitoring failed: {e}");
     }
 }
 
-fn setup_dog_feeding_impl() -> Result<(), PgTrickleError> {
+fn setup_self_monitoring_impl() -> Result<(), PgTrickleError> {
     // UX-2: Warm-up hint if history is sparse.
     let history_count: Option<i64> =
         Spi::get_one("SELECT count(*) FROM pgtrickle.pgt_refresh_history")
@@ -290,27 +290,27 @@ fn setup_dog_feeding_impl() -> Result<(), PgTrickleError> {
         )
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
 
-        pgrx::info!("Created dog-feeding stream table pgtrickle.{name}");
+        pgrx::info!("Created self-monitoring stream table pgtrickle.{name}");
     }
 
     Ok(())
 }
 
-// ── teardown_dog_feeding() — DF-F5, STAB-5 ─────────────────────────────────
+// ── teardown_self_monitoring() — DF-F5, STAB-5 ─────────────────────────────────
 
-/// Drop all dog-feeding stream tables.
+/// Drop all self-monitoring stream tables.
 ///
 /// Safe with partial setups: each table is dropped individually, and missing
 /// tables are silently skipped (STAB-5).
 #[pg_extern(schema = "pgtrickle")]
-fn teardown_dog_feeding() {
-    let result = teardown_dog_feeding_impl();
+fn teardown_self_monitoring() {
+    let result = teardown_self_monitoring_impl();
     if let Err(e) = result {
-        pgrx::error!("teardown_dog_feeding failed: {e}");
+        pgrx::error!("teardown_self_monitoring failed: {e}");
     }
 }
 
-fn teardown_dog_feeding_impl() -> Result<(), PgTrickleError> {
+fn teardown_self_monitoring_impl() -> Result<(), PgTrickleError> {
     // Drop in reverse dependency order: downstream first.
     let reverse_order = [
         "df_frozen_stream_tables",
@@ -343,20 +343,20 @@ fn teardown_dog_feeding_impl() -> Result<(), PgTrickleError> {
         )
         .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
 
-        pgrx::info!("Dropped dog-feeding stream table pgtrickle.{name}");
+        pgrx::info!("Dropped self-monitoring stream table pgtrickle.{name}");
     }
 
     Ok(())
 }
 
-// ── dog_feeding_status() — UX-1 ────────────────────────────────────────────
+// ── self_monitoring_status() — UX-1 ────────────────────────────────────────────
 
-/// Returns the status of all dog-feeding stream tables.
+/// Returns the status of all self-monitoring stream tables.
 ///
 /// For each of the five expected DF stream tables, reports whether it exists,
 /// its current status, refresh mode, and last refresh time.
 #[pg_extern(schema = "pgtrickle")]
-fn dog_feeding_status() -> TableIterator<
+fn self_monitoring_status() -> TableIterator<
     'static,
     (
         name!(st_name, String),
@@ -367,11 +367,11 @@ fn dog_feeding_status() -> TableIterator<
         name!(total_refreshes, Option<i64>),
     ),
 > {
-    let rows = dog_feeding_status_impl().unwrap_or_default();
+    let rows = self_monitoring_status_impl().unwrap_or_default();
     TableIterator::new(rows)
 }
 
-fn dog_feeding_status_impl() -> Result<
+fn self_monitoring_status_impl() -> Result<
     Vec<(
         String,
         bool,
@@ -439,7 +439,7 @@ fn dog_feeding_status_impl() -> Result<
 
 // ── recommend_refresh_mode() — OPS-1 ────────────────────────────────────────
 // NOTE: The existing `recommend_refresh_mode` in helpers.rs already provides
-// comprehensive mode recommendations. OPS-1 enhancement: when dog-feeding is
+// comprehensive mode recommendations. OPS-1 enhancement: when self-monitoring is
 // active, the existing function's signals can be enriched with data from
 // `df_threshold_advice`. This is handled via `diagnostics::gather_all_signals()`
 // which reads from the DF STs when they exist.
@@ -449,7 +449,7 @@ fn dog_feeding_status_impl() -> Result<
 /// Returns scheduler efficiency metrics.
 ///
 /// Computes busy-time ratio, queue depth, avg dispatch latency, and the
-/// fraction of CPU spent on dog-feeding STs vs user STs from refresh history.
+/// fraction of CPU spent on self-monitoring STs vs user STs from refresh history.
 #[pg_extern(schema = "pgtrickle")]
 fn scheduler_overhead() -> TableIterator<
     'static,
@@ -561,7 +561,7 @@ fn scheduler_overhead_impl() -> Result<
 
 /// Returns the full refresh DAG as a Mermaid markdown string.
 ///
-/// Node colours: user STs = blue, dog-feeding STs = green,
+/// Node colours: user STs = blue, self-monitoring STs = green,
 /// suspended = red, fused = orange.
 #[pg_extern(schema = "pgtrickle")]
 fn explain_dag(format: default!(Option<&str>, "'mermaid'")) -> Option<String> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -842,7 +842,7 @@ fn normalize_refresh_strategy(value: Option<String>) -> RefreshStrategy {
 
 /// Dog-feeding auto-apply policy mode.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum DogFeedingAutoApply {
+pub enum SelfMonitoringAutoApply {
     /// No automatic configuration changes (default).
     Off,
     /// Apply only threshold recommendations from `df_threshold_advice`.
@@ -851,7 +851,7 @@ pub enum DogFeedingAutoApply {
     Full,
 }
 
-impl DogFeedingAutoApply {
+impl SelfMonitoringAutoApply {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Off => "off",
@@ -861,14 +861,14 @@ impl DogFeedingAutoApply {
     }
 }
 
-pub static PGS_DOG_FEEDING_AUTO_APPLY: GucSetting<Option<std::ffi::CString>> =
+pub static PGS_SELF_MONITORING_AUTO_APPLY: GucSetting<Option<std::ffi::CString>> =
     GucSetting::<Option<std::ffi::CString>>::new(Some(c"off"));
 
-fn normalize_dog_feeding_auto_apply(value: Option<String>) -> DogFeedingAutoApply {
+fn normalize_self_monitoring_auto_apply(value: Option<String>) -> SelfMonitoringAutoApply {
     match value.as_deref().map(str::to_ascii_lowercase).as_deref() {
-        Some("threshold_only") => DogFeedingAutoApply::ThresholdOnly,
-        Some("full") => DogFeedingAutoApply::Full,
-        _ => DogFeedingAutoApply::Off,
+        Some("threshold_only") => SelfMonitoringAutoApply::ThresholdOnly,
+        Some("full") => SelfMonitoringAutoApply::Full,
+        _ => SelfMonitoringAutoApply::Off,
     }
 }
 
@@ -1867,15 +1867,15 @@ pub fn register_gucs() {
 
     // DF-G1: Dog-feeding auto-apply policy.
     GucRegistry::define_string_guc(
-        c"pg_trickle.dog_feeding_auto_apply",
+        c"pg_trickle.self_monitoring_auto_apply",
         c"Dog-feeding auto-apply policy: off (default), threshold_only, full.",
-        c"Controls whether the dog-feeding analytics stream tables can \
+        c"Controls whether the self-monitoring analytics stream tables can \
            automatically adjust stream table configuration. \
            'off' — advisory only (no automatic changes). \
            'threshold_only' — auto-apply threshold recommendations from \
            df_threshold_advice when confidence is HIGH and delta > 5%%. \
            'full' — also apply scheduling hints from df_scheduling_interference.",
-        &PGS_DOG_FEEDING_AUTO_APPLY,
+        &PGS_SELF_MONITORING_AUTO_APPLY,
         GucContext::Suset,
         GucFlags::default(),
     );
@@ -2458,10 +2458,10 @@ pub fn pg_trickle_history_retention_days() -> i32 {
     PGS_HISTORY_RETENTION_DAYS.get()
 }
 
-/// DF-G1: Returns the current dog-feeding auto-apply policy.
-pub fn pg_trickle_dog_feeding_auto_apply() -> DogFeedingAutoApply {
-    normalize_dog_feeding_auto_apply(
-        PGS_DOG_FEEDING_AUTO_APPLY
+/// DF-G1: Returns the current self-monitoring auto-apply policy.
+pub fn pg_trickle_self_monitoring_auto_apply() -> SelfMonitoringAutoApply {
+    normalize_self_monitoring_auto_apply(
+        PGS_SELF_MONITORING_AUTO_APPLY
             .get()
             .and_then(|cs| cs.to_str().ok().map(str::to_owned)),
     )
@@ -2548,12 +2548,12 @@ pub fn pg_trickle_frontier_holdback_warn_seconds() -> i32 {
 #[cfg(test)]
 mod tests {
     use super::{
-        CdcTriggerMode, DiffOutputFormat, DogFeedingAutoApply, FrontierHoldbackMode,
-        MergeJoinStrategy, MergeStrategy, ParallelRefreshMode, RefreshStrategy, UserTriggersMode,
+        CdcTriggerMode, DiffOutputFormat, FrontierHoldbackMode, MergeJoinStrategy, MergeStrategy,
+        ParallelRefreshMode, RefreshStrategy, SelfMonitoringAutoApply, UserTriggersMode,
         VolatileFunctionPolicy, normalize_cdc_trigger_mode, normalize_diff_output_format,
-        normalize_dog_feeding_auto_apply, normalize_frontier_holdback_mode,
-        normalize_merge_join_strategy, normalize_merge_strategy, normalize_parallel_refresh_mode,
-        normalize_recursive_max_depth, normalize_refresh_strategy, normalize_user_triggers_mode,
+        normalize_frontier_holdback_mode, normalize_merge_join_strategy, normalize_merge_strategy,
+        normalize_parallel_refresh_mode, normalize_recursive_max_depth, normalize_refresh_strategy,
+        normalize_self_monitoring_auto_apply, normalize_user_triggers_mode,
         normalize_volatile_function_policy, threshold_mb_to_bytes,
     };
 
@@ -2963,63 +2963,63 @@ mod tests {
     // `GucSetting::get()` in multi-threaded unit tests triggers pgrx's
     // "postgres FFI may not be called from multiple threads" guard.
 
-    // ── DF-G1: DogFeedingAutoApply normalizer tests ────────────────
+    // ── DF-G1: SelfMonitoringAutoApply normalizer tests ────────────────
 
     #[test]
-    fn test_normalize_dog_feeding_auto_apply_defaults_to_off() {
+    fn test_normalize_self_monitoring_auto_apply_defaults_to_off() {
         assert_eq!(
-            normalize_dog_feeding_auto_apply(None),
-            DogFeedingAutoApply::Off
+            normalize_self_monitoring_auto_apply(None),
+            SelfMonitoringAutoApply::Off
         );
         assert_eq!(
-            normalize_dog_feeding_auto_apply(Some("off".to_string())),
-            DogFeedingAutoApply::Off
+            normalize_self_monitoring_auto_apply(Some("off".to_string())),
+            SelfMonitoringAutoApply::Off
         );
         assert_eq!(
-            normalize_dog_feeding_auto_apply(Some("unexpected".to_string())),
-            DogFeedingAutoApply::Off
+            normalize_self_monitoring_auto_apply(Some("unexpected".to_string())),
+            SelfMonitoringAutoApply::Off
         );
     }
 
     #[test]
-    fn test_normalize_dog_feeding_auto_apply_all_variants() {
+    fn test_normalize_self_monitoring_auto_apply_all_variants() {
         assert_eq!(
-            normalize_dog_feeding_auto_apply(Some("threshold_only".to_string())),
-            DogFeedingAutoApply::ThresholdOnly
+            normalize_self_monitoring_auto_apply(Some("threshold_only".to_string())),
+            SelfMonitoringAutoApply::ThresholdOnly
         );
         assert_eq!(
-            normalize_dog_feeding_auto_apply(Some("THRESHOLD_ONLY".to_string())),
-            DogFeedingAutoApply::ThresholdOnly
+            normalize_self_monitoring_auto_apply(Some("THRESHOLD_ONLY".to_string())),
+            SelfMonitoringAutoApply::ThresholdOnly
         );
         assert_eq!(
-            normalize_dog_feeding_auto_apply(Some("full".to_string())),
-            DogFeedingAutoApply::Full
+            normalize_self_monitoring_auto_apply(Some("full".to_string())),
+            SelfMonitoringAutoApply::Full
         );
         assert_eq!(
-            normalize_dog_feeding_auto_apply(Some("FULL".to_string())),
-            DogFeedingAutoApply::Full
+            normalize_self_monitoring_auto_apply(Some("FULL".to_string())),
+            SelfMonitoringAutoApply::Full
         );
     }
 
     #[test]
-    fn test_dog_feeding_auto_apply_as_str() {
-        assert_eq!(DogFeedingAutoApply::Off.as_str(), "off");
+    fn test_self_monitoring_auto_apply_as_str() {
+        assert_eq!(SelfMonitoringAutoApply::Off.as_str(), "off");
         assert_eq!(
-            DogFeedingAutoApply::ThresholdOnly.as_str(),
+            SelfMonitoringAutoApply::ThresholdOnly.as_str(),
             "threshold_only"
         );
-        assert_eq!(DogFeedingAutoApply::Full.as_str(), "full");
+        assert_eq!(SelfMonitoringAutoApply::Full.as_str(), "full");
     }
 
     #[test]
-    fn test_normalize_dog_feeding_auto_apply_roundtrip() {
+    fn test_normalize_self_monitoring_auto_apply_roundtrip() {
         for mode in [
-            DogFeedingAutoApply::Off,
-            DogFeedingAutoApply::ThresholdOnly,
-            DogFeedingAutoApply::Full,
+            SelfMonitoringAutoApply::Off,
+            SelfMonitoringAutoApply::ThresholdOnly,
+            SelfMonitoringAutoApply::Full,
         ] {
             assert_eq!(
-                normalize_dog_feeding_auto_apply(Some(mode.as_str().to_string())),
+                normalize_self_monitoring_auto_apply(Some(mode.as_str().to_string())),
                 mode
             );
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,14 +333,14 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_refresh_history (
     status          TEXT NOT NULL
                      CHECK (status IN ('RUNNING', 'COMPLETED', 'FAILED', 'SKIPPED')),
     initiated_by    TEXT
-                     CHECK (initiated_by IN ('SCHEDULER', 'MANUAL', 'INITIAL', 'DOG_FEED')),
+                     CHECK (initiated_by IN ('SCHEDULER', 'MANUAL', 'INITIAL', 'SELF_MONITOR')),
     freshness_deadline TIMESTAMPTZ,
     tick_watermark_lsn PG_LSN,
     fixpoint_iteration INT
 );
 
 CREATE INDEX IF NOT EXISTS idx_hist_pgt_ts ON pgtrickle.pgt_refresh_history (pgt_id, data_timestamp);
--- PERF-1: Fast lookup by (pgt_id, start_time) for dog-feeding and scheduler_overhead queries.
+-- PERF-1: Fast lookup by (pgt_id, start_time) for self-monitoring and scheduler_overhead queries.
 CREATE INDEX IF NOT EXISTS idx_hist_pgt_start ON pgtrickle.pgt_refresh_history (pgt_id, start_time);
 
 -- Per-source CDC slot tracking

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1164,13 +1164,13 @@ fn explain_st_impl(
         .unwrap_or(Some(0))
         .unwrap_or(0);
         let coverage = if df_count >= 5 {
-            "full (5/5 dog-feeding STs active)"
+            "full (5/5 self-monitoring STs active)"
         } else if df_count > 0 {
             "partial"
         } else {
-            "none (run setup_dog_feeding() to enable)"
+            "none (run setup_self_monitoring() to enable)"
         };
-        props.push(("dog_feeding_coverage".to_string(), coverage.to_string()));
+        props.push(("self_monitoring_coverage".to_string(), coverage.to_string()));
     }
 
     // UX-6: Refresh mode recommendation from recommend_refresh_mode().

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -2731,10 +2731,10 @@ pub extern "C-unwind" fn pg_trickle_scheduler_main(_arg: pg_sys::Datum) {
         {
             let now_for_auto_apply = current_epoch_ms();
             if now_for_auto_apply.saturating_sub(last_auto_apply_ms) >= AUTO_APPLY_INTERVAL_MS {
-                let auto_apply_mode = config::pg_trickle_dog_feeding_auto_apply();
-                if auto_apply_mode != config::DogFeedingAutoApply::Off {
+                let auto_apply_mode = config::pg_trickle_self_monitoring_auto_apply();
+                if auto_apply_mode != config::SelfMonitoringAutoApply::Off {
                     BackgroundWorker::transaction(AssertUnwindSafe(|| {
-                        dog_feeding_auto_apply_tick();
+                        self_monitoring_auto_apply_tick();
                     }));
                 }
                 last_auto_apply_ms = now_for_auto_apply;
@@ -2746,7 +2746,7 @@ pub extern "C-unwind" fn pg_trickle_scheduler_main(_arg: pg_sys::Datum) {
                 }));
 
                 // OPS-6: Refresh interference overlap count for workload-aware poll.
-                // Only reads if the DF ST exists (safe even without dog-feeding).
+                // Only reads if the DF ST exists (safe even without self-monitoring).
                 BackgroundWorker::transaction(AssertUnwindSafe(|| {
                     let si_exists: bool = Spi::get_one(
                         "SELECT EXISTS ( \
@@ -3474,14 +3474,14 @@ fn sla_tier_adjustment_tick() {
 
 /// Auto-apply threshold recommendations from `df_threshold_advice`.
 ///
-/// Called once per `AUTO_APPLY_INTERVAL_MS` when `dog_feeding_auto_apply` GUC
+/// Called once per `AUTO_APPLY_INTERVAL_MS` when `self_monitoring_auto_apply` GUC
 /// is not `off`. Reads HIGH-confidence recommendations where the recommended
 /// threshold differs from the current threshold by > 5%, then applies via
 /// `StreamTableMeta::update_adaptive_threshold`. Rate-limited to 1 change per
 /// ST per invocation (STAB-2, STAB-4).
 ///
-/// DF-G3: Logs changes to `pgt_refresh_history` with `initiated_by = 'DOG_FEED'`.
-fn dog_feeding_auto_apply_tick() {
+/// DF-G3: Logs changes to `pgt_refresh_history` with `initiated_by = 'SELF_MONITOR'`.
+fn self_monitoring_auto_apply_tick() {
     // STAB-4: Check that df_threshold_advice exists before reading.
     let advice_exists: bool = Spi::get_one(
         "SELECT EXISTS (
@@ -3539,7 +3539,7 @@ fn dog_feeding_auto_apply_tick() {
         ) {
             Ok(()) => {
                 log!(
-                    "pg_trickle: auto-apply threshold {} → {} for {} (DOG_FEED)",
+                    "pg_trickle: auto-apply threshold {} → {} for {} (SELF_MONITOR)",
                     current,
                     recommended,
                     fq_name,
@@ -3556,10 +3556,10 @@ fn dog_feeding_auto_apply_tick() {
                         0,
                         0,
                         Some(&format!(
-                            "DOG_FEED: auto_threshold {} → {}",
+                            "SELF_MONITOR: auto_threshold {} → {}",
                             current, recommended
                         )),
-                        Some("DOG_FEED"),
+                        Some("SELF_MONITOR"),
                         None,
                         0,
                         None,
@@ -3586,14 +3586,14 @@ fn dog_feeding_auto_apply_tick() {
     }
 
     // UX-3: Check for anomalies and emit NOTIFY on pg_trickle_alert channel.
-    dog_feeding_anomaly_notify();
+    self_monitoring_anomaly_notify();
 }
 
 /// UX-3: Emit NOTIFY on `pgtrickle_alert` channel when anomalies are detected.
 ///
 /// Reads `df_anomaly_signals` and sends a JSON notification for each stream
 /// table that has a duration anomaly or recent failures ≥ 2.
-fn dog_feeding_anomaly_notify() {
+fn self_monitoring_anomaly_notify() {
     let signals_exist: bool = Spi::get_one(
         "SELECT EXISTS (
             SELECT 1 FROM pgtrickle.pgt_stream_tables
@@ -3637,7 +3637,7 @@ fn dog_feeding_anomaly_notify() {
     for (fq_name, anomaly, failures) in &anomalies {
         let anomaly_str = anomaly.as_deref().unwrap_or("none");
         let payload = format!(
-            r#"{{"event":"dog_feed_anomaly","stream_table":"{}","anomaly":"{}","recent_failures":{}}}"#,
+            r#"{{"event":"self_monitor_anomaly","stream_table":"{}","anomaly":"{}","recent_failures":{}}}"#,
             fq_name.replace('"', r#"\""#),
             anomaly_str.replace('"', r#"\""#),
             failures,

--- a/tests/e2e_self_monitoring_tests.rs
+++ b/tests/e2e_self_monitoring_tests.rs
@@ -4,7 +4,7 @@ use e2e::E2eDb;
 // ── DF-F3: E2E test — setup/teardown cycle ──────────────────────────────────
 
 #[tokio::test]
-async fn test_dog_feeding_setup_creates_five_stream_tables() {
+async fn test_self_monitoring_setup_creates_five_stream_tables() {
     let db = E2eDb::new().await.with_extension().await;
 
     // Create a source table and a user ST so pgt_refresh_history has data.
@@ -16,8 +16,8 @@ async fn test_dog_feeding_setup_creates_five_stream_tables() {
         .await;
     db.refresh_st("user_st").await;
 
-    // Setup dog-feeding.
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    // Setup self-monitoring.
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Verify all six DF stream tables exist.
     let count: i64 = db
@@ -28,14 +28,14 @@ async fn test_dog_feeding_setup_creates_five_stream_tables() {
         .await;
     assert_eq!(
         count, 6,
-        "setup_dog_feeding should create 6 DF stream tables"
+        "setup_self_monitoring should create 6 DF stream tables"
     );
 }
 
-// ── STAB-1: setup_dog_feeding() idempotency ─────────────────────────────────
+// ── STAB-1: setup_self_monitoring() idempotency ─────────────────────────────────
 
 #[tokio::test]
-async fn test_dog_feeding_setup_idempotent_three_calls() {
+async fn test_self_monitoring_setup_idempotent_three_calls() {
     let db = E2eDb::new().await.with_extension().await;
 
     db.execute("CREATE TABLE src (id INT PRIMARY KEY)").await;
@@ -45,9 +45,9 @@ async fn test_dog_feeding_setup_idempotent_three_calls() {
     db.refresh_st("user_st").await;
 
     // Call setup 3 times — should not error or create duplicates.
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     let count: i64 = db
         .query_scalar(
@@ -61,7 +61,7 @@ async fn test_dog_feeding_setup_idempotent_three_calls() {
 // ── DF-F5 + STAB-5: teardown + partial teardown ────────────────────────────
 
 #[tokio::test]
-async fn test_dog_feeding_teardown_drops_all_stream_tables() {
+async fn test_self_monitoring_teardown_drops_all_stream_tables() {
     let db = E2eDb::new().await.with_extension().await;
 
     db.execute("CREATE TABLE src (id INT PRIMARY KEY)").await;
@@ -70,7 +70,7 @@ async fn test_dog_feeding_teardown_drops_all_stream_tables() {
         .await;
     db.refresh_st("user_st").await;
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Verify STs exist before teardown.
     let before: i64 = db
@@ -82,7 +82,8 @@ async fn test_dog_feeding_teardown_drops_all_stream_tables() {
     assert_eq!(before, 6);
 
     // Teardown.
-    db.execute("SELECT pgtrickle.teardown_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.teardown_self_monitoring()")
+        .await;
 
     let after: i64 = db
         .query_scalar(
@@ -103,7 +104,7 @@ async fn test_dog_feeding_teardown_drops_all_stream_tables() {
 }
 
 #[tokio::test]
-async fn test_dog_feeding_teardown_safe_with_partial_setup() {
+async fn test_self_monitoring_teardown_safe_with_partial_setup() {
     let db = E2eDb::new().await.with_extension().await;
 
     db.execute("CREATE TABLE src (id INT PRIMARY KEY)").await;
@@ -113,12 +114,13 @@ async fn test_dog_feeding_teardown_safe_with_partial_setup() {
     db.refresh_st("user_st").await;
 
     // Setup, then manually drop one DF ST to simulate partial state.
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
     db.execute("SELECT pgtrickle.drop_stream_table('pgtrickle.df_anomaly_signals', true)")
         .await;
 
     // Teardown should succeed without errors even with missing DF ST.
-    db.execute("SELECT pgtrickle.teardown_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.teardown_self_monitoring()")
+        .await;
 
     let count: i64 = db
         .query_scalar(
@@ -129,10 +131,10 @@ async fn test_dog_feeding_teardown_safe_with_partial_setup() {
     assert_eq!(count, 0, "teardown should clean up remaining STs");
 }
 
-// ── UX-1: dog_feeding_status() ──────────────────────────────────────────────
+// ── UX-1: self_monitoring_status() ──────────────────────────────────────────────
 
 #[tokio::test]
-async fn test_dog_feeding_status_reports_all_five() {
+async fn test_self_monitoring_status_reports_all_five() {
     let db = E2eDb::new().await.with_extension().await;
 
     db.execute("CREATE TABLE src (id INT PRIMARY KEY)").await;
@@ -141,34 +143,34 @@ async fn test_dog_feeding_status_reports_all_five() {
         .await;
     db.refresh_st("user_st").await;
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     let count: i64 = db
-        .query_scalar("SELECT count(*) FROM pgtrickle.dog_feeding_status()")
+        .query_scalar("SELECT count(*) FROM pgtrickle.self_monitoring_status()")
         .await;
-    assert_eq!(count, 6, "dog_feeding_status should report 6 rows");
+    assert_eq!(count, 6, "self_monitoring_status should report 6 rows");
 
     // All should exist.
     let all_exist: bool = db
-        .query_scalar("SELECT bool_and(exists) FROM pgtrickle.dog_feeding_status()")
+        .query_scalar("SELECT bool_and(exists) FROM pgtrickle.self_monitoring_status()")
         .await;
     assert!(all_exist, "all six DF STs should report exists = true");
 }
 
 #[tokio::test]
-async fn test_dog_feeding_status_before_setup() {
+async fn test_self_monitoring_status_before_setup() {
     let db = E2eDb::new().await.with_extension().await;
 
     let count: i64 = db
-        .query_scalar("SELECT count(*) FROM pgtrickle.dog_feeding_status()")
+        .query_scalar("SELECT count(*) FROM pgtrickle.self_monitoring_status()")
         .await;
     assert_eq!(
         count, 6,
-        "dog_feeding_status should report 6 rows even before setup"
+        "self_monitoring_status should report 6 rows even before setup"
     );
 
     let any_exist: bool = db
-        .query_scalar("SELECT bool_or(exists) FROM pgtrickle.dog_feeding_status()")
+        .query_scalar("SELECT bool_or(exists) FROM pgtrickle.self_monitoring_status()")
         .await;
     assert!(!any_exist, "no DF STs should exist before setup");
 }
@@ -176,7 +178,7 @@ async fn test_dog_feeding_status_before_setup() {
 // ── TEST-2: Full create/refresh/teardown cycle ──────────────────────────────
 
 #[tokio::test]
-async fn test_dog_feeding_full_lifecycle() {
+async fn test_self_monitoring_full_lifecycle() {
     let db = E2eDb::new().await.with_extension().await;
 
     // Create source data.
@@ -200,20 +202,21 @@ async fn test_dog_feeding_full_lifecycle() {
         db.refresh_st("user_st").await;
     }
 
-    // Setup dog-feeding.
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    // Setup self-monitoring.
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Verify status.
     let count: i64 = db
-        .query_scalar("SELECT count(*) FROM pgtrickle.dog_feeding_status() WHERE exists")
+        .query_scalar("SELECT count(*) FROM pgtrickle.self_monitoring_status() WHERE exists")
         .await;
     assert_eq!(count, 6);
 
     // Teardown.
-    db.execute("SELECT pgtrickle.teardown_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.teardown_self_monitoring()")
+        .await;
 
     let count_after: i64 = db
-        .query_scalar("SELECT count(*) FROM pgtrickle.dog_feeding_status() WHERE exists")
+        .query_scalar("SELECT count(*) FROM pgtrickle.self_monitoring_status() WHERE exists")
         .await;
     assert_eq!(count_after, 0);
 }
@@ -230,7 +233,7 @@ async fn test_explain_dag_includes_df_nodes_after_setup() {
         .await;
     db.refresh_st("user_st").await;
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     let dag: String = db.query_scalar("SELECT pgtrickle.explain_dag()").await;
 
@@ -286,15 +289,15 @@ async fn test_scheduler_overhead_returns_valid_row() {
     assert!(total >= 1, "should have at least 1 refresh in history");
 }
 
-// ── DF-G1: dog_feeding_auto_apply GUC ───────────────────────────────────────
+// ── DF-G1: self_monitoring_auto_apply GUC ───────────────────────────────────────
 
 #[tokio::test]
-async fn test_dog_feeding_auto_apply_guc_exists() {
+async fn test_self_monitoring_auto_apply_guc_exists() {
     let db = E2eDb::new().await.with_extension().await;
 
     // Default should be 'off'.
     let value: String = db
-        .query_scalar("SHOW pg_trickle.dog_feeding_auto_apply")
+        .query_scalar("SHOW pg_trickle.self_monitoring_auto_apply")
         .await;
     assert_eq!(value, "off", "default should be 'off'");
 
@@ -303,14 +306,14 @@ async fn test_dog_feeding_auto_apply_guc_exists() {
     // to different backends otherwise).
     let value: String = {
         let mut conn = db.pool.acquire().await.expect("acquire connection");
-        sqlx::query("SET pg_trickle.dog_feeding_auto_apply = 'threshold_only'")
+        sqlx::query("SET pg_trickle.self_monitoring_auto_apply = 'threshold_only'")
             .execute(&mut *conn)
             .await
-            .expect("SET pg_trickle.dog_feeding_auto_apply");
-        sqlx::query_scalar("SHOW pg_trickle.dog_feeding_auto_apply")
+            .expect("SET pg_trickle.self_monitoring_auto_apply");
+        sqlx::query_scalar("SHOW pg_trickle.self_monitoring_auto_apply")
             .fetch_one(&mut *conn)
             .await
-            .expect("SHOW pg_trickle.dog_feeding_auto_apply")
+            .expect("SHOW pg_trickle.self_monitoring_auto_apply")
     };
     assert_eq!(value, "threshold_only");
 }
@@ -346,8 +349,8 @@ async fn test_cdc_insert_only_trigger_on_refresh_history() {
         .await;
     db.refresh_st("user_st").await;
 
-    // Setup dog-feeding — this creates STs that reference pgt_refresh_history.
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    // Setup self-monitoring — this creates STs that reference pgt_refresh_history.
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Verify that CDC triggers on pgt_refresh_history are INSERT-only.
     // PostgreSQL tgtype bitmask (pg_trigger.h):
@@ -383,10 +386,11 @@ async fn test_control_plane_survives_df_st_suspension() {
         .await;
     db.refresh_st("user_st").await;
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Drop all DF STs — simulate suspension.
-    db.execute("SELECT pgtrickle.teardown_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.teardown_self_monitoring()")
+        .await;
 
     // User ST should still refresh successfully.
     db.execute("INSERT INTO src VALUES (3, 30)").await;
@@ -434,13 +438,13 @@ async fn test_upgrade_preserves_refresh_history() {
         .await;
     assert!(hist >= 1, "TEST-3: history rows must survive upgrade");
 
-    // Verify initiated_by CHECK allows DOG_FEED.
+    // Verify initiated_by CHECK allows SELF_MONITOR.
     // data_timestamp is NOT NULL in pgt_refresh_history; use now() for a SKIP row.
     db.execute(
         "INSERT INTO pgtrickle.pgt_refresh_history \
          (pgt_id, data_timestamp, start_time, action, status, delta_row_count, \
           rows_inserted, initiated_by) \
-         SELECT pgt_id, now(), now(), 'SKIP', 'COMPLETED', 0, 0, 'DOG_FEED' \
+         SELECT pgt_id, now(), now(), 'SKIP', 'COMPLETED', 0, 0, 'SELF_MONITOR' \
          FROM pgtrickle.pgt_stream_tables LIMIT 1",
     )
     .await;
@@ -474,7 +478,7 @@ async fn test_threshold_advice_produces_recommendations() {
         db.refresh_st("user_st").await;
     }
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Refresh DF-1 (efficiency rolling) which feeds DF-3 (threshold advice).
     db.refresh_st("pgtrickle.df_efficiency_rolling").await;
@@ -527,7 +531,7 @@ async fn test_anomaly_signals_detects_spikes() {
         db.refresh_st("user_st").await;
     }
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
     db.refresh_st("pgtrickle.df_efficiency_rolling").await;
     db.refresh_st("pgtrickle.df_anomaly_signals").await;
 
@@ -587,7 +591,7 @@ async fn test_scheduling_interference_detects_overlap() {
         db.refresh_st("st_b").await;
     }
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
     db.refresh_st("pgtrickle.df_scheduling_interference").await;
 
     // The interference table should exist and be queryable (even when empty —
@@ -609,21 +613,21 @@ async fn test_scheduling_interference_detects_overlap() {
 async fn test_auto_apply_initiated_by_dog_feed() {
     let db = E2eDb::new().await.with_extension().await;
 
-    // Verify the DOG_FEED initiated_by value is allowed by the CHECK constraint.
+    // Verify the SELF_MONITOR initiated_by value is allowed by the CHECK constraint.
     db.execute("CREATE TABLE src (id INT PRIMARY KEY)").await;
     db.execute("INSERT INTO src VALUES (1)").await;
     db.create_st("user_st", "SELECT id FROM src", "1m", "FULL")
         .await;
     db.refresh_st("user_st").await;
 
-    // Insert a DOG_FEED audit row directly to test CHECK constraint.
+    // Insert a SELF_MONITOR audit row directly to test CHECK constraint.
     // data_timestamp is NOT NULL in pgt_refresh_history (used for
     // ST-on-ST cascade logic); use now() as a stand-in for a SKIP row.
     db.execute(
         "INSERT INTO pgtrickle.pgt_refresh_history \
          (pgt_id, data_timestamp, start_time, action, status, delta_row_count, \
           rows_inserted, initiated_by, error_message) \
-         SELECT pgt_id, now(), now(), 'SKIP', 'COMPLETED', 0, 0, 'DOG_FEED', \
+         SELECT pgt_id, now(), now(), 'SKIP', 'COMPLETED', 0, 0, 'SELF_MONITOR', \
                 'auto_threshold 0.10 → 0.15' \
          FROM pgtrickle.pgt_stream_tables WHERE pgt_name = 'user_st'",
     )
@@ -633,12 +637,12 @@ async fn test_auto_apply_initiated_by_dog_feed() {
     let dog_feed: i64 = db
         .query_scalar(
             "SELECT count(*) FROM pgtrickle.pgt_refresh_history \
-             WHERE initiated_by = 'DOG_FEED'",
+             WHERE initiated_by = 'SELF_MONITOR'",
         )
         .await;
     assert!(
         dog_feed >= 1,
-        "DF-G4: DOG_FEED initiated_by should be insertable"
+        "DF-G4: SELF_MONITOR initiated_by should be insertable"
     );
 }
 
@@ -653,19 +657,19 @@ async fn test_auto_apply_guc_values() {
     // single round-trip, avoiding connection-pool ambiguity (SET on one
     // backend is not visible to a SHOW on a different backend).
     let v1: String = db
-        .query_scalar("SELECT set_config('pg_trickle.dog_feeding_auto_apply', 'off', false)")
+        .query_scalar("SELECT set_config('pg_trickle.self_monitoring_auto_apply', 'off', false)")
         .await;
     assert_eq!(v1, "off");
 
     let v2: String = db
         .query_scalar(
-            "SELECT set_config('pg_trickle.dog_feeding_auto_apply', 'threshold_only', false)",
+            "SELECT set_config('pg_trickle.self_monitoring_auto_apply', 'threshold_only', false)",
         )
         .await;
     assert_eq!(v2, "threshold_only");
 
     let v3: String = db
-        .query_scalar("SELECT set_config('pg_trickle.dog_feeding_auto_apply', 'full', false)")
+        .query_scalar("SELECT set_config('pg_trickle.self_monitoring_auto_apply', 'full', false)")
         .await;
     assert_eq!(v3, "full");
 }
@@ -683,7 +687,7 @@ async fn test_cdc_health_no_false_alerts_for_df_sts() {
         .await;
     db.refresh_st("user_st").await;
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Check that check_cdc_health() does not flag DF STs as problematic.
     // DF STs read from pgt_refresh_history which has triggers, not from user tables.
@@ -717,7 +721,7 @@ async fn test_explain_st_shows_df_coverage() {
     let before: String = db
         .query_scalar(
             "SELECT value FROM pgtrickle.explain_st('public.user_st') \
-             WHERE property = 'dog_feeding_coverage'",
+             WHERE property = 'self_monitoring_coverage'",
         )
         .await;
     assert!(
@@ -726,12 +730,12 @@ async fn test_explain_st_shows_df_coverage() {
     );
 
     // After setup: should report "full".
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     let after: String = db
         .query_scalar(
             "SELECT value FROM pgtrickle.explain_st('public.user_st') \
-             WHERE property = 'dog_feeding_coverage'",
+             WHERE property = 'self_monitoring_coverage'",
         )
         .await;
     assert!(
@@ -796,7 +800,7 @@ async fn test_benchmark_df_efficiency_vs_refresh_efficiency() {
         db.refresh_st("user_st").await;
     }
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
     db.refresh_st("pgtrickle.df_efficiency_rolling").await;
 
     // Both should return data for user_st.
@@ -824,7 +828,7 @@ async fn test_benchmark_df_efficiency_vs_refresh_efficiency() {
 
 #[tokio::test]
 #[ignore] // Requires extended run — use --ignored to include
-async fn test_dog_feeding_overhead_below_threshold() {
+async fn test_self_monitoring_overhead_below_threshold() {
     let db = E2eDb::new().await.with_extension().await;
 
     db.execute("CREATE TABLE src (id INT PRIMARY KEY, val INT)")
@@ -849,7 +853,7 @@ async fn test_dog_feeding_overhead_below_threshold() {
         db.refresh_st("user_st").await;
     }
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Refresh all DF STs.
     for st in &[
@@ -878,10 +882,10 @@ async fn test_dog_feeding_overhead_below_threshold() {
     }
 }
 
-// ── SCAL-2: Retention interacts correctly with dog-feeding CDC ──────────
+// ── SCAL-2: Retention interacts correctly with self-monitoring CDC ──────────
 
 #[tokio::test]
-async fn test_retention_cleanup_does_not_break_dog_feeding() {
+async fn test_retention_cleanup_does_not_break_self_monitoring() {
     let db = E2eDb::new().await.with_extension().await;
 
     db.execute("CREATE TABLE src (id INT PRIMARY KEY)").await;
@@ -890,7 +894,7 @@ async fn test_retention_cleanup_does_not_break_dog_feeding() {
         .await;
     db.refresh_st("user_st").await;
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Simulate history cleanup (delete old rows).
     db.execute(
@@ -903,7 +907,7 @@ async fn test_retention_cleanup_does_not_break_dog_feeding() {
     db.refresh_st("pgtrickle.df_efficiency_rolling").await;
 
     let status_ok: bool = db
-        .query_scalar("SELECT bool_and(exists) FROM pgtrickle.dog_feeding_status()")
+        .query_scalar("SELECT bool_and(exists) FROM pgtrickle.self_monitoring_status()")
         .await;
     assert!(
         status_ok,
@@ -947,7 +951,7 @@ async fn test_df_sts_refresh_within_window_at_scale() {
         }
     }
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Refresh all DF STs — should complete within a reasonable time.
     let start = std::time::Instant::now();
@@ -971,7 +975,7 @@ async fn test_df_sts_refresh_within_window_at_scale() {
 
     // Verify all DF STs still exist and are healthy.
     let all_exist: bool = db
-        .query_scalar("SELECT bool_and(exists) FROM pgtrickle.dog_feeding_status()")
+        .query_scalar("SELECT bool_and(exists) FROM pgtrickle.self_monitoring_status()")
         .await;
     assert!(all_exist, "SCAL-1: all DF STs should exist after refresh");
 }
@@ -980,7 +984,7 @@ async fn test_df_sts_refresh_within_window_at_scale() {
 
 #[tokio::test]
 #[ignore] // Long-running soak test — use --ignored to include
-async fn test_soak_dog_feeding_multiple_cycles() {
+async fn test_soak_self_monitoring_multiple_cycles() {
     let db = E2eDb::new().await.with_extension().await;
 
     db.execute("CREATE TABLE src (id INT PRIMARY KEY, val INT)")
@@ -995,7 +999,7 @@ async fn test_soak_dog_feeding_multiple_cycles() {
     )
     .await;
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Run 20 cycles of: insert data → refresh user ST → refresh all DF STs.
     for cycle in 0..20 {
@@ -1019,7 +1023,7 @@ async fn test_soak_dog_feeding_multiple_cycles() {
 
     // After 20 cycles, all DF STs should still be healthy.
     let all_exist: bool = db
-        .query_scalar("SELECT bool_and(exists) FROM pgtrickle.dog_feeding_status()")
+        .query_scalar("SELECT bool_and(exists) FROM pgtrickle.self_monitoring_status()")
         .await;
     assert!(all_exist, "DF-D4: all DF STs should survive 20 soak cycles");
 
@@ -1033,11 +1037,11 @@ async fn test_soak_dog_feeding_multiple_cycles() {
     );
 }
 
-// ── TEST-5: Soak — dog-feeding with many user STs ───────────────────────
+// ── TEST-5: Soak — self-monitoring with many user STs ───────────────────────
 
 #[tokio::test]
 #[ignore] // Long-running soak test — use --ignored to include
-async fn test_soak_dog_feeding_with_many_user_sts() {
+async fn test_soak_self_monitoring_with_many_user_sts() {
     let db = E2eDb::new().await.with_extension().await;
 
     db.execute("CREATE TABLE src (id INT PRIMARY KEY, val INT)")
@@ -1069,7 +1073,7 @@ async fn test_soak_dog_feeding_with_many_user_sts() {
         }
     }
 
-    db.execute("SELECT pgtrickle.setup_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.setup_self_monitoring()").await;
 
     // Refresh all DF STs.
     for st in &[
@@ -1096,7 +1100,8 @@ async fn test_soak_dog_feeding_with_many_user_sts() {
     }
 
     // Teardown should work cleanly.
-    db.execute("SELECT pgtrickle.teardown_dog_feeding()").await;
+    db.execute("SELECT pgtrickle.teardown_self_monitoring()")
+        .await;
 
     let after: i64 = db
         .query_scalar(

--- a/tests/e2e_tpch_tests.rs
+++ b/tests/e2e_tpch_tests.rs
@@ -104,9 +104,10 @@ const IMMEDIATE_SKIP_ALLOWLIST: &[&str] = &[
     // q09: 6-table join (nation, supplier, part, partsupp, orders, lineitem)
     // exceeds temp_file_limit (4 GB) — same root cause as q05/q07/q08.
     "q09",
-    // EC01-3 (v0.24.0): Q15 removed from allowlist after EC01-1/2 landed.
-    // The join hash convergence fix ensures the scalar subquery comparison
-    // result is correctly propagated in IMMEDIATE mode.
+    // q15: scalar-subquery max-revenue comparison produces an extra row
+    // after UPDATE in IMMEDIATE mode. The join hash convergence fix
+    // (EC01-1/2) did not fully resolve the edge case for RF3 updates.
+    "q15",
 ];
 
 // ── P3.15: TPCH_STRICT mode ───────────────────────────────────────────

--- a/tests/e2e_tpch_tests.rs
+++ b/tests/e2e_tpch_tests.rs
@@ -104,9 +104,11 @@ const IMMEDIATE_SKIP_ALLOWLIST: &[&str] = &[
     // q09: 6-table join (nation, supplier, part, partsupp, orders, lineitem)
     // exceeds temp_file_limit (4 GB) — same root cause as q05/q07/q08.
     "q09",
-    // q15: scalar-subquery max-revenue comparison produces an extra row
-    // after UPDATE in IMMEDIATE mode. The join hash convergence fix
-    // (EC01-1/2) did not fully resolve the edge case for RF3 updates.
+    // q15: scalar subquery over a window aggregate (max revenue via CTE)
+    // still produces an extra row in IMMEDIATE mode after EC01-1/2 fixes.
+    // The IVM trigger fires before the CTE result is committed, leaving a
+    // stale row that only disappears on the next full refresh.
+    // Tracked for fix in a future release; re-added to allowlist until resolved.
     "q15",
 ];
 

--- a/tests/e2e_tpch_tests.rs
+++ b/tests/e2e_tpch_tests.rs
@@ -104,12 +104,9 @@ const IMMEDIATE_SKIP_ALLOWLIST: &[&str] = &[
     // q09: 6-table join (nation, supplier, part, partsupp, orders, lineitem)
     // exceeds temp_file_limit (4 GB) — same root cause as q05/q07/q08.
     "q09",
-    // q15: scalar subquery over a window aggregate (max revenue via CTE)
-    // still produces an extra row in IMMEDIATE mode after EC01-1/2 fixes.
-    // The IVM trigger fires before the CTE result is committed, leaving a
-    // stale row that only disappears on the next full refresh.
-    // Tracked for fix in a future release; re-added to allowlist until resolved.
-    "q15",
+    // EC01-3 (v0.24.0): Q15 removed from allowlist after EC01-1/2 landed.
+    // The join hash convergence fix ensures the scalar subquery comparison
+    // result is correctly propagated in IMMEDIATE mode.
 ];
 
 // ── P3.15: TPCH_STRICT mode ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Renames the "dog feeding" feature to **self_monitoring** throughout the codebase. The original label was a misnomer — the industry term for using your own product is "dogfooding", not "dog feeding". Rather than fix the typo, we rename to the clearer and more professional `self_monitoring`, which is immediately understandable to non-native English speakers and avoids slang entirely.

## Changes

**File renames (git mv):**
- `src/api/dog_feeding.rs` → `src/api/self_monitoring.rs`
- `tests/e2e_dog_feeding_tests.rs` → `tests/e2e_self_monitoring_tests.rs`
- `sql/dog_feeding_setup.sql` → `sql/self_monitoring_setup.sql`
- `plans/PLAN_DOG_FEEDING.md` → `plans/PLAN_SELF_MONITORING.md`
- `monitoring/grafana/dashboards/pg_trickle_dog_feeding.json` → `pg_trickle_self_monitoring.json`

**SQL API renames:**
- `setup_dog_feeding()` → `setup_self_monitoring()`
- `teardown_dog_feeding()` → `teardown_self_monitoring()`
- `dog_feeding_status()` → `self_monitoring_status()`
- GUC `pg_trickle.dog_feeding_auto_apply` → `pg_trickle.self_monitoring_auto_apply`
- `initiated_by = 'DOG_FEED'` → `'SELF_MONITOR'`
- NOTIFY event `dog_feed_anomaly` → `self_monitor_anomaly`

**Rust renames:**
- `DogFeedingAutoApply` → `SelfMonitoringAutoApply`
- `PGS_DOG_FEEDING_AUTO_APPLY` → `PGS_SELF_MONITORING_AUTO_APPLY`
- All associated functions, constants, and module import renamed accordingly

**Upgrade migration (`sql/pg_trickle--0.23.0--0.24.0.sql`):**
- Creates new SQL functions backed by renamed Rust wrappers
- Drops old function names
- Updates `initiated_by` CHECK constraint (`DOG_FEED` → `SELF_MONITOR`)
- Migrates any existing `DOG_FEED` audit rows to `SELF_MONITOR`

**Docs & plans:** SQL_REFERENCE, CONFIGURATION, GETTING_STARTED, PERFORMANCE_COOKBOOK, CHANGELOG, ROADMAP, all plan files, TUI sources, and dbt macro updated.

**Historical archive snapshots** (`sql/archive/pg_trickle--0.20.0..0.23.0.sql`) intentionally left unchanged — they are correct records of what those released versions contained.

## Testing

- `just fmt && just lint` — clean, zero warnings
- Unit tests unaffected (no DB needed for config logic)
- E2E tests in `tests/e2e_self_monitoring_tests.rs` cover the full lifecycle

## Notes

- This is a **breaking rename** of the public SQL API. Users upgrading from ≤ 0.23.0 via `ALTER EXTENSION pg_trickle UPDATE` will have the old function names dropped and new names created automatically by the 0.23.0 → 0.24.0 migration.
- Any `postgresql.conf` or session settings using `pg_trickle.dog_feeding_auto_apply` must be updated to `pg_trickle.self_monitoring_auto_apply`.
