### PR TITLE
fix(security): use preceding-line nosemgrep to silence alerts 579-583

### DIFF
--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -433,8 +433,8 @@ pub fn rebuild_publication_for_partitioned_source(
 
     // Drop and recreate to ensure publish_via_partition_root is set.
     // Both identifiers are properly quoted above before interpolation.
+    // nosemgrep: rust.spi.run.dynamic-format — DDL cannot be parameterized; identifiers are quoted via quote_ident
     Spi::run(&format!(
-        // nosemgrep: rust.spi.run.dynamic-format — DDL cannot be parameterized; identifiers are quoted via quote_ident
         "DROP PUBLICATION IF EXISTS {pub_name_quoted}; \
          CREATE PUBLICATION {pub_name_quoted} FOR TABLE {table_name} \
          WITH (publish_via_partition_root = true)"

--- a/src/refresh/mod.rs
+++ b/src/refresh/mod.rs
@@ -941,8 +941,8 @@ fn apply_planner_hints(estimated_delta: i64, st_relid: pg_sys::Oid, scan_count: 
                 e
             );
         }
+        // nosemgrep: rust.spi.run.dynamic-format — mb is a numeric value; SET LOCAL cannot use params
         if let Err(e) = Spi::run(&format!("SET LOCAL work_mem = '{mb}MB'")) {
-            // nosemgrep: rust.spi.run.dynamic-format — mb is a numeric value; SET LOCAL cannot use params
             pgrx::debug1!("[pg_trickle] D-1: failed to SET LOCAL work_mem: {}", e);
         }
     } else if estimated_delta >= PLANNER_HINT_NESTLOOP_THRESHOLD {
@@ -1783,8 +1783,8 @@ fn deallocate_prepared_merge_statement(_pgt_id: i64) {
     {
         let pgt_id = _pgt_id;
         let stmt = format!("__pgt_merge_{pgt_id}");
+        // nosemgrep: rust.spi.query.dynamic-format — stmt is derived from numeric pgt_id
         let exists = Spi::get_one::<bool>(&format!(
-            // nosemgrep: rust.spi.query.dynamic-format — stmt is derived from numeric pgt_id
             "SELECT EXISTS(SELECT 1 FROM pg_prepared_statements WHERE name = '{stmt}')"
         ))
         .unwrap_or(Some(false))
@@ -5643,8 +5643,8 @@ pub fn execute_differential_refresh(
             // session within this same backend.
             // Note: DEALLOCATE does not support IF EXISTS in PostgreSQL.
             // Check pg_prepared_statements first to avoid an error.
+            // nosemgrep: rust.spi.query.dynamic-format — stmt_name is derived from numeric pgt_id
             let stale_exists = Spi::get_one::<bool>(&format!(
-                // nosemgrep: rust.spi.query.dynamic-format — stmt_name is derived from numeric pgt_id
                 "SELECT EXISTS(SELECT 1 FROM pg_prepared_statements WHERE name = '{stmt_name}')"
             ))
             .unwrap_or(Some(false))
@@ -5652,8 +5652,8 @@ pub fn execute_differential_refresh(
             if stale_exists {
                 let _ = Spi::run(&format!("DEALLOCATE {stmt_name}")); // nosemgrep: rust.spi.run.dynamic-format — stmt_name is derived from numeric pgt_id, not user input
             }
+            // nosemgrep: rust.spi.run.dynamic-format — stmt_name and type_list are derived from numeric IDs; parameterized_merge_sql is an internal template
             Spi::run(&format!(
-                // nosemgrep: rust.spi.run.dynamic-format — stmt_name and type_list are derived from numeric IDs; parameterized_merge_sql is an internal template
                 "PREPARE {stmt_name} ({type_list}) AS {}",
                 resolved.parameterized_merge_sql
             ))


### PR DESCRIPTION
## Summary

PR #599 attempted to move `// nosemgrep` comments inline with each `Spi::run()` /
`Spi::get_one()` call, but two problems prevented it from working:

1. **`format!()` body comments** — a `// nosemgrep` placed as the first line inside
   a multi-line `format!(…)` argument is inside the macro invocation, *not* on the
   same line as the outer `Spi::run(` expression that Semgrep flags.
2. **`if let` trailing comment** — rustfmt moves a trailing comment from after `{`
   to the first line inside the block body, putting it on the wrong line again.

The fix in this PR uses **preceding-line suppression**: move each `// nosemgrep`
comment to a standalone comment line immediately *before* the `Spi::run(` /
`Spi::get_one(` call. Semgrep 1.x (including 1.159.0 used in CI) recognises a
`nosemgrep` comment on the line directly above a finding as a valid suppression.
Standalone comment lines are never moved by rustfmt.

## Changes

- `src/cdc.rs:436` — publication rebuild DDL (`Spi::run` + `format!`)
- `src/refresh/mod.rs:944` — `SET LOCAL work_mem` (`if let Err … Spi::run`)
- `src/refresh/mod.rs:1786` — DEALLOCATE existence check (`Spi::get_one` + `format!`)
- `src/refresh/mod.rs:5646` — DEALLOCATE existence check #2 (`Spi::get_one` + `format!`)
- `src/refresh/mod.rs:5655` — `PREPARE` statement (`Spi::run` + `format!`)

No logic changes — suppression comment placement only.

## Testing

- `just fmt` — passes, preceding-line comments are not moved
- `just lint` — passes, zero warnings

## Notes

These 5 findings correspond to open code-scanning alerts 579–583 on
`https://github.com/grove/pg-trickle/security/code-scanning`.  They will
auto-close once Semgrep re-scans `main` after this PR merges.
