### PR TITLE
docs(plans): webui and mcp server architecture

### DIFF
--- a/plans/ANALYSIS_MONOREPO.md
+++ b/plans/ANALYSIS_MONOREPO.md
@@ -1,0 +1,689 @@
+# Repo Structure Analysis — Monorepo vs Separate Repos
+
+> **Status:** Analysis (DRAFT — 2026-04-22, rev 4)
+> **Decision:** Keep separate repos (3 repos). See [Recommendation](#recommendation).
+> **Related:** [ANALYSIS_UNIFIED_VS_SEPARATE_UI.md](webui/ANALYSIS_UNIFIED_VS_SEPARATE_UI.md) ·
+> [PLAN_WEBUI.md](webui/PLAN_WEBUI.md)
+
+---
+
+## Table of Contents
+
+- [Context](#context)
+- [Current State](#current-state)
+- [The Forces Pushing Toward a Monorepo](#the-forces-pushing-toward-a-monorepo)
+- [The Forces Pushing Against](#the-forces-pushing-against)
+- [Chosen Approach: 3 Separate Repos](#chosen-approach-3-separate-repos)
+- [What This Means for CI](#what-this-means-for-ci)
+- [Release & Versioning](#release--versioning)
+- [Console Embedding](#console-embedding)
+- [Impact on the UI Decision](#impact-on-the-ui-decision)
+- [Risk Register](#risk-register)
+- [Comparison: Monorepo vs 3 Repos](#comparison-monorepo-vs-3-repos)
+- [Decision Criteria Checklist](#decision-criteria-checklist)
+- [Recommendation](#recommendation)
+
+---
+
+## Context
+
+The pg-trickle ecosystem has two PostgreSQL extensions, two HTTP services,
+a web console, a TUI, and a dbt adapter. The question was whether the
+two extensions and their companion binaries should share a single Cargo
+workspace and git repo, or remain separate.
+
+After analysis through revs 1–3, the decision is to **keep 3 separate
+repos** — one per extension plus a standalone unified web console.
+
+### Adoption reality
+
+| | pg-trickle | pg-ripple |
+|---|---|---|
+| **GitHub stars** | ~80 | 0 |
+| **External users** | Some (growing) | None (not announced) |
+| **Releases** | 26 | 47 |
+| **Maturity** | Production-track | Feature-complete, pre-v1.0 |
+
+pg-ripple has **zero external adoption**. It has not been announced,
+has no stars, and no external contributors. This eliminates the
+strongest argument against a monorepo ("users will think pg-ripple
+needs pg-trickle") because those users don't exist yet. The framing
+of both products can be defined from scratch.
+
+pg-trickle has ~80 stars and is the only product with external
+traction. Making it the nucleus of a larger platform adds value to
+existing users' investment rather than fragmenting attention.
+
+### The platform is pg-trickle
+
+Each tool alone competes in a narrow niche against established players.
+But the combined pitch is unique and hard to replicate:
+
+> **pg-trickle** is a modular data platform built into PostgreSQL 18.
+> Incremental view maintenance, a knowledge graph engine, a cross-cluster
+> streaming relay, and a unified admin console — all as PostgreSQL
+> extensions. Use one component or all of them. No separate
+> infrastructure.
+
+Nobody else offers IVM + triplestore + relay as composable PostgreSQL
+extensions with a shared admin UI. RisingWave is a separate database.
+Neo4j is a separate database. Apache Jena is a separate system.
+Materialize is hosted-only. The "it's all just PostgreSQL" angle is a
+differentiator that gets *stronger* with more components.
+
+**The platform name is pg-trickle** — not "Grove" or any new name.
+pg-trickle already has 80 stars and brand recognition. Renaming
+would throw that away. The name fits: "trickle" evokes continuous
+data flow, which is what the entire platform does. IVM is a trickle
+of incremental changes. The relay trickles data across clusters.
+Even the triplestore's CDC subscriptions trickle change notifications.
+
+The repo stays `grove/pg-trickle`. No rename needed. The 80-star repo
+just gets richer — that's pure upside.
+
+PostgreSQL extension names remain independent SQL-level identifiers:
+`CREATE EXTENSION pg_trickle` and `CREATE EXTENSION pg_ripple`. The
+platform is pg-trickle; the triplestore component has its own extension
+name, just as PostgreSQL itself ships `pg_stat_statements` and
+`pg_trgm` under the PostgreSQL umbrella.
+
+This is NOT a question about the frontend apps (the unified console).
+That decision is covered in
+[ANALYSIS_UNIFIED_VS_SEPARATE_UI.md](webui/ANALYSIS_UNIFIED_VS_SEPARATE_UI.md).
+This analysis focuses on the Rust crates and their repo structure.
+
+---
+
+## Current State
+
+### grove/pg-trickle (this repo)
+
+```
+Cargo.toml          ← workspace root (members: ".", "pgtrickle-tui")
+├── src/            ← pg_trickle extension (cdylib + lib)
+├── sql/            ← extension SQL
+├── tests/          ← E2E + integration tests
+├── benches/        ← Criterion benchmarks
+├── fuzz/           ← fuzz targets
+├── scripts/        ← 17 build/test/bench scripts
+├── pgtrickle-tui/  ← TUI binary (workspace member)
+├── dbt-pgtrickle/  ← dbt adapter (Python/Jinja, not in Cargo workspace)
+├── plans/          ← 18 plan docs + 12 subdirectories
+├── docs/           ← mdBook documentation
+├── .github/workflows/ ← 19 CI workflows
+└── (relay planned but not yet in repo)
+```
+
+- **Language:** Rust (Edition 2024), pgrx 0.17, PostgreSQL 18
+- **Workspace members:** pg_trickle (root), pgtrickle-tui
+- **Version:** 0.26.0 (26 releases)
+- **CI:** 19 workflows, path-filtered where applicable
+- **Test tiers:** Unit, integration, light E2E, full E2E, TPC-H,
+  dbt, benchmarks, fuzz, SQLancer, stability/soak
+
+### grove/pg-ripple (separate repo)
+
+```
+Cargo.toml          ← single-crate (no workspace yet)
+├── src/            ← pg_ripple extension (cdylib + lib)
+├── sql/            ← extension SQL
+├── tests/          ← pg_test + regress + integration
+├── benchmarks/     ← BSBM, throughput, WatDiv
+├── fuzz/           ← fuzz targets
+├── scripts/        ← test/build scripts
+├── pg_ripple_http/ ← HTTP service binary (likely its own crate)
+├── plans/          ← plan docs
+├── docs/           ← mdBook documentation
+├── docker/         ← Docker infra
+└── .github/workflows/ ← CI workflows
+```
+
+- **Language:** Rust (Edition 2024), pgrx 0.17, PostgreSQL 18
+- **Version:** 0.47.0 (47 releases)
+- **Test tiers:** Unit, pgrx regress, W3C conformance (~3,000 tests),
+  Jena (~1,000), WatDiv, LUBM, BSBM, OWL 2 RL, proptest, fuzz
+- **Key property:** Works independently. pg_trickle is an optional
+  companion for IVM views.
+
+### Cross-product integration surface (today)
+
+| Integration point | Where it lives | What it does |
+|---|---|---|
+| IVM SPARQL views | pg-ripple SQL + docs | `pg_trickle` used as optional companion for live-updating SPARQL views |
+| Shared PG instance | Deployment-level | Both extensions in one `CREATE EXTENSION` sequence |
+| ExtVP statistics | pg-ripple plans | pg_trickle stream tables for predicate selectivity stats |
+
+The integration is currently loose coupling: pg-ripple references
+pg-trickle by name in docs and SQL, but there is no Rust-level crate
+dependency. This could deepen (shared types, shared catalog access
+patterns) or stay loose.
+
+---
+
+## The Forces Pushing Toward a Monorepo
+
+### 1. Identical toolchain — zero marginal cost
+
+Both projects use:
+- Rust Edition 2024
+- pgrx 0.17.0 (pinned to exact version)
+- PostgreSQL 18
+- Axum + Tokio (for HTTP services)
+- serde + serde_json
+- thiserror
+- xxhash-rust
+- cargo-fuzz, proptest
+- The same pgrx test infrastructure
+- The same Docker base images
+
+A shared `Cargo.lock` and `deny.toml` eliminates duplicate dependency
+management. When pgrx releases 0.18, one PR updates the lockfile
+instead of two coordinated PRs.
+
+### 2. Atomic cross-product changes
+
+Today, adding a pg-trickle feature that pg-ripple's IVM layer should
+use requires:
+1. PR + merge in pg-trickle
+2. Release pg-trickle
+3. PR in pg-ripple referencing the new release
+4. Test the integration
+
+In a workspace:
+1. One PR touches both `extensions/pg-trickle/` and
+   `extensions/pg-ripple/`
+2. `cargo check --workspace` verifies the interface immediately
+3. CI runs cross-product integration tests atomically
+
+This matters more as integration deepens (shared error types, shared
+catalog access patterns, the console API serving both products).
+
+### 3. The console problem
+
+The web console serves both extensions. In a two-repo world it must
+live in a third repo. In a monorepo it lives in `apps/console/` with
+natural proximity to both backends.
+
+**Counter-argument (decisive):** The console is a Next.js app that
+talks to REST APIs over HTTP. It has no compile-time dependency on
+either Rust crate. API changes are versioned — the console targets
+`/api/v1/*` on whichever backends are reachable. A third repo
+(`grove/surface`) is not an orphan; it's the shared meeting
+point that belongs to neither extension, which is exactly right.
+The console's release cycle is driven by frontend concerns (Next.js,
+shadcn/ui), not Rust extension releases.
+
+### 4. CI infrastructure deduplication
+
+Both repos maintain:
+- pgrx installation steps (slow, ~3 min each)
+- Docker image builds for E2E tests
+- Testcontainers setup
+- Benchmark infrastructure
+- Coverage collection
+- Security scanning (CodeQL, Semgrep, dependency audit)
+- Release automation
+
+A monorepo shares the base CI infrastructure (pgrx install, Docker
+layer caching, security scanning) while keeping product-specific test
+suites in separate path-filtered workflows.
+
+### 5. Documentation coherence
+
+The "getting started" story for the full platform (pg-trickle +
+pg-ripple + relay) currently spans two repos and two doc sites. A
+monorepo enables a single mdBook with extension-specific chapters.
+The tutorial "Create an auto-updating SPARQL view" naturally references
+both extensions — in a monorepo, both are local links.
+
+### 6. Shared scripts and testing patterns
+
+Both repos have overlapping test infrastructure:
+- Docker image builds for E2E
+- Testcontainers helpers
+- Benchmark comparison scripts
+- Coverage collection
+- Fuzz targets
+
+These can be shared libraries in the workspace rather than duplicated.
+
+### 7. Platform identity
+
+The pg-trickle ecosystem is evolving from "two independent extensions" toward
+a platform. A monorepo makes the platform structure visible in the file
+tree. "This is a platform with two extensions, two services, and shared
+tools" is immediately obvious from the directory listing. In two repos,
+the platform is an invisible concept that only exists in documentation.
+
+---
+
+## The Forces Pushing Against
+
+### 1. pg-ripple's independence is a product feature
+
+pg-ripple's pitch is: "A knowledge graph engine built into PostgreSQL.
+No separate graph database. No data pipelines. No extra infrastructure."
+
+If pg-ripple lives inside a monorepo, does a prospective user think
+"do I need pg-trickle?" even though the answer is no?
+
+**Updated assessment (rev 3):** This concern is theoretical.
+pg-ripple has zero external users and has not been announced. There
+is no existing audience whose perception would be disrupted. The
+framing can be set from the start: "pg-trickle is a modular data
+platform. pg-ripple is its triplestore component. Install only what
+you need."
+
+Moreover, launching pg-ripple *as part of a platform* is arguably a
+stronger positioning than launching it as a standalone extension
+competing head-to-head against Jena, Virtuoso, and Blazegraph. The
+"it's all just PostgreSQL" platform story is more compelling than
+"here's another triplestore." Users discovering pg-trickle's IVM
+engine also discover they can add a knowledge graph for free.
+
+**Mitigation:** The repo stays `grove/pg-trickle` — the established
+name with 80 stars. Each component gets its own
+`extensions/pg-ripple/README.md` that serves as the product page.
+crates.io and Docker Hub listings point to the component-specific
+README. The root README frames pg-trickle as a platform with
+composable components.
+
+**Residual risk:** Low. First impressions are controlled by the repo
+README and the product docs, not by the directory listing. And the
+platform framing actually helps rather than hurts.
+
+### 2. Git history loss or complexity
+
+pg-ripple has 47 releases of git history. Options:
+
+| Approach | Preserves history? | Clean tree? | Complexity |
+|---|---|---|---|
+| `git subtree add` | Yes (interleaved) | No (commits mixed) | Medium |
+| `git filter-repo` + merge | Yes (rewritten paths) | Yes | High |
+| Fresh copy + archive original | No (in monorepo) | Yes | Low |
+| git submodule | Yes (separate) | Yes | High (ongoing) |
+
+None of these are great. Subtree merge produces a confusing `git log`.
+filter-repo is powerful but error-prone. Fresh copy is clean but loses
+`git blame` for 47 releases of work. Submodules are universally hated.
+
+**Mitigation:** Archive `grove/pg-ripple` as read-only with a
+"Moved to grove/pg-trickle" banner. Developers who need historical blame
+use the archived repo. The monorepo starts with a clean import commit.
+Not ideal, but the simplest option that doesn't create ongoing pain.
+
+**Residual risk:** Low-medium. Historical blame is occasionally useful
+but not daily. Most blame queries are about recent code.
+
+### 3. CI wall-clock time
+
+Combined test suite if everything runs:
+- pg-trickle: unit + integration + light E2E + full E2E + TPC-H +
+  benchmarks + fuzz + dbt + stability ≈ 45 min
+- pg-ripple: unit + W3C + Jena + WatDiv + LUBM + BSBM + OWL 2 RL +
+  proptest + fuzz ≈ 30 min
+
+Without path filtering, every PR runs ~75 min of CI. That's
+unacceptable.
+
+**Mitigation:** Mandatory path-filtered workflows. A change to
+`extensions/pg-ripple/src/` triggers only `ci-ripple.yml`. A change
+to `extensions/pg-trickle/src/` triggers only `ci-trickle.yml`. A
+change touching both (or shared infra) triggers both plus
+`ci-integration.yml`.
+
+GitHub Actions `paths` and `paths-ignore` filters handle this natively.
+The `dorny/paths-filter` action provides finer-grained control within
+a single workflow file if needed.
+
+**Residual risk:** Low, IF path filtering is set up correctly from day
+one. Risk of "it works on my machine" if someone forgets to add a new
+path to the filter.
+
+### 4. Release coordination temptation
+
+A monorepo creates psychological pressure to sync versions or cut
+releases together. pg-ripple at v0.47 and pg-trickle at v0.26 must
+remain independently versioned. If someone starts saying "let's wait
+for pg-trickle to finish feature X before releasing pg-ripple," the
+monorepo has caused harm.
+
+**Mitigation:** Separate git tags (`pg-trickle-v0.26.0`,
+`pg-ripple-v0.47.0`), separate release workflows, separate changelogs,
+separate version fields in each `Cargo.toml`. `cargo release` supports
+`--package` for workspace members. Document the "independent versions"
+policy in AGENTS.md.
+
+**Residual risk:** Low with discipline. The tooling supports it.
+
+### 5. Contributor confusion
+
+A new user files an issue about SPARQL performance. They land in a repo
+that's mostly about streaming materialized views. The issue template
+must ask "Which extension?" and the labeling must be clear.
+
+**Mitigation:** Issue templates with extension selector. Labels:
+`ext:pg-trickle`, `ext:pg-ripple`, `svc:relay`, `svc:ripple-http`,
+`app:console`, `app:moire`. Good templates eliminate most confusion.
+
+**Residual risk:** Low. Most monorepos (Babel, Next.js, Turborepo)
+handle this fine with labels.
+
+### 6. crates.io and packaging complexity
+
+Both extensions publish to crates.io as separate crates. Workspace
+publishing requires `cargo publish --package pg_trickle` and
+`cargo publish --package pg_ripple` separately. PGXN archives need
+separate build steps. Docker images need separate Dockerfiles.
+
+**Mitigation:** All of this already works with Cargo workspaces.
+`pgtrickle-tui` is already a workspace member with its own publish
+step. Adding more members is incremental.
+
+**Residual risk:** Very low. Cargo workspaces are designed for this.
+
+### 7. Build time increase
+
+`cargo build --workspace` compiles everything. A developer working only
+on pg-ripple doesn't want to compile pg-trickle.
+
+**Mitigation:** `cargo build --package pg_ripple` compiles only
+pg-ripple and its dependencies. The workspace `default-members` key
+can be set so that bare `cargo build` only builds a subset. The
+`justfile` provides per-extension targets: `just build-ripple`,
+`just build-trickle`.
+
+**Residual risk:** Very low. Cargo handles this natively.
+
+---
+
+## Chosen Approach: 3 Separate Repos
+
+Instead of a monorepo, keep each product in its own repo with a new
+third repo for the unified web console:
+
+```
+grove/pg-trickle              ← IVM extension + relay + TUI + dbt adapter
+├── Cargo.toml                workspace root
+├── src/                      pg_trickle extension (unchanged)
+├── sql/
+├── tests/
+├── benches/
+├── fuzz/
+├── pgtrickle-tui/            TUI (existing workspace member)
+├── pgtrickle-relay/          Relay (NEW workspace member)
+├── dbt-pgtrickle/            dbt adapter
+├── plans/
+├── docs/
+└── .github/workflows/
+
+grove/pg-ripple               ← Triplestore extension + SPARQL HTTP service
+├── Cargo.toml                workspace root (or will become one)
+├── src/                      pg_ripple extension
+├── sql/
+├── tests/
+├── benchmarks/
+├── fuzz/
+├── pg_ripple_http/           SPARQL Protocol HTTP service (workspace member)
+├── plans/
+├── docs/
+└── .github/workflows/
+
+grove/surface           ← Unified web console (NEW repo)
+├── package.json              Next.js app
+├── src/
+│   ├── app/                  App Router pages
+│   ├── components/           UI components
+│   ├── lib/                  API clients, hooks
+│   │   ├── relay-client.ts   Relay API client
+│   │   ├── ripple-client.ts  pg_ripple_http API client
+│   │   └── capabilities.ts   Backend detection
+│   └── styles/
+├── public/
+└── .github/workflows/
+```
+
+### Why the relay lives in pg-trickle
+
+The relay is tightly coupled to pg-trickle:
+- Streams from pg-trickle stream tables
+- Uses the same CDC infrastructure
+- Will share Rust types with the extension (change events, table
+  metadata, DAG structures)
+- Its release cadence follows pg-trickle releases
+
+Making it a workspace member (like the TUI already is) is natural.
+`pg_ripple_http` stays in `grove/pg-ripple` for the same reason —
+it's tightly coupled to pg-ripple's internals.
+
+### Why the console is its own repo
+
+The console is a Next.js app. It talks to the relay API and
+`pg_ripple_http` API over HTTP. It has:
+- No Rust code
+- No compile-time dependency on either extension
+- A release cycle driven by frontend concerns (Next.js, React,
+  shadcn/ui), not Rust extension releases
+- Its own CI (ESLint, TypeScript, Playwright E2E)
+- Its own deployment story (Docker, Vercel, or embedded in either
+  Rust binary via `rust-embed`)
+
+Putting it in either extension's repo would create an asymmetry —
+it serves both equally. A standalone repo is the honest home.
+
+### Cross-product integration
+
+The integration surface between the two extensions stays at the SQL
+level (pg-ripple optionally uses pg-trickle for IVM views). There is
+no Rust-level crate dependency today, and the architecture doesn't
+require one — both extensions talk to PostgreSQL, not to each other's
+Rust APIs.
+
+If shared Rust types ever become necessary (e.g. a shared error type
+or catalog access pattern), a small `pgtrickle-common` crate published
+to crates.io handles this without a monorepo.
+
+---
+
+## What This Means for CI
+
+Each repo owns its entire CI pipeline. No path-filtering complexity.
+
+| Repo | CI scope | Trigger |
+|------|----------|---------|
+| `grove/pg-trickle` | Extension unit/integration/E2E, relay tests, TUI tests, dbt, benchmarks, fuzz | All existing workflows, unchanged |
+| `grove/pg-ripple` | Extension unit/regress/W3C/BSBM/WatDiv, pg_ripple_http tests, fuzz | All existing workflows, unchanged |
+| `grove/surface` | ESLint, TypeScript, Playwright E2E against mock APIs | New, simple workflow |
+
+**Cross-product CI:** A scheduled or manual-dispatch workflow in one
+repo (or a separate integration test setup) can test the full stack:
+both extensions + relay + pg_ripple_http + console. This runs nightly
+or on-demand, not on every PR.
+
+The pgrx version bump problem ("two PRs") is real but minor. It
+happens a few times a year, takes minutes, and both PRs can be
+opened in parallel.
+
+---
+
+## Release & Versioning
+
+Independent versions, always. Simpler than a monorepo because each
+repo uses plain `vX.Y.Z` tags without product prefixes:
+
+```
+grove/pg-trickle:     v0.26.0, v0.27.0, ...
+grove/pg-ripple:      v0.47.0, v0.48.0, ...
+grove/surface:  v0.1.0,  v0.2.0,  ...
+```
+
+Each repo has its own tags, release workflows, and changelogs. No
+risk of version coupling creep — the repo boundary makes it
+structurally impossible.
+
+---
+
+## Console Embedding
+
+The console (`grove/surface`) publishes its static build as a
+GitHub release asset (tarball of the Next.js `out/` directory). Both
+Rust binaries can optionally embed it via `rust-embed`:
+
+```
+surface CI:
+  npm run build → out/ → published as GitHub release asset (tar.gz)
+
+pgtrickle-relay build (when --features console):
+  Download surface-vX.Y.Z.tar.gz → embed via rust-embed
+
+pg_ripple_http build (when --features console):
+  Download surface-vX.Y.Z.tar.gz → embed via rust-embed
+```
+
+The console version is pinned in each binary's build config, allowing
+independent upgrades. For standalone deployment, the same static output
+is published as a Docker image or deployed to Vercel/Cloudflare.
+
+---
+
+## Impact on the UI Decision
+
+The 3-repo approach **aligns with** the single unified console from
+[ANALYSIS_UNIFIED_VS_SEPARATE_UI.md](webui/ANALYSIS_UNIFIED_VS_SEPARATE_UI.md):
+
+| Decision | Monorepo | 3 repos (chosen) |
+|---|---|---|
+| Console location | `apps/console/` inside monorepo | `grove/surface` — own repo |
+| Console API changes | Atomic PR (API + frontend) | Versioned API contract, separate PRs |
+| Console neutrality | Lives inside pg-trickle repo — slight asymmetry | Own repo — serves both extensions equally |
+| pg-ripple independence | Must be explained via README | Obvious from repo boundary |
+| Relay ownership | Must be explained via directory structure | Obvious — it's a workspace member in pg-trickle |
+
+The console as its own repo is actually *more natural* for a UI that
+serves two independent extensions. It doesn't live inside either
+product's repo — it's the shared meeting point.
+
+---
+
+## Risk Register
+
+| # | Risk | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| R1 | Duplicate pgrx version management | Medium | Low (time) | Open both PRs in parallel, takes minutes | Low |
+| R2 | Cross-product API drift | Low | Medium | Versioned `/api/v1/*` contracts, integration tests | Low |
+| R3 | Console orphaned (no clear owner) | Low | Low | Own repo with own CI, linked from both product READMEs | Very low |
+| R4 | Duplicate CI infrastructure | Medium | Low (maintenance) | Shared GitHub Actions (reusable workflows or actions) | Low |
+| R5 | Platform identity invisible | Low | Low | Console UI makes the platform visible; README cross-links | Low |
+| R6 | Shared Rust types needed later | Low | Medium | Publish `pgtrickle-common` crate if needed | Low |
+
+---
+
+## Comparison: Monorepo vs 3 Repos
+
+| Concern | Monorepo | 3 repos (chosen) |
+|---|---|---|
+| **Dependency updates** | One PR, one lockfile | Two PRs (minor, infrequent) |
+| **Cross-product changes** | Atomic PR | Separate PRs, versioned API contract |
+| **Console ownership** | `apps/console/` alongside backends | Own repo — neutral ground, serves both |
+| **CI infrastructure** | Shared base, path-filtered | Each repo owns its CI — simpler per-repo |
+| **pg-ripple independence** | Requires README explanation | Obvious from repo boundary |
+| **Release coupling** | Possible (preventable with discipline) | Structurally impossible |
+| **Developer onboarding** | Clone one repo, navigate dirs | Clone only the repo you need |
+| **Git history** | pg-ripple history starts at import | Full history preserved per-product |
+| **Rust-level shared types** | Natural workspace dependencies | Needs published crate (if ever needed) |
+| **Platform visibility** | Visible in file tree | Visible through console UI and docs |
+| **Migration effort** | Significant (restructure + import) | Zero — keep what exists |
+| **Path-filtering complexity** | Must get it right from day 1 | Not needed — each repo is self-contained |
+
+---
+
+## Decision Criteria Checklist
+
+### Favour monorepo if:
+
+- [ ] Cross-product integration will deepen to Rust-level shared types
+- [ ] You want atomic PRs for API + frontend changes
+- [ ] Duplicate CI infrastructure maintenance is a real pain point
+- [ ] You expect many more workspace members in future
+- [ ] The team grows large enough for a dedicated platform team
+
+### Favour 3 repos if:
+
+- [x] pg-ripple's independent identity matters for adoption
+- [x] The cross-product integration stays at the SQL level
+- [x] The console serves both extensions equally (neutral repo)
+- [x] You want zero migration effort
+- [x] Each product's CI should be self-contained
+- [x] Solo developer — coordination cost between repos is trivial
+- [x] You're not building the console any time soon (no urgency)
+
+---
+
+## Recommendation
+
+**Keep 3 separate repos.**
+
+```
+grove/pg-trickle       — IVM extension + relay + TUI + dbt adapter
+grove/pg-ripple        — Triplestore + pg_ripple_http
+grove/surface          — Unified web console ("surface of the platform")
+```
+
+### Why this changed from rev 3
+
+Revs 1–3 recommended a monorepo with increasing urgency. The arguments
+for a monorepo are real — shared toolchain, atomic cross-product PRs,
+a natural home for the console. But the arguments against are also
+real, and the deciding factors are practical:
+
+1. **Zero migration effort.** Both repos stay exactly where they are.
+   No restructuring, no import, no path-filtering setup. The relay
+   joins `grove/pg-trickle` as a workspace member (like the TUI), and
+   `grove/surface` gets created when the console is ready.
+
+2. **pg-ripple independence is obvious.** With its own repo, nobody
+   asks "do I need pg-trickle to use the triplestore?" The repo
+   boundary is the clearest possible signal.
+
+3. **The console is neutral territory.** A unified console that serves
+   both extensions shouldn't live inside either extension's repo. Its
+   own repo (`grove/surface`) is the honest home — it depends
+   on both backends' APIs equally.
+
+4. **Solo developer.** The coordination cost of multi-repo is
+   proportional to team size. With one developer, it's trivial —
+   you just merge one PR then the other. The monorepo's "atomic
+   cross-product PR" benefit matters more for teams.
+
+5. **The platform story is told by the UI, not the repo structure.**
+   Users discover the platform through the unified console, the
+   documentation, and the README cross-links — not by browsing the
+   GitHub directory listing.
+
+### The platform pitch still works
+
+The platform is pg-trickle. The pitch doesn't change:
+
+> **pg-trickle** is a modular data platform built into PostgreSQL 18.
+>
+> | Component | Extension | What it does |
+> |---|---|---|
+> | **IVM engine** | `pg_trickle` | Streaming materialized views with differential maintenance |
+> | **Triplestore** | `pg_ripple` | Knowledge graph engine — SPARQL, Datalog, SHACL, vector search |
+> | **Relay** | — | Cross-cluster streaming connector (Kafka, NATS, webhook) |
+> | **Console** | — | Unified admin dashboard for all components |
+>
+> Install one component or all of them. No separate infrastructure.
+> Everything runs inside your existing PostgreSQL.
+
+This pitch works regardless of whether the code is in 1 repo or 3.
+Users don't care about repo structure. They care about what they can
+`CREATE EXTENSION`.
+
+### Future escape hatch
+
+If cross-product integration deepens significantly (shared Rust types,
+shared catalog access, workspace-level `cargo check` becomes valuable),
+the monorepo option remains available. Going from 3 repos → monorepo
+is straightforward. The analysis in this document (forces for/against,
+proposed monorepo structure) is preserved for that eventuality.

--- a/plans/INDEX.md
+++ b/plans/INDEX.md
@@ -125,3 +125,23 @@ new entries when creating documents.
 | [PLAN_TEST_SUITE_TPC_H.md](testing/PLAN_TEST_SUITE_TPC_H.md) | PLAN | Complete | TPC-H test suite |
 | [PLAN_TEST_PYRAMID_REBALANCE.md](testing/PLAN_TEST_PYRAMID_REBALANCE.md) | PLAN | Proposed | Shift coverage down the pyramid — extract unit tests, light-E2E tier |
 | [STATUS_TESTING.md](testing/STATUS_TESTING.md) | STATUS | — | Testing & coverage status |
+
+## ui/
+
+| File | Type | Status | Summary |
+|------|------|--------|---------|
+| [PLAN_TUI.md](ui/PLAN_TUI.md) | PLAN | Implemented | Terminal UI v0.14 (F1–F21) |
+| [PLAN_TUI_PART_2.md](ui/PLAN_TUI_PART_2.md) | PLAN | Implemented | TUI v0.15 operational features (T9–T14) |
+| [PLAN_TUI_PART_3.md](ui/PLAN_TUI_PART_3.md) | PLAN | Planned | TUI v0.21 self-monitoring integration |
+
+## relay/
+
+| File | Type | Status | Summary |
+|------|------|--------|---------|
+| [PLAN_RELAY_CLI.md](relay/PLAN_RELAY_CLI.md) | PLAN | Design review complete | Bidirectional relay CLI (`pgtrickle-relay`) |
+
+## webui/
+
+| File | Type | Status | Summary |
+|------|------|--------|---------|
+| [PLAN_WEBUI.md](webui/PLAN_WEBUI.md) | PLAN | Draft | Web dashboard & management console — analysis and implementation plan |

--- a/plans/INDEX.md
+++ b/plans/INDEX.md
@@ -145,3 +145,4 @@ new entries when creating documents.
 | File | Type | Status | Summary |
 |------|------|--------|---------|
 | [PLAN_WEBUI.md](webui/PLAN_WEBUI.md) | PLAN | Draft | Web dashboard & management console — analysis and implementation plan |
+| [PLAN_WEBUI_STYLE.md](webui/PLAN_WEBUI_STYLE.md) | PLAN | Draft | WebUI style, navigation, colour system, and screen layouts |

--- a/plans/relay/PLAN_RELAY_CLI.md
+++ b/plans/relay/PLAN_RELAY_CLI.md
@@ -944,11 +944,20 @@ lifecycle:
 | Source connection lost | Reconnect with exponential backoff. Pause relay until reconnected. |
 | Sink connection lost | Reconnect with exponential backoff. Pause relay until reconnected. |
 | Sink publish failure (transient) | Retry the batch up to 3 times with backoff. Do not acknowledge. |
-| Sink publish failure (permanent, e.g. 400) | Log error, skip the message, emit `relay_errors_total{kind="sink_permanent"}`. Advance offset to avoid poison-pill blocking. |
-| Payload decode error | Log error, skip the message. Emit `relay_errors_total{kind="decode"}`. |
-| Claim-check fetch failure | Retry up to 3 times. If permanent, log + skip + emit error metric. |
+| Sink publish failure (permanent, e.g. 400) | Write to `pgtrickle.relay_dead_letters` (`error_type = 'sink_permanent'`). Advance offset. Emit `relay_errors_total{kind="sink_permanent"}`. |
+| Payload decode error | Write to `pgtrickle.relay_dead_letters` (`error_type = 'decode'`). Advance offset. Emit `relay_errors_total{kind="decode"}`. |
+| Claim-check fetch failure | Retry up to 3 times. If permanent, write to DLQ (`error_type = 'claim_check'`). |
 | Inbox write failure (transient) | Retry with backoff. Do not ack source message. |
-| Inbox write failure (permanent) | Log error, skip message, emit `relay_errors_total{kind="inbox_permanent"}`. |
+| Inbox write failure (permanent) | Write to `pgtrickle.relay_dead_letters` (`error_type = 'inbox_permanent'`). Advance offset. Emit `relay_errors_total{kind="inbox_permanent"}`. |
+
+**No silent message loss.** Every permanently-failed message is written
+to `pgtrickle.relay_dead_letters` before advancing the offset.
+Silent discard (log + skip) is not acceptable — see AGENTS.md:
+"Data loss is unacceptable."
+
+`raw_payload` is captured best-effort (may be NULL if the message was
+undecipherable before any fields could be extracted). `pipeline_name`,
+`error_type`, `error_message`, and `failed_at` are always recorded.
 
 All retries use jittered exponential backoff to avoid thundering herds.
 

--- a/plans/relay/PLAN_RELAY_CLI.md
+++ b/plans/relay/PLAN_RELAY_CLI.md
@@ -4,6 +4,7 @@
 > **Created:** 2026-04-18
 > **Category:** Tooling — Bidirectional Relay
 > **Related:** [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](../patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) ·
+> [PLAN_WEBUI.md](../webui/PLAN_WEBUI.md) ·
 > [ROADMAP v0.25.0](../../ROADMAP.md#v0250--relay-cli-pgtrickle-relay)
 
 ---
@@ -30,6 +31,7 @@
   - [A.14 Catalog Schema (Config Tables)](#a14-catalog-schema-config-tables)
   - [A.15 Horizontal Scaling & Work Distribution](#a15-horizontal-scaling--work-distribution)
   - [A.16 Secret Reference Interpolation](#a16-secret-reference-interpolation)
+  - [A.17 WebUI Readiness (Cross-Reference)](#a17-webui-readiness-cross-reference)
 - [Part B — Sink Backends (Forward Mode)](#part-b--sink-backends-forward-mode)
   - [B.1 NATS JetStream](#b1-nats-jetstream)
   - [B.2 HTTP Webhook](#b2-http-webhook)
@@ -1441,6 +1443,102 @@ ERROR pipeline=orders-to-kafka error="secret not found: env var KAFKA_SASL_PASSW
       via the `get_relay_config()` / `list_relay_configs()` functions which
       return the raw (unreferenced) JSONB; the relay resolves references
       locally. Document the role setup in SQL_REFERENCE.md.
+
+---
+
+### A.17 WebUI Readiness (Cross-Reference)
+
+> **See:** [PLAN_WEBUI.md](../webui/PLAN_WEBUI.md) for the full WebUI
+> analysis and implementation plan.
+
+The relay binary will host the pg-trickle WebUI — a browser-based
+dashboard and management console served as static assets via `rust-embed`.
+This decision affects the relay's core architecture from day one. The
+following requirements must be met in the initial scaffold (RELAY-1)
+to avoid a costly refactor when the WebUI is added:
+
+#### AppState Design
+
+All shared state must be centralized in a single `Arc<AppState>` struct
+that is shared between relay worker tasks and Axum HTTP handlers:
+
+```rust
+pub struct AppState {
+    /// PostgreSQL connection pool
+    pub pg_pool: PgPool,
+
+    /// Pipeline registry (active forward/reverse pipelines with status)
+    pub pipelines: Arc<RwLock<PipelineRegistry>>,
+
+    /// Prometheus metrics handle (shared with relay workers)
+    pub metrics: Arc<RelayMetrics>,
+
+    /// Shutdown token (coordinates relay workers + HTTP server)
+    pub shutdown: CancellationToken,
+
+    /// WebSocket broadcast channel (NOTIFY alerts, pipeline state changes)
+    pub ws_broadcast: broadcast::Sender<WsEvent>,
+
+    /// Configuration (auth mode, log level, feature flags)
+    pub config: Arc<RelayConfig>,
+}
+```
+
+This structure is passed as Axum state to all route handlers and as a
+reference to all relay worker tasks. The coordinator, workers, and HTTP
+handlers all read from and write to the same `PipelineRegistry`.
+
+#### Single Axum Instance
+
+All HTTP functionality must run on a single Axum `Router`:
+
+```
+:9090/metrics          Prometheus scrape (existing)
+:9090/health           Health check (existing)
+:9090/health/drained   Drain check (existing)
+:9090/webhook/...      Webhook receiver (existing, reverse mode)
+:9090/api/v1/...       JSON API (WebUI backend — stubbed initially)
+:9090/api/v1/ws        WebSocket (live alerts — stubbed initially)
+:9090/ui/...           Static frontend assets (stubbed initially)
+```
+
+The `/api/v1/` and `/ui/` route groups are feature-gated behind
+`--features webui`. The minimal relay binary (sidecar image) does not
+include them.
+
+#### WebSocket Broadcast Channel
+
+The `ws_broadcast` channel in `AppState` must be initialized from day one
+and fed by:
+
+- The `LISTEN pg_trickle_alert` NOTIFY listener (already planned for
+  config hot-reload)
+- Pipeline state changes (connected/disconnected, lag updates)
+- Fuse state changes
+
+Even without WebUI consumers, the channel is zero-cost (no subscribers =
+no allocation). This avoids retrofitting broadcast into the coordinator
+later.
+
+#### Implications for RELAY-1
+
+The crate structure gains:
+
+```
+pgtrickle-relay/src/
+  ├── state.rs            # AppState struct + builder
+  └── api/                # (stubbed, behind --features webui)
+      ├── mod.rs          # Router construction
+      └── health.rs       # /api/v1/health (mirrors /health with richer JSON)
+```
+
+And a `dashboard/` directory for the Next.js frontend (empty initially):
+
+```
+pgtrickle-relay/dashboard/
+  ├── package.json        # (created when frontend work begins)
+  └── README.md           # "WebUI frontend — see PLAN_WEBUI.md"
+```
 
 ---
 

--- a/plans/relay/PLAN_RELAY_CLI.md
+++ b/plans/relay/PLAN_RELAY_CLI.md
@@ -956,8 +956,13 @@ Silent discard (log + skip) is not acceptable — see AGENTS.md:
 "Data loss is unacceptable."
 
 `raw_payload` is captured best-effort (may be NULL if the message was
-undecipherable before any fields could be extracted). `pipeline_name`,
-`error_type`, `error_message`, and `failed_at` are always recorded.
+undecipherable before any fields could be extracted) and is **immutable
+after write** — neither the relay nor the WebUI may modify it, as it is
+the forensic record of exactly what the upstream system sent.
+`pipeline_name`, `error_type`, `error_message`, and `failed_at` are
+always recorded. `operator_notes` is a free-text field that operators
+may fill in via the WebUI before retrying, to document root cause and
+remediation steps.
 
 All retries use jittered exponential backoff to avoid thundering herds.
 

--- a/plans/webui/ANALYSIS_UNIFIED_VS_SEPARATE_UI.md
+++ b/plans/webui/ANALYSIS_UNIFIED_VS_SEPARATE_UI.md
@@ -1,0 +1,438 @@
+# Unified vs Separate UIs — Deep Analysis
+
+> **Status:** Analysis (DRAFT — 2026-04-22, rev 4)
+> **Decision:** One unified web console covering admin + exploration + curation.
+> **Scope:** Should pg-trickle admin, pg-ripple admin, data exploration,
+> and future record linkage be one UI, two, or more?
+
+---
+
+## Repo & Deployment Reality
+
+Before analysing UI boundaries, the physical layout matters:
+
+| Repo | Contains | HTTP service |
+|------|----------|--------------|
+| `grove/pg-trickle` | IVM extension + `pgtrickle-relay` binary + TUI + dbt | Relay: Axum on `:9090` (metrics, health, webhook, API) |
+| `grove/pg-ripple` | Triplestore extension + `pg_ripple_http` binary | HTTP: Axum (SPARQL Protocol, Prometheus, health) |
+| `grove/surface` | Unified web console (NEW, Next.js) | — |
+
+**pg-ripple is independent.** It works without pg-trickle installed.
+A user may run pg-ripple alone (knowledge graph, SPARQL, Datalog) and
+never touch pg-trickle or the relay. Hardwiring admin UI into the relay
+binary means pg-ripple-only users get **no admin interface at all**.
+This was a flaw in the original rev 1 analysis.
+
+**Both Rust binaries are Axum servers.** The relay and `pg_ripple_http`
+share the same HTTP stack (Axum + Tokio). Either can embed static
+frontend files via `rust-embed`. Both already serve health/metrics.
+
+---
+
+## The UIs Under Consideration
+
+### 1. pg-trickle Admin (planned — PLAN_WEBUI.md)
+
+Operational console for streaming materialized views. Topology graph,
+SLA monitoring, refresh timeline, DVM operator inspector, relay pipeline
+management, column-level lineage, CDC health, health scorecard.
+
+**Users:** SRE, data engineer, platform engineer, LLM agents.
+
+### 2. pg-ripple Admin (not yet planned)
+
+Operational monitoring for the knowledge graph engine: dictionary cache
+stats, VP table sizes, delta→main compaction, named graph metrics, SHACL
+validation status, inference job monitoring, CDC subscription health.
+
+**Users:** DBA, data engineer managing the knowledge graph.
+
+### 3. moire — Data Explorer (BLUEPRINT exists, nothing built)
+
+Faceted parallax navigation for knowledge graphs. SPARQL-driven entity
+set browsing, type/relationship/graph browsers, semantic zoom. Works
+against ANY SPARQL 1.1 endpoint, not just pg-ripple.
+
+**Users:** Data analyst, knowledge engineer, researcher, developer.
+
+### 4. Record Linkage Tool (future)
+
+Entity resolution / deduplication workflow for pg-ripple. Interactive:
+review candidate match pairs, tune similarity thresholds, confirm/reject
+links, bulk-apply `owl:sameAs` assertions. Likely combines graph
+exploration (browse entities being compared) with a review workflow
+(queue of candidate pairs, accept/reject/skip).
+
+**Users:** Data steward, knowledge engineer, data quality analyst.
+
+---
+
+## Key Architectural Facts
+
+| | pg-trickle admin | pg-ripple admin | moire | Record linkage |
+|--|---|---|---|---|
+| **Purpose** | Monitor streaming pipelines | Monitor KG engine | Explore graph data | Curate entity matches |
+| **Activity** | Reactive monitoring | Reactive monitoring | Open-ended exploration | Guided workflow |
+| **Backend** | `pgtrickle-relay` API | `pg_ripple_http` API | Any SPARQL 1.1 | `pg_ripple_http` API |
+| **Protocol** | REST/JSON + WebSocket | REST/JSON | SPARQL Protocol | REST/JSON + SPARQL |
+| **Coupling** | pg-trickle relay | pg-ripple | Endpoint-agnostic | pg-ripple |
+| **Session** | Brief, reactive | Brief, reactive | Long, interactive | Medium, task-oriented |
+
+**Critical relationship:** pg-ripple uses pg-trickle for IVM. A SPARQL
+view materialised by pg-ripple appears as a pg-trickle stream table in
+the topology graph. Both extensions CAN run in the same PostgreSQL
+instance — but pg-ripple also runs alone.
+
+---
+
+## Deployment Scenarios
+
+The UI architecture must work for ALL of these:
+
+| Scenario | Extensions | HTTP services | Needs UI for |
+|----------|-----------|---------------|--------------|
+| **A. Full stack** | pg-trickle + pg-ripple | relay + pg_ripple_http | Streaming admin + KG admin + data exploration |
+| **B. pg-ripple only** | pg-ripple | pg_ripple_http | KG admin + data exploration |
+| **C. pg-trickle only** | pg-trickle | relay | Streaming admin |
+| **D. External SPARQL** | (none) | (any SPARQL endpoint) | Data exploration only |
+
+Scenario B is the killer constraint. If the console is hardwired into
+the relay binary, pg-ripple-only users get nothing. pg-ripple must have
+its own admin story independent of pg-trickle.
+
+---
+
+## Activity Classification
+
+Four distinct activity types, which drives the UI split:
+
+| Activity | Nature | Session | Example tools in the wild |
+|----------|--------|---------|--------------------------|
+| **Streaming pipeline admin** | Reactive monitoring, incident response | Brief (2–10 min) | RisingWave Dashboard, Confluent Control Center |
+| **Knowledge graph admin** | Reactive monitoring, health checks | Brief (2–10 min) | Fuseki admin, Stardog Studio (ops tab) |
+| **Data exploration** | Open-ended browsing, discovery | Long (10–60 min) | Stardog Studio (query tab), Metaphactory, Linked Data Fragments |
+| **Data curation / record linkage** | Guided workflow, review queue | Medium (10–30 min) | Dedupe.io, OpenRefine, Tamr |
+
+Key insight: the first two are both "admin monitoring" — same cognitive
+mode, same session length, same UX pattern (list → detail → remediation).
+The last two are both "data work" — interactive, user-driven, longer
+sessions. This suggests the split.
+
+---
+
+## Option A: One App Per Concern (4 UIs)
+
+Four apps: trickle-admin, ripple-admin, moire, record-linkage.
+
+**Verdict: Over-split.** Both admin UIs are thin (~15 panels each in
+isolation). Maintaining four separate Next.js apps with four CI
+pipelines and four sets of dependencies is excessive. The two admin
+concerns share the same UX pattern and will share components (health
+cards, timeline charts, alert feeds).
+
+---
+
+## Option B: One Unified UI (Chosen — see rev 4 update)
+
+Everything in one app. Revs 1–3 dismissed this as "over-merged" because
+it would destroy moire's endpoint agnosticism. Rev 4 reconsiders:
+
+- **moire doesn't exist yet.** There are zero users of a standalone
+  SPARQL explorer. The endpoint-agnostic use case is speculative.
+- **One developer, one codebase.** Two Next.js apps = 2× CI, 2×
+  dependency maintenance, 2× deployment stories. The overhead isn't
+  justified at this stage.
+- **Precedent.** Stardog Studio, pgAdmin, and Grafana all combine
+  monitoring + data work in one shell. Nobody complains.
+- **Extraction is easy.** Going from 1 UI → 2 (extract the exploration
+  module into its own app) is straightforward. Going from 2 → 1 (merge
+  codebases, reconcile shared state, deduplicate components) is painful.
+
+The sidebar shows/hides sections based on detected backends — the same
+progressive detection model from the original console design, just
+extended to cover exploration and curation too.
+
+See [Option C: One Unified Console](#option-c-one-unified-console-recommendation)
+for the full design.
+
+---
+
+## Option C: One Unified Console — **Surface** (Recommendation)
+
+A single Next.js app named **surface** (`grove/surface`) that covers ALL
+four concerns: pg-trickle admin, pg-ripple admin, data exploration,
+and record linkage.
+
+**Why "surface":** trickles and ripples are both visible at the water's
+surface. The console literally is the surface layer of the platform —
+the point where all the underlying data motion becomes observable.
+It also avoids encoding either extension's name into the UI brand,
+keeping it neutral ground between pg-trickle and pg-ripple.
+
+**Not hardwired to either binary** — it's a
+standalone app that connects to whichever backends are available.
+
+### Progressive feature detection at startup
+
+| Backend detected | Sections shown |
+|-----------------|----------------|
+| Relay API reachable | Streaming: topology, tables, SLA, CDC, relay pipelines, timeline |
+| pg_ripple_http reachable | Knowledge Graph: admin, exploration, SHACL, inference, record linkage |
+| Both reachable | Full console — all sections + cross-cutting IVM views |
+| Neither reachable | Connection setup screen |
+
+### Deployment flexibility — three hosting options
+
+```
+Option 1: Embedded in relay via rust-embed
+  relay binary serves /console/ (pg-trickle sections always visible,
+  pg-ripple sections if pg_ripple_http is reachable)
+
+Option 2: Embedded in pg_ripple_http via rust-embed
+  pg_ripple_http serves /console/ (KG sections always visible,
+  streaming sections if relay is reachable)
+
+Option 3: Standalone deployment (Docker, Vercel, etc.)
+  Connects to relay and/or pg_ripple_http via configured URLs
+```
+
+This solves the pg-ripple-only problem: scenario B users embed the
+console in `pg_ripple_http` and get KG admin + data exploration. The
+streaming sections are simply hidden (no relay detected). If they
+later add pg-trickle and the relay, those sections light up
+automatically.
+
+### Why one app works
+
+1. **Same operator.** The person monitoring stream table health is the
+   same person who will browse the knowledge graph and do record
+   linkage. In a small-to-medium deployment, there's one DBA or data
+   engineer wearing all hats. Sending them to two different apps with
+   two different URLs is unnecessary friction.
+
+2. **Cross-cutting objects.** An IVM SPARQL view IS a pg-trickle
+   stream table. Showing its pipeline health AND its graph data in
+   the same app eliminates context-switching.
+
+3. **Unified alerting.** pg-ripple events (SHACL violation, compaction
+   stall, cache thrashing) and pg-trickle events (SLA breach, CDC
+   failure, fuse blown) belong in the same alert feed.
+
+4. **Shared component surface.** Health scorecards, alert feeds,
+   timeline charts, entity detail views, data tables — massive
+   component reuse within one codebase.
+
+5. **One codebase to maintain.** One CI pipeline, one set of
+   dependencies, one deployment story. For a solo developer, this
+   matters more than architectural purity.
+
+6. **Extract later if needed.** If the standalone SPARQL explorer
+   use case proves real (someone wanting to browse Wikidata without
+   pg-trickle), the exploration module can be extracted into its own
+   app. Going from 1 → 2 apps is easy. Going from 2 → 1 is hard.
+
+### Navigation (full stack, both backends detected)
+
+```
+  Dashboard         ← unified health summary
+  Streaming
+  ├── Tables        ← stream tables, IVM views get 🔷 graph badge
+  ├── Topology
+  ├── Relay Pipelines
+  ├── CDC Health
+  └── Timeline
+  Knowledge Graph
+  ├── Explore       ← faceted entity navigation, type/graph browsers
+  ├── Graphs        ← named graph list with sizes
+  ├── Dictionary & Storage
+  ├── SHACL Shapes
+  ├── Inference Rules
+  ├── Subscriptions
+  └── Record Linkage ← candidate pairs, compare, accept/reject
+  Health            ← unified scorecard (both systems)
+  Alerts            ← unified feed
+```
+
+When only one backend is detected, the other section's nav group is
+simply absent. If only `pg_ripple_http` is detected, the user sees
+Knowledge Graph (with Explore, admin, and record linkage) + Health +
+Alerts — a complete experience without pg-trickle.
+
+### API design — two base URLs, one frontend
+
+The console frontend talks to whichever backends are available:
+
+```
+Relay API:           relay:9090/api/v1/tables, /dag, /health, ...
+pg_ripple_http API:  ripple:3030/api/v1/graphs, /cache, /shacl, ...
+                     ripple:3030/sparql  (SPARQL Protocol for exploration)
+```
+
+The frontend stores both base URLs in config. When embedded in one
+binary, that binary's API is always `localhost`; the other binary's
+API is configured via environment variable or auto-discovered.
+
+### Record linkage as a console module
+
+Record linkage lives in the console under Knowledge Graph → Record
+Linkage. It reuses the same entity detail components from Explore.
+This works because:
+
+1. **Same backend.** Record linkage uses `pg_ripple_http` — same API
+   the console already talks to for KG admin.
+
+2. **Shared components.** Entity detail views, predicate tables,
+   graph neighbourhood visualisation — all built for the Explore
+   section, reused by record linkage.
+
+3. **Same session.** A data steward doing record linkage will browse
+   entities to decide if they match. Having Explore one click away in
+   the same app (not a different URL) is essential.
+
+4. **Progressive enablement.** Record linkage appears under Knowledge
+   Graph only when `pg_ripple_http` is detected. It's never shown to
+   pg-trickle-only users.
+
+---
+
+## Where Does the Code Live?
+
+### Repo structure
+
+```
+grove/pg-trickle              ← IVM extension + relay + TUI + dbt
+grove/pg-ripple               ← Triplestore + pg_ripple_http
+grove/surface                 ← Unified web console (“surface of the platform”)
+```
+
+See [ANALYSIS_MONOREPO.md](../ANALYSIS_MONOREPO.md) for the full
+rationale for 3 separate repos.
+
+**Why the console gets its own repo:**
+
+1. **Serves both extensions equally.** Putting it inside either
+   extension's repo creates an asymmetry. A standalone repo is neutral
+   ground.
+
+2. **Different technology.** Next.js/TypeScript app with its own CI
+   (ESLint, TypeScript, Playwright) — not Rust, not pgrx.
+
+3. **Independent release cycle.** Frontend ships when frontend is
+   ready, not when either extension releases.
+
+### Embedding workflow
+
+Both Rust binaries consume the console's pre-built static files:
+
+```
+surface CI:
+  npm run build → out/ → published as GitHub release asset (tar.gz)
+
+pgtrickle-relay build (when --features console):
+  Download surface-vX.Y.Z.tar.gz → embed via rust-embed
+
+pg_ripple_http build (when --features console):
+  Download surface-vX.Y.Z.tar.gz → embed via rust-embed
+```
+
+This keeps the frontend build out of `cargo build` entirely. The Rust
+binaries just embed a pre-built tarball. The console version is pinned
+in each binary's build config, allowing independent upgrades.
+
+---
+
+## How This Handles Each Scenario
+
+| Scenario | Console deployment | Result |
+|----------|--------------------|--------|
+| **A. Full stack** | Embedded in relay (all sections visible) | Streaming admin + KG admin + data exploration + record linkage |
+| **B. pg-ripple only** | Embedded in pg_ripple_http (KG sections only) | KG admin + data exploration + record linkage |
+| **C. pg-trickle only** | Embedded in relay (streaming sections only) | Streaming admin |
+| **D. Standalone** | Docker / Vercel, configured with backend URLs | Connects to whichever backends are reachable |
+
+Every scenario works. No user is left without a UI. No product is
+forced to depend on another product just to get admin tooling.
+
+---
+
+## Comparison Matrix
+
+| Concern | 4 UIs | 2 UIs (rev 3) | 1 UI (chosen) |
+|---------|-------|---------------|---------------|
+| Maintenance burden | High (4 codebases) | Medium (2 codebases) | **Low (1 codebase)** |
+| pg-ripple standalone admin | ✅ Own app | ✅ Console embedded in pg_ripple_http | ✅ Same — embedded in pg_ripple_http |
+| Data exploration | ✅ moire standalone | ✅ moire standalone | ✅ Explore section in console |
+| Record linkage home | Own thin app | Module in moire | Module in console (KG section) |
+| Cross-cutting IVM view | ❌ Context switch | ✅ Console + moire linked | **✅ Same page** |
+| Deployment flexibility | 4 deployments | Console: 3 options; moire: standalone | Console: 3 options |
+| Standalone SPARQL explorer | ✅ moire works alone | ✅ moire works alone | ❌ Not available — extract later if needed |
+| Cognitive coherence | Good per UI | Good (monitoring vs data) | Good enough — sidebar sections separate activities |
+| Solo dev overhead | Prohibitive | Manageable | **Minimal** |
+| Future extensibility | Add more thin apps | New admin → console; new data → moire | New sections → console |
+
+The main tradeoff: losing the standalone SPARQL explorer use case
+(someone exploring Wikidata without any pg-trickle/pg-ripple). This
+is speculative — moire has zero users and zero code. If this use case
+proves real later, the Explore module can be extracted into its own
+app.
+
+---
+
+## Implementation Sequencing
+
+### Phase 0: API scaffolds (parallel work in both repos)
+
+- `pg-trickle` relay: `/api/v1/` routes as planned in PLAN_WEBUI.md
+- `pg-ripple` pg_ripple_http: add `/api/v1/` routes for KG operational
+  data (graphs, cache, SHACL, inference, subscriptions)
+
+Both APIs serve JSON. Both are useful immediately for scripting,
+Grafana, and LLM agents — no frontend needed yet.
+
+### Phase 1: Console with streaming admin (`grove/surface`)
+
+Next.js app. Connects to relay API. Progressive feature detection.
+Tier 1 read-only streaming dashboard (topology, tables, SLA, CDC,
+timeline).
+
+### Phase 2: KG admin sections
+
+Add Knowledge Graph admin sections. Connect to `pg_ripple_http` API.
+Graphs, dictionary, SHACL, inference, subscriptions.
+
+### Phase 3: Explore section
+
+Add faceted entity navigation under Knowledge Graph → Explore. SPARQL
+queries against `pg_ripple_http`'s SPARQL endpoint. Entity detail,
+type/graph browsers, semantic zoom.
+
+### Phase 4: Console Tier 2 + Record linkage
+
+Console write operations (relay pipeline management, fuse reset).
+Record linkage module under Knowledge Graph.
+
+---
+
+## Recommendation
+
+**Build one unified web console (`grove/surface`).**
+
+A single Next.js app that covers admin monitoring, data exploration,
+and data curation for both pg-trickle and pg-ripple. Progressive
+backend detection shows only relevant sections. Embeddable in either
+Rust binary or deployed standalone.
+
+**Key design decisions:**
+
+- Console is a **standalone Next.js app in its own repo**, not inside
+  either extension's repo. It serves both equally.
+- Console uses **two API base URLs** (relay + pg_ripple_http), not a
+  unified API. Each backend owns its own API surface.
+- **Progressive sections.** Streaming sections appear when the relay
+  is reachable. Knowledge Graph sections (admin, explore, record
+  linkage) appear when `pg_ripple_http` is reachable.
+- Record linkage is a **module in the console** under Knowledge Graph,
+  reusing the Explore section's entity components.
+- The standalone SPARQL explorer use case (moire) is **deferred**.
+  If it proves needed, the Explore module can be extracted. This is
+  cheaper than maintaining two apps from the start.

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -490,6 +490,24 @@ optimized for different tasks:
 | Filter by refresh mode or schema | Pipelines list with faceted filters |
 | See end-to-end latency | Pipeline detail (cumulative lag) |
 
+**Pipelines are always maximal paths.** A pipeline goes from a leaf
+source all the way to a leaf sink — there is no separate addressable
+concept of a "partial pipeline" (e.g. `a→b` within `a→b→c`). Partial
+views are accessed by interacting within a pipeline or topology view:
+
+- **Click a node** inside the pipeline detail → opens a detail panel
+  for that node; shows its immediate upstream and downstream edges.
+- **Topology `?focus=<name>&depth=N`** → scopes the graph to the
+  N-hop neighbourhood around a named node. This is the URL to
+  bookmark when you only care about one segment of a longer chain.
+- **Click an edge between two schema groups** in the Topology Level 0
+  view → drills into Level 1 scoped to flows between those two
+  schemas only.
+
+Keeping pipelines as maximal paths avoids duplicate entries in the
+pipelines list — `a→b` and `a→b→c` would otherwise both appear and
+require users to decide which is "the real one".
+
 ### Unified Topology Graph
 
 The centrepiece of the WebUI. A multi-level interactive graph using

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -247,17 +247,13 @@ guarantees from Phase 0. Breaking changes require a version bump
 and automation scripts depend on predictable schemas.
 
 ```
-# Flows — end-to-end data paths derived from the DAG
-GET  /api/v1/flows                      All end-to-end flows (source → sink paths)
-GET  /api/v1/flows/:id                  Single flow detail (all nodes in the path)
-
-# Stream tables
-GET  /api/v1/tables                     Stream table list + status
-GET  /api/v1/tables/:name               Detail view for one stream table
-GET  /api/v1/tables/:name/history       Refresh history
-GET  /api/v1/tables/:name/lineage       Column-level lineage
-GET  /api/v1/tables/:name/operator-tree DVM operator tree (DOT format)
-GET  /api/v1/tables/:name/sample        Sample rows (LIMIT 50)
+# Tables — stream tables with type annotations and E2E lag
+GET  /api/v1/tables                     All stream tables (type, staleness, E2E lag, SLA)
+GET  /api/v1/tables/:schema/:table      Table detail + bidirectional lineage
+GET  /api/v1/tables/:schema/:table/history       Refresh history
+GET  /api/v1/tables/:schema/:table/lineage       Column-level lineage
+GET  /api/v1/tables/:schema/:table/operator-tree DVM operator tree (DOT format)
+GET  /api/v1/tables/:schema/:table/sample        Sample rows (LIMIT 50)
 
 # Health (aggregates CDC, fuses, slots, workers, relay status)
 GET  /api/v1/health                     Health scorecard
@@ -440,73 +436,80 @@ writing SQL manually.
 
 ## Key Features — Detailed Design
 
-### Pipelines (End-to-End Flows)
+### Tables
 
-The primary navigational concept in the WebUI. A **pipeline** (also
-called a **flow**) is an end-to-end data path derived from the DAG:
-every maximal path from a leaf source (base table or relay reverse
-input) to a leaf sink (stream table with no dependents, or relay
-forward output).
+The primary list view. Every stream table in the deployment, annotated
+with its structural role derived from the DAG. No separate "pipelines"
+concept — a pipeline is just a table plus its upstream lineage, so the
+two views are the same thing.
+
+**Structural type** is inferred from the DAG and relay config at query
+time:
+
+| Type | How inferred |
+|------|-------------|
+| **inbox** | A relay inbox config writes into this table |
+| **outbox** | A relay outbox config reads from this table |
+| **source** | Base table with CDC; no stream-table ancestors |
+| **intermediate** | Has both upstream and downstream stream tables |
+| **leaf** | Stream table with no stream-table descendants |
+| **orphan** | No upstream source and no relay inbox |
+| **union** | Multiple upstream stream tables (fan-in) |
+
+These types are not mutually exclusive — a table can be `leaf + union`.
+They are shown as small badge chips on each row.
+
+**E2E lag** is computed for every table: the maximum cumulative
+staleness from any root source to this table. For a leaf table this is
+the end-to-end delivery latency. For an intermediate table it shows
+how stale its inputs are. This single metric is more useful than
+separating "pipeline E2E lag" (leaves only) from "table staleness"
+(all) — it degrades gracefully.
 
 ```
-Kafka:orders → orders_raw → revenue_7d → regional_summary → NATS:analytics
+Table                 Type          Staleness  E2E Lag   SLA
+────────────────────  ───────────   ─────────  ────────  ────────────
+regional_summary      leaf union    45s        61s       ████████ 🔴
+revenue_7d            intermediate  12s        28s       ████ 🟡
+orders_raw            inbox         3s         3s        █ 🟢
+canonical             intermediate  5s         18s       ██ 🟢
+customers             orphan        —          —         —
 ```
 
-That is one pipeline. pg-trickle doesn't store pipelines as a formal
-object — they are computed at query time from the DAG. The
-`GET /api/v1/flows` endpoint returns all maximal source-to-sink paths,
-each with:
+- **Row click:** Opens table detail with bidirectional lineage.
+- **Sort:** Default is worst SLA first (problems at the top).
+- **Faceted filters:** Schema, type badge, refresh mode (DIFF/FULL), SLA status.
+- **Search:** Matches table name or schema.
 
-- A stable ID (hash of the node sequence)
-- The ordered list of nodes in the path
-- Aggregate SLA status (worst node determines the flow's status)
-- End-to-end latency (cumulative staleness from source to sink)
-- Throughput (minimum throughput across edges — the bottleneck)
+**Table detail** shows the table's own metrics plus its **bidirectional
+lineage**: upstream on the left (root cause analysis — what feeds this
+table and how stale is each branch?) and downstream on the right (blast
+radius — what depends on this table and what breaks if it's unhealthy?).
+The upstream and downstream DAGs are shown together in a single lineage
+view with the selected table centred. Both upstream and downstream nodes
+are clickable to navigate to their own detail pages.
 
-**Why pipelines instead of tables or relay connectors as the list view:**
-Users think in terms of data flows, not individual nodes. "Is my
-orders-to-analytics flow healthy?" is a more natural question than
-"Is `regional_summary` healthy?" The pipeline view answers the first
-question directly. Individual node detail (stream table stats, relay
-connector config) is accessed by clicking a node within a pipeline.
-
-A stream table that appears in multiple flows (e.g., a shared dimension
-table like `customers`) appears in multiple pipeline rows — correctly
-reflecting its operational blast radius.
-
-**Orphan tables** (stream tables with no downstream consumers and no
-upstream relay source) appear as single-node pipelines. This makes
-orphans visible rather than hidden.
-
-The **Pipelines** page is the list/tabular view of the same information
-that the **Topology** page shows spatially. Two views of the same data,
-optimized for different tasks:
+The **Tables** page and the **Topology** page are two views of the
+same data:
 
 | Task | Best view |
 |---|---|
 | Understand system architecture | Topology (graph) |
-| Find the flow breaching SLA | Pipelines (sorted by worst SLA) |
-| Trace data from source to sink | Pipeline detail (ordered node list) |
-| Filter by refresh mode or schema | Pipelines list with faceted filters |
-| See end-to-end latency | Pipeline detail (cumulative lag) |
+| Find the table breaching SLA | Tables (sorted by worst SLA) |
+| Trace what feeds a specific table | Table detail (lineage — upstream side) |
+| Trace what depends on a table | Table detail (lineage — downstream side) |
+| Filter by type or refresh mode | Tables list with faceted filters |
+| See end-to-end latency | Tables list (E2E lag column) |
 
-**Pipelines are always maximal paths.** A pipeline goes from a leaf
-source all the way to a leaf sink — there is no separate addressable
-concept of a "partial pipeline" (e.g. `a→b` within `a→b→c`). Partial
-views are accessed by interacting within a pipeline or topology view:
+**Sub-views within lineage.** Sub-sections are accessed by interacting
+within the view:
 
-- **Click a node** inside the pipeline detail → opens a detail panel
-  for that node; shows its immediate upstream and downstream edges.
+- **Click a node** in the lineage view → navigates to that table's
+  own detail page (centering the lineage on the new node).
 - **Topology `?focus=<name>&depth=N`** → scopes the graph to the
-  N-hop neighbourhood around a named node. This is the URL to
-  bookmark when you only care about one segment of a longer chain.
-- **Click an edge between two schema groups** in the Topology Level 0
-  view → drills into Level 1 scoped to flows between those two
-  schemas only.
-
-Keeping pipelines as maximal paths avoids duplicate entries in the
-pipelines list — `a→b` and `a→b→c` would otherwise both appear and
-require users to decide which is "the real one".
+  N-hop neighbourhood around any named node.
+- **Click an edge between two schema groups** in Topology Level 0 →
+  drills into Level 1 scoped to flows between those two schemas.
 
 ### Unified Topology Graph
 

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -79,6 +79,55 @@ an accessible alternative to managed streaming platforms (RisingWave
 Cloud, Confluent Cloud, Materialize) while retaining PostgreSQL as the
 foundation.
 
+### Key architectural decisions
+
+**No logic in JavaScript.** Every derived value that an external tool
+(Grafana, Prometheus, alertmanager) could usefully see is computed in
+the database or API layer, never in the browser. The three layers are:
+- *DB* — structural table types, E2E lag, SLA %, root-cause/blast-radius
+  classification. All queryable directly from SQL.
+- *API* — assembles transport annotations from relay config tables;
+  computes nothing that SQL cannot.
+- *Browser* — graph layout positions, relative timestamps, UI state.
+
+**Topology = schemas only.** The Level 0 topology graph shows one node
+per PostgreSQL schema. External transports (Kafka, NATS, webhook) are
+small icon annotations on schema nodes, not separate graph nodes. A
+typical shop uses one Kafka cluster for everything — a Kafka node would
+add noise, not information. Layout is computed automatically from
+inter-schema edge direction by dagre/elkjs with no manual tier
+assignment.
+
+**Tables list, not a pipelines list.** There is no separate "pipelines"
+concept. A pipeline is just a table plus its upstream lineage — the same
+thing. Each stream table has a structural type (inbox / outbox / leaf /
+intermediate / union / orphan) inferred from the DAG by
+`pgtrickle.table_classifications`. E2E lag is shown on every table, not
+just leaf tables. Fan-in/fan-out topologies (10 sources × 10 sinks)
+produce N table rows, not 100 path rows.
+
+**Root cause vs inherited breach in the DB.** `pgtrickle.breach_events`
+is a stream table that classifies each breach as `root` (independent
+failure) or `inherited` (cascade from upstream). The UI, Grafana
+dashboards, and Prometheus alerts all read from this single source of
+truth. The sidebar badge counts root cause events only — not downstream
+noise. A single broken inbox cascading to 10 outputs produces 1 alert
+entry and 1 badge count, not 11.
+
+**Bidirectional lineage on every table.** The table detail page shows
+upstream (root cause analysis — what feeds this table?) and downstream
+(blast radius — what breaks if this table fails?) in a single centred
+lineage view. Clicking any node re-centres the view on that node.
+Toggling between table-level and column-level granularity happens in
+the same canvas.
+
+**Single-schema auto-navigate with breadcrumb.** If the deployment has
+only one schema, the topology opens directly at Level 1 (individual
+nodes) rather than a pointless single-node Level 0. The breadcrumb
+always shows `Systems > <schema>` so the operator can navigate back,
+see the schemas-as-groups model, and understand how a second schema
+would appear.
+
 ---
 
 ## Motivation

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -500,8 +500,18 @@ individual node.
 **Three zoom levels:**
 
 **Level 0 — Systems overview (landing).** One node per PostgreSQL
-schema. External relay endpoints (Kafka, NATS, etc.) appear as leaf
-nodes attached to the schema containing their inbox/outbox table.
+schema. External relay endpoints (Kafka, NATS, webhook, etc.) appear
+as leaf circles attached to the schema that contains their inbox or
+outbox table.
+
+A schema can have **multiple relay inboxes from different backends** —
+one Kafka consumer, one webhook receiver, one file watcher — all
+writing into the same `erp_raw` schema. At Level 0 they each appear
+as a separate leaf circle on the `erp_raw` node. The schema remains
+the single named group: "Is ERP data healthy?" is answered by
+`erp_raw`'s aggregate status badge, regardless of how many backends
+feed it or what transport they use. The schema is the logical unit;
+the relay endpoints are transport plumbing.
 
 **Level 1 — Group detail.** Click a schema group or an edge between
 two groups to see all individual nodes within that scope. Shows
@@ -1226,23 +1236,29 @@ named.
 **Level 0 — Systems overview (hub-and-spoke).** One node per schema.
 Each schema node shows: object count, aggregate SLA status (worst
 child), pipeline count on connecting edges. External relay endpoints
-appear as unlabelled leaf nodes attached to the schemas that contain
-their inbox/outbox tables. This view is always readable regardless of
+appear as leaf circles attached to the schemas that contain their
+inbox/outbox tables. Multiple inboxes feeding the same schema
+(Kafka + webhook + file, all writing into `erp_raw`) each get their
+own leaf circle — but the schema is the single named node answering
+"Is ERP data healthy?" This view is always readable regardless of
 total object count.
 
 ```
-┌────────┐     ┌─────────┐     ┌───────────┐     ┌───────────┐     ┌──────┐
-│ Kafka  │────▶│ erp_raw │────▶│ canonical │────▶│ analytics │────▶│ NATS │
-│        │     │ 3 tables│     │ 45 tables │     │ 8 tables  │     │      │
-│        │     │ ● 3     │     │● 43🟡1🔴1 │     │ ● 8       │     │      │
-└────────┘     └─────────┘     └───────────┘     └───────────┘     └──────┘
+●Kafka─┐
+       ├──▶┌─────────┐     ┌───────────┐     ┌───────────┐
+●HTTP──┘   │ erp_raw │────▶│ canonical │────▶│ analytics │────▶NATS●
+           │ 5 tables│     │ 45 tables │     │ 8 tables  │
+           │ ● 5     │     │● 43🟡1🔴1 │     │ ● 8       │────▶Kafka●
+           └─────────┘     └───────────┘     └───────────┘
 ```
 
-Middle: PG schemas. Leaf nodes on left: relay reverse pipeline
-endpoints (backend type icon + connected/disconnected status). Leaf
-nodes on right: relay forward pipeline endpoints. Layout position is
-auto-inferred: schemas that contain only base tables and relay inboxes
-are placed left; schemas with outboxes and relay forwards are placed
+Middle: PG schemas. Leaf circles on left: relay reverse pipeline
+endpoints (backend type icon + connected/disconnected). Leaf circles
+on right: relay forward pipeline endpoints. Multiple endpoints on the
+same side of a schema are shown as a stack of circles. Layout
+position is auto-inferred: schemas that contain only base tables and
+relay inboxes are placed left; schemas with outboxes and relay
+forwards are placed
 right; everything else is center. No configuration required.
 
 **Level 1 — Schema detail.** Click a schema group → shows all individual

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -500,18 +500,18 @@ individual node.
 **Three zoom levels:**
 
 **Level 0 — Systems overview (landing).** One node per PostgreSQL
-schema. External relay endpoints (Kafka, NATS, webhook, etc.) appear
-as leaf circles attached to the schema that contains their inbox or
-outbox table.
+schema. That's it — no external system nodes. The schemas are the
+business domains; external transports (Kafka, webhook, NATS, etc.)
+are implementation details shown as small icon annotations on the
+schema node that uses them.
 
-A schema can have **multiple relay inboxes from different backends** —
-one Kafka consumer, one webhook receiver, one file watcher — all
-writing into the same `erp_raw` schema. At Level 0 they each appear
-as a separate leaf circle on the `erp_raw` node. The schema remains
-the single named group: "Is ERP data healthy?" is answered by
-`erp_raw`'s aggregate status badge, regardless of how many backends
-feed it or what transport they use. The schema is the logical unit;
-the relay endpoints are transport plumbing.
+A schema that ingests from Kafka shows a `⟵ kafka` badge on its left
+edge. A schema that publishes via webhook shows a `webhook ⟶` badge
+on its right edge. A bidirectional schema shows both. Hovering the
+badge shows connection status and which relay config(s) are active.
+This keeps Level 0 readable at a glance — every node is a named
+business domain, and the transport annotations answer "how does data
+get in/out?" without cluttering the graph with infrastructure nodes.
 
 **Level 1 — Group detail.** Click a schema group or an edge between
 two groups to see all individual nodes within that scope. Shows
@@ -531,9 +531,7 @@ directly.
 
 | Node type | Shape | Colour | Badge |
 |-----------|-------|--------|-------|
-| Schema group (Level 0) | Rounded rectangle, thick border | Worst-child SLA colour | Object count + status summary |
-| External relay endpoint (Level 0 leaf) | Circle | Blue (connected) / Red (disconnected) | Backend type icon |
-| External source (Kafka, NATS, ...) | Rounded rectangle | Grey | Backend icon |
+| Schema group (Level 0) | Rounded rectangle, thick border | Worst-child SLA colour | Object count + status summary; transport icon annotations on edges |
 | Relay pipeline | Hexagon | Blue (connected) / Red (disconnected) | Lag rows |
 | Inbox / Outbox table | Rectangle, dashed border | Teal | Buffer depth |
 | Source base table | Rectangle | White | CDC mode |
@@ -1227,39 +1225,31 @@ conventions required.
 
 **Single grouping axis: PostgreSQL schemas.** Every PG object (stream
 table, base table, inbox table, outbox table) has exactly one schema
-via `pg_class.relnamespace`. That schema IS the group. External relay
-endpoints (Kafka brokers, NATS servers) are simple leaf nodes on the
-edge of the schema that contains their inbox/outbox table — they show
-backend type and connection status but are not separately grouped or
-named.
+via `pg_class.relnamespace`. That schema IS the group. External
+transports (Kafka, NATS, webhooks, etc.) are not graph nodes — they
+are annotations on the schema nodes that use them.
 
-**Level 0 — Systems overview (hub-and-spoke).** One node per schema.
-Each schema node shows: object count, aggregate SLA status (worst
-child), pipeline count on connecting edges. External relay endpoints
-appear as leaf circles attached to the schemas that contain their
-inbox/outbox tables. Multiple inboxes feeding the same schema
-(Kafka + webhook + file, all writing into `erp_raw`) each get their
-own leaf circle — but the schema is the single named node answering
-"Is ERP data healthy?" This view is always readable regardless of
-total object count.
+**Transport annotations.** A schema with an active relay inbox shows
+a small inbound transport badge on its left side; a schema with a
+relay outbox shows an outbound badge on its right side. The badge
+shows the backend type icon (Kafka, NATS, webhook, S3, etc.) and
+colour-codes connected/disconnected. This answers "how does data flow
+in and out?" without adding infrastructure noise to the graph.
+A single Kafka cluster feeding five schemas is implicit — each schema
+just shows `⟵ kafka` on its inbound side.
 
 ```
-●Kafka─┐
-       ├──▶┌─────────┐     ┌───────────┐     ┌───────────┐
-●HTTP──┘   │ erp_raw │────▶│ canonical │────▶│ analytics │────▶NATS●
-           │ 5 tables│     │ 45 tables │     │ 8 tables  │
-           │ ● 5     │     │● 43🟡1🔴1 │     │ ● 8       │────▶Kafka●
-           └─────────┘     └───────────┘     └───────────┘
+┌─────────────────┐     ┌───────────────┐     ┌───────────────┐
+│    erp_raw      │────▶│   canonical   │────▶│   analytics   │
+│    5 tables     │     │   45 tables   │     │   8 tables    │
+│ ⟵kafka ⟵webhook │     │  ●43 🟡1 🔴1  │     │     ●8        │ kafka⟶
+└─────────────────┘     └───────────────┘     └───────────────┘
+       ↑↓ webhook  (bidirectional sync)
 ```
 
-Middle: PG schemas. Leaf circles on left: relay reverse pipeline
-endpoints (backend type icon + connected/disconnected). Leaf circles
-on right: relay forward pipeline endpoints. Multiple endpoints on the
-same side of a schema are shown as a stack of circles. Layout
-position is auto-inferred: schemas that contain only base tables and
-relay inboxes are placed left; schemas with outboxes and relay
-forwards are placed
-right; everything else is center. No configuration required.
+**Layout is fully automatic.** The graph layout algorithm (dagre /
+elkjs) positions schema nodes based on inter-schema edge direction
+alone — no manual tier assignment and no configuration required.
 
 **Level 1 — Schema detail.** Click a schema group → shows all individual
 nodes within that schema, with edges to adjacent schemas and to the

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -317,6 +317,13 @@ GET  /api/v1/relay/pipelines            All relay pipelines (forward + reverse)
 GET  /api/v1/relay/pipelines/:id        Single pipeline detail
 GET  /api/v1/relay/pipelines/:id/lag    Lag metrics for a pipeline
 
+# Dead letter queue
+GET  /api/v1/dlq                        All unresolved dead letters (paginated)
+GET  /api/v1/dlq/:pipeline              Dead letters for one pipeline
+POST /api/v1/dlq/:id/retry              Re-attempt delivery of one dead letter
+POST /api/v1/dlq/:id/discard           Mark resolved without retry
+POST /api/v1/dlq/discard-all/:pipeline Bulk discard for a pipeline
+
 # Operational detail (sub-resources of Health in the UI)
 GET  /api/v1/cdc/sources                CDC source table status
 GET  /api/v1/cdc/buffers                Change buffer sizes
@@ -827,7 +834,8 @@ form.
 ### Health Scorecard
 
 Aggregates all `health_check()` results, slot health, change buffer
-sizes, and relay pipeline lag into a single page. Severity-sorted.
+sizes, relay pipeline lag, and dead letter counts into a single page.
+Severity-sorted.
 
 | Check | Status | Detail | Remediation |
 |-------|--------|--------|-------------|
@@ -837,7 +845,44 @@ sizes, and relay pipeline lag into a single page. Severity-sorted.
 | Buffer growth | 🔴 Critical | `orders`: 15,204 rows, growing | [Investigate →] |
 | Relay: kafka-fwd | ✅ Connected | 0 lag rows | — |
 | Relay: nats-rev | ⚠️ Degraded | 342 lag rows, 12s behind | [View pipeline →] |
+| Dead letters | 🔴 Critical | 47 unresolved across 2 pipelines | [View DLQ →] |
 | Fuses | ✅ All armed | 0 blown | — |
+
+**Dead letter queues.** When a relay message fails permanently —
+payload decode error, schema mismatch, permanent sink rejection — the
+message is written to `pgtrickle.relay_dead_letters` instead of being
+silently discarded. A non-zero and growing DLQ count is a health check
+failure surfaced here and in `breach_events`.
+
+```sql
+CREATE TABLE pgtrickle.relay_dead_letters (
+    id           BIGSERIAL PRIMARY KEY,
+    failed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    pipeline_name TEXT NOT NULL,         -- FK to relay_inbox/outbox_config.name
+    direction    TEXT NOT NULL,          -- 'inbox' or 'outbox'
+    error_type   TEXT NOT NULL,          -- 'decode', 'sink_permanent', 'inbox_permanent'
+    error_message TEXT NOT NULL,
+    raw_payload  JSONB,                  -- best-effort capture of the failed message
+    retry_count  INT NOT NULL DEFAULT 0,
+    resolved_at  TIMESTAMPTZ,            -- NULL = unresolved
+    resolved_by  TEXT                   -- 'manual', 'retry_success', 'discarded'
+);
+```
+
+The WebUI DLQ view (linked from Health) shows unresolved dead letters
+per pipeline with payload inspection, retry, and discard actions.
+A table's inbox dead letter count is also visible in the Tables list
+when the table has an associated relay inbox — a non-zero count is
+another signal that data is not arriving as expected.
+
+API:
+```
+GET  /api/v1/dlq                        All unresolved dead letters (paginated)
+GET  /api/v1/dlq/:pipeline              Dead letters for one pipeline
+POST /api/v1/dlq/:id/retry              Re-attempt delivery of one dead letter
+POST /api/v1/dlq/:id/discard           Mark as resolved without retry
+POST /api/v1/dlq/discard-all/:pipeline Bulk discard for a pipeline
+```
 
 Links in the "Remediation" column navigate to the relevant detail page
 or action form.

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -490,25 +490,40 @@ optimized for different tasks:
 
 ### Unified Topology Graph
 
-The centrepiece of the WebUI. A single interactive graph showing the
-complete event flow, including relay nodes:
+The centrepiece of the WebUI. A multi-level interactive graph using
+**semantic zoom** — the graph shows the logical structure at whatever
+level of detail the user is looking at, from systems overview to
+individual node.
 
-```
-[Kafka topic] ──▶ relay reverse ──▶ [inbox: orders_raw]
-                                          │
-                                          ▼
-                                [stream: revenue_7d]
-                                          │
-                                [stream: regional_summary]
-                                          │
-                                          ▼
-                               [outbox: summary_out] ──▶ relay forward ──▶ [NATS subject]
-```
+**Three zoom levels:**
+
+**Level 0 — Systems overview (landing).** One node per PostgreSQL
+schema and one node per relay connection name. Hub-and-spoke layout.
+Always readable regardless of total stream table count. Each node
+shows: object count, aggregate SLA status (worst child), pipeline
+count on connecting edges. See [OQ-12](#oq-12-large-deployment-ui-scalability)
+for the full design.
+
+**Level 1 — Group detail.** Click a schema group or an edge between
+two groups to see all individual nodes within that scope. Shows
+partial pipelines between adjacent groups (e.g., all flows from
+`erp_raw` to `canonical`). This is the level where individual stream
+table nodes appear with their status badges.
+
+**Level 2 — Individual flow.** Click a specific flow line to see the
+full pipeline detail — every node from source to sink with staleness,
+buffer depth, SLA budget.
+
+For **small deployments** (all objects in `public`, no relay), Level 0
+and Level 1 collapse into a single flat graph showing all nodes
+directly.
 
 **Node types and visual encoding:**
 
 | Node type | Shape | Colour | Badge |
 |-----------|-------|--------|-------|
+| Schema group (Level 0) | Rounded rectangle, thick border | Worst-child SLA colour | Object count + status summary |
+| External system (Level 0) | Rounded rectangle | Grey | Pipeline count + backend icon |
 | External source (Kafka, NATS, ...) | Rounded rectangle | Grey | Backend icon |
 | Relay pipeline | Hexagon | Blue (connected) / Red (disconnected) | Lag rows |
 | Inbox / Outbox table | Rectangle, dashed border | Teal | Buffer depth |
@@ -518,13 +533,18 @@ complete event flow, including relay nodes:
 **Edge encoding:**
 
 - Width proportional to throughput (rows/sec over last 5 min)
+- At Level 0: width proportional to pipeline count, colour = worst SLA
 - Colour: green (healthy), amber (lag growing), red (SLA breach)
 - Animated dots for active data flow (like RisingWave's backpressure)
 
 **Interactions:**
 
-- Click a node → opens detail panel (stats, config, history)
+- Click a group node (Level 0) → drill into Level 1 (schema detail)
+- Click an edge between groups → show partial pipelines between them
+- Click a node (Level 1) → opens detail panel (stats, config, history)
 - Hover an edge → shows throughput, lag, last update timestamp
+- Breadcrumb trail at top: Systems > erp_raw > orders_raw
+- Back button / breadcrumb returns to previous zoom level
 - Time slider → replays historical state using `refresh_timeline()` data
 - Zoom/pan, drag-to-rearrange
 - Deep-linkable: `/ui/topology?focus=revenue_7d` highlights a node
@@ -1187,51 +1207,77 @@ and raw WebSocket can be added later if needed.
 
 ### OQ-12: Large-deployment UI scalability
 
-pg-trickle can scale to 1000+ stream tables. The WebUI's topology
+~~pg-trickle can scale to 1000+ stream tables. The WebUI's topology
 graph and list views must handle this, but the right approach is an
-open design question.
+open design question.~~
 
-**Industry precedent:** No comparable tool shows a global topology
-graph at scale. RisingWave's relation graph breaks above ~100 nodes.
-Snowflake and Databricks both use **per-object lineage** (click a
-table → see its upstream/downstream) rather than a global graph, plus
-hierarchical browsing and search for discovery.
+**Decision: Multi-level semantic zoom using schemas and connection
+names.** The topology graph uses a three-level hierarchy derived
+entirely from existing PostgreSQL and relay configuration — no new
+metadata required.
 
-The pattern across all three:
+Two grouping axes, both pre-existing:
 
-| Concern | How they solve it |
-|---|---|
-| Discovery | Search + filter + hierarchical browse |
-| Understanding relationships | Per-object scoped lineage graph |
-| Global overview | Lists with status indicators, not graphs |
-| Scale | Pagination / virtual scroll + server-side filtering |
+| Axis | Mechanism | Source |
+|---|---|---|
+| PG objects (stream tables, base tables, inboxes, outboxes) | PostgreSQL schemas | `pg_class.relnamespace` |
+| External systems (Kafka brokers, NATS servers, etc.) | Relay connection names | `[connections.*]` in relay TOML |
 
-**What we know:**
+**Level 0 — Systems overview (hub-and-spoke).** One node per schema
+(for PG objects) and one node per relay connection name (for external
+systems). Each node shows: object count, aggregate SLA status (worst
+child), pipeline count on edges. This view is always readable
+regardless of total node count — even 50 source systems produce a
+manageable graph.
 
-- The global topology graph works well for small deployments (<50–100
-  nodes) and is the right landing page for them.
-- For large deployments, the primary navigation shifts to search +
-  pipeline list + per-object scoped lineage.
-- The API must support server-side filtering, pagination, and scoped
-  topology queries (`GET /api/v1/dag/topology?focus=<name>&depth=N`).
-- Virtual scrolling (`@tanstack/react-table`) handles 10k-row lists
-  in the browser.
+```
+┌──────────┐     ┌─────────┐     ┌───────────┐     ┌───────────┐     ┌───────────────┐
+│ erp-kafka│────▶│ erp_raw │────▶│ canonical │────▶│ analytics │────▶│analytics-nats │
+│ 3 topics │     │ 3 tables│     │ 45 tables │     │ 8 tables  │     │ 2 subjects    │
+│ ● 3      │     │ ● 3     │     │ ● 43 🟡1 🔴1│  │ ● 8      │     │ ● 2           │
+└──────────┘     └─────────┘     └───────────┘     └───────────┘     └───────────────┘
+```
 
-**Open sub-questions:**
+Left: relay connection names (reverse/inbound). Middle: PG schemas.
+Right: relay connection names (forward/outbound). Layout position is
+auto-inferred: schemas containing only base tables + relay inboxes
+are placed left; schemas with outboxes + relay forwards are placed
+right; everything else is center. No manual layout configuration
+required.
 
-1. At what node count should the landing page switch from global graph
-   to pipeline list? (~50? ~100? User-configurable?)
-2. Should the global graph show a clustered/summarized view at scale
-   (collapsed groups with health badges) or simply not render?
-3. Should the scoped graph (per-object lineage) be a separate page or
-   a filtered state of the topology page
-   (`/ui/topology?focus=revenue_7d&depth=2`)?
-4. How should the search experience work — command palette, search bar
-   in sidebar, or both?
+**Level 1 — Schema / connection detail.** Click a schema group or an
+edge between two groups → shows all individual nodes within that
+scope, with edges to/from adjacent groups. Supports **partial
+pipelines**: "Show me all flows from `erp-kafka` to `canonical`"
+without rendering what happens downstream of canonical.
 
-This requires prototyping and user testing. The Tier 1 implementation
-should target the <100 node case (global graph + pipeline list). The
-large-deployment UX is a Tier 2 design task.
+**Level 2 — Individual flow.** Click a specific node or flow → full
+pipeline detail (every node with staleness, buffer depth, SLA). Same
+as the pipeline detail view.
+
+**Fallback for no grouping.** If all objects are in the `public` schema
+and no relay connections are configured, the topology falls back to
+the flat graph (all individual nodes). The WebUI shows a hint:
+"Organize stream tables into schemas to enable the systems overview."
+
+**Why schemas, not a custom grouping table.** Schemas are PostgreSQL's
+native organizational primitive. They align with dbt's `schema` config,
+data vault patterns (raw/business vault schemas), medallion
+architecture (bronze/silver/gold), and standard access control
+(`GRANT USAGE ON SCHEMA`). Adding a `layer` or `source_group` column
+would duplicate what schemas already provide and diverge from
+PostgreSQL conventions.
+
+**API support:**
+
+```
+GET /api/v1/dag/topology?level=0             Systems overview
+GET /api/v1/dag/topology?level=1&schema=erp_raw  Schema drill-in
+GET /api/v1/dag/topology?level=1&from=erp_raw&to=canonical
+                                              Partial pipeline view
+GET /api/v1/dag/topology?focus=revenue_7d&depth=2
+                                              Per-object neighbourhood
+```
 
 ### OQ-11: Agent guardrails
 

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -87,7 +87,7 @@ The current getting-started path requires:
 
 1. Install the PostgreSQL extension
 2. Write SQL to create stream tables and configure CDC
-3. Install the relay binary and write TOML configuration
+3. Install the relay binary and configure it via SQL
 4. Use the TUI or raw SQL to monitor
 
 Each step requires a different tool and a different skill set. The WebUI
@@ -404,10 +404,12 @@ write operations. SQL preview before every action.
 | **Manual refresh** | `SELECT pgtrickle.refresh(...)` |
 | **Pause/resume stream table** | `SELECT pgtrickle.alter_stream_table(...)` |
 
-**Backend form:** When creating a pipeline, the form includes a dropdown
-for backend type (Kafka, NATS, Redis, etc.) and renders the relevant
-fields dynamically. Credential fields display as `${env:VAR}` references
-with documentation inline — secrets never pass through the WebUI.
+**Backend form:** When creating a pipeline, the form generates the
+`INSERT INTO pgtrickle.relay_outbox_config` or `relay_inbox_config` SQL
+with the JSONB config object. Credential fields are shown as
+`${env:VAR_NAME}` or `${file:/path/to/secret}` reference tokens —
+the relay resolves these from the process environment at startup.
+Secrets never pass through the WebUI or get stored in the database.
 
 ### Tier 3 — Stream Table Wizard & Full Setup (Deprioritized)
 
@@ -498,11 +500,8 @@ individual node.
 **Three zoom levels:**
 
 **Level 0 — Systems overview (landing).** One node per PostgreSQL
-schema and one node per relay connection name. Hub-and-spoke layout.
-Always readable regardless of total stream table count. Each node
-shows: object count, aggregate SLA status (worst child), pipeline
-count on connecting edges. See [OQ-12](#oq-12-large-deployment-ui-scalability)
-for the full design.
+schema. External relay endpoints (Kafka, NATS, etc.) appear as leaf
+nodes attached to the schema containing their inbox/outbox table.
 
 **Level 1 — Group detail.** Click a schema group or an edge between
 two groups to see all individual nodes within that scope. Shows
@@ -523,7 +522,7 @@ directly.
 | Node type | Shape | Colour | Badge |
 |-----------|-------|--------|-------|
 | Schema group (Level 0) | Rounded rectangle, thick border | Worst-child SLA colour | Object count + status summary |
-| External system (Level 0) | Rounded rectangle | Grey | Pipeline count + backend icon |
+| External relay endpoint (Level 0 leaf) | Circle | Blue (connected) / Red (disconnected) | Backend type icon |
 | External source (Kafka, NATS, ...) | Rounded rectangle | Grey | Backend icon |
 | Relay pipeline | Hexagon | Blue (connected) / Red (disconnected) | Lag rows |
 | Inbox / Outbox table | Rectangle, dashed border | Teal | Buffer depth |
@@ -1205,68 +1204,69 @@ most firewall-friendly option and covers remote agents, CI/CD
 pipelines, and browser-based tools. stdio transport (for local agents)
 and raw WebSocket can be added later if needed.
 
-### OQ-12: Large-deployment UI scalability
+### OQ-12: Large-deployment UI scalability — schema-based semantic zoom
 
 ~~pg-trickle can scale to 1000+ stream tables. The WebUI's topology
 graph and list views must handle this, but the right approach is an
 open design question.~~
 
-**Decision: Multi-level semantic zoom using schemas and connection
-names.** The topology graph uses a three-level hierarchy derived
-entirely from existing PostgreSQL and relay configuration — no new
-metadata required.
+**Decision: Multi-level semantic zoom using schemas only.** The topology
+graph groups all objects — including inbox and outbox tables — by
+PostgreSQL schema. No new metadata, no JSONB parsing, no naming
+conventions required.
 
-Two grouping axes, both pre-existing:
+**Single grouping axis: PostgreSQL schemas.** Every PG object (stream
+table, base table, inbox table, outbox table) has exactly one schema
+via `pg_class.relnamespace`. That schema IS the group. External relay
+endpoints (Kafka brokers, NATS servers) are simple leaf nodes on the
+edge of the schema that contains their inbox/outbox table — they show
+backend type and connection status but are not separately grouped or
+named.
 
-| Axis | Mechanism | Source |
-|---|---|---|
-| PG objects (stream tables, base tables, inboxes, outboxes) | PostgreSQL schemas | `pg_class.relnamespace` |
-| External systems (Kafka brokers, NATS servers, etc.) | Relay connection names | `[connections.*]` in relay TOML |
-
-**Level 0 — Systems overview (hub-and-spoke).** One node per schema
-(for PG objects) and one node per relay connection name (for external
-systems). Each node shows: object count, aggregate SLA status (worst
-child), pipeline count on edges. This view is always readable
-regardless of total node count — even 50 source systems produce a
-manageable graph.
+**Level 0 — Systems overview (hub-and-spoke).** One node per schema.
+Each schema node shows: object count, aggregate SLA status (worst
+child), pipeline count on connecting edges. External relay endpoints
+appear as unlabelled leaf nodes attached to the schemas that contain
+their inbox/outbox tables. This view is always readable regardless of
+total object count.
 
 ```
-┌──────────┐     ┌─────────┐     ┌───────────┐     ┌───────────┐     ┌───────────────┐
-│ erp-kafka│────▶│ erp_raw │────▶│ canonical │────▶│ analytics │────▶│analytics-nats │
-│ 3 topics │     │ 3 tables│     │ 45 tables │     │ 8 tables  │     │ 2 subjects    │
-│ ● 3      │     │ ● 3     │     │ ● 43 🟡1 🔴1│  │ ● 8      │     │ ● 2           │
-└──────────┘     └─────────┘     └───────────┘     └───────────┘     └───────────────┘
+┌────────┐     ┌─────────┐     ┌───────────┐     ┌───────────┐     ┌──────┐
+│ Kafka  │────▶│ erp_raw │────▶│ canonical │────▶│ analytics │────▶│ NATS │
+│        │     │ 3 tables│     │ 45 tables │     │ 8 tables  │     │      │
+│        │     │ ● 3     │     │● 43🟡1🔴1 │     │ ● 8       │     │      │
+└────────┘     └─────────┘     └───────────┘     └───────────┘     └──────┘
 ```
 
-Left: relay connection names (reverse/inbound). Middle: PG schemas.
-Right: relay connection names (forward/outbound). Layout position is
-auto-inferred: schemas containing only base tables + relay inboxes
-are placed left; schemas with outboxes + relay forwards are placed
-right; everything else is center. No manual layout configuration
-required.
+Middle: PG schemas. Leaf nodes on left: relay reverse pipeline
+endpoints (backend type icon + connected/disconnected status). Leaf
+nodes on right: relay forward pipeline endpoints. Layout position is
+auto-inferred: schemas that contain only base tables and relay inboxes
+are placed left; schemas with outboxes and relay forwards are placed
+right; everything else is center. No configuration required.
 
-**Level 1 — Schema / connection detail.** Click a schema group or an
-edge between two groups → shows all individual nodes within that
-scope, with edges to/from adjacent groups. Supports **partial
-pipelines**: "Show me all flows from `erp-kafka` to `canonical`"
-without rendering what happens downstream of canonical.
+**Level 1 — Schema detail.** Click a schema group → shows all individual
+nodes within that schema, with edges to adjacent schemas and to the
+external relay endpoints. Supports **partial pipelines**: clicking the
+edge between `erp_raw` and `canonical` shows only the flows between
+those two schemas.
 
-**Level 2 — Individual flow.** Click a specific node or flow → full
-pipeline detail (every node with staleness, buffer depth, SLA). Same
-as the pipeline detail view.
+**Level 2 — Individual flow.** Click a specific flow → full pipeline
+detail (every node with staleness, buffer depth, SLA). Same as the
+pipeline detail view.
 
 **Fallback for no grouping.** If all objects are in the `public` schema
-and no relay connections are configured, the topology falls back to
-the flat graph (all individual nodes). The WebUI shows a hint:
-"Organize stream tables into schemas to enable the systems overview."
+and no relay connections are configured, the topology renders a flat
+graph with all individual nodes directly. No extra clicks required for
+small deployments.
 
-**Why schemas, not a custom grouping table.** Schemas are PostgreSQL's
-native organizational primitive. They align with dbt's `schema` config,
-data vault patterns (raw/business vault schemas), medallion
-architecture (bronze/silver/gold), and standard access control
-(`GRANT USAGE ON SCHEMA`). Adding a `layer` or `source_group` column
-would duplicate what schemas already provide and diverge from
-PostgreSQL conventions.
+**Why schemas only, not a custom grouping table.** Schemas are
+PostgreSQL's native organizational primitive. They align with dbt's
+`schema` config, data vault patterns (raw/business vault schemas),
+medallion architecture (bronze/silver/gold), and standard access
+control (`GRANT USAGE ON SCHEMA`). Inbox and outbox tables already
+live in meaningful schemas by convention — no additional metadata
+needed to group them.
 
 **API support:**
 

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -26,6 +26,7 @@
   - [Tier 2 — Relay Pipeline Management](#tier-2--relay-pipeline-management)
   - [Tier 3 — Stream Table Wizard & Full Setup](#tier-3--stream-table-wizard--full-setup)
 - [Key Features — Detailed Design](#key-features--detailed-design)
+  - [Pipelines (End-to-End Flows)](#pipelines-end-to-end-flows)
   - [Unified Topology Graph](#unified-topology-graph)
   - [SLA Budget & Lag Monitoring](#sla-budget--lag-monitoring)
   - [DVM Operator Inspector](#dvm-operator-inspector)
@@ -246,6 +247,11 @@ guarantees from Phase 0. Breaking changes require a version bump
 and automation scripts depend on predictable schemas.
 
 ```
+# Flows — end-to-end data paths derived from the DAG
+GET  /api/v1/flows                      All end-to-end flows (source → sink paths)
+GET  /api/v1/flows/:id                  Single flow detail (all nodes in the path)
+
+# Stream tables
 GET  /api/v1/tables                     Stream table list + status
 GET  /api/v1/tables/:name               Detail view for one stream table
 GET  /api/v1/tables/:name/history       Refresh history
@@ -253,31 +259,41 @@ GET  /api/v1/tables/:name/lineage       Column-level lineage
 GET  /api/v1/tables/:name/operator-tree DVM operator tree (DOT format)
 GET  /api/v1/tables/:name/sample        Sample rows (LIMIT 50)
 
+# Health (aggregates CDC, fuses, slots, workers, relay status)
 GET  /api/v1/health                     Health scorecard
 GET  /api/v1/health/checks              Individual health checks
+
+# DAG / topology
 GET  /api/v1/dag                        Full DAG (nodes + edges + metadata)
 GET  /api/v1/dag/topology               Extended DAG with relay nodes
 
+# Relay connectors
 GET  /api/v1/relay/pipelines            All relay pipelines (forward + reverse)
 GET  /api/v1/relay/pipelines/:id        Single pipeline detail
 GET  /api/v1/relay/pipelines/:id/lag    Lag metrics for a pipeline
 
+# Operational detail (sub-resources of Health in the UI)
 GET  /api/v1/cdc/sources                CDC source table status
 GET  /api/v1/cdc/buffers                Change buffer sizes
 GET  /api/v1/cdc/slots                  Replication slot health
-
 GET  /api/v1/scheduler/workers          Worker pool status
 GET  /api/v1/scheduler/jobs             Job queue depth
 GET  /api/v1/fuses                      Fuse/circuit-breaker state
 
+# Activity
 GET  /api/v1/timeline                   Refresh timeline (time-series)
 GET  /api/v1/alerts                     Recent alerts (paginated)
 
+# Write operations
 POST /api/v1/sql/preview                Validate SQL, return DVM analysis
 POST /api/v1/sql/execute                Execute SQL (with auth check)
 POST /api/v1/fuses/:name/reset          Reset a blown fuse
 POST /api/v1/tables/:name/refresh       Trigger manual refresh
 ```
+
+The CDC, fuse, scheduler, and slot endpoints remain in the API for
+programmatic access and the Health page's drill-down views. They are
+not top-level navigation items in the WebUI — they live under Health.
 
 Every write endpoint (`POST`) requires authentication in `pg` and `oidc`
 modes. In `none` mode, writes use the relay's PG connection.
@@ -421,6 +437,56 @@ writing SQL manually.
 ---
 
 ## Key Features — Detailed Design
+
+### Pipelines (End-to-End Flows)
+
+The primary navigational concept in the WebUI. A **pipeline** (also
+called a **flow**) is an end-to-end data path derived from the DAG:
+every maximal path from a leaf source (base table or relay reverse
+input) to a leaf sink (stream table with no dependents, or relay
+forward output).
+
+```
+Kafka:orders → orders_raw → revenue_7d → regional_summary → NATS:analytics
+```
+
+That is one pipeline. pg-trickle doesn't store pipelines as a formal
+object — they are computed at query time from the DAG. The
+`GET /api/v1/flows` endpoint returns all maximal source-to-sink paths,
+each with:
+
+- A stable ID (hash of the node sequence)
+- The ordered list of nodes in the path
+- Aggregate SLA status (worst node determines the flow's status)
+- End-to-end latency (cumulative staleness from source to sink)
+- Throughput (minimum throughput across edges — the bottleneck)
+
+**Why pipelines instead of tables or relay connectors as the list view:**
+Users think in terms of data flows, not individual nodes. "Is my
+orders-to-analytics flow healthy?" is a more natural question than
+"Is `regional_summary` healthy?" The pipeline view answers the first
+question directly. Individual node detail (stream table stats, relay
+connector config) is accessed by clicking a node within a pipeline.
+
+A stream table that appears in multiple flows (e.g., a shared dimension
+table like `customers`) appears in multiple pipeline rows — correctly
+reflecting its operational blast radius.
+
+**Orphan tables** (stream tables with no downstream consumers and no
+upstream relay source) appear as single-node pipelines. This makes
+orphans visible rather than hidden.
+
+The **Pipelines** page is the list/tabular view of the same information
+that the **Topology** page shows spatially. Two views of the same data,
+optimized for different tasks:
+
+| Task | Best view |
+|---|---|
+| Understand system architecture | Topology (graph) |
+| Find the flow breaching SLA | Pipelines (sorted by worst SLA) |
+| Trace data from source to sink | Pipeline detail (ordered node list) |
+| Filter by refresh mode or schema | Pipelines list with faceted filters |
+| See end-to-end latency | Pipeline detail (cumulative lag) |
 
 ### Unified Topology Graph
 
@@ -1118,6 +1184,54 @@ transport: Streamable HTTP (HTTP+SSE). This is the simplest,
 most firewall-friendly option and covers remote agents, CI/CD
 pipelines, and browser-based tools. stdio transport (for local agents)
 and raw WebSocket can be added later if needed.
+
+### OQ-12: Large-deployment UI scalability
+
+pg-trickle can scale to 1000+ stream tables. The WebUI's topology
+graph and list views must handle this, but the right approach is an
+open design question.
+
+**Industry precedent:** No comparable tool shows a global topology
+graph at scale. RisingWave's relation graph breaks above ~100 nodes.
+Snowflake and Databricks both use **per-object lineage** (click a
+table → see its upstream/downstream) rather than a global graph, plus
+hierarchical browsing and search for discovery.
+
+The pattern across all three:
+
+| Concern | How they solve it |
+|---|---|
+| Discovery | Search + filter + hierarchical browse |
+| Understanding relationships | Per-object scoped lineage graph |
+| Global overview | Lists with status indicators, not graphs |
+| Scale | Pagination / virtual scroll + server-side filtering |
+
+**What we know:**
+
+- The global topology graph works well for small deployments (<50–100
+  nodes) and is the right landing page for them.
+- For large deployments, the primary navigation shifts to search +
+  pipeline list + per-object scoped lineage.
+- The API must support server-side filtering, pagination, and scoped
+  topology queries (`GET /api/v1/dag/topology?focus=<name>&depth=N`).
+- Virtual scrolling (`@tanstack/react-table`) handles 10k-row lists
+  in the browser.
+
+**Open sub-questions:**
+
+1. At what node count should the landing page switch from global graph
+   to pipeline list? (~50? ~100? User-configurable?)
+2. Should the global graph show a clustered/summarized view at scale
+   (collapsed groups with health badges) or simply not render?
+3. Should the scoped graph (per-object lineage) be a separate page or
+   a filtered state of the topology page
+   (`/ui/topology?focus=revenue_7d&depth=2`)?
+4. How should the search experience work — command palette, search bar
+   in sidebar, or both?
+
+This requires prototyping and user testing. The Tier 1 implementation
+should target the <100 node case (global graph + pipeline list). The
+large-deployment UX is a Tier 2 design task.
 
 ### OQ-11: Agent guardrails
 

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -523,9 +523,12 @@ table nodes appear with their status badges.
 full pipeline detail — every node from source to sink with staleness,
 buffer depth, SLA budget.
 
-For **small deployments** (all objects in `public`, no relay), Level 0
-and Level 1 collapse into a single flat graph showing all nodes
-directly.
+**Single-schema auto-navigation.** If the deployment has only one
+schema, the topology automatically opens at Level 1 (the schema
+detail view) rather than stopping at a Level 0 with a single node.
+The breadcrumb always shows `Systems > <schema>` so the user can
+navigate back to Level 0, see that schemas are the grouping unit,
+and understand how a second schema would appear.
 
 **Node types and visual encoding:**
 
@@ -1261,10 +1264,10 @@ those two schemas.
 detail (every node with staleness, buffer depth, SLA). Same as the
 pipeline detail view.
 
-**Fallback for no grouping.** If all objects are in the `public` schema
-and no relay connections are configured, the topology renders a flat
-graph with all individual nodes directly. No extra clicks required for
-small deployments.
+**Single-schema auto-navigation.** If only one schema exists, the
+topology opens directly at Level 1. The breadcrumb always renders
+`Systems > <schema>` so the user can click back to Level 0 and
+discover that schemas are the grouping primitive.
 
 **Why schemas only, not a custom grouping table.** Schemas are
 PostgreSQL's native organizational primitive. They align with dbt's

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -40,6 +40,10 @@
   - [OpenAPI Specification](#openapi-specification)
 - [Comparison with RisingWave Dashboard](#comparison-with-risingwave-dashboard)
 - [Sequencing & Dependencies](#sequencing--dependencies)
+  - [Prerequisites](#prerequisites)
+  - [Delivery Phases](#delivery-phases)
+  - [Relay `AppState` Requirements (Day 1)](#relay-appstate-requirements-day-1)
+  - [Self-Monitoring via Stream Tables (Dogfooding)](#self-monitoring-via-stream-tables-dogfooding)
 - [Open Questions](#open-questions)
 
 ---
@@ -279,16 +283,69 @@ modes. In `none` mode, writes use the relay's PG connection.
 
 ### Real-Time Data
 
-Two mechanisms for live updates:
+Two distinct live-update tiers, both delivered via the same WebSocket
+channel (`/api/v1/ws`):
 
-**WebSocket** (`/api/v1/ws`): Subscribed to the `pg_trickle_alert` NOTIFY
-channel and relay pipeline state changes. The frontend connects on load
-and receives structured JSON events for: alerts, staleness changes,
-refresh completions, relay lag updates, fuse state changes.
+#### Tier A — State Live (badge/metric updates)
 
-**Polling fallback:** For environments where WebSocket is blocked (some
-corporate proxies), the frontend falls back to polling `/api/v1/health`
-and `/api/v1/dag/topology` at a configurable interval (default 5s).
+Node decorations update without changing graph structure: staleness
+counters tick up, buffer depth badges change, relay lag updates, SLA
+colour transitions (green → amber → red), alert feed entries appear.
+
+Source: `pg_trickle_alert` NOTIFY channel + relay pipeline state
+changes broadcast from `AppState.ws_broadcast`. Frontend receives
+`WsEvent::StateUpdate` and patches node/edge data in-place — no
+graph re-layout required.
+
+#### Tier B — Structure Live (topology changes)
+
+Graph nodes and edges appear or disappear: a new stream table is
+created, a relay pipeline is added, a CDC trigger is enabled on a
+source table. This requires a graph re-fetch and re-render.
+
+Source: a new `pgtrickle_structure_changed` NOTIFY channel emitted
+by the existing DDL event trigger hooks in the extension. The relay
+listens on this channel alongside `pg_trickle_alert` and broadcasts
+`WsEvent::TopologyChanged` to connected WebSocket clients.
+
+Frontend behaviour on `WsEvent::TopologyChanged`:
+1. Re-fetch `GET /api/v1/dag/topology`
+2. Diff the new node/edge list against the current graph
+3. Animate nodes appearing (fade-in) or disappearing (fade-out)
+4. Preserve current zoom/pan position and node layout where possible
+
+The topology payload is small (tens of nodes in typical deployments),
+so a full re-fetch is simpler and sufficient — no differential graph
+patching needed.
+
+**Round-trip latency** from "Apply" click to node appearing on graph:
+- PG DDL execution + trigger: ~5–20 ms
+- NOTIFY delivery: ~1 ms
+- Relay LISTEN → `WsEvent::TopologyChanged`: ~1 ms
+- Browser re-fetch + re-render: ~50–100 ms
+- **Total: ~100 ms** — tight enough to feel instantaneous
+
+**Multi-user coordination:** All connected WebUI clients (multiple
+browser tabs, multiple team members) receive the same
+`WsEvent::TopologyChanged` event simultaneously. An SRE watching the
+topology dashboard sees a new stream table appear the moment a data
+engineer or LLM agent applies the `CREATE STREAM TABLE` SQL — without
+refreshing the page.
+
+**Optimistic updates (Tier 2+):** When the current user applies SQL
+via the WebUI's SQL preview model, the frontend can show the new node
+*immediately* (before PG confirms) and reconcile with the server
+response. If execution fails, the optimistic node is removed and the
+error is shown. This requires the frontend to predict the topology
+change from the SQL statement — feasible for simple cases
+(`CREATE STREAM TABLE`, relay pipeline insert) but not for complex DDL.
+Implemented as a Tier 2 enhancement, not required for Tier 1.
+
+**Polling fallback:** For environments where WebSocket is blocked
+(some corporate proxies), the frontend falls back to polling
+`/api/v1/health` and `/api/v1/dag/topology` at a configurable
+interval (default 5s). Structure changes are detected by comparing
+the node list on each poll.
 
 ---
 
@@ -405,9 +462,15 @@ complete event flow, including relay nodes:
 - Zoom/pan, drag-to-rearrange
 - Deep-linkable: `/ui/topology?focus=revenue_7d` highlights a node
 
+**Live updates:**
+- `WsEvent::StateUpdate` → badge values update in-place (no re-layout)
+- `WsEvent::TopologyChanged` → re-fetch topology, animate new/removed
+  nodes, preserve zoom/pan and existing node positions
+- Optimistic node insertion when the current user applies SQL (Tier 2+)
+
 **Implementation:** Cytoscape.js or reactflow for the graph layout. DAG
 data from `/api/v1/dag/topology` (extends `dependency_tree()` with relay
-pipeline nodes). Refreshed every 5s via WebSocket push or polling.
+pipeline nodes). WebSocket-driven updates; 5s polling fallback.
 
 ### SLA Budget & Lag Monitoring
 
@@ -806,6 +869,14 @@ with:
 - A stubbed `/ui` route returning 200 OK (placeholder for the frontend)
 - The JSON API layer (`/api/v1/...`) as the backend for the WebUI
 
+The pg-trickle extension must emit a `pgtrickle_structure_changed`
+NOTIFY whenever topology changes: stream table created/dropped,
+CDC trigger enabled/disabled, relay pipeline config changed. The relay
+listens on this channel alongside `pg_trickle_alert` and uses it to
+drive `WsEvent::TopologyChanged` broadcasts. This NOTIFY is cheap
+(~2 µs, inside the existing DDL trigger path) and can be added in the
+same release as the relay.
+
 ### Delivery Phases
 
 | Phase | Content | Depends on |
@@ -835,7 +906,12 @@ pub struct AppState {
     /// Shutdown token (coordinates relay workers + HTTP server)
     pub shutdown: CancellationToken,
 
-    /// WebSocket broadcast channel (NOTIFY alerts, pipeline state changes)
+    /// WebSocket broadcast channel (NOTIFY alerts, topology changes, state updates)
+    /// WsEvent variants:
+    ///   StateUpdate { table, staleness_secs, buffer_rows, lag_rows, sla_status }
+    ///   TopologyChanged { source: "ddl" | "relay_config" }
+    ///   Alert { channel, payload }
+    ///   RelayPipelineChanged { pipeline_name, status }
     pub ws_broadcast: broadcast::Sender<WsEvent>,
 
     /// Configuration (auth mode, log level, feature flags)
@@ -846,6 +922,102 @@ pub struct AppState {
 This structure is shared between relay worker tasks and HTTP handlers.
 Designing it correctly in RELAY-1 avoids a painful refactor when the
 WebUI is added.
+
+### Self-Monitoring via Stream Tables (Dogfooding)
+
+The WebUI uses pg-trickle stream tables to power several of its own
+derived metrics. This is the canonical dogfooding use case: the product
+monitoring itself, with those monitoring stream tables visible as
+first-class nodes in the topology graph.
+
+**Governing rule:** The `/health` endpoint and the live-badge
+`WsEvent::StateUpdate` path **always use direct queries** — they must
+never depend on stream tables. If the scheduler is stopped or the
+extension is degraded, those paths must still work. Stream tables are
+only used for **derived aggregate metrics** where a small amount of
+staleness is acceptable and the value comes from incremental maintenance
+over time.
+
+#### Candidate stream tables
+
+The relay creates these stream tables during its own initialisation
+(via `pgtrickle.relay_setup()`), sourced exclusively from stable,
+public-facing catalog views and relay-owned sample tables:
+
+| Stream table | Source | WebUI consumer | Refresh mode |
+|---|---|---|---|
+| `pgtrickle._staleness_samples` | Relay worker polls `get_staleness()`, inserts rows | N/A — source table | N/A |
+| `pgtrickle.sla_burn_rate` | `_staleness_samples` (1 h window) | SLA budget progress bars, burn-rate trend arrows | DIFFERENTIAL (`regr_slope` via aux cols) |
+| `pgtrickle.refresh_percentiles` | `pgt_refresh_log` (rolling 1 h / 24 h) | Refresh timeline P50/P95/P99 overlays | DIFFERENTIAL (algebraic aggregates) |
+| `pgtrickle.buffer_growth_rate` | `_staleness_samples` (derivative per table) | Buffer depth trend badges | DIFFERENTIAL |
+| `pgtrickle.end_to_end_lag` | `pg_stat_stream_tables` + DAG edges | Topology graph edge widths | FULL (recursive CTE — upgraded when recursive IVM ships) |
+
+#### Example: `sla_burn_rate`
+
+The relay inserts a staleness sample for each stream table every
+`pg_trickle.relay_sample_interval` seconds (default 15 s):
+
+```sql
+-- Source table: populated by the relay worker, not user-managed
+CREATE TABLE pgtrickle._staleness_samples (
+    sampled_at  timestamptz NOT NULL DEFAULT now(),
+    table_name  text        NOT NULL,
+    staleness_s float4      NOT NULL
+);
+
+-- Stream table: rolling SLA burn rate, refreshed every 15 s
+CREATE STREAM TABLE pgtrickle.sla_burn_rate AS
+SELECT
+    table_name,
+    avg(staleness_s)                                            AS mean_staleness_s,
+    max(staleness_s)                                            AS max_staleness_s,
+    regr_slope(staleness_s, extract(epoch FROM sampled_at))     AS staleness_trend_s_per_s,
+    count(*)                                                    AS sample_count
+FROM pgtrickle._staleness_samples
+WHERE sampled_at > now() - interval '1 hour'
+GROUP BY table_name;
+SCHEDULE '15 seconds';
+```
+
+`staleness_trend_s_per_s` is the burn rate: a value of `0.5` means the
+table is gaining half a second of staleness for every wall-clock second
+elapsed. Given a 30 s SLA and current staleness of 20 s, it will breach
+in `(30 − 20) / 0.5 = 20 s`. This is exactly the value the SLA budget
+progress bar displays as remaining budget.
+
+The aggregate uses `regr_slope()`, which is algebraic and maintained
+incremantally by the DVM engine via auxiliary sum/count columns — no
+full-table rescan on each 15 s tick.
+
+#### Meta-observability property
+
+Because these stream tables are registered in `pgt_stream_tables`, they
+appear in the topology graph as first-class nodes. An SRE investigating
+a staleness spike can see at a glance whether `sla_burn_rate` itself is
+stale — meaning the burn-rate indicators in the WebUI are running on
+outdated data. The monitoring is transparent about its own freshness.
+No external monitoring tool provides this self-describing property.
+
+Further: clicking the `sla_burn_rate` node in the topology graph opens
+the DVM operator inspector showing the `regr_slope` aggregate strategy,
+its auxiliary columns, and the current change buffer depth of
+`_staleness_samples`. The observability stack is fully introspectable.
+
+#### Bootstrap safety rule
+
+| Data path | Source | Stream table allowed? |
+|---|---|---|
+| `/health` endpoint | `health_check()` — direct query | **No** |
+| `WsEvent::StateUpdate` live badges | NOTIFY + direct queries | **No** |
+| SLA burn rate chart | `pgtrickle.sla_burn_rate` | **Yes** |
+| Refresh percentiles overlay | `pgtrickle.refresh_percentiles` | **Yes** |
+| Topology edge width (throughput) | `pgtrickle.end_to_end_lag` | **Yes** (with polling fallback to direct query) |
+| Buffer depth badge (live) | Direct `change_buffer_sizes()` | **No** |
+| Buffer growth trend line | `pgtrickle.buffer_growth_rate` | **Yes** |
+
+The invariant: anything that must work when the scheduler is stopped or
+the extension is degraded uses direct queries. Derived, time-aggregated,
+trend data uses stream tables.
 
 ---
 

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -443,8 +443,10 @@ with its structural role derived from the DAG. No separate "pipelines"
 concept — a pipeline is just a table plus its upstream lineage, so the
 two views are the same thing.
 
-**Structural type** is inferred from the DAG and relay config at query
-time:
+**Structural type** is served by the API from `pgtrickle.table_classifications`,
+a plain SQL view computed in the database — not derived in the API
+server or browser. This means Grafana dashboards and external tools
+can query the same type classifications directly:
 
 | Type | How inferred |
 |------|-------------|
@@ -459,12 +461,11 @@ time:
 These types are not mutually exclusive — a table can be `leaf + union`.
 They are shown as small badge chips on each row.
 
-**E2E lag** is computed for every table: the maximum cumulative
-staleness from any root source to this table. For a leaf table this is
-the end-to-end delivery latency. For an intermediate table it shows
-how stale its inputs are. This single metric is more useful than
-separating "pipeline E2E lag" (leaves only) from "table staleness"
-(all) — it degrades gracefully.
+**E2E lag** is served from `pgtrickle.end_to_end_lag` (a stream table
+maintained by the relay). It holds the maximum cumulative staleness
+from any root source to each table — not computed on request and not
+computed in the browser. Grafana can plot E2E lag time-series directly
+from this table.
 
 ```
 Table                 Type          Staleness  E2E Lag   SLA
@@ -1079,6 +1080,29 @@ extension is degraded, those paths must still work. Stream tables are
 only used for **derived aggregate metrics** where a small amount of
 staleness is acceptable and the value comes from incremental maintenance
 over time.
+
+#### Computation layer assignments
+
+Every derived value must be assigned to exactly one layer. The test:
+**if Grafana or an external alerting tool should see it, it belongs in
+the database — not in the API server and definitely not in JavaScript.**
+
+| Derived value | Layer | Rationale |
+|---|---|---|
+| Structural type (inbox / outbox / leaf / intermediate / union / orphan) | **DB view** `pgtrickle.table_classifications` | Trivial SQL joins on `pgt_stream_tables` + relay config tables; Grafana panels showing table-type breakdown need it |
+| SLA budget % (`staleness / sla_threshold`) | **DB view** alongside `sla_burn_rate` | Same number used in Grafana progress bars and Prometheus gauge |
+| E2E lag (cumulative staleness root→table) | **Stream table** `pgtrickle.end_to_end_lag` | Recursive DAG walk; updated on schedule |
+| Root cause / inherited breach classification | **Stream table** `pgtrickle.breach_events` | Grafana and Prometheus alert on `breach_type = 'root'` directly |
+| Transport annotations (which schemas have relay inboxes/outboxes) | **API layer** (relay reads `relay_inbox_config`, `relay_outbox_config`) | DB has the data; API assembles it; JS renders only |
+| Graph node positions (topology layout) | **Browser** (dagre / elkjs) | Rendering algorithm; meaningless outside the viewport |
+| Relative timestamps ("2m ago") | **Browser** | Time-zone-aware display formatting |
+| Collapsed / expanded state | **Browser** | UI state only |
+
+`pgtrickle.table_classifications` is a plain SQL view (not a stream
+table) because it is cheap to compute on read — it is a join of
+`pg_class`, `pgt_stream_tables`, `pgtrickle.dag_edges`,
+`relay_inbox_config`, and `relay_outbox_config`, all of which are
+already indexed. It does not need incremental maintenance.
 
 #### Candidate stream tables
 

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -318,11 +318,12 @@ GET  /api/v1/relay/pipelines/:id        Single pipeline detail
 GET  /api/v1/relay/pipelines/:id/lag    Lag metrics for a pipeline
 
 # Dead letter queue
-GET  /api/v1/dlq                        All unresolved dead letters (paginated)
-GET  /api/v1/dlq/:pipeline              Dead letters for one pipeline
-POST /api/v1/dlq/:id/retry              Re-attempt delivery of one dead letter
-POST /api/v1/dlq/:id/discard           Mark resolved without retry
-POST /api/v1/dlq/discard-all/:pipeline Bulk discard for a pipeline
+GET   /api/v1/dlq                        All unresolved dead letters (paginated)
+GET   /api/v1/dlq/:pipeline              Dead letters for one pipeline
+PATCH /api/v1/dlq/:id/annotate           Update operator_notes (raw_payload immutable)
+POST  /api/v1/dlq/:id/retry              Re-attempt delivery of one dead letter
+POST  /api/v1/dlq/:id/discard           Mark resolved without retry
+POST  /api/v1/dlq/discard-all/:pipeline Bulk discard for a pipeline
 
 # Operational detail (sub-resources of Health in the UI)
 GET  /api/v1/cdc/sources                CDC source table status
@@ -856,32 +857,56 @@ failure surfaced here and in `breach_events`.
 
 ```sql
 CREATE TABLE pgtrickle.relay_dead_letters (
-    id           BIGSERIAL PRIMARY KEY,
-    failed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    id            BIGSERIAL PRIMARY KEY,
+    failed_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
     pipeline_name TEXT NOT NULL,         -- FK to relay_inbox/outbox_config.name
-    direction    TEXT NOT NULL,          -- 'inbox' or 'outbox'
-    error_type   TEXT NOT NULL,          -- 'decode', 'sink_permanent', 'inbox_permanent'
+    direction     TEXT NOT NULL,          -- 'inbox' or 'outbox'
+    error_type    TEXT NOT NULL,          -- 'decode', 'sink_permanent', 'inbox_permanent', 'claim_check'
     error_message TEXT NOT NULL,
-    raw_payload  JSONB,                  -- best-effort capture of the failed message
-    retry_count  INT NOT NULL DEFAULT 0,
-    resolved_at  TIMESTAMPTZ,            -- NULL = unresolved
-    resolved_by  TEXT                   -- 'manual', 'retry_success', 'discarded'
+    raw_payload   JSONB,                  -- immutable; best-effort capture of the failed message
+    retry_count   INT NOT NULL DEFAULT 0,
+    operator_notes TEXT,                 -- free-text annotation added before retry or discard
+    resolved_at   TIMESTAMPTZ,            -- NULL = unresolved
+    resolved_by   TEXT                   -- 'manual', 'retry_success', 'discarded'
 );
 ```
 
+**`raw_payload` is immutable.** The relay writes it once on failure and
+neither the WebUI nor the API may modify it. It is the forensic record
+of exactly what the upstream system sent. Editing it would silently
+corrupt the audit trail (e.g. "Kafka offset 4521" would no longer
+match the actual bytes received).
+
+**Handling bad data (permanent schema/data mismatch).** Retrying the
+original message will never succeed. The correct pattern is:
+
+1. Annotate the DLQ entry with `operator_notes` explaining the root
+   cause (e.g. "NULL in non-nullable column `user_id`").
+2. **Discard** the DLQ entry.
+3. Fix the data manually: insert a corrected row directly into the
+   target inbox table using the Tier 2 `POST /api/v1/sql/execute`
+   endpoint. The inbox is a plain PostgreSQL table. The execute
+   endpoint records the operator, timestamp, and SQL in the audit
+   log — making the correction fully traceable.
+
+This pattern keeps `raw_payload` honest, reuses existing infrastructure,
+and produces a clear audit trail: DLQ entry (what failed + why) +
+execute-log entry (what the operator inserted instead).
+
 The WebUI DLQ view (linked from Health) shows unresolved dead letters
-per pipeline with payload inspection, retry, and discard actions.
-A table's inbox dead letter count is also visible in the Tables list
-when the table has an associated relay inbox — a non-zero count is
-another signal that data is not arriving as expected.
+per pipeline with payload inspection, annotation, retry, and discard
+actions. A table's inbox dead letter count is also visible in the
+Tables list when the table has an associated relay inbox — a non-zero
+count is another signal that data is not arriving as expected.
 
 API:
 ```
-GET  /api/v1/dlq                        All unresolved dead letters (paginated)
-GET  /api/v1/dlq/:pipeline              Dead letters for one pipeline
-POST /api/v1/dlq/:id/retry              Re-attempt delivery of one dead letter
-POST /api/v1/dlq/:id/discard           Mark as resolved without retry
-POST /api/v1/dlq/discard-all/:pipeline Bulk discard for a pipeline
+GET   /api/v1/dlq                        All unresolved dead letters (paginated)
+GET   /api/v1/dlq/:pipeline              Dead letters for one pipeline
+PATCH /api/v1/dlq/:id/annotate           Update operator_notes on one entry
+POST  /api/v1/dlq/:id/retry              Re-attempt delivery of one dead letter
+POST  /api/v1/dlq/:id/discard           Mark as resolved without retry
+POST  /api/v1/dlq/discard-all/:pipeline Bulk discard for a pipeline
 ```
 
 Links in the "Remediation" column navigate to the relevant detail page

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -1236,7 +1236,8 @@ public-facing catalog views and relay-owned sample tables:
 | `pgtrickle.refresh_percentiles` | `pgt_refresh_log` (rolling 1 h / 24 h) | Refresh timeline P50/P95/P99 overlays | DIFFERENTIAL (algebraic aggregates) |
 | `pgtrickle.buffer_growth_rate` | `_staleness_samples` (derivative per table) | Buffer depth trend badges | DIFFERENTIAL |
 | `pgtrickle.end_to_end_lag` | `pg_stat_stream_tables` + DAG edges | Topology graph edge widths | FULL (recursive CTE — upgraded when recursive IVM ships) |
-| `pgtrickle.breach_events` | `sla_burn_rate` + DAG ancestry | Root cause / inherited breach classification; Grafana alerts | DIFFERENTIAL |
+| `pgtrickle._breach_state` | `_breach_snapshots` (latest snapshot) | Internal — feeds `breach_events` | FULL |
+| `pgtrickle.breach_events` | `_breach_state` + DAG ancestry | Root cause / inherited breach classification; Grafana alerts | FULL |
 
 #### Why `breach_events` must be a stream table, not WebUI logic
 
@@ -1261,6 +1262,11 @@ The WebUI is a consumer of `breach_events`, not the owner of the logic.
 
 #### `pgtrickle.breach_events` schema
 
+The breach classification requires two passes — first determine which
+tables are in breach, then attribute root cause vs inherited. A single
+self-referential query cannot compute `breach_type` while simultaneously
+reading it. The design uses two stream tables:
+
 ```sql
 -- Source table: one row per breach-check tick per table
 -- Populated by relay worker alongside _staleness_samples
@@ -1272,7 +1278,18 @@ CREATE TABLE pgtrickle._breach_snapshots (
     in_breach       boolean     NOT NULL
 );
 
--- Stream table: current breach state with root-cause attribution
+-- Pass 1: current breach state per table (no attribution yet)
+CREATE STREAM TABLE pgtrickle._breach_state AS
+SELECT
+    s.table_name,
+    s.staleness_s,
+    s.sla_threshold_s,
+    s.in_breach
+FROM pgtrickle._breach_snapshots s
+WHERE s.snapped_at = (SELECT max(snapped_at) FROM pgtrickle._breach_snapshots);
+SCHEDULE '15 seconds';
+
+-- Pass 2: root-cause attribution, reading _breach_state (not itself)
 CREATE STREAM TABLE pgtrickle.breach_events AS
 SELECT
     s.table_name,
@@ -1283,11 +1300,11 @@ SELECT
         -- Root cause: in breach AND no upstream stream table is also in breach
         WHEN s.in_breach AND NOT EXISTS (
             SELECT 1
-            FROM pgtrickle.breach_events b
+            FROM pgtrickle._breach_state b
             JOIN pgtrickle.dag_edges e
               ON e.upstream_table = b.table_name
              AND e.downstream_table = s.table_name
-            WHERE b.in_breach AND b.breach_type = 'root'
+            WHERE b.in_breach
         ) THEN 'root'
         WHEN s.in_breach THEN 'inherited'
         ELSE NULL
@@ -1295,33 +1312,41 @@ SELECT
     -- For inherited breaches: name the root cause table
     (
         SELECT b.table_name
-        FROM pgtrickle.breach_events b
+        FROM pgtrickle._breach_state b
         JOIN pgtrickle.dag_ancestors a
           ON a.ancestor = b.table_name
          AND a.descendant = s.table_name
-        WHERE b.breach_type = 'root'
+        WHERE b.in_breach
+          AND NOT EXISTS (
+              SELECT 1
+              FROM pgtrickle._breach_state u
+              JOIN pgtrickle.dag_edges e2
+                ON e2.upstream_table = u.table_name
+               AND e2.downstream_table = b.table_name
+              WHERE u.in_breach
+          )
         ORDER BY a.depth ASC
         LIMIT 1
     ) AS root_cause_table,
     -- Downstream blast radius count
     (
         SELECT count(*)
-        FROM pgtrickle.breach_events b
+        FROM pgtrickle._breach_state b
         JOIN pgtrickle.dag_ancestors a
           ON a.ancestor = s.table_name
          AND a.descendant = b.table_name
         WHERE b.in_breach
     ) AS downstream_casualties
-FROM pgtrickle._breach_snapshots s
-WHERE s.snapped_at = (SELECT max(snapped_at) FROM pgtrickle._breach_snapshots);
+FROM pgtrickle._breach_state s;
 SCHEDULE '15 seconds';
 ```
 
-The recursive self-reference (`breach_events` joining itself for
-ancestry) requires the DAG ancestry materialised view
-(`pgtrickle.dag_ancestors`) as an intermediate. This is a FULL refresh
-table until recursive IVM ships. At 15 s intervals and typical table
-counts (< 1000), the full rescan is fast.
+`_breach_state` is a thin materialisation of the latest breach
+snapshot — it exists solely to break the circular reference.
+`breach_events` reads `_breach_state` (not itself) for the upstream
+breach check, so there is no self-referential join. Both are FULL
+refresh tables until recursive IVM ships. At 15 s intervals and
+typical table counts (< 1000), the full rescan is fast.
 
 **Grafana usage example:**
 
@@ -1603,3 +1628,138 @@ so the audit log records which agent made each change, or require
    (agents can skip it), but the audit log records whether a preview
    was performed. This encourages the safe pattern (validate → review
    → apply) without blocking automation that needs to skip it.
+
+### OQ-13: Pagination strategy
+
+Multiple API endpoints return "paginated" data but no pagination
+contract is defined. Questions:
+
+- Cursor-based (opaque token) or offset-based (`?page=N&limit=M`)?
+  Cursor-based is more robust for live data (no skips/duplicates when
+  rows arrive between pages), but offset-based is simpler for UIs.
+- Default page size? Max limit? (Suggested: 50 default, 200 max.)
+- Response format: `{ data: [...], next_cursor: "..." }` or
+  RFC 8288 `Link` headers?
+
+### OQ-14: API rate limiting and agent throttling
+
+The API is a public contract for LLM agents. A runaway agent loop
+calling `POST /api/v1/sql/execute` repeatedly could be destructive.
+Questions:
+
+- Per-IP or per-session rate limiting on write endpoints?
+- Per-agent quotas (via `X-Agent-Name`)?
+- Circuit-breaker on the API itself (e.g. 429 after N writes/minute)?
+- Read endpoints: rate-limited or unlimited?
+
+### OQ-15: Audit log schema
+
+Multiple features reference "the audit log" (DLQ bad-data remediation,
+agent guardrails, SQL execute) but no schema exists. Need to define:
+
+- Table schema (`pgtrickle.audit_log`?)
+- Columns: timestamp, operator/agent, action type, SQL, result, source IP
+- Retention policy (rolling window? Partition by month? Manual cleanup?)
+- Whether the audit log is a stream table itself (dogfooding)
+
+### OQ-16: `table_classifications` relay dependency
+
+The `table_classifications` view joins `relay_inbox_config` and
+`relay_outbox_config`. If the extension is installed without the relay
+(valid — the relay is optional), the view breaks. Options:
+
+- (a) `LEFT JOIN` with `NULL` transport columns — view always works
+- (b) View is only created by `pgtrickle.relay_setup()`, not by the
+  extension itself
+- (c) `IF EXISTS` conditional join (not standard SQL)
+
+### OQ-17: WebSocket reconnection and event replay
+
+The plan describes WS events and a 5s polling fallback but no
+client-side reconnection strategy. Questions:
+
+- Exponential backoff on disconnect? (Suggested: 1s → 2s → 4s → 30s cap)
+- Event sequence numbers for replay of missed events during disconnect?
+- Stale badge detection: how does the frontend know its live data is
+  outdated after a long disconnect? (Suggested: server sends a
+  `WsEvent::Heartbeat` every 5s; if missed for 15s, show "stale" banner.)
+
+### OQ-18: HTTP caching strategy
+
+The API serves the frontend (high-frequency), Grafana (periodic scrape),
+and scripts (ad hoc). No caching is documented. Questions:
+
+- `Cache-Control` headers for read endpoints? (Suggested: `max-age=5`
+  for topology, `no-cache` for alerts and health.)
+- `ETag` / `If-None-Match` for large payloads (topology, table list)?
+- Server-side response caching for `/api/v1/dag/topology`?
+
+### OQ-19: MCP manifest derivation
+
+The plan defines both a hand-written MCP tool manifest and an
+auto-generated OpenAPI spec (via `utoipa`). These describe the same
+endpoints and can drift. Should the MCP manifest be generated from the
+OpenAPI spec rather than maintained separately?
+
+### OQ-20: Frontend version negotiation
+
+The frontend is embedded via `rust-embed`. After a relay upgrade,
+browser tabs with the old frontend cached may call new/changed API
+endpoints. Questions:
+
+- Force-reload mechanism? (Suggested: relay serves
+  `X-App-Version: <hash>` header; frontend compares on each API
+  response; mismatch triggers a reload prompt.)
+- `ETag`-based cache busting for static assets?
+- Graceful degradation for minor API additions?
+
+### OQ-21: SLA inference for slow-refresh tables
+
+The "2× schedule = warning, 3× = breach" formula does not account for
+refresh duration. A table with a 60s schedule and a 50s P95 refresh
+duration reaches ~110s staleness even when perfectly healthy (refresh
+starts, takes 50s, next refresh not due for 60s). This table would be
+perpetually in warning. Should the formula be:
+
+```
+effective_threshold = multiplier × (schedule_interval + p95_refresh_duration)
+```
+
+### OQ-22: CORS and Content Security Policy
+
+The API may be called cross-origin (Grafana annotation queries,
+embedded iframes — see OQ-7). Questions:
+
+- CORS policy: allow `*` for read endpoints? Restrict writes to
+  same-origin?
+- CSP headers for the frontend: ECharts, graphviz-wasm, and Monaco
+  all require `script-src` relaxation. Document the minimum CSP.
+- Security headers: `X-Frame-Options`, `X-Content-Type-Options`,
+  `Strict-Transport-Security`.
+
+### OQ-23: DLQ retention policy
+
+`relay_dead_letters` stores forensic payload data indefinitely
+(`resolved_at` is set but rows are never deleted). For high-throughput
+systems with persistent schema mismatches, this table grows without
+bound. Questions:
+
+- Auto-cleanup of resolved entries after N days? (Suggested: 30 days.)
+- Archival to cold storage before deletion?
+- Partition by month for efficient cleanup?
+- Size-based cap (e.g. max 100K unresolved entries, oldest auto-discarded)?
+
+### OQ-24: Internationalisation
+
+English only for the initial release. Is there a future need for i18n?
+If not, document the decision explicitly.
+
+### OQ-25: Bundle size budget
+
+ECharts (~400 KB), graphviz-wasm (~1.5 MB), Monaco (~2 MB) — the
+embedded binary carries all of these. Questions:
+
+- Total budget for `rust-embed` static assets? (Suggested: < 5 MB
+  gzipped for Tier 1.)
+- CI gate: fail build if bundle exceeds budget?
+- Lazy-load everything except the core shell + topology page?

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -614,6 +614,30 @@ orders_hourly      61s / 60s    8,102    ██████████   🔴 B
 SLA is "max 30s stale" and the table is 25s stale and trending upward,
 the burn rate shows the remaining time before breach.
 
+**Root cause vs inherited breach.** A table in SLA breach is classified
+as either:
+
+- **Root cause** — the breach originates here. The table's own refresh
+  is failing, stalled, or producing rows too slowly independent of its
+  inputs. Identified when: the table has no stream-table ancestors, or
+  all stream-table ancestors are healthy.
+- **Inherited breach** — the table is breached because an upstream node
+  is breached. Its own refresh is keeping pace; the staleness is flowing
+  down from the root. Identified when: at least one upstream node is
+  itself in root-cause breach.
+
+This distinction affects three things:
+
+1. **Table list:** Root cause rows show `🔴 root`; inherited rows show
+   `🔴 ⬆`. A "Root causes" view mode collapses all casualties under
+   their cause — 1 broken inbox + 10 downstream outputs = 1 entry, not 11.
+2. **Table detail header:** An inherited-breach table shows a banner:
+   "Root cause: `erp_raw.orders_raw` →" so the operator can jump
+   directly to the real problem without reading the lineage graph.
+3. **Alerts feed:** Downstream breach alerts are grouped under the root
+   cause event rather than firing separately. The sidebar badge counts
+   independent root cause events, not total breached tables.
+
 **End-to-end lag:** The topology graph shows cumulative lag through the
 dependency chain. A 2s delay in `orders` CDC that compounds to 45s
 end-to-end staleness in `regional_summary` is visible at a glance. No
@@ -1069,6 +1093,110 @@ public-facing catalog views and relay-owned sample tables:
 | `pgtrickle.refresh_percentiles` | `pgt_refresh_log` (rolling 1 h / 24 h) | Refresh timeline P50/P95/P99 overlays | DIFFERENTIAL (algebraic aggregates) |
 | `pgtrickle.buffer_growth_rate` | `_staleness_samples` (derivative per table) | Buffer depth trend badges | DIFFERENTIAL |
 | `pgtrickle.end_to_end_lag` | `pg_stat_stream_tables` + DAG edges | Topology graph edge widths | FULL (recursive CTE — upgraded when recursive IVM ships) |
+| `pgtrickle.breach_events` | `sla_burn_rate` + DAG ancestry | Root cause / inherited breach classification; Grafana alerts | DIFFERENTIAL |
+
+#### Why `breach_events` must be a stream table, not WebUI logic
+
+Root cause detection and blast radius attribution must live in the
+**database layer**, not in the WebUI. The reasons are:
+
+1. **Grafana / external alerting.** A Grafana dashboard pointing at
+   `pgtrickle.breach_events` gets the same root-cause deduplication
+   as the WebUI, for free. An alertmanager rule can fire on
+   `WHERE breach_type = 'root'` and suppress `inherited` rows —
+   without the WebUI involved at all.
+2. **Prometheus / OpenMetrics export.** The relay can expose
+   `/metrics` scraped from `breach_events` — one time-series per
+   independent root cause, not one per affected table.
+3. **API consumers.** `GET /api/v1/tables` simply reads the
+   `breach_type` and `root_cause_table` columns from `breach_events`
+   — the server does not recompute the DAG walk on every request.
+4. **WebSocket events.** `WsEvent::BreachStarted` carries the
+   `breach_type` field from the stream table row, not computed inline.
+
+The WebUI is a consumer of `breach_events`, not the owner of the logic.
+
+#### `pgtrickle.breach_events` schema
+
+```sql
+-- Source table: one row per breach-check tick per table
+-- Populated by relay worker alongside _staleness_samples
+CREATE TABLE pgtrickle._breach_snapshots (
+    snapped_at      timestamptz NOT NULL DEFAULT now(),
+    table_name      text        NOT NULL,
+    staleness_s     float4      NOT NULL,
+    sla_threshold_s float4      NOT NULL,  -- 3× schedule interval by default
+    in_breach       boolean     NOT NULL
+);
+
+-- Stream table: current breach state with root-cause attribution
+CREATE STREAM TABLE pgtrickle.breach_events AS
+SELECT
+    s.table_name,
+    s.staleness_s,
+    s.sla_threshold_s,
+    s.in_breach,
+    CASE
+        -- Root cause: in breach AND no upstream stream table is also in breach
+        WHEN s.in_breach AND NOT EXISTS (
+            SELECT 1
+            FROM pgtrickle.breach_events b
+            JOIN pgtrickle.dag_edges e
+              ON e.upstream_table = b.table_name
+             AND e.downstream_table = s.table_name
+            WHERE b.in_breach AND b.breach_type = 'root'
+        ) THEN 'root'
+        WHEN s.in_breach THEN 'inherited'
+        ELSE NULL
+    END AS breach_type,
+    -- For inherited breaches: name the root cause table
+    (
+        SELECT b.table_name
+        FROM pgtrickle.breach_events b
+        JOIN pgtrickle.dag_ancestors a
+          ON a.ancestor = b.table_name
+         AND a.descendant = s.table_name
+        WHERE b.breach_type = 'root'
+        ORDER BY a.depth ASC
+        LIMIT 1
+    ) AS root_cause_table,
+    -- Downstream blast radius count
+    (
+        SELECT count(*)
+        FROM pgtrickle.breach_events b
+        JOIN pgtrickle.dag_ancestors a
+          ON a.ancestor = s.table_name
+         AND a.descendant = b.table_name
+        WHERE b.in_breach
+    ) AS downstream_casualties
+FROM pgtrickle._breach_snapshots s
+WHERE s.snapped_at = (SELECT max(snapped_at) FROM pgtrickle._breach_snapshots);
+SCHEDULE '15 seconds';
+```
+
+The recursive self-reference (`breach_events` joining itself for
+ancestry) requires the DAG ancestry materialised view
+(`pgtrickle.dag_ancestors`) as an intermediate. This is a FULL refresh
+table until recursive IVM ships. At 15 s intervals and typical table
+counts (< 1000), the full rescan is fast.
+
+**Grafana usage example:**
+
+```promql
+# Alert on independent root cause breaches only (no noise from cascades)
+SELECT table_name, staleness_s, downstream_casualties
+FROM pgtrickle.breach_events
+WHERE breach_type = 'root'
+```
+
+**Prometheus export:**
+
+The relay's `/metrics` endpoint exposes:
+```
+pgtrickle_breach_root_total            # count of independent root causes
+pgtrickle_breach_inherited_total       # count of downstream casualties
+pgtrickle_table_staleness_seconds{table="...",breach_type="root|inherited|none"}
+```
 
 #### Example: `sla_burn_rate`
 
@@ -1132,6 +1260,9 @@ its auxiliary columns, and the current change buffer depth of
 | Topology edge width (throughput) | `pgtrickle.end_to_end_lag` | **Yes** (with polling fallback to direct query) |
 | Buffer depth badge (live) | Direct `change_buffer_sizes()` | **No** |
 | Buffer growth trend line | `pgtrickle.buffer_growth_rate` | **Yes** |
+| Root cause / blast radius classification | `pgtrickle.breach_events` | **Yes** |
+| `WsEvent::BreachStarted` breach type | `pgtrickle.breach_events` | **Yes** |
+| Prometheus `/metrics` breach gauges | `pgtrickle.breach_events` | **Yes** |
 
 The invariant: anything that must work when the scheduler is stopped or
 the extension is degraded uses direct queries. Derived, time-aggregated,

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -1,0 +1,968 @@
+# WebUI — Analysis & Implementation Plan
+
+> **Status:** Analysis & Design (DRAFT — 2026-04-21)
+> **Created:** 2026-04-21
+> **Category:** Tooling — Web Dashboard & Management Console
+> **Related:** [PLAN_RELAY_CLI.md](../relay/PLAN_RELAY_CLI.md) ·
+> [PLAN_TUI.md](../ui/PLAN_TUI.md) ·
+> [ROADMAP.md](../../ROADMAP.md)
+
+---
+
+## Table of Contents
+
+- [Executive Summary](#executive-summary)
+- [Motivation](#motivation)
+- [Target Users](#target-users)
+- [Architecture](#architecture)
+  - [Hosting Model](#hosting-model)
+  - [Authentication](#authentication)
+  - [Frontend Technology](#frontend-technology)
+  - [Backend API Layer](#backend-api-layer)
+  - [Real-Time Data](#real-time-data)
+- [Feature Tiers](#feature-tiers)
+  - [Tier 1 — Read-Only Dashboard](#tier-1--read-only-dashboard)
+  - [Tier 2 — Relay Pipeline Management](#tier-2--relay-pipeline-management)
+  - [Tier 3 — Stream Table Wizard & Full Setup](#tier-3--stream-table-wizard--full-setup)
+- [Key Features — Detailed Design](#key-features--detailed-design)
+  - [Unified Topology Graph](#unified-topology-graph)
+  - [SLA Budget & Lag Monitoring](#sla-budget--lag-monitoring)
+  - [DVM Operator Inspector](#dvm-operator-inspector)
+  - [Column-Level Lineage](#column-level-lineage)
+  - [Live Change Flow](#live-change-flow)
+  - [Data Explorer](#data-explorer)
+  - [SQL Preview Model](#sql-preview-model)
+  - [Health Scorecard](#health-scorecard)
+  - [Refresh Timeline](#refresh-timeline)
+- [LLM Agent Integration & MCP Server](#llm-agent-integration--mcp-server)
+  - [Impact on Feature Tiers](#impact-on-feature-tiers)
+  - [MCP Server](#mcp-server)
+  - [OpenAPI Specification](#openapi-specification)
+- [Comparison with RisingWave Dashboard](#comparison-with-risingwave-dashboard)
+- [Sequencing & Dependencies](#sequencing--dependencies)
+- [Open Questions](#open-questions)
+
+---
+
+## Executive Summary
+
+The pg-trickle WebUI is a browser-based management console and operational
+dashboard embedded in the `pgtrickle-relay` binary. It provides a complete
+view of the streaming materialization pipeline — from external sources
+through relay ingestion, stream table chains, outboxes, and relay sinks —
+in a single unified interface.
+
+The WebUI replaces the need for direct SQL interaction for common operations
+while keeping SQL as the canonical configuration layer. Every write action
+in the WebUI generates SQL, shows a preview, and executes it against
+PostgreSQL on confirmation. Power users can copy the generated SQL into
+version-controlled migrations.
+
+The JSON API layer (`/api/v1/`) that backs the WebUI is simultaneously
+an **MCP (Model Context Protocol) server** — the same endpoints that the
+frontend calls are discoverable and callable by LLM agents (Copilot,
+Claude, custom agents). This means the API is a first-class integration
+surface, not just WebUI plumbing, and is designed with semver stability
+guarantees from Phase 0.
+
+The scope is deliberately broader than a monitoring dashboard: at full
+maturity, the WebUI enables setting up a complete streaming solution —
+CDC sources, stream tables, relay pipelines — entirely through the
+browser or via LLM agents calling the API. This positions pg-trickle as
+an accessible alternative to managed streaming platforms (RisingWave
+Cloud, Confluent Cloud, Materialize) while retaining PostgreSQL as the
+foundation.
+
+---
+
+## Motivation
+
+The current getting-started path requires:
+
+1. Install the PostgreSQL extension
+2. Write SQL to create stream tables and configure CDC
+3. Install the relay binary and write TOML configuration
+4. Use the TUI or raw SQL to monitor
+
+Each step requires a different tool and a different skill set. The WebUI
+collapses steps 2–4 into a single browser interface. The three audiences
+this unlocks:
+
+- **"I just want it working in 10 minutes"** — the wizard path, no SQL
+  knowledge required.
+- **"I want to understand what's happening"** — the SQL preview at every
+  step teaches the pg-trickle SQL API by example.
+- **"I need full control"** — the SQL escape hatch and CLI still work. The
+  WebUI is additive.
+
+---
+
+## Target Users
+
+### 1. Data Engineer
+
+**Primary use:** Author stream tables and relay pipelines without writing
+SQL from scratch. The DVM compatibility checker gives instant feedback on
+whether a view definition supports DIFFERENTIAL refresh before committing.
+
+**Key features:** Stream table wizard, DVM checker, relay pipeline editor,
+topology graph, column-level lineage.
+
+### 2. SRE / Operator (on-call)
+
+**Primary use:** Assess health during incidents without SSH access. The
+relay's HTTP port is already exposed — `/ui` is just another route.
+
+**Key features:** Health scorecard, SLA budget dashboard, live alert feed,
+fuse management, relay topology with lag indicators, refresh timeline.
+
+### 3. Data Analyst
+
+**Primary use:** Explore derived data and understand lineage — where does
+this metric come from? What tables does it depend on?
+
+**Key features:** Column-level lineage, data explorer (sample rows),
+schema browser, staleness badges.
+
+### 4. Platform Engineer
+
+**Primary use:** Manage relay pipelines at scale, monitor CDC health,
+verify worker pool utilization.
+
+**Key features:** Relay pipeline management, watermark/frontier view,
+worker pool status, fuse control, change buffer inspection.
+
+### 5. LLM Agent / Automation
+
+**Primary use:** Programmatically create stream tables, configure relay
+pipelines, and diagnose issues via the `/api/v1/` JSON API. The same
+API that backs the WebUI frontend is the natural integration surface
+for LLM agents (Copilot, Claude, custom agents) and automation scripts.
+
+**Key features:** `POST /api/v1/sql/preview` (DVM compatibility check
+before applying), `POST /api/v1/sql/execute` (apply changes),
+`GET /api/v1/dag/topology` (understand full pipeline),
+`GET /api/v1/health` (diagnose problems), MCP server endpoints.
+
+**Key insight:** LLM agents will handle most initial setup tasks
+(creating stream tables, configuring relay pipelines) via natural
+language → SQL generation. This reduces the urgency of Tier 3 wizard
+features while increasing the importance of the API layer as a
+first-class integration surface. See
+[LLM Agent Integration & MCP Server](#llm-agent-integration--mcp-server).
+
+---
+
+## Architecture
+
+### Hosting Model
+
+The WebUI is embedded in the `pgtrickle-relay` binary. This follows the
+RisingWave model: the frontend is built to static files (Next.js `out/`
+or equivalent), bundled into the Rust binary via `rust-embed`, and served
+by the existing Axum HTTP server.
+
+```
+pgtrickle-relay serve
+  ├── :9090/metrics          Prometheus scrape
+  ├── :9090/health           Health check (K8s probes)
+  ├── :9090/health/drained   Drain check (rolling deploys)
+  ├── :9090/webhook/...      Reverse-mode webhook receiver
+  ├── :9090/api/v1/...       JSON API (WebUI backend)
+  ├── :9090/api/v1/ws        WebSocket (live alerts, topology updates)
+  └── :9090/ui/...           Static frontend (rust-embed)
+```
+
+**Key property:** No Node.js in production. The frontend is pre-built at
+compile time and embedded as static assets. The relay binary is the only
+thing to deploy.
+
+**Feature-flagged:** `--features webui` controls whether the static assets
+and API routes are compiled in. The minimal relay sidecar image ships
+without it; a "full" image includes the UI. Both images are published.
+
+### Authentication
+
+Three modes, selectable via `--auth none|pg|oidc`:
+
+| Mode | How it works | Use case |
+|------|-------------|----------|
+| **`none`** (default) | No login. WebUI uses the relay's PG connection. | Sidecar behind VPN/ingress |
+| **`pg`** | Login form with PG username/password. Per-session connection pool. Respects PG roles and RLS. | Shared team deployment |
+| **`oidc`** | OAuth2/OIDC login (Google, GitHub, Okta). Maps `sub` claim → PG role via config. | Enterprise / multi-tenant |
+
+Auth is implemented as Axum middleware on the `/api/v1/` and `/ui/` routes.
+The `/metrics` and `/health` endpoints remain unauthenticated (Prometheus
+and K8s probes need direct access).
+
+### Frontend Technology
+
+**Recommended: Next.js (React), built to static HTML, embedded via
+`rust-embed`.**
+
+Rationale:
+
+- The DAG/topology visualization, live backpressure animation, and
+  time-series charts are client-heavy features. Server-side rendering
+  (HTMX) cannot match the UX quality for these use cases.
+- RisingWave uses the same stack (Next.js + static export) and has
+  maintained it for 4+ years successfully.
+- The JS ecosystem for graph rendering (Cytoscape.js, reactflow, D3),
+  charting (ECharts, Recharts), and code editing (Monaco) is
+  unmatched.
+- Build process: `npm run build` → `out/` → `rust-embed` → single
+  binary. CI builds the frontend as a pre-step before `cargo build`.
+
+**Decision: Next.js from the start.** The topology graph, live
+backpressure animations, and time-series charts are the centrepiece
+features and require a proper JS framework. Starting with HTMX would
+require a rewrite for Tier 2/3. CI will include a Node.js + `npm run
+build` pre-step before `cargo build`.
+
+**Alternatives rejected:** HTMX + Askama templates (insufficient for
+graph rendering and real-time UX). Leptos (too small an ecosystem for
+charting and graph visualization).
+
+### Backend API Layer
+
+A JSON REST API under `/api/v1/` that serves three consumers:
+
+1. **WebUI frontend** — the primary consumer, calls these endpoints
+   for all data and write operations.
+2. **LLM agents** — use the same endpoints to understand, configure,
+   and diagnose pg-trickle programmatically. The API is the MCP/tool
+   integration surface (see [MCP Server](#mcp-server)).
+3. **Scripts and third-party tools** — Grafana annotations, CI/CD
+   pipelines, custom dashboards.
+
+The API is treated as a **first-class public contract** with semver
+guarantees from Phase 0. Breaking changes require a version bump
+(`/api/v2/`). This stability commitment is critical because LLM agents
+and automation scripts depend on predictable schemas.
+
+```
+GET  /api/v1/tables                     Stream table list + status
+GET  /api/v1/tables/:name               Detail view for one stream table
+GET  /api/v1/tables/:name/history       Refresh history
+GET  /api/v1/tables/:name/lineage       Column-level lineage
+GET  /api/v1/tables/:name/operator-tree DVM operator tree (DOT format)
+GET  /api/v1/tables/:name/sample        Sample rows (LIMIT 50)
+
+GET  /api/v1/health                     Health scorecard
+GET  /api/v1/health/checks              Individual health checks
+GET  /api/v1/dag                        Full DAG (nodes + edges + metadata)
+GET  /api/v1/dag/topology               Extended DAG with relay nodes
+
+GET  /api/v1/relay/pipelines            All relay pipelines (forward + reverse)
+GET  /api/v1/relay/pipelines/:id        Single pipeline detail
+GET  /api/v1/relay/pipelines/:id/lag    Lag metrics for a pipeline
+
+GET  /api/v1/cdc/sources                CDC source table status
+GET  /api/v1/cdc/buffers                Change buffer sizes
+GET  /api/v1/cdc/slots                  Replication slot health
+
+GET  /api/v1/scheduler/workers          Worker pool status
+GET  /api/v1/scheduler/jobs             Job queue depth
+GET  /api/v1/fuses                      Fuse/circuit-breaker state
+
+GET  /api/v1/timeline                   Refresh timeline (time-series)
+GET  /api/v1/alerts                     Recent alerts (paginated)
+
+POST /api/v1/sql/preview                Validate SQL, return DVM analysis
+POST /api/v1/sql/execute                Execute SQL (with auth check)
+POST /api/v1/fuses/:name/reset          Reset a blown fuse
+POST /api/v1/tables/:name/refresh       Trigger manual refresh
+```
+
+Every write endpoint (`POST`) requires authentication in `pg` and `oidc`
+modes. In `none` mode, writes use the relay's PG connection.
+
+### Real-Time Data
+
+Two mechanisms for live updates:
+
+**WebSocket** (`/api/v1/ws`): Subscribed to the `pg_trickle_alert` NOTIFY
+channel and relay pipeline state changes. The frontend connects on load
+and receives structured JSON events for: alerts, staleness changes,
+refresh completions, relay lag updates, fuse state changes.
+
+**Polling fallback:** For environments where WebSocket is blocked (some
+corporate proxies), the frontend falls back to polling `/api/v1/health`
+and `/api/v1/dag/topology` at a configurable interval (default 5s).
+
+---
+
+## Feature Tiers
+
+### Tier 1 — Read-Only Dashboard
+
+**Goal:** Replace the TUI's monitoring capabilities in a browser. Zero
+write operations. Ships with the first WebUI release.
+
+| Feature | Source data | TUI equivalent |
+|---------|------------|----------------|
+| **Health scorecard** | `health_check()`, `health_summary()` | View 8 (Health Checks) |
+| **Stream table list** | `pg_stat_stream_tables`, `pgt_status()` | View 1 (Dashboard) |
+| **Stream table detail** | `st_refresh_stats()`, `get_staleness()` | View 2 (Detail) |
+| **Unified topology graph** | `dependency_tree()` + relay pipeline config | View 3 (Dependencies) — enhanced |
+| **Refresh timeline** | `refresh_timeline()` | View 4 (Refresh Log) — as chart |
+| **CDC health** | `check_cdc_health()`, `slot_health()` | View 6 (CDC Health) |
+| **Live alerts** | `pg_trickle_alert` via WebSocket | View 9 (Alerts) |
+| **Relay pipeline status** | Relay metrics + pipeline config | *New — no TUI equivalent* |
+| **SLA budget indicators** | `get_staleness()` + schedule interval | *New — no TUI equivalent* |
+| **Worker pool status** | `worker_pool_status()` | View W (Workers) |
+| **Fuse status** | `fuse_status()` | View F (Fuse) — read only |
+| **Configuration view** | GUC values, extension version | View 7 (Configuration) |
+
+### Tier 2 — Relay Pipeline Management
+
+**Goal:** Create, edit, and manage relay pipelines through the UI. First
+write operations. SQL preview before every action.
+
+| Feature | Generated SQL |
+|---------|--------------|
+| **Create forward pipeline** | `INSERT INTO pgtrickle.relay_outbox_config(...)` |
+| **Create reverse pipeline** | `INSERT INTO pgtrickle.relay_inbox_config(...)` |
+| **Edit pipeline** | `UPDATE pgtrickle.relay_outbox_config SET ... WHERE ...` |
+| **Enable/disable pipeline** | `UPDATE ... SET enabled = true/false` |
+| **Delete pipeline** | `DELETE FROM pgtrickle.relay_outbox_config WHERE ...` |
+| **Fuse reset** | `SELECT pgtrickle.reset_fuse(...)` |
+| **Manual refresh** | `SELECT pgtrickle.refresh(...)` |
+| **Pause/resume stream table** | `SELECT pgtrickle.alter_stream_table(...)` |
+
+**Backend form:** When creating a pipeline, the form includes a dropdown
+for backend type (Kafka, NATS, Redis, etc.) and renders the relevant
+fields dynamically. Credential fields display as `${env:VAR}` references
+with documentation inline — secrets never pass through the WebUI.
+
+### Tier 3 — Stream Table Wizard & Full Setup (Deprioritized)
+
+**Goal:** Set up a complete streaming solution through the browser without
+writing SQL manually.
+
+> **Note:** Tier 3 is deprioritized relative to Tiers 1 and 2. LLM agents
+> can already handle most setup tasks (creating stream tables, configuring
+> CDC, writing relay pipeline config) via natural language → SQL generation.
+> The DVM compatibility checker remains high-value as an API endpoint
+> (`POST /api/v1/sql/preview`) that agents call directly. The wizard UI
+> around it is a nice-to-have, not a prerequisite for the "10-minute setup"
+> experience — an agent achieves that today. Tier 3 should be built when
+> there is specific user demand for form-based setup that agents don't
+> cover well.
+
+| Feature | Description |
+|---------|-------------|
+| **DVM compatibility checker** | Paste/type a view definition. Live analysis shows: DIFFERENTIAL eligible ✅ or FULL REFRESH ⚠️ with explanation of unsupported constructs. Uses `validation.rs` logic via the `/api/v1/sql/preview` endpoint. |
+| **Stream table creation wizard** | Form: pick source view, schedule (slider 1s→1h), refresh mode, SLA threshold. Generates `CREATE STREAM TABLE` SQL with preview. |
+| **CDC source enablement** | Pick a table → enable CDC trigger. Generates `pgtrickle.enable_cdc(...)`. |
+| **Schema browser** | Stream tables grouped by schema. Column types, nullability, PK columns marked. Staleness badge on every table. |
+| **Monaco SQL editor** | Embedded SQL editor with pg-trickle function autocomplete, syntax highlighting, and DVM compatibility checking as you type. |
+| **Column-level lineage** | Click a stream table column → trace derivation back to source columns through the entire OpTree. Rendered as a focused sub-graph. |
+| **DVM operator inspector** | For each stream table: visualize the operator tree (Scan → Filter → Join → Aggregate), annotated with which operators are incrementally maintained, which use auxiliary columns, and which force FULL refresh. Rendered via `graphviz-wasm` in the browser. |
+
+---
+
+## Key Features — Detailed Design
+
+### Unified Topology Graph
+
+The centrepiece of the WebUI. A single interactive graph showing the
+complete event flow, including relay nodes:
+
+```
+[Kafka topic] ──▶ relay reverse ──▶ [inbox: orders_raw]
+                                          │
+                                          ▼
+                                [stream: revenue_7d]
+                                          │
+                                [stream: regional_summary]
+                                          │
+                                          ▼
+                               [outbox: summary_out] ──▶ relay forward ──▶ [NATS subject]
+```
+
+**Node types and visual encoding:**
+
+| Node type | Shape | Colour | Badge |
+|-----------|-------|--------|-------|
+| External source (Kafka, NATS, ...) | Rounded rectangle | Grey | Backend icon |
+| Relay pipeline | Hexagon | Blue (connected) / Red (disconnected) | Lag rows |
+| Inbox / Outbox table | Rectangle, dashed border | Teal | Buffer depth |
+| Source base table | Rectangle | White | CDC mode |
+| Stream table | Rectangle, bold border | Green / Amber / Red (by SLA) | Staleness |
+
+**Edge encoding:**
+
+- Width proportional to throughput (rows/sec over last 5 min)
+- Colour: green (healthy), amber (lag growing), red (SLA breach)
+- Animated dots for active data flow (like RisingWave's backpressure)
+
+**Interactions:**
+
+- Click a node → opens detail panel (stats, config, history)
+- Hover an edge → shows throughput, lag, last update timestamp
+- Time slider → replays historical state using `refresh_timeline()` data
+- Zoom/pan, drag-to-rearrange
+- Deep-linkable: `/ui/topology?focus=revenue_7d` highlights a node
+
+**Implementation:** Cytoscape.js or reactflow for the graph layout. DAG
+data from `/api/v1/dag/topology` (extends `dependency_tree()` with relay
+pipeline nodes). Refreshed every 5s via WebSocket push or polling.
+
+### SLA Budget & Lag Monitoring
+
+Inspired by Kafka consumer lag dashboards. Three lag dimensions, each
+visible inline on the stream table list and topology graph:
+
+| Dimension | Metric source | Kafka analog |
+|-----------|--------------|--------------|
+| **Change buffer depth** | `change_buffer_sizes()` | Messages not yet consumed |
+| **Staleness** | `get_staleness()` vs schedule interval | Consumer group time lag |
+| **Relay pipeline lag** | `relay_consumer_lag_rows` | Sink-side consumer lag |
+
+**SLA budget display:**
+
+```
+Table              Staleness    Buffer   SLA Budget   Trend
+revenue_7d         12s / 60s    0 rows   ██░░░ 20%    ↔ stable
+regional_summary   45s / 60s    1,204    ████████ 75% ↑ burning
+orders_hourly      61s / 60s    8,102    ██████████   🔴 BREACH
+```
+
+**Burn rate:** Derived from staleness trend over a sliding window. If the
+SLA is "max 30s stale" and the table is 25s stale and trending upward,
+the burn rate shows the remaining time before breach.
+
+**End-to-end lag:** The topology graph shows cumulative lag through the
+dependency chain. A 2s delay in `orders` CDC that compounds to 45s
+end-to-end staleness in `regional_summary` is visible at a glance. No
+generic monitoring tool understands this relationship.
+
+**SLA configuration:** Inferred from the schedule interval with no
+schema changes required:
+
+- Staleness > 2× schedule interval = **warning** (amber)
+- Staleness > 3× schedule interval = **breach** (red)
+
+For example, a table with a 60s schedule triggers a warning at 120s
+staleness and a breach at 180s. This provides useful SLA monitoring
+out of the box without any user configuration. Explicit per-table SLA
+thresholds (via a SQL function) can be added later if needed.
+
+### DVM Operator Inspector
+
+For each stream table, the WebUI renders the DVM operator tree showing
+exactly how pg-trickle processes incremental changes:
+
+```
+Aggregate (GROUP BY region)
+  ├── strategy: ALGEBRAIC_VIA_AUX
+  ├── auxiliary: __pgt_aux_sum_amount, __pgt_aux_count_amount
+  │
+  └── Join (INNER, orders.customer_id = customers.id)
+        ├── strategy: DIFFERENTIAL (hash join)
+        │
+        ├── Scan: orders (CDC: trigger, PK: order_id)
+        │     └── change buffer: 1,204 rows pending
+        │
+        └── Scan: customers (CDC: trigger, PK: customer_id)
+              └── change buffer: 0 rows pending
+```
+
+**Annotations per node:**
+
+- Differential strategy (invertible, aux columns, group rescan)
+- Auxiliary columns generated and their purpose
+- Why a node might force FULL refresh (volatile function, unsupported
+  construct)
+- Change buffer depth at leaf nodes
+
+**Rendering:** The `OpTree` is serialized as DOT format by the Rust API,
+rendered client-side via `graphviz-wasm` or `d3-graphviz`. This matches
+the RisingWave approach for `explain_distsql`.
+
+### Column-Level Lineage
+
+pg-trickle's `OpTree` AST contains complete derivation information:
+`Scan` nodes with `table_oid` and columns, `Project` nodes with
+expressions and aliases, `Aggregate` nodes with `AggExpr`. This enables
+tracing any output column back to its source columns.
+
+**Example:** Clicking `revenue_7d.total_revenue` shows:
+
+```
+revenue_7d.total_revenue
+  └── SUM(orders.amount)
+        └── orders.amount (numeric, CDC: trigger)
+              └── base table: public.orders, column: amount
+```
+
+**Cross-table lineage:** For chained stream tables, the lineage traces
+through intermediate stream tables back to base tables. This is the
+data catalog feature that teams currently pay for in dbt lineage,
+DataHub, or Amundsen — built-in and always up to date.
+
+### Live Change Flow
+
+A real-time view of data moving through the system. Powered by the
+`pg_trickle_alert` NOTIFY channel over WebSocket.
+
+Events displayed as a scrolling timeline:
+- `orders` table: +1,200 rows captured by CDC trigger
+- `revenue_7d` refresh triggered (DIFFERENTIAL, 45ms, +3 rows / -1 row)
+- `regional_summary` refresh triggered (DIFFERENTIAL, 12ms, +1 row)
+- `summary_outbox`: 1 message published to relay forward pipeline
+- Relay forward: message delivered to NATS `analytics.summary`
+
+This is the streaming equivalent of watching Kafka consumer offsets
+advance in real time.
+
+### Data Explorer
+
+A stream-table-aware schema browser and data preview. **Not** a general
+PostgreSQL browser — scoped to pg-trickle objects only.
+
+**Features:**
+
+- Schema tree: stream tables grouped by schema, source tables with CDC
+  badges
+- Click a table → column list with types, nullability, PK markers
+- "Sample" button: runs `SELECT * FROM ... LIMIT 50` via the API
+- Side-by-side: view definition SQL and the compiled delta SQL (from
+  `explain_delta()`)
+- Staleness badge inline on every table
+- Refresh mode badge with tooltip from `explain_refresh_mode()`
+- Change buffer preview: pending rows for a source table before the next
+  refresh
+
+### SQL Preview Model
+
+Every write action in the WebUI follows the same pattern:
+
+```
+User fills form (or LLM agent generates SQL)
+    ↓
+WebUI renders SQL in a Monaco/code block for review
+    ↓
+User reviews SQL, optionally edits it
+    ↓
+"Apply" button executes the SQL against PostgreSQL
+    ↓
+Result displayed (success + affected rows, or error + explanation)
+```
+
+The SQL preview is also the **human review layer for LLM-generated
+configuration**. When an agent generates a `CREATE STREAM TABLE`
+statement, the WebUI provides the confirmation step — showing exactly
+what will be applied before execution. This is more valuable than a
+form wizard because LLM output is less predictable than a constrained
+form.
+
+**Properties:**
+
+- SQL is the source of truth. The WebUI generates it, never bypasses it.
+- Power users copy the SQL into their migration files.
+- The preview is educational — users learn the pg-trickle API by using
+  the wizard or reviewing agent-generated SQL.
+- Every generated SQL statement is idempotent where possible (`IF NOT
+  EXISTS`, `ON CONFLICT DO NOTHING`).
+- The `POST /api/v1/sql/preview` endpoint enables agents to validate SQL
+  (DVM compatibility, syntax) before proposing it to the user.
+
+### Health Scorecard
+
+Aggregates all `health_check()` results, slot health, change buffer
+sizes, and relay pipeline lag into a single page. Severity-sorted.
+
+| Check | Status | Detail | Remediation |
+|-------|--------|--------|-------------|
+| Scheduler | ✅ Running | 12 tables, 3 workers | — |
+| CDC triggers | ⚠️ Warning | `customers`: trigger disabled | [Re-enable CDC →] |
+| Replication slot | ✅ Active | 2.1 MB retained WAL | — |
+| Buffer growth | 🔴 Critical | `orders`: 15,204 rows, growing | [Investigate →] |
+| Relay: kafka-fwd | ✅ Connected | 0 lag rows | — |
+| Relay: nats-rev | ⚠️ Degraded | 342 lag rows, 12s behind | [View pipeline →] |
+| Fuses | ✅ All armed | 0 blown | — |
+
+Links in the "Remediation" column navigate to the relevant detail page
+or action form.
+
+### Refresh Timeline
+
+Interactive time-series chart of refresh performance across all stream
+tables or filtered to one.
+
+**Axes:**
+- X: time (selectable range: 1h, 6h, 24h, 7d)
+- Y (left): refresh duration (ms) as stacked area per table
+- Y (right): row delta size (inserts + deletes) as bar chart
+
+**Overlays:**
+- SLA threshold line (horizontal, red dashed)
+- Error markers (red dots on the timeline where refreshes failed)
+- Scheduler falling-behind periods (shaded background)
+
+**Data source:** `refresh_timeline(max_rows)` with time-range filtering.
+Cached server-side for the last 24h; older data from the `pgt_refresh_log`
+table.
+
+---
+
+## LLM Agent Integration & MCP Server
+
+### Impact on Feature Tiers
+
+LLM agents (Copilot, Claude, custom tooling) fundamentally change which
+WebUI features are urgent and which are deferrable:
+
+| Feature area | Without agents | With agents | Impact |
+|-------------|---------------|-------------|--------|
+| **Tier 1: Dashboard / monitoring** | Essential | Essential | No change — visual observability is irreducible |
+| **Tier 2: Relay pipeline management** | Essential | Still useful | Forms remain valuable for non-technical users; agents use the API directly |
+| **Tier 3: Setup wizard** | Essential for adoption | Largely covered by agents | Deprioritized — agents generate SQL faster than any form wizard |
+| **API layer (`/api/v1/`)** | WebUI backend | Agent integration surface | Elevated — must be first-class, stable, well-documented |
+| **DVM checker** | Wizard feature | Agent-callable endpoint | Elevated as API; deprioritized as form UI |
+| **SQL preview** | Wizard output | Human review layer for agent-generated SQL | Reframed — more valuable, not less |
+
+The durable value of the WebUI is **operational visibility** (topology
+graph, SLA monitoring, live change flow, operator inspector). These
+features have no LLM substitute — you need to *see* the system to
+understand it. The setup/configuration features are increasingly handled
+by agents calling the API.
+
+### MCP Server
+
+The `/api/v1/` JSON API is a natural **Model Context Protocol (MCP)**
+server. MCP is an open standard for LLM tool integration — each API
+endpoint maps to a tool that an agent can discover and call.
+
+The relay ships an MCP-compatible tool manifest at
+`GET /api/v1/mcp/tools` that describes all available operations:
+
+```json
+{
+  "tools": [
+    {
+      "name": "list_stream_tables",
+      "description": "List all pg-trickle stream tables with status, staleness, refresh mode, and SLA budget",
+      "endpoint": "GET /api/v1/tables",
+      "parameters": {}
+    },
+    {
+      "name": "get_topology",
+      "description": "Get the full DAG including relay pipeline nodes, with lag and buffer depth per edge",
+      "endpoint": "GET /api/v1/dag/topology",
+      "parameters": {}
+    },
+    {
+      "name": "check_health",
+      "description": "Get health scorecard: scheduler, CDC, slots, buffers, relay pipelines, fuses",
+      "endpoint": "GET /api/v1/health",
+      "parameters": {}
+    },
+    {
+      "name": "preview_sql",
+      "description": "Validate SQL and return DVM compatibility analysis. Returns whether the query supports DIFFERENTIAL refresh and why.",
+      "endpoint": "POST /api/v1/sql/preview",
+      "parameters": { "sql": "string" }
+    },
+    {
+      "name": "execute_sql",
+      "description": "Execute SQL against PostgreSQL. Use preview_sql first to validate.",
+      "endpoint": "POST /api/v1/sql/execute",
+      "parameters": { "sql": "string" }
+    },
+    {
+      "name": "get_table_detail",
+      "description": "Get detailed status for a stream table: refresh stats, staleness, refresh mode explanation, column list",
+      "endpoint": "GET /api/v1/tables/:name",
+      "parameters": { "name": "string" }
+    },
+    {
+      "name": "get_column_lineage",
+      "description": "Trace column-level lineage from output columns back to source columns through the full derivation chain",
+      "endpoint": "GET /api/v1/tables/:name/lineage",
+      "parameters": { "name": "string" }
+    },
+    {
+      "name": "get_relay_pipelines",
+      "description": "List all relay pipelines (forward and reverse) with connection status and lag",
+      "endpoint": "GET /api/v1/relay/pipelines",
+      "parameters": {}
+    },
+    {
+      "name": "diagnose_table",
+      "description": "Get diagnostics for a stream table: why it uses FULL vs DIFFERENTIAL refresh, operator tree, change buffer depth",
+      "endpoint": "GET /api/v1/tables/:name/operator-tree",
+      "parameters": { "name": "string" }
+    },
+    {
+      "name": "trigger_refresh",
+      "description": "Trigger an immediate refresh of a stream table",
+      "endpoint": "POST /api/v1/tables/:name/refresh",
+      "parameters": { "name": "string" }
+    },
+    {
+      "name": "reset_fuse",
+      "description": "Reset a blown circuit breaker (fuse) for a stream table",
+      "endpoint": "POST /api/v1/fuses/:name/reset",
+      "parameters": { "name": "string" }
+    }
+  ]
+}
+```
+
+This manifest enables any MCP-compatible agent (VS Code Copilot,
+Claude Desktop, custom agents) to discover and use pg-trickle's full
+API without custom integration code. The agent sees the tool list,
+understands each tool's purpose from the description, and calls the
+HTTP endpoints.
+
+**MCP transport options:**
+
+| Transport | Endpoint | Use case |
+|-----------|----------|----------|
+| **HTTP+SSE (Streamable HTTP)** | `POST /api/v1/mcp` | Standard MCP transport. Agents connect over HTTP; server pushes events (alerts, status changes) via SSE. Works through proxies and firewalls. |
+
+**Decision: HTTP+SSE only** for Phase 0.5. This is the simplest and
+most firewall-friendly transport. WebSocket and stdio transports can
+be added later if demand arises.
+
+**Auth for agents:** Agents authenticate the same way as the WebUI
+(see [Authentication](#authentication)). In `none` mode, agents call
+the API directly. In `pg` mode, agents pass credentials via HTTP
+Basic auth or a session token. In `oidc` mode, agents use a service
+account token.
+
+### OpenAPI Specification
+
+The `/api/v1/` layer ships with an OpenAPI 3.1 specification at
+`GET /api/v1/openapi.json`. This serves three purposes:
+
+1. **LLM agent integration** — agents can read the spec to understand
+   all available endpoints, parameter types, and response schemas
+   without hardcoded knowledge.
+2. **Client generation** — TypeScript types for the Next.js frontend
+   are generated from the spec, ensuring type safety between backend
+   and frontend.
+3. **Documentation** — Swagger UI at `/api/v1/docs` (behind
+   `--features webui`) provides interactive API documentation.
+
+The spec is generated from Rust types using `utoipa` (compile-time
+OpenAPI generation from Axum handlers). This ensures the spec is
+always in sync with the implementation.
+
+---
+
+## Comparison with RisingWave Dashboard
+
+pg-trickle's streaming materialization architecture is closely comparable
+to RisingWave. The relay's sources and sinks are the equivalent of
+RisingWave's built-in source and sink connectors. Stream tables are the
+equivalent of materialized views in RisingWave's streaming engine.
+
+| RisingWave Dashboard Feature | pg-trickle WebUI Equivalent |
+|-----------------------------|-----------------------------|
+| Materialized Views page | Stream table list + detail |
+| Sources page | CDC sources + relay reverse pipelines |
+| Sinks page | Relay forward pipelines |
+| Fragment graph (backpressure per edge) | Unified topology graph (lag/buffer per edge) |
+| Relation graph | DAG view with relay nodes |
+| `explain_distsql` (graphviz-wasm) | DVM operator inspector (graphviz-wasm) |
+| Await tree | Worker pool + job queue |
+| Cluster status | Health scorecard |
+| Internal tables | Change buffer inspection |
+| Historical backpressure | Refresh timeline + historical lag |
+
+**What pg-trickle adds beyond RisingWave:**
+
+- **SLA budgets** — RisingWave has no concept of freshness SLA because
+  it's always-streaming. pg-trickle's scheduled refresh model enables
+  explicit SLA thresholds with burn-rate tracking.
+- **Cross-cluster relay topology** — The relay can bridge multiple PG
+  clusters. The topology graph shows end-to-end flow across clusters
+  in a single view — no equivalent in RisingWave's single-system model.
+- **Column-level lineage** — derivable from the `OpTree` AST. RisingWave
+  does not expose this in the dashboard.
+- **SQL preview model** — configuration-by-wizard that generates auditable
+  SQL. RisingWave's dashboard is read-only.
+- **End-to-end lag through the dependency chain** — cumulative staleness
+  from base table through N-level stream table chains. RisingWave shows
+  per-fragment backpressure but not pipeline-level cumulative lag.
+
+---
+
+## Sequencing & Dependencies
+
+### Prerequisites
+
+The WebUI is hosted inside `pgtrickle-relay`. The relay must ship first
+with:
+
+- `AppState` designed as a proper service state (`Arc<AppState>` with
+  PG pool, pipeline registry, metrics handle, shutdown token)
+- A single Axum instance shared across health, metrics, webhook
+  receiver, and future WebUI routes
+- A stubbed `/ui` route returning 200 OK (placeholder for the frontend)
+- The JSON API layer (`/api/v1/...`) as the backend for the WebUI
+
+### Delivery Phases
+
+| Phase | Content | Depends on |
+|-------|---------|------------|
+| **Phase 0: API scaffold** | `/api/v1/` routes returning JSON for all read endpoints. OpenAPI spec via `utoipa`. No frontend. Useful immediately for scripting, Grafana, and LLM agents. | Relay core (RELAY-1 through RELAY-4) |
+| **Phase 0.5: MCP server** | MCP tool manifest at `/api/v1/mcp/tools`. HTTP+SSE transport at `POST /api/v1/mcp`. Enables LLM agents to discover and use all API endpoints. | Phase 0 |
+| **Phase 1: Tier 1 frontend** | Next.js app with: health scorecard, stream table list, topology graph, refresh timeline, alerts, relay pipeline status. Read-only. | Phase 0 |
+| **Phase 2: Tier 2 forms** | Relay pipeline create/edit/delete forms with SQL preview. Fuse reset, manual refresh, pause/resume. SQL preview doubles as human review layer for agent-generated SQL. | Phase 1 + relay pipeline config tables |
+| **Phase 3: Tier 3 wizard** (deprioritized) | Stream table creation wizard, CDC enablement, Monaco editor. Deferred until user demand — LLM agents cover most setup tasks via the API. Column-level lineage and operator inspector may ship earlier as Tier 1 read-only features. | Phase 2 + OpTree serialization API |
+
+### Relay `AppState` Requirements (Day 1)
+
+The relay scaffold (RELAY-1) must be designed with the WebUI in mind from
+the start. Specifically:
+
+```rust
+pub struct AppState {
+    /// PostgreSQL connection pool (read replicas for API, primary for writes)
+    pub pg_pool: PgPool,
+
+    /// Pipeline registry (active forward/reverse pipelines with status)
+    pub pipelines: Arc<RwLock<PipelineRegistry>>,
+
+    /// Prometheus metrics handle (shared with relay workers)
+    pub metrics: Arc<RelayMetrics>,
+
+    /// Shutdown token (coordinates relay workers + HTTP server)
+    pub shutdown: CancellationToken,
+
+    /// WebSocket broadcast channel (NOTIFY alerts, pipeline state changes)
+    pub ws_broadcast: broadcast::Sender<WsEvent>,
+
+    /// Configuration (auth mode, log level, feature flags)
+    pub config: Arc<RelayConfig>,
+}
+```
+
+This structure is shared between relay worker tasks and HTTP handlers.
+Designing it correctly in RELAY-1 avoids a painful refactor when the
+WebUI is added.
+
+---
+
+## Open Questions
+
+### OQ-1: Naming
+
+The binary currently planned as `pgtrickle-relay` is now the operational
+companion process — relay + dashboard + management console. Should it be
+renamed?
+
+| Option | Reads as |
+|--------|----------|
+| `pgtrickle-relay` | "A relay tool that happens to have a UI" |
+| `pgtrickle-server` | "The companion server process for pg-trickle" |
+| `pgtrickle-ctl` | "The control/admin binary" |
+
+**Current recommendation:** Keep `pgtrickle-relay` for the initial relay
+release. Rename to `pgtrickle-server` when the WebUI ships, if the
+scope warrants it.
+
+### OQ-2: Separate repo for the frontend
+
+The Next.js frontend could live in `pgtrickle-relay/dashboard/` (monorepo)
+or a separate `pgtrickle-dashboard` repo. Monorepo is simpler for CI and
+versioning. Separate repo allows independent frontend releases.
+
+**Current recommendation:** Monorepo (`pgtrickle-relay/dashboard/`),
+matching RisingWave's approach.
+
+### OQ-3: SLA schema design
+
+~~Should SLA thresholds be:
+
+- (a) A column on `pgtrickle.pgt_stream_tables` (`sla_max_staleness_seconds`)
+- (b) A separate `pgtrickle.pgt_sla_config` table
+- (c) Inferred only from the schedule interval (no explicit config)~~
+
+**Decision: (c) Inferred only.** SLA thresholds are derived from the
+schedule interval: staleness > 2× schedule = warning, > 3× = breach.
+No schema changes required. Explicit SLA configuration can be added
+later if users need custom thresholds per table.
+
+### OQ-4: Multi-database visibility
+
+~~The relay connects to one PostgreSQL database. Should the WebUI support
+connecting to multiple databases simultaneously (e.g., for cross-cluster
+topology visualization)?~~
+
+**Decision: Single database only.** The WebUI connects to the same
+PostgreSQL database as the relay. Cross-cluster topology visualization
+is deferred — it significantly increases scope (connection management,
+auth per cluster, merged DAG). Can be revisited when relay-to-relay
+bridging is implemented.
+
+### OQ-5: Dark mode
+
+The TUI is terminal-themed by nature. The WebUI should support dark mode
+(developer preference). Should it be the default?
+
+### OQ-6: Mobile / responsive
+
+The SRE on-call use case implies phone/tablet access. Should Tier 1 be
+responsive, or is desktop-only acceptable initially?
+
+### OQ-7: Embedding in other tools
+
+Should the WebUI be embeddable as an iframe in Grafana dashboards or
+internal portals? This affects CSP headers and auth token forwarding.
+
+### OQ-8: API stability
+
+~~The `/api/v1/` routes will be consumed by the WebUI frontend, but also
+potentially by scripts and third-party tools. Should the API be treated
+as a public contract with semver guarantees from Phase 0?~~
+
+**Decision: Yes.** The API is a first-class integration surface for LLM
+agents, automation scripts, and the WebUI frontend. It ships with an
+OpenAPI 3.1 spec and follows semver: breaking changes require `/api/v2/`.
+This is critical because LLM agents and MCP clients depend on stable
+schemas to function correctly.
+
+### OQ-9: TUI deprecation timeline
+
+The TUI (`pgtrickle-tui`) will eventually be superseded by the WebUI.
+When should the TUI be deprecated? After Tier 1 feature parity? After
+Tier 2?
+
+### OQ-10: MCP protocol version
+
+~~MCP is evolving rapidly. Should the relay target a specific MCP spec
+version (e.g., 2025-03-26), or implement a minimal subset (tool
+discovery + HTTP+SSE transport) and extend as the spec stabilizes?~~
+
+**Decision: HTTP+SSE only.** Phase 0.5 implements a single MCP
+transport: Streamable HTTP (HTTP+SSE). This is the simplest,
+most firewall-friendly option and covers remote agents, CI/CD
+pipelines, and browser-based tools. stdio transport (for local agents)
+and raw WebSocket can be added later if needed.
+
+### OQ-11: Agent guardrails
+
+~~Should the API enforce guardrails for agent-initiated writes? For
+example: require a `X-Agent-Name` header on `POST /api/v1/sql/execute`
+so the audit log records which agent made each change, or require
+`preview_sql` to be called before `execute_sql` for non-human callers.~~
+
+**Decision: Both guardrails.**
+
+1. **`X-Agent-Name` header** — optional but logged. If present on any
+   write endpoint, the agent name is recorded in the audit log
+   alongside the SQL and result. Helps operators trace "who changed
+   this stream table?" back to a specific agent.
+2. **`preview_sql` before `execute_sql`** — the `POST /api/v1/sql/execute`
+   endpoint accepts an optional `preview_token` returned by
+   `POST /api/v1/sql/preview`. When provided, execute validates that
+   the SQL matches the previewed statement. This is not enforced
+   (agents can skip it), but the audit log records whether a preview
+   was performed. This encourages the safe pattern (validate → review
+   → apply) without blocking automation that needs to skip it.

--- a/plans/webui/PLAN_WEBUI.md
+++ b/plans/webui/PLAN_WEBUI.md
@@ -5,6 +5,7 @@
 > **Category:** Tooling — Web Dashboard & Management Console
 > **Related:** [PLAN_RELAY_CLI.md](../relay/PLAN_RELAY_CLI.md) ·
 > [PLAN_TUI.md](../ui/PLAN_TUI.md) ·
+> [PLAN_WEBUI_STYLE.md](PLAN_WEBUI_STYLE.md) ·
 > [ROADMAP.md](../../ROADMAP.md)
 
 ---

--- a/plans/webui/PLAN_WEBUI_STYLE.md
+++ b/plans/webui/PLAN_WEBUI_STYLE.md
@@ -200,8 +200,6 @@ Status colours are used on:
 | Node type | Border colour | Fill colour (dark) | Fill colour (light) |
 |-----------|--------------|-------------------|-------------------|
 | Schema group (Level 0) | Worst-child SLA colour | `zinc-900` | `white` |
-| External relay endpoint (Level 0 leaf) | `blue-500` (connected) / `red-500` (disconnected) | `zinc-800` | `zinc-100` |
-| External source (Kafka, NATS) | `zinc-600` | `zinc-800` | `zinc-100` |
 | Relay pipeline | `blue-500` (connected) / `red-500` (disconnected) | `blue-950` / `red-950` | `blue-50` / `red-50` |
 | Inbox / Outbox table | `teal-500` | `teal-950` | `teal-50` |
 | Source base table | `zinc-500` | `zinc-900` | `white` |
@@ -352,38 +350,39 @@ right edge, top nav to bottom edge). No page heading, no padding. The
 graph IS the page.
 
 The landing view is **Level 0 — Systems overview**: one node per
-PostgreSQL schema, with external relay endpoints as leaf nodes.
-This view is always readable regardless of total node count.
+PostgreSQL schema. External transports (Kafka, NATS, webhook, etc.)
+are shown as icon annotations on schema nodes — not as separate graph
+nodes. Layout is auto-computed from inter-schema edge direction by
+dagre/elkjs — no manual tier assignment.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  [breadcrumb: Systems]                              [legend] │
 │                                                              │
-│  ●Kafka──▶┌─────────┐     ┌───────────┐             │
-│           │ erp_raw │────▶│ canonical │──┐          │
-│  ●Kafka──▶│ 5 tables│     │ 45 tables │  │          │
-│           │ ● 5     │     │●43 🟡1 🔴1│  │          │
-│           └─────────┘     └───────────┘  │          │
-│           ┌─────────┐           │        │          │
-│           │ crm_raw │─────────▶ │        │          │
-│           │ 2 tables│           │        │          │
-│           └─────────┘           ▼        │          │
-│                          ┌───────────┐   │          │
-│                          │ analytics │───┼──▶ NATS● │
-│                          │ 8 tables  │   │          │
-│                          │ ● 8       │   ▼          │
-│                          └───────────┘  Kafka●      │
-│                                                      │
+│  ┌─────────────────┐     ┌─────────────┐     ┌─────────────┐│
+│  │   erp_raw       │────▶│  canonical  │────▶│  analytics  ││
+│  │   5 tables      │     │  45 tables  │     │  8 tables   ││
+│  │ ⟵kafka ⟵webhook │     │ ●43 🟡1 🔴1 │     │  ●8  kafka⟶ ││
+│  └─────────────────┘     └─────────────┘     └─────────────┘│
+│       ↑↓ webhook                                             │
+│   (bidirectional sync)                                       │
+│                                                              │
+│  ┌─────────────────┐                                         │
+│  │   crm_raw       │────▶  (flows into canonical …)          │
+│  │   2 tables      │                                         │
+│  │  ⟵kafka         │                                         │
+│  └─────────────────┘                                         │
+│                                                              │
 │  [minimap]                              [zoom +/−] [fit]    │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-External relay endpoints are leaf circles (●) showing backend type
-icon and connected/disconnected status — not separately named groups.
-The schemas provide all meaningful grouping.
+Transport annotations (`⟵kafka`, `⟵webhook`, `kafka⟶`) are small
+icon badges on the schema node border — green = connected, red =
+disconnected. Hover to see which relay config(s) are active.
 
-**Drilling in (Level 1).** Click a schema group node (e.g. `erp_raw`)
-or click an edge between two groups (e.g. `erp_raw → canonical`).
+**Drilling in (Level 1).** Click a schema node (e.g. `erp_raw`) or
+an edge between two schemas (e.g. `erp_raw → canonical`).
 The graph transitions to show individual nodes within that scope:
 
 ```

--- a/plans/webui/PLAN_WEBUI_STYLE.md
+++ b/plans/webui/PLAN_WEBUI_STYLE.md
@@ -269,7 +269,7 @@ under Health as sub-sections, not as top-level navigation.
 ├──────────────┬──────────────────────────────────────────┤
 │              │                                          │
 │  ◈ Topology  │         [main content area]              │
-│  ⇀ Pipelines │                                          │
+│  ⊞ Tables    │                                          │
 │  ♥ Health  2 │                                          │
 │  ▲ Activity 3│                                          │
 │              │                                          │
@@ -287,7 +287,7 @@ under Health as sub-sections, not as top-level navigation.
 | Item | Icon | Badge | Target |
 |------|------|-------|--------|
 | Topology | Graph icon | — | `/ui/topology` (landing) |
-| Pipelines | Arrow-right-left icon | Count of flows in breach | `/ui/pipelines` |
+| Tables | Table icon | Count of tables in SLA breach | `/ui/tables` |
 | Health | Heart icon | Count of critical + warning checks | `/ui/health` |
 | Activity | Bell icon | Count of unread alerts | `/ui/activity` |
 | Settings | Gear icon (bottom-pinned) | — | `/ui/settings` |
@@ -310,12 +310,10 @@ Next.js App Router with the following route structure:
 /ui/topology                → Topology graph (landing page)
 /ui/topology?focus=<name>   → Topology with node highlighted
 /ui/topology?focus=<name>&depth=2 → Scoped neighbourhood graph
-/ui/pipelines               → Pipelines (end-to-end flows) list
-/ui/pipelines/[id]          → Pipeline detail (ordered node list)
-/ui/pipelines/[id]/[name]   → Stream table detail within a pipeline
-/ui/tables/[name]           → Stream table detail (standalone, for deep links)
-/ui/tables/[name]/lineage   → Column-level lineage (full page)
-/ui/tables/[name]/operators → DVM operator inspector (full page)
+/ui/tables                  → Tables list (all stream tables, sorted worst SLA first)
+/ui/tables/[schema]/[table]          → Table detail + bidirectional lineage
+/ui/tables/[schema]/[table]/lineage  → Column-level lineage (full page)
+/ui/tables/[schema]/[table]/operators → DVM operator inspector (full page)
 /ui/health                  → Health scorecard (CDC, fuses, slots, workers as sub-sections)
 /ui/activity                → Alerts + refresh timeline (tabbed or stacked)
 /ui/settings                → Configuration view
@@ -327,8 +325,9 @@ Displayed at the top of the content area, below the page heading:
 
 ```
 Topology                                  ← no breadcrumb (root page)
-Pipelines > orders → analytics            ← pipeline detail
-Pipelines > orders → analytics > revenue_7d ← table detail within a pipeline
+Tables                                    ← tables list
+Tables > analytics.regional_summary       ← table detail
+Tables > analytics.regional_summary > revenue_7d  ← upstream node detail
 Health > CDC Sources                      ← health sub-section
 ```
 
@@ -437,116 +436,198 @@ The sheet shows:
 
 Clicking "View detail →" navigates to the full detail page.
 
-### Pipelines List
+### Tables List
 
-The primary list view. Shows end-to-end data flows derived from the
-DAG, sorted worst-first by default.
+The primary list view. Every stream table annotated with its structural
+type, sorted worst SLA first by default.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  Pipelines                                      [search 🔍] │
-│                    [All ▼] [Mode: All ▼] [SLA: All ▼]     │
+│  Tables                                         [search 🔍] │
+│             [Schema: All ▼] [Type: All ▼] [SLA: All ▼]    │
 ├──────────────────────────────────────────────────────────────┤
-│  Flow                  Nodes  E2E Lag    SLA      Status  │
-│  ───────────────────  ─────  ─────────  ───────  ────── │
-│  orders → regional_sum  5      45s        ████ 75% 🟡     │
-│  Kafka → analytics      3      12s        ██░ 20%  🟢     │
-│  events → NATS          2      3s         █░ 10%   🟢     │
-│  customers (orphan)     1      0s         ─         ─     │
-│  ...                                                      │
+│  Table                Type          Staleness  E2E Lag  SLA  │
+│  ───────────────────  ──────────    ─────────  ───────  ─── │
+│  analytics.regional_summary  leaf union  45s   61s  ████ 🔴  │
+│  analytics.revenue_7d        intermediate 12s  28s  ██░ 🟡   │
+│  erp_raw.orders_raw          inbox        3s    3s  █ 🟢     │
+│  erp_raw.customers           orphan       —     —   —        │
+│  ...                                                         │
 ├──────────────────────────────────────────────────────────────┤
-│  8 flows                                                  │
+│  24 tables                                                   │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-- **Flow column:** Source → sink shorthand. Monospace.
-- **Nodes column:** Count of stream tables + relay connectors in the path.
-- **E2E Lag:** Cumulative staleness from source to sink.
-- **SLA column:** Progress bar of the worst node in the flow.
-- **Status column:** Coloured dot (green/amber/red) for quick scanning.
-- **Sortable columns:** Default sort by SLA budget descending (worst
-  first — problems at the top).
-- **Row click:** Navigates to pipeline detail.
-- **Faceted filters:** Schema, refresh mode (DIFF/FULL), SLA status
-  (healthy/warning/breach).
-- **Search:** Matches any node name in the flow.
+- **Type column:** Badge chips (inbox / outbox / leaf / intermediate /
+  union / orphan). Multiple badges allowed.
+- **Staleness:** How stale this table's own data is.
+- **E2E Lag:** Max cumulative staleness from any root to this table.
+- **SLA column:** Progress bar of the worst SLA breach in the upstream
+  chain, including this table.
+- **Row click:** Navigates to table detail.
+- **Sortable columns:** Default sort by SLA budget descending.
+- **Faceted filters:** Schema, type badge, refresh mode (DIFF/FULL), SLA status.
+- **Search:** Matches table name or schema.
 
-### Pipeline Detail
+### Table Detail
 
-Ordered list of every node in the flow, from source to sink.
+Shows the table's own metrics plus its **bidirectional lineage** —
+upstream (root causes) on the left, this table in the centre,
+downstream (blast radius) on the right.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  ← Pipelines                                               │
-│  orders → regional_summary             [View in Topology]  │
-│  ● Warning · 5 nodes · E2E lag: 45s                         │
+│  ← Tables                                                    │
+│  analytics.regional_summary       leaf union  [View in Topology] │
+│  🔴 SLA breach · 5 upstream · 2 downstream · E2E lag: 61s    │
 ├──────────────────────────────────────────────────────────────┤
-│                                                            │
-│  ○ orders (base table)          CDC: trigger · 0 buffer    │
-│  │                                                        │
-│  ● orders_raw (stream, DIFF)    3s stale · 0 buffer       │
-│  │                                                        │
-│  ● revenue_7d (stream, DIFF)    12s stale · 0 buffer      │
-│  │                                                        │
-│  ● regional_summary (stream)    45s stale · 1,204 buffer  │
-│  │                                        ⚠️ SLA 75%       │
-│  ○ NATS:analytics (relay fwd)   ● Connected · 0 lag        │
-│                                                            │
+│  [Overview]  [Lineage]  [History]  [Operators]  [SQL]          │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│  Staleness       Buffer Depth      Last Refresh     Avg (1h)  │
+│  45s             1,204 rows        61s ago          180ms     │
+│  E2E Lag: 61s                                                  │
+│                                                               │
+│  Lineage (Overview tab — condensed)                           │
+│                                                               │
+│  UPSTREAM (root causes)        THIS       DOWNSTREAM (impact)  │
+│  ○ orders ──►                                                  │
+│  ├● orders_raw ──►               ┌────────────┐  ►● NATS outbox  │
+│  │ └● revenue_7d ─►─►─►  │ regional  │  ►● exec_report  │
+│  ○ costs ──►              │ _summary  │                    │
+│  └● costs_raw ──►         └────────────┘                    │
+│    └● costs_7d ─►─►─►                                       │
+│                                                               │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-- Each node row is clickable → opens stream table detail (inline
-  expand or navigate to `/ui/pipelines/[id]/[name]`).
-- "View in Topology" button opens the topology graph focused on this
-  flow's nodes.
-- The vertical line connecting nodes visualizes the flow direction.
-- Nodes are annotated with: type (base/stream/relay), refresh mode,
-  staleness, buffer depth, SLA status.
-- Cumulative lag builds up visually down the list — you can see where
-  in the chain the latency is added.
+- Upstream nodes are coloured by SLA status — quickly shows which
+  branch is the root cause of a breach.
+- Downstream nodes are coloured by SLA status — shows blast radius.
+- Click any node → navigates to that table's detail (lineage re-centres on clicked node).
+- "View in Topology" scopes the topology graph to this neighbourhood.
+- The **Lineage** tab expands this to a full-canvas interactive graph.
 
-### Stream Table Detail
+### Table Detail — Full Page
 
-Tabbed layout. Page heading shows table name + status badge.
+All table navigation (from list, from lineage, from topology) lands on
+the same page at `/ui/tables/[schema]/[table]`. Five tabs:
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  ← Tables                                                     │
-│  revenue_7d                              [Refresh ↻] [⋯]    │
-│  ● Healthy · DIFFERENTIAL · every 60s                        │
+│  ← Tables                                                    │
+│  analytics.regional_summary  [leaf] [union]   [Refresh ↻][⋯]│
+│  🔴 SLA breach · DIFFERENTIAL · every 60s                    │
 ├──────────────────────────────────────────────────────────────┤
-│  [Overview]  [History]  [Lineage]  [Operators]  [SQL]        │
-├──────────────────────────────────────────────────────────────┤
+│  [Overview]  [Lineage]  [History]  [Operators]  [SQL]        │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Action buttons (top right, always visible):**
+- `Refresh ↻` — triggers manual refresh (previewed if Tier 2+)
+- `⋯` dropdown — Pause, Resume, View in Topology, Copy table name
+
+---
+
+**Overview tab** (default)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Staleness   Buffer Depth   Last Refresh   Avg (1h)  E2E Lag │
+│  45s         1,204 rows     61s ago        180ms     61s     │
 │                                                               │
-│  Staleness       Buffer Depth      Last Refresh     Avg (1h) │
-│  12s             0 rows            3s ago           45ms     │
+│  ┌─ Refresh sparkline (1h) ──────────────────────────────┐  │
+│  │ ▁▂▃▂▁▂▃▃▂▁▁▂▃▂▁▂▃▃▂▁▁▂▃▂▁▂▃▃▂▁▁▂▃▂▁▂▃▃▂▁          │  │
+│  └───────────────────────────────────────────────────────┘  │
 │                                                               │
-│  ┌─ Refresh History (sparkline, 1h) ────────────────────┐   │
-│  │  ▁▂▃▂▁▂▃▃▂▁▁▂▃▂▁▂▃▃▂▁▁▂▃▂▁▂▃▃▂▁▁▂▃▂▁▂▃▃▂▁        │   │
-│  └──────────────────────────────────────────────────────┘   │
+│  Mini lineage (upstream left · this centre · downstream right)│
+│  ○ orders ──►                                                │
+│  ├● orders_raw ──►           ┌─────────────┐  ►● NATS outbox│
+│  │ └● revenue_7d ───────────►│regional_sum │  ►● exec_report│
+│  ○ costs ──►                 └─────────────┘                │
+│  └● costs_7d ────────────────►                              │
 │                                                               │
 │  Columns                                                      │
-│  Name             Type         Nullable   Source              │
-│  ─────────────    ──────────   ────────   ──────────         │
-│  region           text         NO         customers.region   │
-│  total_revenue    numeric      NO         SUM(orders.amount) │
-│  order_count      bigint       NO         COUNT(*)           │
-│                                                               │
+│  Name              Type       Nullable   DVM source          │
+│  ──────────────    ────────   ────────   ───────────────     │
+│  region            text       NO         orders.region       │
+│  revenue_total     numeric    NO         SUM(orders.amount)  │
+│  order_count       bigint     NO         COUNT(*)            │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-**Tabs:**
+---
 
-- **Overview:** Metrics cards + column list + sparkline (default tab)
-- **History:** Full refresh log table (paginated, sortable by duration/time/delta size)
-- **Lineage:** Column-level lineage graph (per-column DAG, rendered in a sub-graph)
-- **Operators:** DVM operator tree (graphviz-wasm rendering)
-- **SQL:** View definition + compiled delta SQL side-by-side (read-only code blocks)
+**Lineage tab** — full-canvas bidirectional graph
 
-**Action buttons (top right):**
+```
+┌──────────────────────────────────────────────────────────────┐
+│  [Table lineage ●]  [Column lineage ○]       [depth: all ▼] │
+├──────────────────────────────────────────────────────────────┐
+│                                                               │
+│   ○ orders           ┌─────────────┐   ● NATS outbox        │
+│   ├─●orders_raw ────►│             │                         │
+│   │  └─●revenue_7d ─►│regional_sum │──►● exec_report        │
+│   ○ costs            │             │                         │
+│   └──●costs_7d ─────►└─────────────┘                        │
+│                                                               │
+│  [minimap]                              [zoom +/−] [fit]    │
+└──────────────────────────────────────────────────────────────┘
+```
 
-- "Refresh ↻" — triggers manual refresh (SQL preview if Tier 2+)
-- "⋯" dropdown — Pause, Resume, View in Topology, Copy table name
+Toggle between **Table lineage** (node = table) and **Column lineage**
+(node = individual column — shows which upstream columns feed each
+output column). Clicking any node navigates to its detail page,
+re-centering the lineage graph. Depth slider (1 hop / 2 hops / all)
+controls how far upstream and downstream to render.
+
+---
+
+**History tab** — refresh log
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Time             Mode   Duration   Rows Δ   Status          │
+│  ────────────     ─────  ────────   ──────   ──────          │
+│  13:42:01         DIFF   45ms       +12      ✅              │
+│  13:41:01         DIFF   180ms      +3,204   ✅              │
+│  13:40:01         FULL   2,400ms    —        ✅ (fuse reset) │
+│  13:39:01         DIFF   —          —        🔴 error        │
+│  ...                                                         │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Paginated, sortable. Click a row → expands to show error detail or
+delta summary.
+
+---
+
+**Operators tab** — DVM operator tree
+
+Graphviz-wasm rendering of the compiled differential operator tree.
+Read-only. Shows how the SQL query was decomposed into
+`Filter → Join → Aggregate → Consolidate` operators. Useful for
+debugging why a table uses FULL refresh (unsupported operator visible
+here).
+
+---
+
+**SQL tab** — view definition + delta SQL
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  View definition (source)      Delta SQL (compiled)          │
+│  ───────────────────────────   ─────────────────────────    │
+│  SELECT region,                WITH _delta AS (             │
+│    SUM(amount) AS revenue,       SELECT ...                  │
+│    COUNT(*) AS order_count       FROM pgtrickle_changes...   │
+│  FROM orders                   )                            │
+│  GROUP BY region               UPDATE regional_summary ...  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Both panels are read-only syntax-highlighted code blocks. Side-by-side
+on wide screens, stacked on narrow.
 
 ### SLA Budget Dashboard
 

--- a/plans/webui/PLAN_WEBUI_STYLE.md
+++ b/plans/webui/PLAN_WEBUI_STYLE.md
@@ -200,7 +200,7 @@ Status colours are used on:
 | Node type | Border colour | Fill colour (dark) | Fill colour (light) |
 |-----------|--------------|-------------------|-------------------|
 | Schema group (Level 0) | Worst-child SLA colour | `zinc-900` | `white` |
-| External system group (Level 0) | `zinc-600` | `zinc-800` | `zinc-100` |
+| External relay endpoint (Level 0 leaf) | `blue-500` (connected) / `red-500` (disconnected) | `zinc-800` | `zinc-100` |
 | External source (Kafka, NATS) | `zinc-600` | `zinc-800` | `zinc-100` |
 | Relay pipeline | `blue-500` (connected) / `red-500` (disconnected) | `blue-950` / `red-950` | `blue-50` / `red-50` |
 | Inbox / Outbox table | `teal-500` | `teal-950` | `teal-50` |
@@ -352,35 +352,35 @@ right edge, top nav to bottom edge). No page heading, no padding. The
 graph IS the page.
 
 The landing view is **Level 0 — Systems overview**: one node per
-PostgreSQL schema, one node per relay connection name, arranged as a
-hub-and-spoke. This view is always readable regardless of total node
-count.
+PostgreSQL schema, with external relay endpoints as leaf nodes.
+This view is always readable regardless of total node count.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  [breadcrumb: Systems]                              [legend] │
 │                                                              │
-│  ┌──────────┐     ┌─────────┐     ┌───────────┐             │
-│  │ erp-kafka│────▶│ erp_raw │────▶│ canonical │──┐          │
-│  │ 3 topics │     │ 3 tables│     │ 45 tables │  │          │
-│  │ ● 3      │     │ ● 3     │     │ ●43 🟡1 🔴1│  │          │
-│  └──────────┘     └─────────┘     └───────────┘  │          │
-│  ┌──────────┐            ▲               │       │          │
-│  │ crm-kafka│────▶ ┌─────┴───┐           ▼       │          │
-│  │ 2 topics │     │ crm_raw │     ┌───────────┐  │          │
-│  │ ● 2      │     │ 2 tables│     │ analytics │──┼─▶ [nats] │
-│  └──────────┘     └─────────┘     │ 8 tables  │  │          │
-│                                   │ ● 8       │  │          │
-│                                   └───────────┘  │          │
-│                                                  ▼          │
-│                                           ┌────────────┐    │
-│                                           │ kafka-sink │    │
-│                                           │ 2 topics   │    │
-│                                           └────────────┘    │
-│                                                              │
+│  ●Kafka──▶┌─────────┐     ┌───────────┐             │
+│           │ erp_raw │────▶│ canonical │──┐          │
+│  ●Kafka──▶│ 5 tables│     │ 45 tables │  │          │
+│           │ ● 5     │     │●43 🟡1 🔴1│  │          │
+│           └─────────┘     └───────────┘  │          │
+│           ┌─────────┐           │        │          │
+│           │ crm_raw │─────────▶ │        │          │
+│           │ 2 tables│           │        │          │
+│           └─────────┘           ▼        │          │
+│                          ┌───────────┐   │          │
+│                          │ analytics │───┼──▶ NATS● │
+│                          │ 8 tables  │   │          │
+│                          │ ● 8       │   ▼          │
+│                          └───────────┘  Kafka●      │
+│                                                      │
 │  [minimap]                              [zoom +/−] [fit]    │
 └──────────────────────────────────────────────────────────────┘
 ```
+
+External relay endpoints are leaf circles (●) showing backend type
+icon and connected/disconnected status — not separately named groups.
+The schemas provide all meaningful grouping.
 
 **Drilling in (Level 1).** Click a schema group node (e.g. `erp_raw`)
 or click an edge between two groups (e.g. `erp_raw → canonical`).

--- a/plans/webui/PLAN_WEBUI_STYLE.md
+++ b/plans/webui/PLAN_WEBUI_STYLE.md
@@ -199,6 +199,8 @@ Status colours are used on:
 
 | Node type | Border colour | Fill colour (dark) | Fill colour (light) |
 |-----------|--------------|-------------------|-------------------|
+| Schema group (Level 0) | Worst-child SLA colour | `zinc-900` | `white` |
+| External system group (Level 0) | `zinc-600` | `zinc-800` | `zinc-100` |
 | External source (Kafka, NATS) | `zinc-600` | `zinc-800` | `zinc-100` |
 | Relay pipeline | `blue-500` (connected) / `red-500` (disconnected) | `blue-950` / `red-950` | `blue-50` / `red-50` |
 | Inbox / Outbox table | `teal-500` | `teal-950` | `teal-50` |
@@ -349,20 +351,82 @@ and spatial arrangement.
 right edge, top nav to bottom edge). No page heading, no padding. The
 graph IS the page.
 
+The landing view is **Level 0 — Systems overview**: one node per
+PostgreSQL schema, one node per relay connection name, arranged as a
+hub-and-spoke. This view is always readable regardless of total node
+count.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  [breadcrumb: Systems]                              [legend] │
+│                                                              │
+│  ┌──────────┐     ┌─────────┐     ┌───────────┐             │
+│  │ erp-kafka│────▶│ erp_raw │────▶│ canonical │──┐          │
+│  │ 3 topics │     │ 3 tables│     │ 45 tables │  │          │
+│  │ ● 3      │     │ ● 3     │     │ ●43 🟡1 🔴1│  │          │
+│  └──────────┘     └─────────┘     └───────────┘  │          │
+│  ┌──────────┐            ▲               │       │          │
+│  │ crm-kafka│────▶ ┌─────┴───┐           ▼       │          │
+│  │ 2 topics │     │ crm_raw │     ┌───────────┐  │          │
+│  │ ● 2      │     │ 2 tables│     │ analytics │──┼─▶ [nats] │
+│  └──────────┘     └─────────┘     │ 8 tables  │  │          │
+│                                   │ ● 8       │  │          │
+│                                   └───────────┘  │          │
+│                                                  ▼          │
+│                                           ┌────────────┐    │
+│                                           │ kafka-sink │    │
+│                                           │ 2 topics   │    │
+│                                           └────────────┘    │
+│                                                              │
+│  [minimap]                              [zoom +/−] [fit]    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Drilling in (Level 1).** Click a schema group node (e.g. `erp_raw`)
+or click an edge between two groups (e.g. `erp_raw → canonical`).
+The graph transitions to show individual nodes within that scope:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  [breadcrumb: Systems > erp_raw → canonical]      [legend]  │
+│                                                              │
+│  erp_raw                        canonical                   │
+│  ┌──────────────┐               ┌─────────────────────┐     │
+│  │ orders_inbox │──▶ orders_raw ──▶ orders_canonical   │     │
+│  │              │   3s stale       5s stale             │     │
+│  └──────────────┘               └─────────────────────┘     │
+│  ┌──────────────┐               ┌─────────────────────┐     │
+│  │ items_inbox  │──▶ items_raw  ──▶ items_canonical    │     │
+│  │              │   2s stale       4s stale             │     │
+│  └──────────────┘               └─────────────────────┘     │
+│  ┌──────────────┐               ┌─────────────────────┐     │
+│  │ stock_inbox  │──▶ stock_raw  ──▶ stock_canonical 🟡 │     │
+│  │              │   12s stale      45s stale            │     │
+│  └──────────────┘               └─────────────────────┘     │
+│                                                              │
+│  [minimap]                              [zoom +/−] [fit]    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Breadcrumb at top allows navigation back to Level 0. Individual
+nodes show their staleness badges and SLA colours inline.
+
+For **small deployments** (all objects in `public`, no relay), Level 0
+and Level 1 collapse into a single flat graph showing all nodes
+directly — no extra clicks needed.
+
 **Overlays on the graph canvas:**
 
-- **Top-left:** Minimap (reactflow built-in or Cytoscape plugin). ~200×120 px,
-  semi-transparent background. Shows full graph with current viewport
-  highlighted.
-- **Top-right:** Legend toggle button. Clicking opens a floating legend
-  showing node shapes, colours, and edge encodings.
+- **Top-left:** Minimap (~200×120 px, semi-transparent background).
+- **Top-right:** Legend toggle button.
 - **Bottom-left:** Zoom controls (+/−/fit), layout reset button.
 - **Bottom-right:** Time slider (for historical replay, Tier 2+).
   Hidden by default, toggled by a clock icon.
 
-**Right panel (Sheet):** Clicking a node opens a `Sheet` (shadcn/ui
-slide-over panel) from the right edge, ~400 px wide. The graph
-shifts/compresses to accommodate. The sheet shows:
+**Right panel (Sheet):** Clicking an individual node (Level 1+) opens
+a `Sheet` (shadcn/ui slide-over panel) from the right edge, ~400 px
+wide. Clicking a group node (Level 0) drills into Level 1 instead.
+The sheet shows:
 
 - Node name (monospace, with copy button)
 - Status badge (healthy/warning/breach)

--- a/plans/webui/PLAN_WEBUI_STYLE.md
+++ b/plans/webui/PLAN_WEBUI_STYLE.md
@@ -29,13 +29,13 @@
   - [Breadcrumbs](#breadcrumbs)
 - [Screen Layouts](#screen-layouts)
   - [Landing: Topology Graph](#landing-topology-graph)
-  - [Stream Table List](#stream-table-list)
+  - [Pipelines List](#pipelines-list)
+  - [Pipeline Detail](#pipeline-detail)
   - [Stream Table Detail](#stream-table-detail)
   - [SLA Budget Dashboard](#sla-budget-dashboard)
   - [Health Scorecard](#health-scorecard)
   - [Refresh Timeline](#refresh-timeline)
-  - [Relay Pipelines](#relay-pipelines)
-  - [Alerts Feed](#alerts-feed)
+  - [Alerts & Activity Feed](#alerts--activity-feed)
   - [SQL Preview Modal](#sql-preview-modal)
 - [Responsive Behaviour](#responsive-behaviour)
 - [Accessibility](#accessibility)
@@ -259,18 +259,20 @@ Two font families, strictly separated by purpose:
 Left sidebar, collapsible to icons-only. Fixed-position, does not
 scroll with page content. Width: 240 px expanded, 48 px collapsed.
 
+Four top-level items based on user intent, not internal subsystems.
+CDC, fuses, slots, and workers are operational details — they live
+under Health as sub-sections, not as top-level navigation.
+
 ```
 ┌─────────────────────────────────────────────────────────┐
 │ [≡]  pg-trickle                          [dark/light ☾] │
 ├──────────────┬──────────────────────────────────────────┤
 │              │                                          │
 │  ◈ Topology  │         [main content area]              │
-│  ☰ Tables    │                                          │
-│  ⇄ Pipelines │                                          │
-│  ◉ CDC       │                                          │
-│  ♥ Health    │                                          │
-│  ▲ Alerts  3 │                                          │
-│  ⏱ Timeline  │                                          │
+│  ⇀ Pipelines │                                          │
+│  ♥ Health  2 │                                          │
+│  ▲ Activity 3│                                          │
+│              │                                          │
 │              │                                          │
 │              │                                          │
 │              │                                          │
@@ -285,12 +287,9 @@ scroll with page content. Width: 240 px expanded, 48 px collapsed.
 | Item | Icon | Badge | Target |
 |------|------|-------|--------|
 | Topology | Graph icon | — | `/ui/topology` (landing) |
-| Tables | Table icon | Count of tables in breach | `/ui/tables` |
-| Pipelines | Arrow-right-left icon | Count of disconnected | `/ui/pipelines` |
-| CDC | Database icon | Count of unhealthy sources | `/ui/cdc` |
-| Health | Heart icon | Count of critical checks | `/ui/health` |
-| Alerts | Bell icon | Count of unread alerts | `/ui/alerts` |
-| Timeline | Clock icon | — | `/ui/timeline` |
+| Pipelines | Arrow-right-left icon | Count of flows in breach | `/ui/pipelines` |
+| Health | Heart icon | Count of critical + warning checks | `/ui/health` |
+| Activity | Bell icon | Count of unread alerts | `/ui/activity` |
 | Settings | Gear icon (bottom-pinned) | — | `/ui/settings` |
 
 The sidebar uses Lucide icons (included with shadcn/ui). Badges on nav
@@ -310,16 +309,15 @@ Next.js App Router with the following route structure:
 /ui                         → redirect to /ui/topology
 /ui/topology                → Topology graph (landing page)
 /ui/topology?focus=<name>   → Topology with node highlighted
-/ui/tables                  → Stream table list
-/ui/tables/[name]           → Stream table detail (tabbed)
+/ui/topology?focus=<name>&depth=2 → Scoped neighbourhood graph
+/ui/pipelines               → Pipelines (end-to-end flows) list
+/ui/pipelines/[id]          → Pipeline detail (ordered node list)
+/ui/pipelines/[id]/[name]   → Stream table detail within a pipeline
+/ui/tables/[name]           → Stream table detail (standalone, for deep links)
 /ui/tables/[name]/lineage   → Column-level lineage (full page)
 /ui/tables/[name]/operators → DVM operator inspector (full page)
-/ui/pipelines               → Relay pipeline list
-/ui/pipelines/[id]          → Pipeline detail
-/ui/cdc                     → CDC sources + buffers + slots
-/ui/health                  → Health scorecard
-/ui/alerts                  → Alerts feed (paginated, filterable)
-/ui/timeline                → Refresh timeline chart
+/ui/health                  → Health scorecard (CDC, fuses, slots, workers as sub-sections)
+/ui/activity                → Alerts + refresh timeline (tabbed or stacked)
 /ui/settings                → Configuration view
 ```
 
@@ -328,10 +326,10 @@ Next.js App Router with the following route structure:
 Displayed at the top of the content area, below the page heading:
 
 ```
-Topology                          ← no breadcrumb (root page)
-Tables > revenue_7d               ← table detail
-Tables > revenue_7d > Lineage     ← column lineage deep page
-Pipelines > kafka-forward-1       ← pipeline detail
+Topology                                  ← no breadcrumb (root page)
+Pipelines > orders → analytics            ← pipeline detail
+Pipelines > orders → analytics > revenue_7d ← table detail within a pipeline
+Health > CDC Sources                      ← health sub-section
 ```
 
 Breadcrumbs use `text-sm text-muted-foreground` with `>` separators.
@@ -374,34 +372,73 @@ shifts/compresses to accommodate. The sheet shows:
 
 Clicking "View detail →" navigates to the full detail page.
 
-### Stream Table List
+### Pipelines List
+
+The primary list view. Shows end-to-end data flows derived from the
+DAG, sorted worst-first by default.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  Stream Tables                                    [search 🔍] │
+│  Pipelines                                      [search 🔍] │
+│                    [All ▼] [Mode: All ▼] [SLA: All ▼]     │
 ├──────────────────────────────────────────────────────────────┤
-│  Name           Mode    Staleness   Buffer   SLA     Trend  │
-│  ─────────────  ──────  ──────────  ───────  ──────  ─────  │
-│  revenue_7d     DIFF    12s / 60s   0        ██░ 20% ↔      │
-│  regional_sum   DIFF    45s / 60s   1,204    ████ 75% ↑     │
-│  orders_hourly  FULL    61s / 60s   8,102    █████ 🔴 ↑     │
-│  customer_agg   DIFF    3s / 30s    0        █░ 10%  ↔      │
-│  ...                                                         │
+│  Flow                  Nodes  E2E Lag    SLA      Status  │
+│  ───────────────────  ─────  ─────────  ───────  ────── │
+│  orders → regional_sum  5      45s        ████ 75% 🟡     │
+│  Kafka → analytics      3      12s        ██░ 20%  🟢     │
+│  events → NATS          2      3s         █░ 10%   🟢     │
+│  customers (orphan)     1      0s         ─         ─     │
+│  ...                                                      │
 ├──────────────────────────────────────────────────────────────┤
-│  Showing 12 of 12 stream tables        [< 1 2 3 >]          │
+│  8 flows                                                  │
 └──────────────────────────────────────────────────────────────┘
 ```
 
-- **Sortable columns:** Click any header to sort. Default: SLA budget
-  descending (worst first — problems at the top).
-- **Row click:** Navigates to detail page.
-- **Name column:** Monospace. Prefixed with schema if not `public`.
-- **Mode column:** `DIFF` badge (green) or `FULL` badge (amber).
-- **SLA column:** Progress bar using semantic status colours. Text shows
-  percentage consumed.
-- **Trend column:** Arrow icon (↑ burning, ↔ stable, ↓ recovering).
-- **Search:** Filters by table name, schema, or refresh mode. Debounced
-  client-side filter (no API call — the full table list is small).
+- **Flow column:** Source → sink shorthand. Monospace.
+- **Nodes column:** Count of stream tables + relay connectors in the path.
+- **E2E Lag:** Cumulative staleness from source to sink.
+- **SLA column:** Progress bar of the worst node in the flow.
+- **Status column:** Coloured dot (green/amber/red) for quick scanning.
+- **Sortable columns:** Default sort by SLA budget descending (worst
+  first — problems at the top).
+- **Row click:** Navigates to pipeline detail.
+- **Faceted filters:** Schema, refresh mode (DIFF/FULL), SLA status
+  (healthy/warning/breach).
+- **Search:** Matches any node name in the flow.
+
+### Pipeline Detail
+
+Ordered list of every node in the flow, from source to sink.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  ← Pipelines                                               │
+│  orders → regional_summary             [View in Topology]  │
+│  ● Warning · 5 nodes · E2E lag: 45s                         │
+├──────────────────────────────────────────────────────────────┤
+│                                                            │
+│  ○ orders (base table)          CDC: trigger · 0 buffer    │
+│  │                                                        │
+│  ● orders_raw (stream, DIFF)    3s stale · 0 buffer       │
+│  │                                                        │
+│  ● revenue_7d (stream, DIFF)    12s stale · 0 buffer      │
+│  │                                                        │
+│  ● regional_summary (stream)    45s stale · 1,204 buffer  │
+│  │                                        ⚠️ SLA 75%       │
+│  ○ NATS:analytics (relay fwd)   ● Connected · 0 lag        │
+│                                                            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- Each node row is clickable → opens stream table detail (inline
+  expand or navigate to `/ui/pipelines/[id]/[name]`).
+- "View in Topology" button opens the topology graph focused on this
+  flow's nodes.
+- The vertical line connecting nodes visualizes the flow direction.
+- Nodes are annotated with: type (base/stream/relay), refresh mode,
+  staleness, buffer depth, SLA status.
+- Cumulative lag builds up visually down the list — you can see where
+  in the chain the latency is added.
 
 ### Stream Table Detail
 
@@ -496,7 +533,8 @@ Compact — no cards, no whitespace waste.
 
 ### Refresh Timeline
 
-Full-width ECharts time-series. Controls above the chart.
+Full-width ECharts time-series. Lives on the Activity page as a
+prominent section above the alerts feed. Controls above the chart.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -526,30 +564,11 @@ Full-width ECharts time-series. Controls above the chart.
 - Brush zoom: click-drag to zoom into a time range
 - Table filter: dropdown to show one table or all
 
-### Relay Pipelines
+### Alerts & Activity Feed
 
-```
-┌──────────────────────────────────────────────────────────────┐
-│  Relay Pipelines                              [+ New] (Tier 2)│
-├──────────────────────────────────────────────────────────────┤
-│  Forward Pipelines                                            │
-│  Name             Backend   Status       Lag       Throughput │
-│  ──────────────   ───────   ──────────   ───────   ────────  │
-│  kafka-analytics  Kafka     ● Connected  0 rows    1.2k/s    │
-│  nats-events      NATS      ● Connected  342 rows  450/s     │
-│                                                               │
-│  Reverse Pipelines                                            │
-│  Name             Backend   Status       Buffer    Throughput │
-│  ──────────────   ───────   ──────────   ───────   ────────  │
-│  kafka-orders     Kafka     ● Connected  0 rows    800/s     │
-└──────────────────────────────────────────────────────────────┘
-```
-
-Grouped by direction (forward/reverse). Each row click opens detail
-panel. Backend column shows an icon for the backend type (Kafka, NATS,
-Redis, etc.).
-
-### Alerts Feed
+Merges alerts and refresh timeline into a single Activity page
+(two tabs, or stacked with the timeline above and the alerts feed
+below).
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -626,9 +645,9 @@ human review layer for LLM-generated SQL.
 
 **Phone priority pages** (the views an SRE on-call actually needs):
 1. Health scorecard
-2. Alerts feed
-3. SLA budget overview
-4. Stream table list (simplified)
+2. Alerts feed (Activity page)
+3. SLA budget overview (Pipelines, sorted worst-first)
+4. Pipeline detail (simplified)
 
 The topology graph on phone is a "view-only, pinch-zoom" experience —
 useful for a quick glance but not for exploration. A "View on desktop"

--- a/plans/webui/PLAN_WEBUI_STYLE.md
+++ b/plans/webui/PLAN_WEBUI_STYLE.md
@@ -1,0 +1,696 @@
+# WebUI — Style & Navigation Plan
+
+> **Status:** Analysis & Design (DRAFT — 2026-04-21)
+> **Created:** 2026-04-21
+> **Category:** Tooling — Web Dashboard UI/UX
+> **Related:** [PLAN_WEBUI.md](PLAN_WEBUI.md) ·
+> [PLAN_RELAY_CLI.md](../relay/PLAN_RELAY_CLI.md) ·
+> [PLAN_TUI.md](../ui/PLAN_TUI.md)
+
+---
+
+## Table of Contents
+
+- [Design Principles](#design-principles)
+- [Design System & Component Library](#design-system--component-library)
+  - [Core Stack](#core-stack)
+  - [Charting](#charting)
+  - [Topology Graph](#topology-graph)
+  - [Rejected Alternatives](#rejected-alternatives)
+- [Colour System](#colour-system)
+  - [Theme Modes](#theme-modes)
+  - [Semantic Colours](#semantic-colours)
+  - [Node Colours (Topology)](#node-colours-topology)
+  - [Edge Colours (Topology)](#edge-colours-topology)
+- [Typography](#typography)
+- [Navigation Structure](#navigation-structure)
+  - [Sidebar Layout](#sidebar-layout)
+  - [Page Routing](#page-routing)
+  - [Breadcrumbs](#breadcrumbs)
+- [Screen Layouts](#screen-layouts)
+  - [Landing: Topology Graph](#landing-topology-graph)
+  - [Stream Table List](#stream-table-list)
+  - [Stream Table Detail](#stream-table-detail)
+  - [SLA Budget Dashboard](#sla-budget-dashboard)
+  - [Health Scorecard](#health-scorecard)
+  - [Refresh Timeline](#refresh-timeline)
+  - [Relay Pipelines](#relay-pipelines)
+  - [Alerts Feed](#alerts-feed)
+  - [SQL Preview Modal](#sql-preview-modal)
+- [Responsive Behaviour](#responsive-behaviour)
+- [Accessibility](#accessibility)
+- [Open Questions](#open-questions)
+
+---
+
+## Design Principles
+
+Five guiding rules for every screen:
+
+1. **Density over whitespace.** SREs on-call want maximum information
+   per screen. Card-heavy layouts with generous padding waste the
+   viewport. Tables, inline badges, and compact metric rows are
+   preferred over hero cards.
+
+2. **Status colours carry meaning.** Green, amber, and red are reserved
+   exclusively for health/SLA status. They must never be used for
+   decorative purposes, branding, or navigation highlighting. This
+   ensures an SRE scanning the screen can immediately locate problems
+   by colour alone.
+
+3. **Dark mode is the default.** The primary audience (SREs, data
+   engineers, platform engineers) overwhelmingly uses dark-themed
+   tools. Light mode is supported but not the design baseline.
+
+4. **Monospace for system values.** Table names, SQL, metric values,
+   durations, row counts, and column names are always rendered in a
+   monospace font. This visually separates *system data* from *UI
+   chrome* and improves scannability in dense tables.
+
+5. **The graph is the hero.** The topology graph is the centrepiece
+   feature — it gets full-viewport space on the landing page. Other
+   pages support it, not the other way around.
+
+---
+
+## Design System & Component Library
+
+### Core Stack
+
+**shadcn/ui + Tailwind CSS + Radix UI primitives.**
+
+Rationale:
+
+- **shadcn/ui** provides copy-paste components — we own the code, not a
+  dependency. Components are unstyled Radix primitives with Tailwind
+  classes. Customizable without fighting a design system's opinions.
+- **Tailwind CSS** is the standard for Next.js projects. Utility-first
+  means no CSS-in-JS runtime, no specificity wars, and dark mode is a
+  single `dark:` prefix.
+- **Radix UI** handles accessibility (ARIA attributes, keyboard
+  navigation, focus management) at the primitive level. Dialogs,
+  dropdowns, tooltips, and popovers "just work" for screen readers.
+
+Key shadcn/ui components used:
+
+| Component | Used for |
+|-----------|----------|
+| `Table` | Stream table list, CDC sources, relay pipelines, alerts |
+| `Badge` | Status indicators, refresh mode, CDC mode |
+| `Card` | Metric summary tiles (compact, not hero-sized) |
+| `Dialog` | SQL preview modal, confirmation dialogs |
+| `Sheet` | Side panel for node detail (opens from topology graph) |
+| `Tabs` | Stream table detail (overview / history / lineage / operator tree) |
+| `Command` | Command palette (Cmd+K) |
+| `Tooltip` | Hover explanations on badges, metric values |
+| `DropdownMenu` | Context menus on topology nodes, table rows |
+| `Separator` | Section dividers in dense layouts |
+| `ScrollArea` | Scrollable panels (alerts feed, change flow) |
+
+### Charting
+
+**Tremor + ECharts** — two libraries, each used where it excels:
+
+| Library | Used for | Why |
+|---------|----------|-----|
+| **Tremor** | Metric cards, sparklines, status badges, small inline charts | Purpose-built for dashboard metric displays. Tailwind-native. Matches the shadcn/ui aesthetic. |
+| **ECharts** | Refresh timeline (stacked area + bar overlay), SLA burn-rate over time, buffer depth history | Full-featured time-series charting with zoom, brush selection, custom overlays. Tremor's chart components are too limited for multi-axis time-series. |
+
+ECharts is loaded lazily (dynamic import) — only the pages that use
+time-series charts pay the ~400 KB bundle cost. Tremor components are
+included in the core bundle since they're used on nearly every page.
+
+### Topology Graph
+
+**Undecided — two candidates under evaluation:**
+
+| | reactflow | Cytoscape.js |
+|---|---|---|
+| **React integration** | Native React components per node | Imperative API, React wrapper needed |
+| **Custom node rendering** | JSX per node type — badges, status colours, tooltips trivially composable | HTML overlay or canvas rendering — more work for rich nodes |
+| **Layout algorithms** | Manual positioning or dagre plugin | Built-in dagre, cola, cose-bilkent, elk |
+| **Minimap** | Built-in `<MiniMap />` component | Plugin (`cytoscape-navigator`) |
+| **Edge animation** | CSS animation on SVG paths | Canvas-based, custom animation code |
+| **Compound nodes** | Supported via nested groups | Native compound node support |
+| **Bundle size** | ~45 KB gzipped | ~85 KB gzipped (+ layout plugins) |
+| **License** | MIT | MIT |
+
+**Leaning toward reactflow** because:
+- JSX-based custom nodes make the rich status badges and
+  inline metrics per node trivial. Cytoscape requires HTML overlays
+  or canvas drawing for the same result.
+- The topology is a DAG with tens of nodes (not thousands) — reactflow's
+  dagre plugin handles this scale easily.
+- Edge animation (animated dots for data flow) is simpler in SVG/CSS
+  than canvas.
+
+**Decision deferred** to implementation phase. A spike (½ day) should
+build the same 5-node topology in both libraries and compare DX,
+rendering quality, and animation smoothness.
+
+### Rejected Alternatives
+
+| Library | Reason for rejection |
+|---------|---------------------|
+| **Material UI (MUI)** | Wrong aesthetic register — consumer app feel, not developer tool. Excessive padding, opinionated theming system fights customization. Signal says "enterprise admin panel," not "infrastructure monitoring." |
+| **Ant Design** | Used by RisingWave. Viable but heavy (~1 MB), opinionated, and less modern-feeling than shadcn/ui. Data table component is excellent but overkill when we control the data shape. |
+| **Chakra UI** | Similar to MUI in spirit — component library with runtime CSS-in-JS. Tailwind is a better fit for Next.js static export. |
+| **Recharts** | Decent for simple charts but lacks the multi-axis, zoom, and overlay features needed for the refresh timeline. ECharts covers this with less custom code. |
+| **D3 (direct)** | Too low-level for a small frontend team. ECharts and Tremor provide the same visual output with 10× less code. |
+
+---
+
+## Colour System
+
+### Theme Modes
+
+| Mode | Activation | Baseline |
+|------|-----------|----------|
+| **Dark** (default) | System preference or toggle | `zinc-950` background, `zinc-50` foreground |
+| **Light** | Toggle in settings | `white` background, `zinc-950` foreground |
+
+Follows the shadcn/ui theming approach: CSS variables on `:root` and
+`.dark` class, toggled via `next-themes`. All colour references use
+semantic CSS variables (`--background`, `--foreground`, `--muted`, etc.)
+so both themes are maintained by changing ~20 variable values.
+
+### Semantic Colours
+
+These colours convey operational meaning. They are **never** used for
+decorative or branding purposes.
+
+| Token | Dark mode value | Light mode value | Meaning |
+|-------|----------------|-----------------|---------|
+| `--status-healthy` | `emerald-400` | `emerald-600` | Healthy / within SLA / connected |
+| `--status-warning` | `amber-400` | `amber-600` | Warning / SLA burning / degraded |
+| `--status-critical` | `red-400` | `red-600` | Breach / error / disconnected / fuse blown |
+| `--status-inactive` | `zinc-500` | `zinc-400` | Disabled / paused / no data |
+| `--status-info` | `blue-400` | `blue-600` | Informational / in-progress / refreshing |
+
+Status colours are used on:
+- Topology node borders and fills
+- Topology edge strokes
+- SLA budget progress bars
+- Health scorecard status icons
+- Badge backgrounds (`<Badge variant="healthy">`, etc.)
+- Inline staleness text colour
+
+### Node Colours (Topology)
+
+| Node type | Border colour | Fill colour (dark) | Fill colour (light) |
+|-----------|--------------|-------------------|-------------------|
+| External source (Kafka, NATS) | `zinc-600` | `zinc-800` | `zinc-100` |
+| Relay pipeline | `blue-500` (connected) / `red-500` (disconnected) | `blue-950` / `red-950` | `blue-50` / `red-50` |
+| Inbox / Outbox table | `teal-500` | `teal-950` | `teal-50` |
+| Source base table | `zinc-500` | `zinc-900` | `white` |
+| Stream table | `--status-*` (by SLA) | `zinc-900` | `white` |
+| Self-monitoring stream table | `--status-*` (by SLA), dashed border | `zinc-900` | `white` |
+
+Stream table nodes use their SLA status colour for the border: green
+when within budget, amber when burning, red on breach. This means a
+quick glance at the topology shows problem nodes by colour alone.
+
+### Edge Colours (Topology)
+
+| State | Stroke colour | Width | Animation |
+|-------|-------------|-------|-----------|
+| Healthy, flowing | `--status-healthy` | Proportional to throughput | Animated dots (data flowing) |
+| Lag growing | `--status-warning` | Proportional to throughput | Animated dots (slower) |
+| SLA breach on downstream | `--status-critical` | Thick | Animated dots (red) |
+| No recent data | `--status-inactive` | Thin | No animation |
+
+Edge width scales linearly between 1 px (0 rows/sec) and 6 px
+(max throughput in the graph). The animated dots use CSS `stroke-dasharray`
++ `stroke-dashoffset` animation on SVG paths (reactflow) or canvas
+frame animation (Cytoscape).
+
+---
+
+## Typography
+
+Two font families, strictly separated by purpose:
+
+| Font | Used for | Example |
+|------|----------|---------|
+| **Inter** (sans-serif) | UI chrome: nav labels, headings, descriptions, buttons, form labels | "Stream Tables", "Refresh Timeline", "Apply" |
+| **JetBrains Mono** (monospace) | System values: table names, SQL, durations, row counts, column names, staleness values, metric numbers | `revenue_7d`, `45ms`, `1,204 rows`, `SELECT ...` |
+
+**Size scale** (Tailwind defaults):
+
+| Element | Size | Weight |
+|---------|------|--------|
+| Page heading | `text-xl` (20 px) | `font-semibold` |
+| Section heading | `text-lg` (18 px) | `font-semibold` |
+| Table header | `text-sm` (14 px) | `font-medium` |
+| Table cell | `text-sm` (14 px) | `font-normal` |
+| Badge text | `text-xs` (12 px) | `font-medium` |
+| Metric value (large) | `text-2xl` (24 px) mono | `font-semibold` |
+| Metric label | `text-xs` (12 px) | `font-normal`, `text-muted-foreground` |
+| Tooltip | `text-xs` (12 px) | `font-normal` |
+| Nav item | `text-sm` (14 px) | `font-medium` |
+| SQL code block | `text-sm` (14 px) mono | `font-normal` |
+
+---
+
+## Navigation Structure
+
+### Sidebar Layout
+
+Left sidebar, collapsible to icons-only. Fixed-position, does not
+scroll with page content. Width: 240 px expanded, 48 px collapsed.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ [≡]  pg-trickle                          [dark/light ☾] │
+├──────────────┬──────────────────────────────────────────┤
+│              │                                          │
+│  ◈ Topology  │         [main content area]              │
+│  ☰ Tables    │                                          │
+│  ⇄ Pipelines │                                          │
+│  ◉ CDC       │                                          │
+│  ♥ Health    │                                          │
+│  ▲ Alerts  3 │                                          │
+│  ⏱ Timeline  │                                          │
+│              │                                          │
+│              │                                          │
+│              │                                          │
+│──────────────│                                          │
+│  ⚙ Settings  │                                          │
+│  v0.21.0     │                                          │
+└──────────────┴──────────────────────────────────────────┘
+```
+
+**Sidebar elements:**
+
+| Item | Icon | Badge | Target |
+|------|------|-------|--------|
+| Topology | Graph icon | — | `/ui/topology` (landing) |
+| Tables | Table icon | Count of tables in breach | `/ui/tables` |
+| Pipelines | Arrow-right-left icon | Count of disconnected | `/ui/pipelines` |
+| CDC | Database icon | Count of unhealthy sources | `/ui/cdc` |
+| Health | Heart icon | Count of critical checks | `/ui/health` |
+| Alerts | Bell icon | Count of unread alerts | `/ui/alerts` |
+| Timeline | Clock icon | — | `/ui/timeline` |
+| Settings | Gear icon (bottom-pinned) | — | `/ui/settings` |
+
+The sidebar uses Lucide icons (included with shadcn/ui). Badges on nav
+items are small count pills using `--status-critical` or
+`--status-warning` colours. They provide a persistent health summary
+visible from any page.
+
+**Collapse behaviour:** Clicking the hamburger icon `[≡]` collapses the
+sidebar to 48 px, showing only icons. Hovering expands temporarily.
+User preference is persisted in `localStorage`.
+
+### Page Routing
+
+Next.js App Router with the following route structure:
+
+```
+/ui                         → redirect to /ui/topology
+/ui/topology                → Topology graph (landing page)
+/ui/topology?focus=<name>   → Topology with node highlighted
+/ui/tables                  → Stream table list
+/ui/tables/[name]           → Stream table detail (tabbed)
+/ui/tables/[name]/lineage   → Column-level lineage (full page)
+/ui/tables/[name]/operators → DVM operator inspector (full page)
+/ui/pipelines               → Relay pipeline list
+/ui/pipelines/[id]          → Pipeline detail
+/ui/cdc                     → CDC sources + buffers + slots
+/ui/health                  → Health scorecard
+/ui/alerts                  → Alerts feed (paginated, filterable)
+/ui/timeline                → Refresh timeline chart
+/ui/settings                → Configuration view
+```
+
+### Breadcrumbs
+
+Displayed at the top of the content area, below the page heading:
+
+```
+Topology                          ← no breadcrumb (root page)
+Tables > revenue_7d               ← table detail
+Tables > revenue_7d > Lineage     ← column lineage deep page
+Pipelines > kafka-forward-1       ← pipeline detail
+```
+
+Breadcrumbs use `text-sm text-muted-foreground` with `>` separators.
+Each segment is a link except the current page.
+
+---
+
+## Screen Layouts
+
+Text descriptions of each key screen. These are structural layouts,
+not pixel-perfect mockups — they describe the information hierarchy
+and spatial arrangement.
+
+### Landing: Topology Graph
+
+**Full viewport** — the graph fills the entire content area (sidebar to
+right edge, top nav to bottom edge). No page heading, no padding. The
+graph IS the page.
+
+**Overlays on the graph canvas:**
+
+- **Top-left:** Minimap (reactflow built-in or Cytoscape plugin). ~200×120 px,
+  semi-transparent background. Shows full graph with current viewport
+  highlighted.
+- **Top-right:** Legend toggle button. Clicking opens a floating legend
+  showing node shapes, colours, and edge encodings.
+- **Bottom-left:** Zoom controls (+/−/fit), layout reset button.
+- **Bottom-right:** Time slider (for historical replay, Tier 2+).
+  Hidden by default, toggled by a clock icon.
+
+**Right panel (Sheet):** Clicking a node opens a `Sheet` (shadcn/ui
+slide-over panel) from the right edge, ~400 px wide. The graph
+shifts/compresses to accommodate. The sheet shows:
+
+- Node name (monospace, with copy button)
+- Status badge (healthy/warning/breach)
+- Key metrics (staleness, buffer depth, refresh duration)
+- Quick actions (Refresh, View detail, View lineage)
+- Mini refresh history sparkline (last 1 h)
+
+Clicking "View detail →" navigates to the full detail page.
+
+### Stream Table List
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Stream Tables                                    [search 🔍] │
+├──────────────────────────────────────────────────────────────┤
+│  Name           Mode    Staleness   Buffer   SLA     Trend  │
+│  ─────────────  ──────  ──────────  ───────  ──────  ─────  │
+│  revenue_7d     DIFF    12s / 60s   0        ██░ 20% ↔      │
+│  regional_sum   DIFF    45s / 60s   1,204    ████ 75% ↑     │
+│  orders_hourly  FULL    61s / 60s   8,102    █████ 🔴 ↑     │
+│  customer_agg   DIFF    3s / 30s    0        █░ 10%  ↔      │
+│  ...                                                         │
+├──────────────────────────────────────────────────────────────┤
+│  Showing 12 of 12 stream tables        [< 1 2 3 >]          │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- **Sortable columns:** Click any header to sort. Default: SLA budget
+  descending (worst first — problems at the top).
+- **Row click:** Navigates to detail page.
+- **Name column:** Monospace. Prefixed with schema if not `public`.
+- **Mode column:** `DIFF` badge (green) or `FULL` badge (amber).
+- **SLA column:** Progress bar using semantic status colours. Text shows
+  percentage consumed.
+- **Trend column:** Arrow icon (↑ burning, ↔ stable, ↓ recovering).
+- **Search:** Filters by table name, schema, or refresh mode. Debounced
+  client-side filter (no API call — the full table list is small).
+
+### Stream Table Detail
+
+Tabbed layout. Page heading shows table name + status badge.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  ← Tables                                                     │
+│  revenue_7d                              [Refresh ↻] [⋯]    │
+│  ● Healthy · DIFFERENTIAL · every 60s                        │
+├──────────────────────────────────────────────────────────────┤
+│  [Overview]  [History]  [Lineage]  [Operators]  [SQL]        │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│  Staleness       Buffer Depth      Last Refresh     Avg (1h) │
+│  12s             0 rows            3s ago           45ms     │
+│                                                               │
+│  ┌─ Refresh History (sparkline, 1h) ────────────────────┐   │
+│  │  ▁▂▃▂▁▂▃▃▂▁▁▂▃▂▁▂▃▃▂▁▁▂▃▂▁▂▃▃▂▁▁▂▃▂▁▂▃▃▂▁        │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                                                               │
+│  Columns                                                      │
+│  Name             Type         Nullable   Source              │
+│  ─────────────    ──────────   ────────   ──────────         │
+│  region           text         NO         customers.region   │
+│  total_revenue    numeric      NO         SUM(orders.amount) │
+│  order_count      bigint       NO         COUNT(*)           │
+│                                                               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Tabs:**
+
+- **Overview:** Metrics cards + column list + sparkline (default tab)
+- **History:** Full refresh log table (paginated, sortable by duration/time/delta size)
+- **Lineage:** Column-level lineage graph (per-column DAG, rendered in a sub-graph)
+- **Operators:** DVM operator tree (graphviz-wasm rendering)
+- **SQL:** View definition + compiled delta SQL side-by-side (read-only code blocks)
+
+**Action buttons (top right):**
+
+- "Refresh ↻" — triggers manual refresh (SQL preview if Tier 2+)
+- "⋯" dropdown — Pause, Resume, View in Topology, Copy table name
+
+### SLA Budget Dashboard
+
+Accessed from the Tables page via a "SLA Budget" tab or a dedicated
+`/ui/tables?view=sla` toggle.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  SLA Budget Overview                          [worst first ▼] │
+├──────────────────────────────────────────────────────────────┤
+│                                                               │
+│  orders_hourly ████████████████████ 102% 🔴 BREACH           │
+│  61s / 60s · burning at 0.8s/s · breached 45s ago            │
+│                                                               │
+│  regional_summary ████████████░░░░ 75% ⚠️ WARNING            │
+│  45s / 60s · burning at 0.3s/s · breach in ~50s              │
+│                                                               │
+│  revenue_7d ████░░░░░░░░░░░░░░░░ 20% ✅                     │
+│  12s / 60s · stable · no breach expected                     │
+│                                                               │
+│  customer_agg █░░░░░░░░░░░░░░░░░░ 10% ✅                    │
+│  3s / 30s · stable · no breach expected                      │
+│                                                               │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Each row is a wide progress bar coloured by status. Below the bar:
+staleness fraction, burn rate (from `sla_burn_rate` stream table),
+and time-to-breach prediction. Sorted worst-first by default.
+
+### Health Scorecard
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Health                                         4/6 passing  │
+├──────────────────────────────────────────────────────────────┤
+│  🔴 Buffer growth   orders: 15,204 rows, growing   [View →] │
+│  ⚠️ CDC triggers    customers: trigger disabled     [Fix →]  │
+│  ✅ Scheduler       Running · 12 tables · 3 workers          │
+│  ✅ Replication     Active · 2.1 MB retained WAL             │
+│  ✅ Relay: kafka    Connected · 0 lag rows                   │
+│  ✅ Fuses           All armed · 0 blown                      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Severity-sorted (critical → warning → healthy). Each row is a
+single line with: status icon, check name, detail text, action link.
+Compact — no cards, no whitespace waste.
+
+### Refresh Timeline
+
+Full-width ECharts time-series. Controls above the chart.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Refresh Timeline                    [1h] [6h] [24h] [7d]   │
+│                                      [All tables ▼] [⚙]     │
+├──────────────────────────────────────────────────────────────┤
+│  ms                                              rows        │
+│  400 ┤                                           │ 2000      │
+│      │    ╭╮                                     │           │
+│  300 ┤   ╭╯╰╮        ╭──╮                       │ 1500      │
+│      │  ╭╯  ╰╮      ╭╯  ╰╮    ▓▓                │           │
+│  200 ┤──╯    ╰──────╯    ╰────▓▓───         --- │ 1000 SLA  │
+│      │                        ▓▓                 │           │
+│  100 ┤                                           │ 500       │
+│      │                    ●                      │           │
+│    0 ┼──────────────────────────────────────────>│ 0         │
+│      08:00        09:00        10:00       11:00             │
+├──────────────────────────────────────────────────────────────┤
+│  Legend: ── duration (ms)  ▓ row delta  ● error  --- SLA     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- Left Y axis: refresh duration (ms), stacked area per table
+- Right Y axis: row delta count (inserts + deletes), bar chart
+- SLA threshold: horizontal dashed red line
+- Error markers: red dots on timeline
+- Brush zoom: click-drag to zoom into a time range
+- Table filter: dropdown to show one table or all
+
+### Relay Pipelines
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Relay Pipelines                              [+ New] (Tier 2)│
+├──────────────────────────────────────────────────────────────┤
+│  Forward Pipelines                                            │
+│  Name             Backend   Status       Lag       Throughput │
+│  ──────────────   ───────   ──────────   ───────   ────────  │
+│  kafka-analytics  Kafka     ● Connected  0 rows    1.2k/s    │
+│  nats-events      NATS      ● Connected  342 rows  450/s     │
+│                                                               │
+│  Reverse Pipelines                                            │
+│  Name             Backend   Status       Buffer    Throughput │
+│  ──────────────   ───────   ──────────   ───────   ────────  │
+│  kafka-orders     Kafka     ● Connected  0 rows    800/s     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Grouped by direction (forward/reverse). Each row click opens detail
+panel. Backend column shows an icon for the backend type (Kafka, NATS,
+Redis, etc.).
+
+### Alerts Feed
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Alerts                              [All ▼] [Clear read]    │
+├──────────────────────────────────────────────────────────────┤
+│  ● 11:02:45  SLA breach    orders_hourly: 61s > 60s SLA     │
+│  ● 11:02:30  Fuse blown    revenue_7d: 3 consecutive errors  │
+│    11:01:15  CDC warning   customers: trigger disabled        │
+│    11:00:00  Refresh ok    revenue_7d: 45ms, +3/-1 rows      │
+│    10:59:45  Relay lag     nats-events: 342 rows behind      │
+│    ...                                                        │
+├──────────────────────────────────────────────────────────────┤
+│  Showing 50 of 234 alerts             [< 1 2 3 4 5 >]       │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- **●** dot marks unread alerts. Reading clears them (per-session).
+- Severity-filtered dropdown: All, Critical, Warning, Info.
+- Timestamps in monospace, relative ("2m ago") with absolute on hover.
+- Alert text links to the relevant object (table name → table detail,
+  pipeline name → pipeline detail).
+
+### SQL Preview Modal
+
+A `Dialog` (modal) used for all write operations (Tier 2+). Also the
+human review layer for LLM-generated SQL.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  SQL Preview                                          [×]    │
+├──────────────────────────────────────────────────────────────┤
+│  ┌──────────────────────────────────────────────────────┐   │
+│  │  CREATE STREAM TABLE public.revenue_7d AS            │   │
+│  │  SELECT                                              │   │
+│  │      region,                                         │   │
+│  │      SUM(amount) AS total_revenue                    │   │
+│  │  FROM orders                                         │   │
+│  │  JOIN customers USING (customer_id)                  │   │
+│  │  WHERE order_date > now() - interval '7 days'        │   │
+│  │  GROUP BY region                                     │   │
+│  │  SCHEDULE '60 seconds';                              │   │
+│  └──────────────────────────────────────────────────────┘   │
+│                                                               │
+│  DVM Analysis:                                                │
+│  ✅ DIFFERENTIAL eligible                                    │
+│  ✅ All aggregates algebraic (SUM, COUNT)                    │
+│  ⚠️ WHERE clause uses now() — refreshes always see changes   │
+│                                                               │
+│                              [Copy SQL]  [Cancel]  [Apply]   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- SQL block uses JetBrains Mono with syntax highlighting (via
+  `shiki` or `prism`).
+- DVM analysis results shown below the SQL (from `/api/v1/sql/preview`).
+- "Copy SQL" copies to clipboard for migration files.
+- "Apply" executes the SQL. Button uses `--status-healthy` colour
+  (green) to signal a safe action. If DVM analysis shows warnings,
+  the button text changes to "Apply (with warnings)" in amber.
+- Editable (Tier 3): In Tier 3, the SQL block becomes a Monaco editor
+  where the user can modify the generated SQL before applying.
+
+---
+
+## Responsive Behaviour
+
+**Desktop-first. Tablet usable. Phone minimal.**
+
+| Breakpoint | Behaviour |
+|-----------|-----------|
+| ≥ 1280 px (desktop) | Full layout — expanded sidebar, full topology, all columns visible |
+| 768–1279 px (tablet) | Sidebar collapsed to icons by default. Tables hide low-priority columns (trend, throughput). Topology graph is full-width. |
+| < 768 px (phone) | Sidebar becomes a bottom tab bar (5 key items). Tables become card-based. Topology is zoomable/pannable but not ideal. Health scorecard and alerts are the primary phone views. |
+
+**Phone priority pages** (the views an SRE on-call actually needs):
+1. Health scorecard
+2. Alerts feed
+3. SLA budget overview
+4. Stream table list (simplified)
+
+The topology graph on phone is a "view-only, pinch-zoom" experience —
+useful for a quick glance but not for exploration. A "View on desktop"
+banner is shown.
+
+---
+
+## Accessibility
+
+Minimum target: **WCAG 2.1 Level AA.**
+
+| Requirement | Implementation |
+|------------|----------------|
+| Keyboard navigation | Radix primitives handle focus management. All interactive elements reachable via Tab. Topology graph supports arrow-key node traversal. |
+| Screen reader | ARIA labels on all status badges (`aria-label="healthy"`, not just colour). Topology nodes announced with name + status. Alert feed is a live region (`aria-live="polite"`). |
+| Colour contrast | All text meets 4.5:1 contrast ratio in both themes. Status colours are supplemented with icons (✅ ⚠️ 🔴) so colour-blind users don't depend on hue alone. |
+| Reduced motion | `prefers-reduced-motion` disables topology edge animations and transition effects. |
+| Focus indicators | Visible focus ring (2 px `--ring` colour) on all interactive elements. Never hidden. |
+
+---
+
+## Open Questions
+
+### SQ-1: Brand accent colour
+
+The accent colour is used for: active sidebar item, primary buttons
+(non-status), links, focus rings, selected tab underline. It must not
+conflict with the semantic status colours (green/amber/red).
+
+| Option | Notes |
+|--------|-------|
+| **Blue** (`blue-500`) | Safe, professional, clear separation from status colours. Common in dev tools (VS Code, Docker Desktop). |
+| **Teal/cyan** (`teal-500`) | Evokes streaming/data flow. Slightly less conventional. May be too close to the inbox/outbox node colour. |
+| **Purple** (`violet-500`) | Modern dev-tool feel (Linear, Vercel). Distinctive. |
+| **Green** (`emerald-500`) | PostgreSQL heritage. But conflicts with `--status-healthy` — rejected. |
+
+### SQ-2: Command palette
+
+A `Cmd+K` / `Ctrl+K` command palette (using shadcn/ui `Command`
+component, built on `cmdk`) enables power users to:
+
+- Jump to any stream table by name
+- Trigger a manual refresh
+- Navigate to any page
+- Search alerts
+- Toggle dark/light mode
+
+Implementation cost is low (~1 day with `cmdk`). Question: should it
+ship with Tier 1 or Tier 2?
+
+### SQ-3: Topology graph library
+
+reactflow vs Cytoscape.js — see the comparison table in
+[Topology Graph](#topology-graph). Decision deferred to a ½-day spike
+during implementation.
+
+### SQ-4: SQL syntax highlighting
+
+Options for the read-only SQL display (Tier 1–2) and editable SQL
+(Tier 3):
+
+| Tier | Library | Rationale |
+|------|---------|-----------|
+| 1–2 | **Shiki** | Static highlighting, no runtime JS. Supports PostgreSQL grammar. Used by Next.js docs. |
+| 3 | **Monaco Editor** | Full editing with autocomplete, inline errors, bracket matching. Heavy (~2 MB) but loaded only on the SQL editing page. |

--- a/plans/webui/PLAN_WEBUI_STYLE.md
+++ b/plans/webui/PLAN_WEBUI_STYLE.md
@@ -410,9 +410,11 @@ The graph transitions to show individual nodes within that scope:
 Breadcrumb at top allows navigation back to Level 0. Individual
 nodes show their staleness badges and SLA colours inline.
 
-For **small deployments** (all objects in `public`, no relay), Level 0
-and Level 1 collapse into a single flat graph showing all nodes
-directly — no extra clicks needed.
+**Single-schema auto-navigation.** When only one schema exists, the
+topology opens directly at Level 1. The breadcrumb still renders
+`Systems > <schema>` so the user can navigate back to Level 0 and
+discover the grouping model — useful when they later add a second
+schema.
 
 **Overlays on the graph canvas:**
 

--- a/plans/webui/PLAN_WEBUI_STYLE.md
+++ b/plans/webui/PLAN_WEBUI_STYLE.md
@@ -29,14 +29,16 @@
   - [Breadcrumbs](#breadcrumbs)
 - [Screen Layouts](#screen-layouts)
   - [Landing: Topology Graph](#landing-topology-graph)
-  - [Pipelines List](#pipelines-list)
-  - [Pipeline Detail](#pipeline-detail)
-  - [Stream Table Detail](#stream-table-detail)
+  - [Tables List](#tables-list)
+  - [Table Detail](#table-detail)
+  - [Table Detail — Full Page](#table-detail--full-page)
   - [SLA Budget Dashboard](#sla-budget-dashboard)
   - [Health Scorecard](#health-scorecard)
+  - [Dead Letter Queue](#dead-letter-queue)
   - [Refresh Timeline](#refresh-timeline)
   - [Alerts & Activity Feed](#alerts--activity-feed)
   - [SQL Preview Modal](#sql-preview-modal)
+  - [Loading, Empty & Error States](#loading-empty--error-states)
 - [Responsive Behaviour](#responsive-behaviour)
 - [Accessibility](#accessibility)
 - [Open Questions](#open-questions)
@@ -106,6 +108,7 @@ Key shadcn/ui components used:
 | `DropdownMenu` | Context menus on topology nodes, table rows |
 | `Separator` | Section dividers in dense layouts |
 | `ScrollArea` | Scrollable panels (alerts feed, change flow) |
+| `Toast` (Sonner) | Success/error feedback for write operations (Tier 2+): fuse reset, manual refresh, DLQ retry/discard |
 
 ### Charting
 
@@ -200,7 +203,6 @@ Status colours are used on:
 | Node type | Border colour | Fill colour (dark) | Fill colour (light) |
 |-----------|--------------|-------------------|-------------------|
 | Schema group (Level 0) | Worst-child SLA colour | `zinc-900` | `white` |
-| Relay pipeline | `blue-500` (connected) / `red-500` (disconnected) | `blue-950` / `red-950` | `blue-50` / `red-50` |
 | Inbox / Outbox table | `teal-500` | `teal-950` | `teal-50` |
 | Source base table | `zinc-500` | `zinc-900` | `white` |
 | Stream table | `--status-*` (by SLA) | `zinc-900` | `white` |
@@ -713,6 +715,7 @@ and time-to-breach prediction. Sorted worst-first by default.
 │  ✅ Scheduler       Running · 12 tables · 3 workers          │
 │  ✅ Replication     Active · 2.1 MB retained WAL             │
 │  ✅ Relay: kafka    Connected · 0 lag rows                   │
+│  🔴 Dead letters    47 unresolved across 2 pipelines [DLQ →] │
 │  ✅ Fuses           All armed · 0 blown                      │
 └──────────────────────────────────────────────────────────────┘
 ```
@@ -720,6 +723,61 @@ and time-to-breach prediction. Sorted worst-first by default.
 Severity-sorted (critical → warning → healthy). Each row is a
 single line with: status icon, check name, detail text, action link.
 Compact — no cards, no whitespace waste.
+
+### Dead Letter Queue
+
+Linked from the Health scorecard's "DLQ →" action. Shows unresolved
+dead letters per relay pipeline with payload inspection and operator
+actions.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Dead Letter Queue                    47 unresolved  [🔍]   │
+│             [Pipeline: All ▼] [Error type: All ▼]           │
+├──────────────────────────────────────────────────────────────┤
+│  ID    Failed       Pipeline     Error       Message         │
+│  ────  ───────────  ──────────   ─────────   ──────────────  │
+│  1204  2m ago       kafka-fwd    decode      invalid JSON at │
+│  1203  5m ago       kafka-fwd    decode      unexpected EOF  │
+│  1198  12m ago      nats-rev     sink_perm   NOT NULL violat │
+│  ...                                                         │
+├──────────────────────────────────────────────────────────────┤
+│  Showing 20 of 47               [< 1 2 3 >]                 │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Row expansion.** Clicking a row expands to show:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  ▾ #1204 · kafka-fwd · decode · 2m ago                       │
+│                                                               │
+│  Error:  invalid JSON at byte 42: unexpected '}' after ','   │
+│  Retry count: 0                                               │
+│                                                               │
+│  Payload (read-only):                                        │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │  {"order_id": 9102, "amount": 45.00, }                │  │
+│  └────────────────────────────────────────────────────────┘  │
+│                                                               │
+│  Operator notes:                                             │
+│  ┌────────────────────────────────────────────────────────┐  │
+│  │  (add annotation before retry or discard)              │  │
+│  └────────────────────────────────────────────────────────┘  │
+│                                                               │
+│                           [Retry]  [Discard]  [Copy payload] │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- Payload panel is read-only (syntax-highlighted JSON). The
+  `raw_payload` is immutable — see PLAN_WEBUI.md §Health Scorecard.
+- Operator notes is an editable text area (saved via
+  `PATCH /api/v1/dlq/:id/annotate`).
+- "Retry" re-attempts delivery of the original message.
+- "Discard" marks resolved without retry.
+- "Copy payload" copies JSON to clipboard for manual correction
+  via the SQL execute endpoint.
+- Bulk discard: checkbox column + "Discard selected" button at top.
 
 ### Refresh Timeline
 
@@ -836,6 +894,37 @@ human review layer for LLM-generated SQL.
 - Editable (Tier 3): In Tier 3, the SQL block becomes a Monaco editor
   where the user can modify the generated SQL before applying.
 
+### Loading, Empty & Error States
+
+Every data-fetching screen must handle three non-happy-path states.
+Without these, an SRE cannot distinguish "the system is healthy" from
+"the dashboard is broken."
+
+**Loading.** Skeleton screens (shadcn/ui `Skeleton` component) matching
+the shape of the expected content. No spinners. Tables show skeleton
+rows; metric cards show skeleton values; the topology graph shows a
+pulsing placeholder canvas. Loading state must be visually distinct
+from empty state.
+
+**Empty (zero state).** Shown when the query succeeds but returns no
+data (e.g. no stream tables created yet, no alerts in the feed, no
+dead letters). Each screen has a contextual empty message:
+
+| Screen | Empty message |
+|--------|--------------|
+| Tables list | "No stream tables yet. Create one with SQL or ask an agent." |
+| Topology | "No stream tables. The graph will appear when the first stream table is created." |
+| Alerts | "No alerts. The system is healthy." |
+| DLQ | "No dead letters. All relay messages delivered successfully." |
+| Refresh timeline | "No refresh history. Tables will appear here after their first refresh." |
+
+**Error.** API-unreachable or 5xx responses show a banner at the top of
+the content area (not a modal — the user may still need to navigate).
+Includes: error summary, last successful data timestamp, and a "Retry"
+button. WebSocket disconnection shows a persistent amber banner:
+"Live updates disconnected. Retrying…" with a countdown to next
+reconnection attempt.
+
 ---
 
 ## Responsive Behaviour
@@ -851,8 +940,8 @@ human review layer for LLM-generated SQL.
 **Phone priority pages** (the views an SRE on-call actually needs):
 1. Health scorecard
 2. Alerts feed (Activity page)
-3. SLA budget overview (Pipelines, sorted worst-first)
-4. Pipeline detail (simplified)
+3. Tables list (sorted worst SLA first)
+4. Table detail (simplified)
 
 The topology graph on phone is a "view-only, pinch-zoom" experience —
 useful for a quick glance but not for exploration. A "View on desktop"
@@ -918,3 +1007,36 @@ Options for the read-only SQL display (Tier 1–2) and editable SQL
 |------|---------|-----------|
 | 1–2 | **Shiki** | Static highlighting, no runtime JS. Supports PostgreSQL grammar. Used by Next.js docs. |
 | 3 | **Monaco Editor** | Full editing with autocomplete, inline errors, bracket matching. Heavy (~2 MB) but loaded only on the SQL editing page. |
+
+### SQ-5: Animation and transition timing
+
+No timing guidelines are specified for: page transitions, tab
+switching, modal open/close, topology drill-in (Level 0 → Level 1),
+node appear/disappear on structure changes, edge dot animation speed.
+Without a shared timing spec, implementation will be inconsistent.
+
+Suggested baseline:
+- Page/tab transitions: 150 ms ease-out
+- Modal/sheet open: 200 ms ease-out; close: 150 ms ease-in
+- Topology drill-in: 300 ms with node crossfade
+- Edge dot animation: 2s loop (healthy), 4s (warning), 1s (breach)
+- `prefers-reduced-motion`: all durations → 0 ms
+
+### SQ-6: Accessibility testing in CI
+
+WCAG 2.1 AA is the target but no testing tooling or CI integration is
+specified. Options:
+
+- `axe-core` in unit tests (via `@axe-core/react`)
+- Lighthouse CI accessibility audit on every build
+- Manual screen-reader testing cadence (quarterly?)
+
+### SQ-7: Topology graph keyboard navigation
+
+The accessibility section mentions "arrow-key node traversal" but does
+not specify the interaction model. Questions:
+
+- How does focus enter the graph canvas? (Tab into graph → first node?)
+- Arrow keys: follow edges (directional) or cycle through all nodes?
+- Enter/Space on a focused node: opens Sheet? Drills into Level 1?
+- Escape: returns focus to sidebar?

--- a/plans/webui/PLAN_WEBUI_STYLE.md
+++ b/plans/webui/PLAN_WEBUI_STYLE.md
@@ -439,35 +439,75 @@ Clicking "View detail →" navigates to the full detail page.
 ### Tables List
 
 The primary list view. Every stream table annotated with its structural
-type, sorted worst SLA first by default.
+type. Has two display modes toggled by a button at the top right:
+**Flat** (default) and **Root Causes**.
+
+**Flat mode** — sorted worst SLA first:
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
-│  Tables                                         [search 🔍] │
+│  Tables                     [Flat ●] [Root causes ○]  [🔍] │
 │             [Schema: All ▼] [Type: All ▼] [SLA: All ▼]    │
 ├──────────────────────────────────────────────────────────────┤
 │  Table                Type          Staleness  E2E Lag  SLA  │
 │  ───────────────────  ──────────    ─────────  ───────  ─── │
-│  analytics.regional_summary  leaf union  45s   61s  ████ 🔴  │
-│  analytics.revenue_7d        intermediate 12s  28s  ██░ 🟡   │
-│  erp_raw.orders_raw          inbox        3s    3s  █ 🟢     │
-│  erp_raw.customers           orphan       —     —   —        │
+│  erp_raw.orders_raw   inbox  🔴root  61s        61s  ████ 🔴 │
+│  analytics.regional_summary  leaf ⬆  45s        61s  ████ 🔴 │
+│  analytics.revenue_7d  intermediate ⬆  12s      61s  ████ 🔴 │
+│  analytics.exec_report  leaf ⬆       18s        61s  ████ 🔴 │
+│  erp_raw.customers    orphan         —           —    —      │
 │  ...                                                         │
 ├──────────────────────────────────────────────────────────────┤
-│  24 tables                                                   │
+│  24 tables · 1 root cause · 3 downstream casualties         │
 └──────────────────────────────────────────────────────────────┘
 ```
+
+**Root causes mode** — collapses downstream casualties under their cause:
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Tables                     [Flat ○] [Root causes ●]  [🔍] │
+├──────────────────────────────────────────────────────────────┤
+│  🔴 erp_raw.orders_raw  inbox · 61s stale · 3 downstream affected  │
+│     ↳ analytics.regional_summary  45s stale                 │
+│     ↳ analytics.revenue_7d        12s stale                 │
+│     ↳ analytics.exec_report       18s stale                 │
+│                                                              │
+│  ✅ erp_raw.customers   orphan · —                          │
+│  ...                                                         │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Root causes mode shows only **independent problems** — one entry per
+root cause node. Downstream casualties are listed beneath it, indented.
+This immediately answers "how many real problems do I have?" A single
+broken inbox that cascades to 10 outputs appears as one entry, not 11.
+
+**Root cause detection.** A table is a root cause of a breach when it
+is in breach AND at least one of these is true:
+- It has no stream-table ancestors (it is an inbox or source table), or
+- All of its stream-table ancestors are healthy.
+
+A table is an **inherited breach** (`⬆` badge) when it is in breach
+solely because an upstream node is in breach and its own refresh
+is keeping up with its inputs.
+
+**SLA column semantics:**
+- 🔴 `root` — this node is the independent cause of the breach
+- 🔴 `⬆` — breach inherited from upstream; this node is a casualty
+- 🟡 — warning (approaching breach) independent of upstream
+- 🟢 — healthy
 
 - **Type column:** Badge chips (inbox / outbox / leaf / intermediate /
   union / orphan). Multiple badges allowed.
 - **Staleness:** How stale this table's own data is.
 - **E2E Lag:** Max cumulative staleness from any root to this table.
-- **SLA column:** Progress bar of the worst SLA breach in the upstream
-  chain, including this table.
 - **Row click:** Navigates to table detail.
-- **Sortable columns:** Default sort by SLA budget descending.
+- **Sortable columns:** Default sort by SLA budget descending (root
+  causes float above their casualties in flat mode).
 - **Faceted filters:** Schema, type badge, refresh mode (DIFF/FULL), SLA status.
 - **Search:** Matches table name or schema.
+- **Footer summary:** "N tables · M root causes · K downstream casualties"
 
 ### Table Detail
 
@@ -475,11 +515,15 @@ Shows the table's own metrics plus its **bidirectional lineage** —
 upstream (root causes) on the left, this table in the centre,
 downstream (blast radius) on the right.
 
+When the current table is in an inherited breach, the header shows a
+banner identifying the root cause so the operator can navigate there
+directly without reading through the lineage graph:
+
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  ← Tables                                                    │
 │  analytics.regional_summary       leaf union  [View in Topology] │
-│  🔴 SLA breach · 5 upstream · 2 downstream · E2E lag: 61s    │
+│  🔴 Inherited breach · root cause: erp_raw.orders_raw  [→]  │
 ├──────────────────────────────────────────────────────────────┤
 │  [Overview]  [Lineage]  [History]  [Operators]  [SQL]          │
 ├──────────────────────────────────────────────────────────────┤
@@ -716,15 +760,26 @@ Merges alerts and refresh timeline into a single Activity page
 (two tabs, or stacked with the timeline above and the alerts feed
 below).
 
+**Causal deduplication.** When a root cause event triggers cascading
+downstream breaches, the downstream alerts are suppressed into a
+single grouped event rather than flooding the feed. The feed shows
+one entry for the cause, with an expandable list of casualties beneath
+it. This prevents a single broken inbox from producing dozens of
+alert rows.
+
 ```
 ┌──────────────────────────────────────────────────────────────┐
 │  Alerts                              [All ▼] [Clear read]    │
 ├──────────────────────────────────────────────────────────────┤
-│  ● 11:02:45  SLA breach    orders_hourly: 61s > 60s SLA     │
-│  ● 11:02:30  Fuse blown    revenue_7d: 3 consecutive errors  │
-│    11:01:15  CDC warning   customers: trigger disabled        │
-│    11:00:00  Refresh ok    revenue_7d: 45ms, +3/-1 rows      │
-│    10:59:45  Relay lag     nats-events: 342 rows behind      │
+│  ● 11:02:45  🔴 SLA breach    erp_raw.orders_raw: 61s > 60s  │
+│              ↳ 3 downstream tables also in breach  [expand ▾]│
+│                ↳ analytics.regional_summary  45s stale       │
+│                ↳ analytics.revenue_7d        12s stale       │
+│                ↳ analytics.exec_report       18s stale       │
+│  ● 11:02:30  🔴 Fuse blown    revenue_7d: 3 consecutive errors│
+│    11:01:15  ⚠️ CDC warning   customers: trigger disabled    │
+│    11:00:00  ✅ Refresh ok    revenue_7d: 45ms, +3/−1 rows   │
+│    10:59:45  ⚠️ Relay lag     nats-events: 342 rows behind   │
 │    ...                                                        │
 ├──────────────────────────────────────────────────────────────┤
 │  Showing 50 of 234 alerts             [< 1 2 3 4 5 >]       │
@@ -732,10 +787,14 @@ below).
 ```
 
 - **●** dot marks unread alerts. Reading clears them (per-session).
+- Grouped entries are collapsed by default; clicking `[expand ▾]`
+  shows the casualty list inline.
+- The sidebar badge counts **root cause events only** — not downstream
+  casualties. "3 alerts" means 3 independent problems, not 3 + N
+  downstream noise.
 - Severity-filtered dropdown: All, Critical, Warning, Info.
 - Timestamps in monospace, relative ("2m ago") with absolute on hover.
-- Alert text links to the relevant object (table name → table detail,
-  pipeline name → pipeline detail).
+- Alert text links to the relevant table detail page.
 
 ### SQL Preview Modal
 


### PR DESCRIPTION
## Summary

Comprehensive architecture planning for pg_trickle's WebUI and MCP server infrastructure. This PR finalizes three major decisions:

1. **Repo Structure**: Three separate repos (`grove/pg-trickle`, `grove/pg-ripple`, `grove/surface`) over a monorepo
2. **Console Design**: Single unified web console named **surface** (instead of 4 separate UIs)
3. **Console Naming**: "surface" — where trickles and ripples are both visible at the water's surface; the UI literally is the platform's surface layer

Includes detailed analysis documents with comparison matrices, risk registers, decision criteria, and implementation phases.

## Changes

- **plans/ANALYSIS_MONOREPO.md** (NEW): Complete monorepo vs separate repos analysis (rev 4)
  - Evaluates both approaches with forces for/against
  - Recommends 3 separate repos: minimizes coordination, obvious boundaries, console as neutral ground
  - Covers CI strategy, release/versioning, console embedding via rust-embed
  - Includes 6-item risk register and decision criteria checklist

- **plans/webui/ANALYSIS_UNIFIED_VS_SEPARATE_UI.md** (NEW): Complete UI count and architecture analysis (rev 4)
  - Evaluates 4 UIs vs 2 UIs vs 1 UI → recommends 1 unified console
  - "surface" naming rationale: neutral to both extensions, metaphorically sound
  - Progressive backend detection: sections appear/hide based on reachable backends
  - 4 deployment scenarios: full stack, pg-ripple only, pg-trickle only, standalone
  - 5-phase implementation plan with API scaffolds, admin sections, exploration, record linkage

- Updated all references from `pgtrickle-web` to `surface` throughout both documents
- Added 3-repo layout diagrams, comparison matrices, and scenario tables

## Architecture Context

The web console `grove/surface` will:
- Cover all four concerns: pg-trickle streaming admin, pg-ripple KG admin, data exploration (SPARQL-driven), record linkage
- Detect backends dynamically (pgtrickle-relay + pg_ripple_http endpoints) and show relevant UI sections
- Embed as static build in Rust binaries (via rust-embed) OR run standalone
- Remain independent repo so either extension can be adopted alone
- Be built in Next.js with Playwright E2E tests against mock APIs

## Testing

- Documentation review: both analysis documents are fully cross-referenced
- No code changes — documentation only
- Decisions are informed by platform adoption patterns, maintenance burden, and adoption scenarios

## Notes

Both analysis documents are now in their final (rev 4) state. They form the foundation for detailed implementation planning on:
- `grove/surface` Next.js app bootstrap
- Workspace member setup for pgtrickle-relay in pg-trickle
- API shape for pgtrickle-relay and pg_ripple_http
- E2E testing strategy for surface against mock backends
