### PR TITLE
fix(upgrade): fix 3 upgrade-path bugs blocking v0.24.0 test-upgrade-all

### DIFF
--- a/sql/archive/pg_trickle--0.20.0.sql
+++ b/sql/archive/pg_trickle--0.20.0.sql
@@ -1417,7 +1417,7 @@ AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';
 CREATE  FUNCTION pgtrickle."setup_dog_feeding"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'setup_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1427,7 +1427,7 @@ AS 'MODULE_PATHNAME', 'setup_dog_feeding_wrapper';
 CREATE  FUNCTION pgtrickle."teardown_dog_feeding"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'teardown_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1444,7 +1444,7 @@ CREATE  FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dog_feeding_status_wrapper';
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.21.0.sql
+++ b/sql/archive/pg_trickle--0.21.0.sql
@@ -1417,7 +1417,7 @@ AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';
 CREATE  FUNCTION pgtrickle."setup_dog_feeding"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'setup_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1427,7 +1427,7 @@ AS 'MODULE_PATHNAME', 'setup_dog_feeding_wrapper';
 CREATE  FUNCTION pgtrickle."teardown_dog_feeding"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'teardown_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1444,7 +1444,7 @@ CREATE  FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dog_feeding_status_wrapper';
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.22.0.sql
+++ b/sql/archive/pg_trickle--0.22.0.sql
@@ -563,7 +563,7 @@ CREATE  FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
 )
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dog_feeding_status_wrapper';
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1113,7 +1113,7 @@ AS 'MODULE_PATHNAME', 'refresh_timeline_wrapper';
 CREATE  FUNCTION pgtrickle."setup_dog_feeding"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'setup_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1769,7 +1769,7 @@ AS 'MODULE_PATHNAME', 'get_refresh_history_wrapper';
 CREATE  FUNCTION pgtrickle."teardown_dog_feeding"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'teardown_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.23.0.sql
+++ b/sql/archive/pg_trickle--0.23.0.sql
@@ -772,7 +772,7 @@ CREATE  FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
 )
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dog_feeding_status_wrapper';
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -798,7 +798,7 @@ AS 'MODULE_PATHNAME', 'watermark_status_fn_wrapper';
 CREATE  FUNCTION pgtrickle."teardown_dog_feeding"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'teardown_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1675,7 +1675,7 @@ AS 'MODULE_PATHNAME', 'create_watermark_group_wrapper';
 CREATE  FUNCTION pgtrickle."setup_dog_feeding"() RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'setup_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/pg_trickle--0.19.0--0.20.0.sql
+++ b/sql/pg_trickle--0.19.0--0.20.0.sql
@@ -60,12 +60,12 @@ AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';
 CREATE OR REPLACE FUNCTION pgtrickle."setup_dog_feeding"() RETURNS void
 STRICT
 LANGUAGE c
-AS 'MODULE_PATHNAME', 'setup_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
 
 CREATE OR REPLACE FUNCTION pgtrickle."teardown_dog_feeding"() RETURNS void
 STRICT
 LANGUAGE c
-AS 'MODULE_PATHNAME', 'teardown_dog_feeding_wrapper';
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
 
 CREATE OR REPLACE FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
     "st_name" TEXT,
@@ -77,7 +77,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."dog_feeding_status"() RETURNS TABLE (
 )
 STRICT
 LANGUAGE c
-AS 'MODULE_PATHNAME', 'dog_feeding_status_wrapper';
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 
 CREATE OR REPLACE FUNCTION pgtrickle."scheduler_overhead"() RETURNS TABLE (
     "total_refreshes_1h" bigint,

--- a/sql/pg_trickle--0.23.0--0.24.0.sql
+++ b/sql/pg_trickle--0.23.0--0.24.0.sql
@@ -39,10 +39,9 @@ CREATE INDEX IF NOT EXISTS idx_pgt_rh_pgt_action_ts
 CREATE INDEX IF NOT EXISTS idx_pgt_ct_source_relid
     ON pgtrickle.pgt_change_tracking (source_relid);
 
--- RENAME-1: Rename self_monitoring → self_monitoring SQL API.
--- The "self monitoring" terminology was a misnomer; the industry term is
--- "dogfooding" but the feature name has been standardised to the clearer
--- and more professional "self_monitoring".
+-- RENAME-1: Rename dog_feeding → self_monitoring SQL API.
+-- The "dog_feeding" terminology was internal jargon; the feature has been
+-- renamed to the clearer and more professional "self_monitoring".
 --
 -- Create new functions backed by the renamed Rust wrapper symbols.
 CREATE OR REPLACE FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
@@ -64,10 +63,10 @@ CREATE OR REPLACE FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
     LANGUAGE c STRICT
 AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 
--- Drop the old function names.
-DROP FUNCTION IF EXISTS pgtrickle."setup_self_monitoring"();
-DROP FUNCTION IF EXISTS pgtrickle."teardown_self_monitoring"();
-DROP FUNCTION IF EXISTS pgtrickle."self_monitoring_status"();
+-- Drop the old function names (dog_feeding → self_monitoring rename).
+DROP FUNCTION IF EXISTS pgtrickle."setup_dog_feeding"();
+DROP FUNCTION IF EXISTS pgtrickle."teardown_dog_feeding"();
+DROP FUNCTION IF EXISTS pgtrickle."dog_feeding_status"();
 
 -- Update initiated_by CHECK constraint: add SELF_MONITOR, remove SELF_MONITOR.
 -- Use a two-step approach: drop the old constraint, add the new one.

--- a/sql/pg_trickle--0.23.0--0.24.0.sql
+++ b/sql/pg_trickle--0.23.0--0.24.0.sql
@@ -53,12 +53,12 @@ CREATE OR REPLACE FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
 AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
 
 CREATE OR REPLACE FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
-    st_name text,
-    exists bool,
-    status text,
-    refresh_mode text,
-    last_refresh_at text,
-    total_refreshes bigint
+    "st_name" text,
+    "exists" bool,
+    "status" text,
+    "refresh_mode" text,
+    "last_refresh_at" text,
+    "total_refreshes" bigint
 )
     LANGUAGE c STRICT
 AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';

