### PR TITLE
docs(roadmap): reorder v0.27–v0.29 release sequence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,9 +43,9 @@ coverage, all in plain language.
 - [v0.24.0 — Join Correctness & Durability Hardening](#v0240--join-correctness--durability-hardening)
 - [v0.25.0 — Scheduler Scalability & Pooler Performance](#v0250--scheduler-scalability--pooler-performance)
 - [v0.26.0 — Test & Concurrency Hardening](#v0260--test--concurrency-hardening)
-- [v0.27.0 — Transactional Inbox & Outbox Patterns](#v0270--transactional-inbox--outbox-patterns)
-- [v0.28.0 — Relay CLI (`pgtrickle-relay`)](#v0280--relay-cli-pgtrickle-relay)
-- [v0.29.0 — Operability, Observability & DR](#v0290--operability-observability--dr)
+- [v0.27.0 — Operability, Observability & DR](#v0270--operability-observability--dr)
+- [v0.28.0 — Transactional Inbox & Outbox Patterns](#v0280--transactional-inbox--outbox-patterns)
+- [v0.29.0 — Relay CLI (`pgtrickle-relay`)](#v0290--relay-cli-pgtrickle-relay)
 - [v1.0.0 — Stable Release](#v100--stable-release)
 - [v1.1.0 — PostgreSQL 17 Support](#v110--postgresql-17-support)
 - [v1.2.0 — PGlite Proof of Concept](#v120--pglite-proof-of-concept)
@@ -98,9 +98,9 @@ from the v0.1.x series to 1.0 and beyond.
 | v0.24.0 | Join correctness & durability hardening | ✅ Released |
 | v0.25.0 | Scheduler scalability & pooler performance | ✅ Released |
 | v0.26.0 | Test & concurrency hardening | Planned |
-| v0.27.0 | Transactional inbox & outbox patterns | Planned |
-| v0.28.0 | Relay CLI (`pgtrickle-relay`) — bidirectional outbox→sinks + sources→inbox | Planned |
-| v0.29.0 | Operability, observability & DR — snapshot/PITR, schedule planner, cluster metrics | Planned |
+| v0.27.0 | Operability, observability & DR — snapshot/PITR, schedule planner, cluster metrics | Planned |
+| v0.28.0 | Transactional inbox & outbox patterns | Planned |
+| v0.29.0 | Relay CLI (`pgtrickle-relay`) — bidirectional outbox→sinks + sources→inbox | Planned |
 | v1.0.0 | Stable release (incl. PG 19 compatibility) | Planned |
 | v1.1.0 | PostgreSQL 17 support | Planned |
 | v1.2.0 | PGlite proof of concept | Planned |
@@ -6709,7 +6709,143 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 
 ---
 
-## v0.27.0 — Transactional Inbox & Outbox Patterns
+## v0.27.0 — Operability, Observability & DR
+
+**Status: Planned.** Sourced from [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4, §7, §9 — the remaining actionable items not addressed in v0.24.0–v0.26.0.
+
+> **Release Theme**
+> This release closes the final pre-1.0 operability gaps identified in the
+> v0.23.0 deep-analysis report. Four complementary themes: (1) a **snapshot
+> and PITR API** so fresh replicas can bootstrap from a point-in-time
+> export rather than re-running the full defining query; (2) a
+> **predictive maintenance window planner** that turns the v0.22 cost model
+> into actionable schedule recommendations; (3) a **cluster-wide
+> observability layer** exposing per-database worker allocation from the
+> postmaster and adding per-DB Prometheus metric labels; and (4)
+> **OpenMetrics conformance hardening** for the metrics endpoint, including
+> cluster-wide aggregation and a conformance test. Together these items
+> leave pg_trickle well-positioned for the v1.0 stable release.
+
+### Stream-Table Snapshot & Point-in-Time Restore
+
+> **In plain terms:** `snapshot_stream_table()` exports the current content
+> of a stream table — its frontier, content hash, and all rows — into an
+> archival companion table. `restore_from_snapshot()` rehydrates that state
+> on a fresh replica in seconds, skipping the full defining-query
+> re-execution. Aligns ST state with logical wall-clock for PITR workflows.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| SNAP-1 | **`snapshot_stream_table(name, target)` SQL function.** Exports `(pgt_id, frontier, content_hash, rows)` to an archival table `pgtrickle.snapshot_<name>_<timestamp>`. Creates the table if it does not exist; overwrites with `CREATE TABLE … AS SELECT`. Snapshot includes the frontier LSN and current `pgt_stream_tables` metadata row. `SnapshotAlreadyExists` error variant if `target` is given and already occupied. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+| SNAP-2 | **`restore_from_snapshot(name, source)` SQL function.** Rehydrates a stream table from a snapshot table created by SNAP-1. Replays the archived frontier into `pgt_stream_tables`, bulk-inserts rows, skips the initial full-refresh cycle. `SnapshotSourceNotFound`, `SnapshotSchemaVersionMismatch` error variants. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+| SNAP-3 | **`list_snapshots(name)` + `drop_snapshot(snapshot_table)`.** Monitoring function returning all snapshots for a given ST (name, creation time, row count, frontier, size_bytes). `drop_snapshot` drops the archival table and removes it from the metadata catalog. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+| SNAP-4 | **Tests.** Integration: snapshot → drop ST → restore → verify rows and frontier match; schema-version mismatch returns error; snapshot on IMMEDIATE-mode ST. E2E: fresh-replica bootstrap via snapshot completes in < 5 s for 1M-row ST. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+| SNAP-5 | **Documentation.** SQL_REFERENCE.md: snapshot/restore API. PATTERNS.md: "Replica Bootstrap & PITR Alignment" section. BACKUP_AND_RESTORE.md: updated to cover the snapshot path alongside `pg_dump`. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+
+> **Snapshot/PITR subtotal: ~6 days**
+
+### Predictive Maintenance Window Planner
+
+> **In plain terms:** `recommend_schedule(name)` analyses the per-ST
+> cost-model history (accumulated since v0.22) and returns a recommended
+> `refresh_interval`, peak-window `cron` expression, and confidence score.
+> A longer-term extension can flag expected cost spikes in advance so
+> operators can act before SLA breaches occur.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| PLAN-1 | **`pgtrickle.recommend_schedule(name)` SQL function.** Returns a single JSONB row with `recommended_interval_seconds`, `peak_window_cron`, `confidence` (0–1), and `reasoning` (text). Uses the per-ST `last_full_ms`/`last_diff_ms` history and the v0.25.0 median+MAD model. Confidence is `0.0` if fewer than `pg_trickle.schedule_recommendation_min_samples` (default 20) observations are available. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+| PLAN-2 | **`pgtrickle.schedule_recommendations()` set-returning function.** Returns one row per registered ST with `name`, `current_interval_seconds`, `recommended_interval_seconds`, `delta_pct`, `confidence`, `reasoning`. Sortable by `delta_pct DESC` so operators can quickly find the most mis-tuned STs. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+| PLAN-3 | **Spike-forecast alert.** Post-tick hook: if the cost model predicts the next refresh will exceed the ST's SLA by > 20 %, emit a `pg_trickle_alert` event `predicted_sla_breach` with `stream_table`, `predicted_ms`, and `sla_ms`. Alert is debounced — at most one per `pg_trickle.schedule_alert_cooldown_seconds` (default 300 s). | 1.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+| PLAN-4 | **Tests + documentation.** Unit: `recommend_schedule` returns `confidence = 0.0` before `min_samples`; returns non-trivial recommendation after synthetic history injection; spike-forecast alert fires exactly once per cooldown window. SQL_REFERENCE.md: `recommend_schedule` + `schedule_recommendations` API. CONFIGURATION.md: two new GUCs. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+
+> **Predictive planner subtotal: ~5.5 days**
+
+### Cluster-Wide Observability
+
+> **In plain terms:** The v0.25.0 `worker_allocation_status()` view covers
+> per-database quota usage but only from within a single database connection.
+> This adds a postmaster-level cluster summary visible from any database, tags
+> every Prometheus metric with `db_oid` (enabling per-DB Grafana panels across
+> a cluster), and publishes a multi-tenant deployment guide.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| CLUS-1 | **`pgtrickle.cluster_worker_summary()` SQL function.** Reads the shared-memory worker-pool shmem block (already populated by all DB bgworkers) and returns one row per database: `db_oid`, `db_name`, `workers_active`, `workers_queued`, `quota`, `quota_utilization_pct`. Accessible from any database in the cluster without cross-DB SPI. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4 |
+| CLUS-2 | **Per-DB Prometheus metric labels.** Tag all metrics emitted by `src/metrics_server.rs` with `db_oid=<oid>` and `db_name=<name>` labels. Enables per-DB Grafana panels and per-DB alerting rules without separate endpoints. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4, §9 |
+| CLUS-3 | **`docs/integrations/multi-tenant.md` (new page).** Documents recommended multi-DB deployment patterns: quota allocation formula (`ceil(total_workers / N_databases)`), GUC configuration, Grafana dashboard snippets using `db_name` labels, and `cluster_worker_summary()` usage. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4 |
+| CLUS-4 | **`docs/SCALING.md` update.** Add a "Cluster-wide worker fairness" section cross-referencing `cluster_worker_summary()`, the new quota GUC documentation, and the multi-tenant integration page. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4 |
+
+> **Cluster observability subtotal: ~4 days**
+
+### OpenMetrics Conformance & Metrics Hardening
+
+> **In plain terms:** The `src/metrics_server.rs` endpoint introduced in
+> v0.20 has zero unit tests and no validation that its output conforms to
+> the OpenMetrics text format. This item adds a conformance test, port-conflict
+> and timeout handling, and a cluster-wide aggregation view.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| METR-1 | **OpenMetrics conformance test.** Parse the `/metrics` output with the `openmetrics_parser` crate (or equivalent) and assert no validation errors. Run as a unit test in `src/metrics_server.rs` using a mock request. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §9 |
+| METR-2 | **Port-conflict and timeout unit tests.** Test that `metrics_server::start()` returns a typed `MetricsServerError::PortInUse` when the port is occupied, and `MetricsServerError::Timeout` when the request handler exceeds `pg_trickle.metrics_request_timeout_ms` (new GUC, default 5000 ms). | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §9 |
+| METR-3 | **`pgtrickle.metrics_summary()` cluster-wide aggregation view.** Set-returning function that aggregates key counters across all databases visible in `pg_stat_activity` (refresh count, error count, worker utilisation). Feeds the cluster-level Grafana overview dashboard. | 1.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §9 |
+| METR-4 | **Malformed-HTTP handler.** Catch malformed HTTP requests to the metrics endpoint; return 400 Bad Request with a plain-text error body rather than panicking. Add unit test. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §9 |
+
+> **Metrics hardening subtotal: ~4 days**
+
+### Dependency Upgrades
+
+> **In plain terms:** pgrx 0.18.0 updates the proc-macro and SPI interfaces.
+> This item upgrades the dependency, audits all `pg_sys::*` call sites for
+> breaking changes, and validates the full test suite under the new version.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| DEP-1 | **pgrx 0.17.0 → 0.18.0 upgrade.** Bump `pgrx` and `pgrx-tests` in `Cargo.toml`; run `cargo pgrx init` for the target PG 18 version; resolve any API breakage in proc-macro annotations, SPI call sites, memory-context helpers, and `pg_sys::*` usages. | 1–2d | — |
+| DEP-2 | **Full test suite validation.** Run `just test-all` under pgrx 0.18.0; fix any regressions. Update `AGENTS.md` pgrx version reference. | 0.5d | — |
+
+> **Dependency upgrades subtotal: ~1.5–2.5 days**
+
+### Implementation Phases
+
+| Phase | Description | Duration |
+|-------|-------------|----------|
+| Phase 1 | Snapshot/PITR: catalog, SQL functions, tests, documentation | Days 1–6 |
+| Phase 2 | Predictive planner: `recommend_schedule`, `schedule_recommendations`, spike-forecast alert, tests | Days 6–11.5 |
+| Phase 3 | Cluster observability: `cluster_worker_summary`, per-DB labels, multi-tenant docs, SCALING.md | Days 11.5–15.5 |
+| Phase 4 | Metrics hardening: OpenMetrics conformance, port-conflict tests, aggregation view, malformed-HTTP handler | Days 15.5–19.5 |
+| Phase 5 | Dependency upgrades: pgrx 0.18.0, full test-suite validation | Days 19.5–21.5 |
+| Phase 6 | Integration testing, upgrade script, documentation review | Days 21.5–24 |
+
+> **v0.27.0 total: ~3–4 weeks** (~24 person-days solo)
+
+**Exit criteria:**
+- [ ] SNAP-1: `snapshot_stream_table()` creates archival table with correct frontier and row data
+- [ ] SNAP-2: `restore_from_snapshot()` rehydrates ST; first refresh cycle after restore is DIFFERENTIAL (not FULL)
+- [ ] SNAP-3: `list_snapshots()` lists all snapshots for a ST; `drop_snapshot()` removes archival table and catalog row
+- [ ] SNAP-4: Fresh-replica bootstrap via snapshot completes in < 5 s for 1M-row ST
+- [ ] SNAP-5: BACKUP_AND_RESTORE.md updated; PATTERNS.md "Replica Bootstrap & PITR Alignment" section added
+- [ ] PLAN-1: `recommend_schedule()` returns `confidence = 0.0` before `min_samples`; returns non-trivial recommendation with synthetic history
+- [ ] PLAN-2: `schedule_recommendations()` returns one row per ST; sortable by `delta_pct`
+- [ ] PLAN-3: `predicted_sla_breach` alert fires once per cooldown window; no duplicate alerts
+- [ ] PLAN-4: All unit tests for planner pass; two new GUCs documented
+- [ ] CLUS-1: `cluster_worker_summary()` returns accurate per-DB worker counts from any database in the cluster
+- [ ] CLUS-2: All Prometheus metrics carry `db_oid` and `db_name` labels; existing Grafana dashboard templates updated
+- [ ] CLUS-3: `docs/integrations/multi-tenant.md` published with quota formula and Grafana snippets
+- [ ] CLUS-4: `docs/SCALING.md` cluster-wide fairness section added
+- [ ] METR-1: OpenMetrics conformance test passes; zero parse errors on live `/metrics` output
+- [ ] METR-2: Port-conflict test returns `MetricsServerError::PortInUse`; timeout test returns `MetricsServerError::Timeout`
+- [ ] METR-3: `metrics_summary()` returns aggregated counters; Grafana cluster-overview query documented
+- [ ] METR-4: Malformed HTTP request returns 400 Bad Request; no panic
+- [ ] DEP-1: pgrx bumped to 0.18.0; all API breakage resolved; extension builds clean
+- [ ] DEP-2: `just test-all` passes under pgrx 0.18.0; `AGENTS.md` pgrx version reference updated
+- [ ] Extension upgrade path tested (`0.26.0 → 0.27.0`)
+- [ ] `just check-version-sync` passes
+
+---
+
+## v0.28.0 — Transactional Inbox & Outbox Patterns
 
 **Status: Planned.** Driven by [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) and [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md). Outbox helper moved here from v0.22.0 to ship alongside the inbox helper and production-grade advanced features as a complete transactional messaging solution.
 
@@ -6733,18 +6869,18 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 
 ---
 
-### Known Limitations in v0.27.0
+### Known Limitations in v0.28.0
 
 | Limitation | Rationale | Future Path |
 |------------|-----------|-------------|
 | **Outbox requires DIFFERENTIAL mode.** `enable_outbox()` on `IMMEDIATE`-mode stream tables returns `OutboxRequiresNotImmediateMode`. | Outbox writes one row per refresh cycle inside the refresh transaction. IMMEDIATE refreshes fire inside every source transaction; adding an outbox INSERT there imposes that cost on every application write. | Post-1.0 opt-in GUC if demand justifies. |
 | **Ordering and priority are mutually exclusive per inbox.** Calling both `enable_inbox_ordering()` and `enable_inbox_priority()` on the same inbox returns `InboxOrderingPriorityConflict`. | Per-aggregate sequence ordering must surface the next message in sequence regardless of priority level; priority tiers violate that guarantee. | Use separate inboxes per priority class, each with `enable_inbox_ordering()` applied independently. |
-| **Gap detection degrades above ~100K aggregates.** The `gaps_<inbox>` stream table uses `LEAD()` over pending messages, which is O(N log N) in pending message count — not O(sequence range). This is a significant improvement over the `generate_series` approach; however, refresh time still scales with pending message volume. | Acceptable up to ~1M pending messages at 30 s schedule. Above 10M pending messages, auto-refresh may be slow; use `inbox_ordering_gaps()` for on-demand checks. | Post-v0.27.0: delta-based detection scanning only aggregates with recent activity. |
+| **Gap detection degrades above ~100K aggregates.** The `gaps_<inbox>` stream table uses `LEAD()` over pending messages, which is O(N log N) in pending message count — not O(sequence range). This is a significant improvement over the `generate_series` approach; however, refresh time still scales with pending message volume. | Acceptable up to ~1M pending messages at 30 s schedule. Above 10M pending messages, auto-refresh may be slow; use `inbox_ordering_gaps()` for on-demand checks. | Post-v0.28.0: delta-based detection scanning only aggregates with recent activity. |
 | **Consumer groups provide at-least-once delivery per consumer instance, not exactly-once globally.** | Exactly-once is achieved by composition: relay uses broker idempotency keys; inbox uses `ON CONFLICT (event_id) DO NOTHING`. Three-layer deduplication is more resilient than a monolithic exactly-once guarantee. | Design decision. Documented in PATTERNS.md and SQL_REFERENCE.md. |
-| **AUTO mode may fall back to FULL refresh while outbox is enabled.** When AUTO refresh falls back to FULL, the outbox header row carries `"full_refresh": true`. If the number of current rows exceeds `outbox_inline_threshold_rows`, the claim-check path applies: rows land in `outbox_delta_rows_<st>` and the relay fetches via cursor. A `pg_trickle_alert outbox_full_refresh` event is emitted regardless of which path is taken. Relays must detect the `full_refresh` flag, apply snapshot semantics (upsert rather than publish-as-new), and handle either inline or claim-check payloads. | AUTO refresh adapts to IVM cost at runtime; blocking the FULL fallback permanently would compromise the adaptation that makes AUTO useful. The sentinel flag preserves correctness; the claim-check path prevents memory exhaustion on large tables. | Reference relay updated in OUTBOX-8 to demonstrate all combinations. Post-v0.27.0: consider a GUC to disable FULL fallback per ST when outbox is enabled. |
-| **`next_<inbox>` ordered ST scans all processed rows.** The `last_processed` CTE in the aggregate-ordered ST runs `MAX(sequence_num) GROUP BY aggregate_id` over every processed row on each refresh. For inboxes with large volumes of processed history this grows without bound. | A partial index `(aggregate_id, sequence_num) WHERE processed_at IS NOT NULL` is created by `enable_inbox_ordering()` to mitigate this at v0.27.0, making it an index-only scan. Scaling thresholds: < 100K rows → < 5 ms at 1 s schedule; 100K–1M → increase schedule to `5s`; > 1M → increase to `10s–30s`; > 10M → use `inbox_ordering_gaps()` on-demand only. | Post-v0.27.0: introduce `pgt_inbox_sequence_state` catalog table updated atomically via `advance_inbox_sequence()`, making the CTE O(changed aggregates). |
+| **AUTO mode may fall back to FULL refresh while outbox is enabled.** When AUTO refresh falls back to FULL, the outbox header row carries `"full_refresh": true`. If the number of current rows exceeds `outbox_inline_threshold_rows`, the claim-check path applies: rows land in `outbox_delta_rows_<st>` and the relay fetches via cursor. A `pg_trickle_alert outbox_full_refresh` event is emitted regardless of which path is taken. Relays must detect the `full_refresh` flag, apply snapshot semantics (upsert rather than publish-as-new), and handle either inline or claim-check payloads. | AUTO refresh adapts to IVM cost at runtime; blocking the FULL fallback permanently would compromise the adaptation that makes AUTO useful. The sentinel flag preserves correctness; the claim-check path prevents memory exhaustion on large tables. | Reference relay updated in OUTBOX-8 to demonstrate all combinations. Post-v0.28.0: consider a GUC to disable FULL fallback per ST when outbox is enabled. |
+| **`next_<inbox>` ordered ST scans all processed rows.** The `last_processed` CTE in the aggregate-ordered ST runs `MAX(sequence_num) GROUP BY aggregate_id` over every processed row on each refresh. For inboxes with large volumes of processed history this grows without bound. | A partial index `(aggregate_id, sequence_num) WHERE processed_at IS NOT NULL` is created by `enable_inbox_ordering()` to mitigate this at v0.28.0, making it an index-only scan. Scaling thresholds: < 100K rows → < 5 ms at 1 s schedule; 100K–1M → increase schedule to `5s`; > 1M → increase to `10s–30s`; > 10M → use `inbox_ordering_gaps()` on-demand only. | Post-v0.28.0: introduce `pgt_inbox_sequence_state` catalog table updated atomically via `advance_inbox_sequence()`, making the CTE O(changed aggregates). |
 | **Global consumer monitoring STs created once, not reference-counted.** `pgt_consumer_status`, `pgt_consumer_group_lag`, `pgt_consumer_active_leases` are auto-created on the first `create_consumer_group()` call. They must be created idempotently and torn down only when the last consumer group for an outbox is dropped. | A single set of monitoring STs per outbox is correct and cheaper than per-group STs. | Implementation: `create_stream_table()` called with `if_not_exists := true`; `drop_consumer_group()` decrements a reference count and drops STs at zero. |
-| **Outbox relay latency bounded by poll interval.** Relays discover new outbox rows by polling. The pg_trickle extension emits `pg_notify('pgtrickle_outbox_new', outbox_table_name)` after each outbox INSERT (v0.27.0), but the `pgtrickle-relay` binary does not yet use LISTEN — it starts polling on the standard interval. Minimum relay latency today equals the poll interval (`visibility_seconds`). | The NOTIFY is cheap (≈2 µs, inside the existing refresh transaction) and is emitted from v0.27.0 onwards so relay authors can begin using it immediately. The `pgtrickle-relay` CLI will use LISTEN/NOTIFY in v0.28.0. | v0.28.0 relay: subscribe to `pgtrickle_outbox_new` for sub-100 ms wake-up (see E2E latency benchmark in PLAN_RELAY_CLI.md §E.5). |
+| **Outbox relay latency bounded by poll interval.** Relays discover new outbox rows by polling. The pg_trickle extension emits `pg_notify('pgtrickle_outbox_new', outbox_table_name)` after each outbox INSERT (v0.28.0), but the `pgtrickle-relay` binary does not yet use LISTEN — it starts polling on the standard interval. Minimum relay latency today equals the poll interval (`visibility_seconds`). | The NOTIFY is cheap (≈2 µs, inside the existing refresh transaction) and is emitted from v0.28.0 onwards so relay authors can begin using it immediately. The `pgtrickle-relay` CLI will use LISTEN/NOTIFY in v0.29.0. | v0.29.0 relay: subscribe to `pgtrickle_outbox_new` for sub-100 ms wake-up (see E2E latency benchmark in PLAN_RELAY_CLI.md §E.5). |
 | **`replay_inbox_messages()` accepts only explicit event ID lists.** A free-form `where_clause` parameter was removed to eliminate SQL injection risk. | `EXPLAIN`-based validation of dynamic SQL is insufficient; parameterised `WHERE event_id = ANY($1)` is the safe API. | Operators who need filter-based replay should run a parameterised `SELECT ARRAY_AGG(event_id) ... WHERE <condition>` first, then pass the result to `replay_inbox_messages()`. |
 
 ---
@@ -6895,7 +7031,7 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 | B-TEST | Part B integration tests, multi-relay E2E, ordered inbox E2E | Days 28–31 |
 | B-DOC | Part B documentation, advanced PATTERNS.md sections, reference relay implementations | Days 31–33 |
 
-> **v0.27.0 total: ~6–7 weeks solo / ~4–5 weeks with two developers working Part A and Part B tracks in parallel** (Part A: essential patterns + Part B: production patterns)
+> **v0.28.0 total: ~6–7 weeks solo / ~4–5 weeks with two developers working Part A and Part B tracks in parallel** (Part A: essential patterns + Part B: production patterns)
 
 **Exit criteria:**
 - [ ] OUTBOX-1/2: `enable_outbox()` creates outbox table + `pgt_outbox_latest_<st>` view with correct schema; catalog row present
@@ -6937,12 +7073,12 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 - [ ] INBOX-B4: `inbox_is_my_partition(aggregate_id, worker_id, total_workers)` returns BOOLEAN; no messages lost across N workers; usable in prepared statements without SQL interpolation
 - [ ] SHARED-B3: Ordered inbox E2E: 10 out-of-order arrivals per aggregate delivered to processor in order
 - [ ] SHARED-B4: dbt adapter updated with consumer group and inbox ordering properties
-- [ ] Extension upgrade path tested (`0.26.0 → 0.27.0`) — `sql/pg_trickle--0.26.0--0.27.0.sql` validated by `scripts/check_upgrade_completeness.sh`
+- [ ] Extension upgrade path tested (`0.27.0 → 0.28.0`) — `sql/pg_trickle--0.27.0--0.28.0.sql` validated by `scripts/check_upgrade_completeness.sh`
 - [ ] `just check-version-sync` passes
 
 ---
 
-## v0.28.0 — Relay CLI (`pgtrickle-relay`)
+## v0.29.0 — Relay CLI (`pgtrickle-relay`)
 
 **Status: Planned.** See [plans/relay/PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) for the full design.
 
@@ -6954,7 +7090,7 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 > sources and writes them into pg-trickle inbox tables. Both directions share
 > symmetric Source/Sink trait abstractions, config system, observability, and
 > error handling. Implemented as a workspace member alongside `pgtrickle-tui`,
-> with 8 backends behind Cargo feature flags. The relay makes the v0.27.0
+> with 8 backends behind Cargo feature flags. The relay makes the v0.28.0
 > outbox and inbox immediately usable — zero custom relay code required.
 >
 > See [plans/relay/PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md)
@@ -7038,9 +7174,9 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 | Phase 4 | Tests: unit, Testcontainers integration (forward + reverse), consumer group E2E, benchmarks | Days 25–32 |
 | Phase 5 | Distribution: Docker, CI binaries, Homebrew, docs, cargo publish | Days 32–34.5 |
 
-> **v0.28.0 total: ~36.5 days solo / ~23 days with two developers**
+> **v0.29.0 total: ~36.5 days solo / ~23 days with two developers**
 > (Phases 1–2 forward sinks and Phase 3 reverse sources can be parallelised.
-> Requires v0.27.0 outbox + consumer groups for full forward E2E; reverse
+> Requires v0.28.0 outbox + consumer groups for full forward E2E; reverse
 > mode only needs inbox table schema.)
 
 **Exit criteria:**
@@ -7081,142 +7217,6 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 - [ ] RELAY-30: Reverse config: event type extraction + column mapping works
 - [ ] RELAY-31: All reverse Testcontainers integration tests pass per source
 - [ ] RELAY-32: Reverse dedup: duplicate source message produces 1 inbox row; crash recovery zero loss
-- [ ] Extension upgrade path tested (`0.27.0 → 0.28.0`)
-- [ ] `just check-version-sync` passes
-
----
-
-## v0.29.0 — Operability, Observability & DR
-
-**Status: Planned.** Sourced from [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4, §7, §9 — the remaining actionable items not addressed in v0.24.0–v0.28.0.
-
-> **Release Theme**
-> This release closes the final pre-1.0 operability gaps identified in the
-> v0.23.0 deep-analysis report. Four complementary themes: (1) a **snapshot
-> and PITR API** so fresh replicas can bootstrap from a point-in-time
-> export rather than re-running the full defining query; (2) a
-> **predictive maintenance window planner** that turns the v0.22 cost model
-> into actionable schedule recommendations; (3) a **cluster-wide
-> observability layer** exposing per-database worker allocation from the
-> postmaster and adding per-DB Prometheus metric labels; and (4)
-> **OpenMetrics conformance hardening** for the metrics endpoint, including
-> cluster-wide aggregation and a conformance test. Together these items
-> leave pg_trickle well-positioned for the v1.0 stable release.
-
-### Stream-Table Snapshot & Point-in-Time Restore
-
-> **In plain terms:** `snapshot_stream_table()` exports the current content
-> of a stream table — its frontier, content hash, and all rows — into an
-> archival companion table. `restore_from_snapshot()` rehydrates that state
-> on a fresh replica in seconds, skipping the full defining-query
-> re-execution. Aligns ST state with logical wall-clock for PITR workflows.
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| SNAP-1 | **`snapshot_stream_table(name, target)` SQL function.** Exports `(pgt_id, frontier, content_hash, rows)` to an archival table `pgtrickle.snapshot_<name>_<timestamp>`. Creates the table if it does not exist; overwrites with `CREATE TABLE … AS SELECT`. Snapshot includes the frontier LSN and current `pgt_stream_tables` metadata row. `SnapshotAlreadyExists` error variant if `target` is given and already occupied. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-| SNAP-2 | **`restore_from_snapshot(name, source)` SQL function.** Rehydrates a stream table from a snapshot table created by SNAP-1. Replays the archived frontier into `pgt_stream_tables`, bulk-inserts rows, skips the initial full-refresh cycle. `SnapshotSourceNotFound`, `SnapshotSchemaVersionMismatch` error variants. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-| SNAP-3 | **`list_snapshots(name)` + `drop_snapshot(snapshot_table)`.** Monitoring function returning all snapshots for a given ST (name, creation time, row count, frontier, size_bytes). `drop_snapshot` drops the archival table and removes it from the metadata catalog. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-| SNAP-4 | **Tests.** Integration: snapshot → drop ST → restore → verify rows and frontier match; schema-version mismatch returns error; snapshot on IMMEDIATE-mode ST. E2E: fresh-replica bootstrap via snapshot completes in < 5 s for 1M-row ST. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-| SNAP-5 | **Documentation.** SQL_REFERENCE.md: snapshot/restore API. PATTERNS.md: "Replica Bootstrap & PITR Alignment" section. BACKUP_AND_RESTORE.md: updated to cover the snapshot path alongside `pg_dump`. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-
-> **Snapshot/PITR subtotal: ~6 days**
-
-### Predictive Maintenance Window Planner
-
-> **In plain terms:** `recommend_schedule(name)` analyses the per-ST
-> cost-model history (accumulated since v0.22) and returns a recommended
-> `refresh_interval`, peak-window `cron` expression, and confidence score.
-> A longer-term extension can flag expected cost spikes in advance so
-> operators can act before SLA breaches occur.
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| PLAN-1 | **`pgtrickle.recommend_schedule(name)` SQL function.** Returns a single JSONB row with `recommended_interval_seconds`, `peak_window_cron`, `confidence` (0–1), and `reasoning` (text). Uses the per-ST `last_full_ms`/`last_diff_ms` history and the v0.25.0 median+MAD model. Confidence is `0.0` if fewer than `pg_trickle.schedule_recommendation_min_samples` (default 20) observations are available. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-| PLAN-2 | **`pgtrickle.schedule_recommendations()` set-returning function.** Returns one row per registered ST with `name`, `current_interval_seconds`, `recommended_interval_seconds`, `delta_pct`, `confidence`, `reasoning`. Sortable by `delta_pct DESC` so operators can quickly find the most mis-tuned STs. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-| PLAN-3 | **Spike-forecast alert.** Post-tick hook: if the cost model predicts the next refresh will exceed the ST's SLA by > 20 %, emit a `pg_trickle_alert` event `predicted_sla_breach` with `stream_table`, `predicted_ms`, and `sla_ms`. Alert is debounced — at most one per `pg_trickle.schedule_alert_cooldown_seconds` (default 300 s). | 1.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-| PLAN-4 | **Tests + documentation.** Unit: `recommend_schedule` returns `confidence = 0.0` before `min_samples`; returns non-trivial recommendation after synthetic history injection; spike-forecast alert fires exactly once per cooldown window. SQL_REFERENCE.md: `recommend_schedule` + `schedule_recommendations` API. CONFIGURATION.md: two new GUCs. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-
-> **Predictive planner subtotal: ~5.5 days**
-
-### Cluster-Wide Observability
-
-> **In plain terms:** The v0.25.0 `worker_allocation_status()` view covers
-> per-database quota usage but only from within a single database connection.
-> This adds a postmaster-level cluster summary visible from any database, tags
-> every Prometheus metric with `db_oid` (enabling per-DB Grafana panels across
-> a cluster), and publishes a multi-tenant deployment guide.
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| CLUS-1 | **`pgtrickle.cluster_worker_summary()` SQL function.** Reads the shared-memory worker-pool shmem block (already populated by all DB bgworkers) and returns one row per database: `db_oid`, `db_name`, `workers_active`, `workers_queued`, `quota`, `quota_utilization_pct`. Accessible from any database in the cluster without cross-DB SPI. | 2d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4 |
-| CLUS-2 | **Per-DB Prometheus metric labels.** Tag all metrics emitted by `src/metrics_server.rs` with `db_oid=<oid>` and `db_name=<name>` labels. Enables per-DB Grafana panels and per-DB alerting rules without separate endpoints. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4, §9 |
-| CLUS-3 | **`docs/integrations/multi-tenant.md` (new page).** Documents recommended multi-DB deployment patterns: quota allocation formula (`ceil(total_workers / N_databases)`), GUC configuration, Grafana dashboard snippets using `db_name` labels, and `cluster_worker_summary()` usage. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4 |
-| CLUS-4 | **`docs/SCALING.md` update.** Add a "Cluster-wide worker fairness" section cross-referencing `cluster_worker_summary()`, the new quota GUC documentation, and the multi-tenant integration page. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §4 |
-
-> **Cluster observability subtotal: ~4 days**
-
-### OpenMetrics Conformance & Metrics Hardening
-
-> **In plain terms:** The `src/metrics_server.rs` endpoint introduced in
-> v0.20 has zero unit tests and no validation that its output conforms to
-> the OpenMetrics text format. This item adds a conformance test, port-conflict
-> and timeout handling, and a cluster-wide aggregation view.
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| METR-1 | **OpenMetrics conformance test.** Parse the `/metrics` output with the `openmetrics_parser` crate (or equivalent) and assert no validation errors. Run as a unit test in `src/metrics_server.rs` using a mock request. | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §9 |
-| METR-2 | **Port-conflict and timeout unit tests.** Test that `metrics_server::start()` returns a typed `MetricsServerError::PortInUse` when the port is occupied, and `MetricsServerError::Timeout` when the request handler exceeds `pg_trickle.metrics_request_timeout_ms` (new GUC, default 5000 ms). | 1d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §9 |
-| METR-3 | **`pgtrickle.metrics_summary()` cluster-wide aggregation view.** Set-returning function that aggregates key counters across all databases visible in `pg_stat_activity` (refresh count, error count, worker utilisation). Feeds the cluster-level Grafana overview dashboard. | 1.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §9 |
-| METR-4 | **Malformed-HTTP handler.** Catch malformed HTTP requests to the metrics endpoint; return 400 Bad Request with a plain-text error body rather than panicking. Add unit test. | 0.5d | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §9 |
-
-> **Metrics hardening subtotal: ~4 days**
-
-### Dependency Upgrades
-
-> **In plain terms:** pgrx 0.18.0 updates the proc-macro and SPI interfaces.
-> This item upgrades the dependency, audits all `pg_sys::*` call sites for
-> breaking changes, and validates the full test suite under the new version.
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| DEP-1 | **pgrx 0.17.0 → 0.18.0 upgrade.** Bump `pgrx` and `pgrx-tests` in `Cargo.toml`; run `cargo pgrx init` for the target PG 18 version; resolve any API breakage in proc-macro annotations, SPI call sites, memory-context helpers, and `pg_sys::*` usages. | 1–2d | — |
-| DEP-2 | **Full test suite validation.** Run `just test-all` under pgrx 0.18.0; fix any regressions. Update `AGENTS.md` pgrx version reference. | 0.5d | — |
-
-> **Dependency upgrades subtotal: ~1.5–2.5 days**
-
-### Implementation Phases
-
-| Phase | Description | Duration |
-|-------|-------------|----------|
-| Phase 1 | Snapshot/PITR: catalog, SQL functions, tests, documentation | Days 1–6 |
-| Phase 2 | Predictive planner: `recommend_schedule`, `schedule_recommendations`, spike-forecast alert, tests | Days 6–11.5 |
-| Phase 3 | Cluster observability: `cluster_worker_summary`, per-DB labels, multi-tenant docs, SCALING.md | Days 11.5–15.5 |
-| Phase 4 | Metrics hardening: OpenMetrics conformance, port-conflict tests, aggregation view, malformed-HTTP handler | Days 15.5–19.5 |
-| Phase 5 | Dependency upgrades: pgrx 0.18.0, full test-suite validation | Days 19.5–21.5 |
-| Phase 6 | Integration testing, upgrade script, documentation review | Days 21.5–24 |
-
-> **v0.29.0 total: ~3–4 weeks** (~24 person-days solo)
-
-**Exit criteria:**
-- [ ] SNAP-1: `snapshot_stream_table()` creates archival table with correct frontier and row data
-- [ ] SNAP-2: `restore_from_snapshot()` rehydrates ST; first refresh cycle after restore is DIFFERENTIAL (not FULL)
-- [ ] SNAP-3: `list_snapshots()` lists all snapshots for a ST; `drop_snapshot()` removes archival table and catalog row
-- [ ] SNAP-4: Fresh-replica bootstrap via snapshot completes in < 5 s for 1M-row ST
-- [ ] SNAP-5: BACKUP_AND_RESTORE.md updated; PATTERNS.md "Replica Bootstrap & PITR Alignment" section added
-- [ ] PLAN-1: `recommend_schedule()` returns `confidence = 0.0` before `min_samples`; returns non-trivial recommendation with synthetic history
-- [ ] PLAN-2: `schedule_recommendations()` returns one row per ST; sortable by `delta_pct`
-- [ ] PLAN-3: `predicted_sla_breach` alert fires once per cooldown window; no duplicate alerts
-- [ ] PLAN-4: All unit tests for planner pass; two new GUCs documented
-- [ ] CLUS-1: `cluster_worker_summary()` returns accurate per-DB worker counts from any database in the cluster
-- [ ] CLUS-2: All Prometheus metrics carry `db_oid` and `db_name` labels; existing Grafana dashboard templates updated
-- [ ] CLUS-3: `docs/integrations/multi-tenant.md` published with quota formula and Grafana snippets
-- [ ] CLUS-4: `docs/SCALING.md` cluster-wide fairness section added
-- [ ] METR-1: OpenMetrics conformance test passes; zero parse errors on live `/metrics` output
-- [ ] METR-2: Port-conflict test returns `MetricsServerError::PortInUse`; timeout test returns `MetricsServerError::Timeout`
-- [ ] METR-3: `metrics_summary()` returns aggregated counters; Grafana cluster-overview query documented
-- [ ] METR-4: Malformed HTTP request returns 400 Bad Request; no panic
-- [ ] DEP-1: pgrx bumped to 0.18.0; all API breakage resolved; extension builds clean
-- [ ] DEP-2: `just test-all` passes under pgrx 0.18.0; `AGENTS.md` pgrx version reference updated
 - [ ] Extension upgrade path tested (`0.28.0 → 0.29.0`)
 - [ ] `just check-version-sync` passes
 


### PR DESCRIPTION
## Summary

Reorders the v0.27–v0.29 release sequence in `ROADMAP.md` so that the
operability-focused milestone ships before the inbox/outbox and relay work.

| Before | After |
|--------|-------|
| v0.27.0 — Transactional Inbox & Outbox Patterns | v0.27.0 — Operability, Observability & DR |
| v0.28.0 — Relay CLI (`pgtrickle-relay`) | v0.28.0 — Transactional Inbox & Outbox Patterns |
| v0.29.0 — Operability, Observability & DR | v0.29.0 — Relay CLI (`pgtrickle-relay`) |

## Changes

- Promoted **Operability, Observability & DR** from v0.29.0 → v0.27.0.
- Shifted **Transactional Inbox & Outbox Patterns** from v0.27.0 → v0.28.0.
- Shifted **Relay CLI** from v0.28.0 → v0.29.0.
- Updated all version numbers in the table of contents, milestone summary table, section headings, and in-line cross-references throughout the file.

## Testing

- No code changes — documentation-only edit.
- Verified section headings, TOC anchors, summary table, and in-line cross-references are consistent after the reorder.

## Notes

The Operability milestone (snapshot/PITR, schedule planner, cluster metrics)
is a prerequisite for production deployments and was prioritised above the
inbox/outbox work to unblock users running pg_trickle in managed environments.
