### PR TITLE
fix(upgrade): correct C symbol for worker_allocation_status in 0.24 to 0.25 upgrade SQL

### DIFF
--- a/sql/archive/pg_trickle--0.25.0.sql
+++ b/sql/archive/pg_trickle--0.25.0.sql
@@ -1836,7 +1836,7 @@ RETURNS TABLE (
     "cluster_max"    bigint
 )
     LANGUAGE c STRICT
-AS 'MODULE_PATHNAME', 'worker_allocation_status_wrapper';
+AS 'MODULE_PATHNAME', 'worker_allocation_status_fn_wrapper';
 
 /* </end connected objects> */
 

--- a/sql/pg_trickle--0.24.0--0.25.0.sql
+++ b/sql/pg_trickle--0.24.0--0.25.0.sql
@@ -37,7 +37,7 @@ RETURNS TABLE (
     "cluster_max"    bigint
 )
     LANGUAGE c STRICT
-AS 'MODULE_PATHNAME', 'worker_allocation_status_wrapper';
+AS 'MODULE_PATHNAME', 'worker_allocation_status_fn_wrapper';
 
 -- Record the schema version for the upgrade chain.
 INSERT INTO pgtrickle.pgt_schema_version (version, description)


### PR DESCRIPTION
Fixes Upgrade E2E CI failures (run 24706496300): 0.24.0->0.25.0 and 0.1.3->0.25.0 both failed with exit code 100.

Root cause: the upgrade script referenced C symbol 'worker_allocation_status_wrapper' but pgrx generates 'worker_allocation_status_fn_wrapper' from the Rust function name fn worker_allocation_status_fn(). This caused every ALTER EXTENSION pg_trickle UPDATE TO '0.25.0' to fail with: could not find function worker_allocation_status_wrapper in pg_trickle.so.

Fix: changed symbol to worker_allocation_status_fn_wrapper in both sql/pg_trickle--0.24.0--0.25.0.sql and sql/archive/pg_trickle--0.25.0.sql.