--- a/tests/e2e_upgrade_tests.rs
+++ b/tests/e2e_upgrade_tests.rs
@@ -879,6 +879,31 @@ async fn test_upgrade_schema_additions_from_sql() {
         to_version
     );
 
+    // Pre-collect all functions explicitly DROPped anywhere in the upgrade
+    // chain.  A function created in step N and then dropped in step M > N
+    // will not exist in the final state, so we must skip those assertions.
+    let dropped_functions: std::collections::HashSet<(String, String)> = sql_files
+        .iter()
+        .flat_map(|p| {
+            let raw = std::fs::read_to_string(p).unwrap_or_default();
+            let content: String = raw
+                .lines()
+                .filter(|l| !l.trim_start().starts_with("--"))
+                .collect::<Vec<_>>()
+                .join("\n");
+            regex_lite::Regex::new(r#"(?i)DROP\s+FUNCTION\s+(?:IF\s+EXISTS\s+)?(\w+)\."(\w+)""#)
+                .unwrap()
+                .captures_iter(&content)
+                .map(|c| {
+                    (
+                        c.get(1).unwrap().as_str().to_lowercase(),
+                        c.get(2).unwrap().as_str().to_lowercase(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
     let mut checks = 0;
 
     for sql_path in &sql_files {
@@ -959,6 +984,10 @@ async fn test_upgrade_schema_additions_from_sql() {
         {
             let schema = cap.get(1).unwrap().as_str().to_lowercase();
             let func = cap.get(2).unwrap().as_str().to_lowercase();
+            // Skip functions explicitly dropped later in the same upgrade chain
+            if dropped_functions.contains(&(schema.clone(), func.clone())) {
+                continue;
+            }
             let exists: bool = db
                 .query_scalar(&format!(
                     "SELECT EXISTS( \


### PR DESCRIPTION
## Summary

Three upgrade-path bugs prevented `just test-upgrade-all` from passing all 27
upgrade paths (26 adjacent steps + full chain 0.1.3 → 0.24.0) when running
against the v0.24.0 binary.  All bugs are fixed and the full suite now passes
cleanly.

## Changes

- **Rename C wrapper symbols in archive SQL files (0.20.0 – 0.23.0) and the
  0.19.0 → 0.20.0 upgrade script** — the v0.24.0 `.so` no longer exports
  `setup_dog_feeding_wrapper`, `teardown_dog_feeding_wrapper`, or
  `dog_feeding_status_wrapper`; they were renamed to the
  `*_self_monitoring_wrapper` equivalents.  Updated all four archive SQL files
  and the upgrade script that first introduced those symbols.

- **Quote reserved-keyword column names in `self_monitoring_status()` RETURNS
  TABLE** — the 0.23.0 → 0.24.0 upgrade script used `exists bool` as a column
  name in a `RETURNS TABLE` clause; `EXISTS` is a reserved keyword in
  PostgreSQL 18 and causes a syntax error.  All six column names are now
  double-quoted (`"st_name"`, `"exists"`, `"status"`, `"refresh_mode"`,
  `"last_refresh_at"`, `"total_refreshes"`).

- **Fix DROP statements in 0.23.0 → 0.24.0 upgrade script** — the script was
  dropping the newly-created `self_monitoring` functions instead of the old
  `dog_feeding` functions it was replacing.  Fixed to drop
  `pgtrickle."setup_dog_feeding"()`, `pgtrickle."teardown_dog_feeding"()`, and
  `pgtrickle."dog_feeding_status"()`.

- **Fix `test_upgrade_schema_additions_from_sql` for full upgrade chain** — the
  test checks that every function declared by a `CREATE [OR REPLACE] FUNCTION`
  in any upgrade script exists in the final database.  For the full chain
  (0.1.3 → 0.24.0) this is incorrect for functions that are introduced in one
  step and explicitly dropped in a later step (e.g. `setup_dog_feeding`
  introduced in 0.19.0 → 0.20.0, dropped in 0.23.0 → 0.24.0).  The test now
  builds a `dropped_functions` set from all `DROP FUNCTION` statements across
  the chain and skips assertions for those functions.

## Testing

- `just check-version-sync` — 6/6 checks pass
- `just check-upgrade-all` — 26/26 upgrade step completeness checks pass
- `just test-upgrade-all` — all 27 upgrade paths pass (26 adjacent + full
  chain 0.1.3 → 0.24.0), 18 tests × 27 paths = 486 test runs, 0 failures

## Notes

The archive SQL files (used to build the FROM image for each upgrade pair) must
always reference the C wrapper symbols that exist in the **current** binary, not
the symbols that existed when that version was originally released.  When Rust
wrapper functions are renamed, all archive files for versions that included those
functions must be updated in the same commit.
