### PR TITLE
docs(plans): overall project assessment v3 + full roadmap refresh (v0.27.0+)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7445,6 +7445,9 @@ remove the lint-suppression attribute. **Schema change:** No.
 | UX-13 | Add snapshot demo to `PLAYGROUND.md` | XS | P2 |
 | UX-14 | Track CNPG 1.29 compatibility: update `cnpg/cluster-example.yaml` and CI | S | P1 |
 | UX-15 | Open tracking issue for dbt-core 1.11 upgrade path | XS | P1 |
+| UX-16 | Add noisy-neighbour example + alert to `docs/integrations/multi-tenant.md` | XS | P3 |
+| UX-17 | Add `recommend_schedule` tuning recipe to `PERFORMANCE_COOKBOOK.md` | XS | P3 |
+| UX-18 | Annotate `dbt-pgtrickle/README.md` with compatible extension version range | XS | P3 |
 
 **UX-1** — `schedule_recommendation_min_samples` (default 20),
 `schedule_alert_cooldown_seconds` (default 300), `metrics_request_timeout_ms`
@@ -7529,6 +7532,22 @@ beta. Open a tracking GitHub issue: note the mashumaro blocker, watch the
 1.11 release, and add a CI job testing against 1.11 once the dep resolves.
 **Schema change:** No.
 
+**UX-16** — `docs/integrations/multi-tenant.md` is excellent but has no worked
+example of a noisy-neighbour scenario. Add one: show a high-frequency stream
+table starving others, the Prometheus alert expression, and the remediation
+step (`pg_trickle.per_db_refresh_quota_ms`). **Schema change:** No.
+
+**UX-17** — `PERFORMANCE_COOKBOOK.md` should include a recipe:
+"Use `recommend_schedule` to right-size a 100-table dbt project." Walk
+through a cold-start, initial history collection, and the first
+auto-recommendation. Link to `CONFIGURATION.md` for the relevant GUCs.
+**Schema change:** No.
+
+**UX-18** — `dbt-pgtrickle/README.md` does not state which extension version
+it is tested against. Add a compatibility matrix row (e.g.
+`dbt-pgtrickle 0.5.x` → `pg_trickle ≥0.25.0`) so users know what to pin.
+**Schema change:** No.
+
 ---
 
 ### Test Coverage
@@ -7549,6 +7568,11 @@ beta. Open a tracking GitHub issue: note the mashumaro blocker, watch the
 | TEST-12 | E2E: snapshot under concurrent `refresh_stream_table` | S | P1 |
 | TEST-13 | E2E: snapshot → `pg_dump` → `pg_restore` round-trip | M | P1 |
 | TEST-14 | Promote G17-MDB multi-database soak test from `stability-tests.yml` to `ci.yml` | S | P1 |
+| TEST-15 | E2E: WAL decoder failure injection (slot missing / wrong plugin) | S | P2 |
+| TEST-16 | E2E: statement-level CDC with mixed INSERT/UPDATE/DELETE ordering invariants | S | P2 |
+| TEST-17 | E2E: `restore_from_snapshot` rollback on mid-INSERT constraint violation | S | P2 |
+| TEST-18 | Property: `cluster_worker_summary` consistency under crash (proptest) | S | P2 |
+| TEST-19 | Property: predictive planner monotone in history length (proptest) | S | P2 |
 
 ---
 
@@ -7579,12 +7603,12 @@ beta. Open a tracking GitHub issue: note the mashumaro blocker, watch the
 | Phase 2 | P0 docs: UX-1, UX-2, TEST-6, TEST-11 | Days 6–9 |
 | Phase 3 | P1 stability + safety: STAB-2, STAB-3, STAB-5, STAB-6, CORR-2, CORR-3 | Days 9–14 |
 | Phase 4 | P1 architecture: SCAL-2, PERF-1, PERF-2 | Days 14–19 |
-| Phase 5 | P1 test coverage: TEST-1 through TEST-14, PERF-3 | Days 19–26 |
-| Phase 6 | P1 docs & UX: UX-3 through UX-15, TUI parity | Days 26–32 |
+| Phase 5 | P1/P2 test coverage: TEST-1 through TEST-19, PERF-3 | Days 19–27 |
+| Phase 6 | P1/P2/P3 docs & UX: UX-3 through UX-18, TUI parity | Days 27–34 |
 
-> **v0.30.0 total: ~6–7 weeks** (correctness-critical path ~10 days;
+> **v0.30.0 total: ~7–8 weeks** (correctness-critical path ~10 days;
 > documentation and test coverage ~14 days; architecture improvements ~8 days;
-> new test targets ~6 days)
+> new test targets ~8 days; Low-priority doc polish ~4 days)
 
 **Exit criteria:**
 - [ ] CORR-1: `test_tpch_q07_ec01b_combined_delete` passes reliably over 50 runs; IMMEDIATE-mode property tests show zero phantom drift

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,6 +46,7 @@ coverage, all in plain language.
 - [v0.27.0 — Operability, Observability & DR](#v0270--operability-observability--dr)
 - [v0.28.0 — Transactional Inbox & Outbox Patterns](#v0280--transactional-inbox--outbox-patterns)
 - [v0.29.0 — Relay CLI (`pgtrickle-relay`)](#v0290--relay-cli-pgtrickle-relay)
+- [v0.30.0 — Pre-GA Correctness & Stability Sprint](#v0300--pre-ga-correctness--stability-sprint)
 - [v1.0.0 — Stable Release](#v100--stable-release)
 - [v1.1.0 — PostgreSQL 17 Support](#v110--postgresql-17-support)
 - [v1.2.0 — PGlite Proof of Concept](#v120--pglite-proof-of-concept)
@@ -53,6 +54,9 @@ coverage, all in plain language.
 - [v1.4.0 — PGlite WASM Extension](#v140--pglite-wasm-extension)
 - [v1.5.0 — PGlite Reactive Integration](#v150--pglite-reactive-integration)
 - [v1.6.0 — TUI Self-Monitoring Integration](#v160--tui-self-monitoring-integration)
+- [v1.7.0 — Performance & Scheduler Intelligence](#v170--performance--scheduler-intelligence)
+- [v1.8.0 — Reactive Subscriptions & Zero-Downtime Operations](#v180--reactive-subscriptions--zero-downtime-operations)
+- [v1.9.0 — Temporal IVM & Columnar Materialization](#v190--temporal-ivm--columnar-materialization)
 - [Post-1.0 — Scale, Ecosystem & Platform Expansion](#post-10--scale-ecosystem--platform-expansion)
 <!-- TOC end -->
 
@@ -100,7 +104,8 @@ from the v0.1.x series to 1.0 and beyond.
 | v0.26.0 | Test & concurrency hardening | ✅ Released |
 | v0.27.0 | Operability, observability & DR — snapshot/PITR, schedule planner, cluster metrics | ✅ Released |
 | v0.28.0 | Transactional inbox & outbox patterns | Planned |
-| v0.29.0 | Operability, observability & DR — snapshot/PITR, schedule planner, cluster metrics | Planned |
+| v0.29.0 | Relay CLI (`pgtrickle-relay`) | Planned |
+| v0.30.0 | Pre-GA correctness & stability sprint — EC-01 fix, snapshot atomicity, SQLSTATE classifier, caches | Planned |
 | v1.0.0 | Stable release (incl. PG 19 compatibility) | Planned |
 | v1.1.0 | PostgreSQL 17 support | Planned |
 | v1.2.0 | PGlite proof of concept | Planned |
@@ -108,6 +113,9 @@ from the v0.1.x series to 1.0 and beyond.
 | v1.4.0 | PGlite WASM extension | Planned |
 | v1.5.0 | PGlite reactive integration | Planned |
 | v1.6.0 | TUI self-monitoring integration | Planned |
+| v1.7.0 | Performance & scheduler intelligence — adaptive batching, plan-aware routing, L0 dshash cache | Planned |
+| v1.8.0 | Reactive subscriptions & zero-downtime operations — subscribe() API, shadow-ST ALTER QUERY | Planned |
+| v1.9.0 | Temporal IVM & columnar materialization — time-travel, SCD-2, columnar storage backend | Planned |
 
 ---
 
@@ -7222,6 +7230,310 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 
 ---
 
+## v0.30.0 — Pre-GA Correctness & Stability Sprint
+
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §3, §4, §7, §8.
+This release must land **before** v1.0.0 GA. Its purpose is to close every
+P0 and P1 gap identified in the v0.27.0 assessment so that the stable
+release inherits a clean correctness baseline.
+
+> **Release Theme**
+> v0.30.0 is the quality gate between the feature-rich v0.28–v0.29 arc and
+> the v1.0 stable release. It fixes the remaining correctness defects that
+> could produce silent wrong answers (EC-01 phantom drift, snapshot
+> non-atomicity), eliminates the operational failure modes that could
+> surprise production operators (unbounded IVM/template caches, text-based
+> SPI error classification, snapshot partial-restore data loss), closes the
+> documentation gaps that block self-service operation (upgrade notes, GUC
+> reference, ERRORS guide), and hardens the test suite with the fuzz and E2E
+> coverage that the new SNAP/PLAN/CLUS/METR functionality currently lacks.
+> No new user-visible SQL API is added. The release is a prerequisite for
+> `v1.0.0`; any item not landed here will block GA.
+
+---
+
+### Correctness
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| CORR-1 | Complete EC-01 phantom-row convergence | M | P0 |
+| CORR-2 | Generalise SubLink detection to CASE/COALESCE/FuncCall | S | P1 |
+| CORR-3 | Replace `SELECT * EXCEPT` with explicit column list in restore | S | P1 |
+
+**CORR-1 — Complete EC-01 phantom-row convergence.**
+The v0.24.0 hash fix is necessary but not sufficient: `is_deduplicated:
+false` at `src/dvm/operators/join.rs:657–668` still forces the MERGE to
+aggregate by row-id, and the conditional wiring that invokes
+`src/refresh/phd1.rs` cross-cycle cleanup is incomplete. Option A:
+wire every refresh cycle through unconditional PH-D1 cleanup with a small
+batch size. Option B: re-derive the Part-2 row-id from the retained
+base-table key snapshot so that `is_deduplicated: true` can be set for
+INNER joins. Verify with the deterministic reproducer from
+`test_tpch_q07_ec01b_combined_delete` and the IMMEDIATE-mode property
+tests. **Schema change:** No. **Dependencies:** v0.24.0 PH-D1 skeleton.
+
+**CORR-2 — SubLink detection for CASE/COALESCE/FuncCall.**
+`node_tree_contains_sublink` only recurses into `T_BoolExpr` arguments;
+SubLinks inside `T_CaseExpr`, `T_CoalesceExpr`, or function-argument lists
+silently downgrade the query to FULL refresh without a user-visible
+message. Generalise the walker or emit a `NOTICE` on forced downgrade.
+**Schema change:** No. **Dependencies:** None.
+
+**CORR-3 — Explicit column list for restore.**
+`restore_from_snapshot_impl` unconditionally emits `SELECT * EXCEPT(…)`,
+which is only available on PG 18 with specific minor-version patches.
+Replace with a `pg_attribute` catalog walk that builds the explicit column
+list, eliminating PG-minor sensitivity entirely. **Schema change:** No.
+**Dependencies:** None.
+
+---
+
+### Stability
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| STAB-1 | Wrap snapshot/restore in SubTransaction RAII + exclusive lock | M | P0 |
+| STAB-2 | Bound `IVM_DELTA_CACHE` via clock-style eviction | S | P1 |
+| STAB-3 | Age-based purge for L2 template-cache catalog table | S | P1 |
+| STAB-4 | Surface snapshot catalog INSERT failure as WARNING | XS | P0 |
+| STAB-5 | Replace `wal_decoder.rs` `.expect()` with `c"test_decoding"` | XS | P1 |
+| STAB-6 | Clear IVM thread-local cache via `XactCallback` on subxact abort | S | P1 |
+
+**STAB-1 — Snapshot/restore atomicity.**
+`snapshot_stream_table_impl` and `restore_from_snapshot_impl`
+(`src/api/snapshot.rs:90–260`) run independent SPI statements with no
+subxact bracket. A backend crash between the `CREATE TABLE AS` and the
+catalog `INSERT` leaves an orphan table; a mid-restore statement failure
+leaves the storage table truncated. Wrap the entire operation in the same
+`SubTransaction` RAII helper used by `src/scheduler.rs:250–308`. For
+restore, open with `LOCK TABLE … IN ACCESS EXCLUSIVE MODE` before the
+`TRUNCATE`. Propagate snapshot-version-check failure as typed
+`SnapshotSchemaVersionMismatch` instead of silently treating `None` as
+compatible. **Schema change:** No. **Dependencies:** scheduler SubTransaction
+helper (shipped v0.27.0).
+
+**STAB-2 — Bound `IVM_DELTA_CACHE`.**
+The thread-local `IVM_DELTA_CACHE` at `src/ivm.rs:107–143` has no eviction.
+Implement a clock-style eviction that respects `pg_trickle.template_cache_max_entries`
+— the same GUC already used by the L1 delta-template cache.
+**Schema change:** No. **Dependencies:** None.
+
+**STAB-3 — L2 template-cache age purge.**
+`src/template_cache.rs` writes one row per stream table but never purges
+stale entries from ALTER QUERY without DROP or source-OID renumbering. Add a
+`cached_at TIMESTAMPTZ` column (migration) and a lightweight batched DELETE in
+the scheduler's launcher tick, age-bounded by a new
+`pg_trickle.template_cache_max_age_hours` GUC (default 168 h = 7 days).
+**Schema change:** Yes — `ALTER TABLE pgtrickle.pgt_template_cache ADD COLUMN
+cached_at TIMESTAMPTZ NOT NULL DEFAULT now()`.
+
+**STAB-4 — Snapshot catalog INSERT failure warning.**
+`snapshot_stream_table_impl` discards the `Result` of the catalog `INSERT INTO
+pgtrickle.pgt_snapshots` with a `// best-effort` comment at
+`src/api/snapshot.rs:152–167`. A silent failure produces a function return
+value (the snapshot path) that `list_snapshots()` will never find. Promote the
+failure to a pgrx `WARNING` message. **Schema change:** No.
+
+**STAB-5 — `wal_decoder.rs` `.expect()` removal.**
+`CString::new("test_decoding").expect(…)` at `src/wal_decoder.rs:307` is the
+last production `.expect()` outside the sound `unreachable!()` post-`report()`
+calls. Replace with `c"test_decoding"` (compile-time `CStr` literal; Rust 1.77+
+stable) to eliminate the unreachable runtime path entirely. **Schema change:** No.
+
+**STAB-6 — IVM cache `XactCallback`.**
+If an IVM trigger function fails mid-statement, the
+`__pgt_newtable_<oid>` / `__pgt_oldtable_<oid>` temp tables are cleaned up by
+PG subxact abort, but the thread-local `IVM_DELTA_CACHE` is not cleared. A stale
+entry can survive a failed apply and be reused in the next statement. Register a
+`XactCallback` that calls `invalidate_ivm_delta_cache` on
+`XACT_EVENT_ABORT_SUB`. **Schema change:** No.
+
+---
+
+### Performance
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| PERF-1 | Implement L0 shared-shmem dshash template cache | L | P1 |
+| PERF-2 | Bound parser memory via `max_parse_nodes` GUC + `XactCallback` | M | P1 |
+| PERF-3 | Add missing benchmark suite (SNAP, PLAN, CLUS, IVM apply, WAL decoder) | M | P1 |
+
+**PERF-1 — L0 dshash shared-memory template cache.**
+`src/shmem.rs:680–710` wires `L0_POPULATED_VERSION` as a signal that the L2
+catalog cache was populated, but the actual `dshash` data structure that would
+store delta SQL in shared memory is not implemented. Build the dshash store
+so that any backend can satisfy a cache lookup from shared memory rather than
+paying the ~1 ms L2 catalog SELECT on every cold start. Expected win: erase
+the remaining cold-backend latency tail in high-backend-count deployments.
+**Schema change:** No. **Dependencies:** `pg_dsm_create` and `dshash_create`
+pgrx bindings (available in pgrx 0.18).
+
+**PERF-2 — Parser memory bounds.**
+`pg_trickle.max_parse_depth` (G13-SD) bounds recursion depth but not total
+node count. A large `IN (1, …, 1_000_000)` list still allocates unboundedly in
+`PARSE_ADVISORY_WARNINGS` and `cte_ctx.registry`. Add a
+`pg_trickle.max_parse_nodes` GUC (default 100 000) and reject queries that
+exceed it with `QueryTooComplex`. Clear thread-locals at end-of-statement via
+`XactCallback`. **Schema change:** No (new GUC only).
+
+**PERF-3 — Missing benchmarks.**
+Seven performance-critical paths have no Criterion coverage: snapshot/restore
+round-trip, predictive planner `recommend_schedule` at varying history lengths,
+`cluster_worker_summary()` at scale, L2 template-cache hit/miss latency, IVM
+apply path, WAL decoder poll loop, multi-database fairness. Add a benchmark
+file or extend `benches/refresh_bench.rs` to cover all seven.
+**Schema change:** No.
+
+---
+
+### Scalability
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| SCAL-1 | Replace text-based SPI error classification with SQLSTATE codes | M | P0 |
+| SCAL-2 | Replace `refresh::*` blanket re-exports with explicit `pub use` | XS | P1 |
+
+**SCAL-1 — SQLSTATE-based error classification.**
+`classify_spi_error_retryable` at `src/error.rs:213–260` matches English text
+fragments. On a PostgreSQL build with non-English `lc_messages`, every pattern
+silently breaks and every SPI error becomes retryable. Push SQLSTATE through
+pgrx (`pg_sys::ErrorData.sqlerrcode`) and classify by 5-character code.
+**Schema change:** No. **Dependencies:** pgrx 0.18 ErrorData access.
+
+**SCAL-2 — Explicit `pub use` in `refresh/mod.rs`.**
+`src/refresh/mod.rs` exposes `pub use codegen::*; pub use merge::*; pub use
+orchestrator::*;`, promoting every new public symbol automatically. Convert to
+explicit re-export lists to enforce module boundary discipline without breaking
+callers. **Schema change:** No.
+
+---
+
+### Ease of Use
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| UX-1 | Document all v0.27.0 GUCs in `CONFIGURATION.md` | S | P0 |
+| UX-2 | Document v0.15.0–v0.27.0 upgrade notes in `UPGRADING.md` | M | P0 |
+| UX-3 | Document new error variants (HINT/DETAIL) in `ERRORS.md` | S | P1 |
+| UX-4 | Complete `SQL_REFERENCE.md` for SNAP/PLAN/CLUS/METR functions | S | P1 |
+| UX-5 | Add TUI parity for SNAP/PLAN/CLUS/METR functions | M | P1 |
+| UX-6 | Ship first-party Grafana dashboard JSON in `monitoring/grafana/` | M | P1 |
+| UX-7 | Document `pg_trickle_dump` in `BACKUP_AND_RESTORE.md` | XS | P1 |
+| UX-8 | Add snapshot/PITR walkthrough to `GETTING_STARTED.md` | S | P1 |
+
+**UX-1** — `schedule_recommendation_min_samples` (default 20),
+`schedule_alert_cooldown_seconds` (default 300), `metrics_request_timeout_ms`
+(default 5000), `change_buffer_durability` (`unlogged|logged|sync`), and
+several others from Appendix C of the assessment are missing from the
+`CONFIGURATION.md` TOC. Add full Property/Default/Range/Context + Tuning
+Guidance sections for each.
+
+**UX-2** — `UPGRADING.md` stops at `0.13.0 → 0.14.0`. Add upgrade notes
+(breaking changes, migration script highlights, GUC renames) for every
+release from v0.15.0 through v0.27.0.
+
+**UX-3** — New error variants shipped since v0.23.0 (`SnapshotAlreadyExists`,
+`SnapshotSourceNotFound`, `SnapshotSchemaVersionMismatch`, `DiagnosticError`,
+`PublicationAlreadyExists`, `PublicationNotFound`, `PublicationRebuildFailed`,
+`SlaTooSmall`, `ChangedColsBitmaskFailed`) have no HINT/DETAIL entries in
+`ERRORS.md`.
+
+**UX-4** — Spot-check confirms `cluster_worker_summary()` and
+`metrics_summary()` are referenced from `SCALING.md` but do not have full
+sections in `SQL_REFERENCE.md`. Add complete parameter/return-type/example
+entries for all eight SNAP/PLAN/CLUS/METR functions.
+
+**UX-5** — `pgtrickle-tui` has no panels for `snapshot_stream_table`,
+`restore_from_snapshot`, `list_snapshots`, `recommend_schedule`,
+`schedule_recommendations`, `cluster_worker_summary`, `metrics_summary`.
+Add SNAP/PLAN/CLUS/METR views to the TUI alongside the existing stream-table
+management screens.
+
+**UX-6** — The `monitoring/grafana/` directory has no first-party dashboard
+JSON. The dashboard snippets in `docs/integrations/multi-tenant.md` are the
+only artefact. Ship a baseline dashboard covering refresh latency, CDC buffer
+growth, IVM lock-mode distribution, and per-DB cluster metrics.
+
+**UX-7** — `src/bin/pg_trickle_dump.rs` (458 LOC) is the only
+out-of-database backup tool. Document usage, flags, and restore procedure
+in `BACKUP_AND_RESTORE.md`.
+
+**UX-8** — Add a "Snapshot and Point-in-Time Recovery" section to
+`GETTING_STARTED.md` with a worked example: take a snapshot, simulate data
+loss, restore from snapshot, verify.
+
+---
+
+### Test Coverage
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| TEST-1 | E2E: snapshot atomicity under crash (orphan table detection) | M | P0 |
+| TEST-2 | E2E: snapshot version mismatch | S | P1 |
+| TEST-3 | E2E: predictive planner with N < `min_samples` | S | P1 |
+| TEST-4 | E2E: multi-DB worker fairness under contention | M | P1 |
+| TEST-5 | Integration: `IVM_DELTA_CACHE` bounded over 1000 ALTER QUERY cycles | S | P1 |
+| TEST-6 | Integration: `classify_spi_error_retryable` with `lc_messages=fr_FR` | S | P0 |
+| TEST-7 | Fuzz: WAL decoder | M | P1 |
+| TEST-8 | Fuzz: MERGE template generator | M | P1 |
+| TEST-9 | Fuzz: snapshot SQL builder | S | P1 |
+| TEST-10 | Fuzz: DAG SCC graph shapes | S | P2 |
+| TEST-11 | EC-01 deterministic reproducer (replaces flaky `test_tpch_q07_*`) | M | P0 |
+
+---
+
+### Conflicts & Risks
+
+- **STAB-3** requires a schema migration (adding `cached_at` column). Include
+  in `sql/pg_trickle--0.29.0--0.30.0.sql`; verify via
+  `scripts/check_upgrade_completeness.sh`.
+- **CORR-1** touches the DVM join delta pipeline — the highest-risk module.
+  Must be gated behind full TPC-H property test suite before merge.
+- **PERF-1** requires `dshash` pgrx bindings that may not yet be fully
+  stabilised in pgrx 0.18; de-risk with a spike before committing to the
+  milestone.
+- **SCAL-1** changes observable retry semantics. Roll out behind a
+  `pg_trickle.use_sqlstate_classification` GUC (default `false`) initially,
+  flip to `true` in v0.31.0 after one release of parallel validation.
+
+### Implementation Phases
+
+| Phase | Description | Duration |
+|-------|-------------|----------|
+| Phase 1 | P0 correctness + stability: CORR-1, STAB-1, STAB-4, SCAL-1 | Days 1–6 |
+| Phase 2 | P0 docs: UX-1, UX-2, TEST-6, TEST-11 | Days 6–9 |
+| Phase 3 | P1 stability + safety: STAB-2, STAB-3, STAB-5, STAB-6, CORR-2, CORR-3 | Days 9–14 |
+| Phase 4 | P1 architecture: SCAL-2, PERF-1, PERF-2 | Days 14–19 |
+| Phase 5 | P1 test coverage: TEST-1 through TEST-9, PERF-3 | Days 19–25 |
+| Phase 6 | P1 docs & UX: UX-3 through UX-8, UX-5 TUI | Days 25–30 |
+
+> **v0.30.0 total: ~5–6 weeks** (correctness-critical path ~10 days;
+> documentation and test coverage ~12 days; architecture improvements ~8 days)
+
+**Exit criteria:**
+- [ ] CORR-1: `test_tpch_q07_ec01b_combined_delete` passes reliably over 50 runs; IMMEDIATE-mode property tests show zero phantom drift
+- [ ] CORR-2: Parser emits `NOTICE` when SubLink inside CASE/COALESCE forces FULL downgrade
+- [ ] CORR-3: `restore_from_snapshot` uses explicit column list; works on PG 18.0 and 18.x
+- [ ] STAB-1: Snapshot under crash leaves no orphan tables (TEST-1); restore under concurrent refresh is safe
+- [ ] STAB-2: `IVM_DELTA_CACHE` size bounded by `template_cache_max_entries` (TEST-5)
+- [ ] STAB-3: L2 template-cache catalog table purged by scheduler tick; `cached_at` column present in migration
+- [ ] STAB-4: `snapshot_stream_table` emits `WARNING` when catalog INSERT fails
+- [ ] STAB-5: `wal_decoder.rs:307` uses `c"test_decoding"`; `just lint` clean
+- [ ] STAB-6: IVM cache cleared on subxact abort via `XactCallback`
+- [ ] SCAL-1: Retry classification by SQLSTATE; `lc_messages=fr_FR` test passes (TEST-6)
+- [ ] PERF-3: All seven missing benchmarks present and passing Criterion baseline gate
+- [ ] UX-1: All Appendix C GUCs documented in `CONFIGURATION.md`
+- [ ] UX-2: `UPGRADING.md` covers v0.15.0 → v0.27.0
+- [ ] UX-3: All new error variants have HINT/DETAIL in `ERRORS.md`
+- [ ] UX-4: All eight SNAP/PLAN/CLUS/METR functions have full SQL_REFERENCE entries
+- [ ] UX-5: TUI shows SNAP/PLAN/CLUS/METR panels
+- [ ] UX-6: `monitoring/grafana/pg_trickle.json` ships and renders in Grafana 11+
+- [ ] TEST-7/8/9: New fuzz targets run in CI; no crashes after 24 h
+- [ ] Extension upgrade path tested (`0.29.0 → 0.30.0`)
+- [ ] `just check-version-sync` passes
+
+---
+
 ## v1.0.0 — Stable Release
 
 **Goal:** First officially supported release. Semantic versioning locks in.
@@ -9261,6 +9573,301 @@ TUI/CLI visualization enhancement for the self-monitoring views. Recommended fro
 
 ---
 
+## v1.7.0 — Performance & Scheduler Intelligence
+
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §4, §5, §10.3, §10.4.
+
+> **Release Theme**
+> v1.7.0 turns the scheduler from a round-robin dispatcher into an adaptive
+> execution engine. Three orthogonal improvements land together: adaptive
+> batching groups stream tables that share a source so the change-buffer scan
+> is paid once per source per cycle; plan-aware delta routing selects
+> `merge_strategy` per-refresh from `EXPLAIN ANALYZE` output instead of
+> requiring per-stream-table tuning; and the L0 shared-shmem dshash cache
+> (if not completed in v0.30.0) finishes the three-tier caching story by
+> placing hot delta SQL in shared memory, making cold backends
+> indistinguishable from warm ones. Each improvement is independently
+> deployable and hidden behind a GUC, so operators can adopt them
+> incrementally.
+
+---
+
+### Performance
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| PERF-1 | Adaptive batching: coalesce STs sharing a source table | L | P1 |
+| PERF-2 | Plan-aware delta routing: auto-select `merge_strategy` | M | P1 |
+| PERF-3 | IVM lock-mode observability counter | XS | P1 |
+| PERF-4 | Switch IVM transition tables to ENR (drop temp tables) | M | P1 |
+| PERF-5 | L0 dshash shared-shmem cache (if deferred from v0.30.0) | L | P1 |
+
+**PERF-1 — Adaptive batching.**
+The scheduler currently dispatches each ready stream table independently.
+An adaptive batcher notices when two or more stream tables share the same
+source table and refresh window, and coalesces their change-buffer scans:
+one `SELECT * FROM pgtrickle_changes.changes_<oid>` per source table per
+tick instead of one per downstream stream table. Expected win: 10–30%
+throughput improvement for multi-tenant deployments with shared sources.
+Controlled by `pg_trickle.adaptive_batch_coalescing` GUC (default `true`).
+**Schema change:** No. **Dependencies:** v0.25.0 scheduler snapshot cache.
+
+**PERF-2 — Plan-aware delta routing.**
+Today `merge_strategy` is a per-stream-table setting requiring manual tuning.
+After each differential refresh, inspect the `EXPLAIN (FORMAT JSON)` output
+from the MERGE; if the estimated cost of `delete_insert` is lower than
+`merge` (e.g. because the index cardinality ratio exceeds a heuristic
+threshold), switch for the next cycle. The existing heuristic code in
+`src/refresh/codegen.rs` provides the skeleton. Controlled by
+`pg_trickle.adaptive_merge_strategy` GUC (default `false` initially).
+**Schema change:** No.
+
+**PERF-3 — IVM lock-mode counter.**
+`IvmLockMode::for_query` (src/ivm.rs:48–91) silently falls back to
+`Exclusive` on any parse failure. Add a Prometheus counter
+`pgtrickle_ivm_lock_mode_total{mode="exclusive_due_to_parse_error"}` and
+expose it via `metrics_summary()`. Operators can then audit whether their
+IMMEDIATE-mode queries are taking unnecessarily broad locks.
+**Schema change:** No (new metric only).
+
+**PERF-4 — ENR-based IVM transition tables.**
+The IVM trigger functions use PostgreSQL temporary tables to materialise
+`NEW TABLE` / `OLD TABLE` transition data (comment at `src/ivm.rs:30–37`).
+PostgreSQL 18 supports referencing ephemeral named relations (ENRs) directly
+inside trigger bodies, eliminating the intermediate temp-table overhead.
+Rewrite the trigger function builders to reference the ENR by name.
+**Schema change:** No.
+
+---
+
+### Scalability
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| SCAL-1 | Back-pressure signal when change buffer exceeds threshold | S | P2 |
+| SCAL-2 | Multi-DB singleton refresh broker concept (design only) | S | P2 |
+
+**SCAL-1** — Expose a `pgtrickle_alert change_buffer_backpressure` event
+when a change buffer grows past `pg_trickle.buffer_alert_threshold` for
+more than N consecutive refresh cycles. This is a signal rather than a
+throttle — actual back-pressure requires application-level cooperation —
+but it gives operators the Prometheus alert hook they need.
+
+**SCAL-2** — Draft a design document for a "refresh broker" that de-duplicates
+expensive source-table scans across databases in the same cluster. A foreign-
+data-wrapper view shared across two databases today causes each scheduler to
+pay the full scan cost independently. The design doc need not ship code; it
+should inform v1.8+ or Post-1.0 architecture.
+
+---
+
+### Test Coverage
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| TEST-1 | Benchmark regression gate for adaptive batching | S | P1 |
+| TEST-2 | Benchmark regression gate for plan-aware routing | S | P1 |
+| TEST-3 | Integration: ENR trigger vs temp-table parity | S | P1 |
+
+---
+
+### Exit Criteria
+
+- [ ] PERF-1: Adaptive batching reduces change-buffer scan count to 1 per source per tick; benchmark shows ≥ 10% throughput improvement at 50+ STs sharing 5 sources
+- [ ] PERF-2: Plan-aware strategy flip logged; benchmark shows no regression; unit-tested with mock EXPLAIN output
+- [ ] PERF-3: `pgtrickle_ivm_lock_mode_total{mode="exclusive_due_to_parse_error"}` metric emitted; visible in `metrics_summary()`
+- [ ] PERF-4: IVM trigger functions reference ENR by name; temp tables eliminated; E2E parity tests pass
+- [ ] Extension upgrade path tested (`1.6.0 → 1.7.0`)
+- [ ] `just check-version-sync` passes
+
+---
+
+## v1.8.0 — Reactive Subscriptions & Zero-Downtime Operations
+
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.1, §10.8.
+
+> **Release Theme**
+> v1.8.0 delivers two long-requested operational capabilities. Reactive
+> subscriptions expose stream-table changes as PostgreSQL `NOTIFY` events,
+> enabling browser-side reactive UIs and event-driven microservices with
+> nothing but a standard PG connection — no Kafka, no Debezium, no Hasura.
+> Zero-downtime view evolution adds a shadow-ST mode to `ALTER QUERY` that
+> builds the new query's materialisation side-by-side with the live table,
+> then swaps atomically — eliminating the operational risk of running
+> `ALTER QUERY` on a large production stream table.
+
+---
+
+### Correctness
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| CORR-1 | Reactive subscription: coalesce NOTIFY storms | S | P0 |
+
+**CORR-1** — The subscribe API must coalesce rapid successive changes into a
+single NOTIFY payload (or a "changes pending" signal) when the refresh
+interval is shorter than the LISTEN client's poll loop. Implement a
+`pg_trickle.notify_coalesce_ms` GUC (default 250 ms) and a per-stream-table
+flag that debounces NOTIFY calls.
+
+---
+
+### Ease of Use
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| UX-1 | `pgtrickle.subscribe(name, channel)` and `unsubscribe()` SQL functions | M | P0 |
+| UX-2 | `pg_trickle.notify_coalesce_ms` GUC | XS | P0 |
+| UX-3 | `ALTER QUERY` shadow-ST mode (`shadow_build := true` parameter) | L | P1 |
+| UX-4 | `pgtrickle.view_evolution_status(name)` monitoring function | S | P1 |
+| UX-5 | Documentation: subscribe() quick-start + shadow-ST runbook | M | P1 |
+
+**UX-1 — Reactive subscription API.**
+`pgtrickle.subscribe(stream_table TEXT, channel TEXT)` registers a per-stream-
+table listener: after every successful differential or full refresh, if the
+delta is non-empty, the refresh path emits `pg_notify(channel, payload_jsonb::text)`
+within the same transaction. The payload carries `{"name": …, "refresh_id": …,
+"inserted_count": N, "deleted_count": N}`. Build on the `pg_notify`
+infrastructure already wired by the v0.28.0 outbox. `pgtrickle.unsubscribe(name, channel)`
+removes the registration; `pgtrickle.list_subscriptions()` returns all active
+registrations. **Schema change:** Yes — new `pgtrickle.pgt_subscriptions`
+catalog table.
+
+**UX-3 — Shadow-ST for zero-downtime `ALTER QUERY`.**
+Today `ALTER QUERY` triggers a full refresh of the stream table. For tables
+with millions of rows, this causes a multi-minute outage during which the
+stream table is locked. A `shadow_build := true` parameter to `alter_query()`
+creates a parallel stream table `__pgt_shadow_<name>` built from the new query,
+refreshes it to convergence in the background without locking the live table,
+then atomically swaps the storage tables and drops the shadow. The live table
+is readable and writable throughout. The new query goes live at the next refresh
+cycle after the swap. **Schema change:** Yes — add `in_shadow_build BOOLEAN` and
+`shadow_table_name TEXT` columns to `pgtrickle.pgt_stream_tables`.
+
+---
+
+### Test Coverage
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| TEST-1 | E2E: subscribe() receives NOTIFY on every non-empty refresh | M | P0 |
+| TEST-2 | E2E: NOTIFY coalescing under high-frequency refresh | S | P1 |
+| TEST-3 | E2E: shadow-ST ALTER QUERY while reads/writes are in flight | L | P1 |
+| TEST-4 | E2E: shadow-ST rollback if new query fails to converge | M | P1 |
+
+---
+
+### Conflicts & Risks
+
+- **UX-3** (shadow-ST) touches the refresh orchestrator and catalog — the
+  highest-change-risk modules. Must ship behind a feature flag, stabilised
+  with the full TPC-H test suite before removing the flag.
+- Shadow-ST competes with the live stream table's change buffer, potentially
+  doubling CDC write overhead during the build window. Add a
+  `shadow_refresh_throttle_ms` GUC to rate-limit background refreshes.
+
+### Exit Criteria
+
+- [ ] UX-1: `subscribe()` / `unsubscribe()` / `list_subscriptions()` registered; NOTIFY emitted on non-empty refresh; `pgt_subscriptions` catalog table in migration script
+- [ ] CORR-1: NOTIFY coalescing tested at 10 Hz refresh; client receives ≤ 1 NOTIFY per `notify_coalesce_ms` window
+- [ ] UX-3: Shadow-ST builds in background; swap is atomic; live table readable throughout; rollback on convergence failure documented
+- [ ] UX-4: `view_evolution_status()` returns `in_progress | converged | failed` with row counts
+- [ ] Extension upgrade path tested (`1.7.0 → 1.8.0`)
+- [ ] `just check-version-sync` passes
+
+---
+
+## v1.9.0 — Temporal IVM & Columnar Materialization
+
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.2, §10.7.
+
+> **Release Theme**
+> v1.9.0 unlocks two analytic workload patterns that the current streaming
+> engine cannot serve. Temporal IVM lets a stream table maintain a rolling
+> history of how its rows have changed over time — providing first-class
+> SCD-Type-2 semantics without external ETL or separate audit tables.
+> Columnar materialization lets a stream table store its result set in
+> Citus columnar storage (or pg_mooncake), dramatically reducing storage
+> footprint and query I/O for analytic consumers that scan the materialised
+> result set but never write to it. Together they close the OLTP→OLAP
+> bridging gap and make pg_trickle viable as the materialization layer for
+> dashboards and reporting queries.
+
+---
+
+### Correctness
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| CORR-1 | Temporal IVM: two-dimensional frontier (LSN, timestamp) | L | P0 |
+| CORR-2 | Columnar: verify differential MERGE compatibility with columnar storage | M | P0 |
+
+**CORR-1** — Temporal IVM requires extending the frontier model from a
+one-dimensional LSN cursor to a two-dimensional `(frontier_lsn, valid_from_ts)`
+pair. Each row carries a `__pgt_valid_from TIMESTAMPTZ` and an optional
+`__pgt_valid_to TIMESTAMPTZ`. Rows are never physically deleted; instead a
+"close" delta sets `valid_to`. Queries against the stream table with `AS OF
+TIMESTAMP $1` resolve to the materialised row version valid at that timestamp.
+**Schema change:** Yes — new `temporal_mode BOOLEAN` column on
+`pgtrickle.pgt_stream_tables`; new `__pgt_valid_from`/`__pgt_valid_to`
+columns auto-added to the storage table when `temporal_mode = true`.
+
+**CORR-2** — Citus columnar and pg_mooncake use append-only storage models.
+Verify that the differential MERGE (`MERGE INTO storage USING delta`) is
+compatible with append-only semantics (likely requires `DELETE + INSERT`
+merge strategy for columnar targets). Add a `storage_backend` column to
+`pgtrickle.pgt_stream_tables` and route merge codegen accordingly.
+
+---
+
+### Ease of Use
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| UX-1 | `create_stream_table(…, temporal := true)` parameter | M | P0 |
+| UX-2 | `AS OF TIMESTAMP` query rewrite in DVM parser | L | P1 |
+| UX-3 | `create_stream_table(…, storage_backend := 'columnar')` parameter | M | P1 |
+| UX-4 | Automatic `delete_insert` strategy for columnar backends | S | P1 |
+| UX-5 | Documentation: temporal IVM tutorial + SCD-Type-2 worked example | M | P1 |
+| UX-6 | Documentation: columnar backend setup guide (Citus + pg_mooncake) | S | P1 |
+
+---
+
+### Test Coverage
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| TEST-1 | Integration: temporal stream table `AS OF TIMESTAMP` round-trip | L | P0 |
+| TEST-2 | Integration: SCD-Type-2 dimension pattern end-to-end | M | P1 |
+| TEST-3 | Integration: columnar stream table MERGE parity with heap | M | P0 |
+| TEST-4 | Integration: temporal + columnar combined (temporal columnar ST) | M | P2 |
+
+---
+
+### Conflicts & Risks
+
+- **CORR-1** requires a non-trivial DVM engine extension (two-dimensional
+  frontier). Spike in v1.8.0 first; do not commit to the milestone until
+  the spike proves the approach is sound.
+- **CORR-2** depends on the Citus columnar or pg_mooncake extension being
+  present; CI must add a Testcontainers image with one of these available.
+  Gate columnar support behind `pg_trickle.columnar_backend` GUC (default
+  `none`); the CI matrix should test at least one columnar provider.
+- The combination of temporal mode and columnar storage is a P2 stretch
+  goal; do not block the release on it.
+
+### Exit Criteria
+
+- [ ] CORR-1/UX-1: `create_stream_table(…, temporal := true)` creates storage table with `__pgt_valid_from`/`__pgt_valid_to`; rows never physically deleted
+- [ ] UX-2: `AS OF TIMESTAMP $1` query rewrites resolve against the materialised history
+- [ ] TEST-1: Temporal round-trip test passes: insert → update → delete, query at t₀/t₁/t₂ returns correct historical rows
+- [ ] TEST-2: SCD-Type-2 dimension pattern: slowly-changing customer table materialised with full history, current-version query using `WHERE valid_to IS NULL`
+- [ ] CORR-2/UX-3: Columnar stream table creates; `delete_insert` strategy used automatically; columnar MERGE E2E parity test passes
+- [ ] Extension upgrade path tested (`1.8.0 → 1.9.0`)
+- [ ] `just check-version-sync` passes
+
+---
+
 ## Post-1.0 Addendum — Cross-Cluster & Visual Tooling
 
 The following items from [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 are explicitly post-1.0 and are tracked here rather than in a numbered milestone:
@@ -9269,6 +9876,14 @@ The following items from [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSES
 |------|-------------|----------|-----|
 | POST-XC | **Cross-cluster fan-out via `pgtrickle-relay`.** A relay mode that reads from one cluster's outbox and applies to another cluster's inbox. Optional CRDT-style conflict resolution for last-write-wins counters. Enables multi-region read-replica patterns without a full replication setup. | Medium | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
 | POST-VIS | **GUI workflow designer + visual DAG editor.** Extend `pgtrickle-tui` with a visual DAG editor and an EXPLAIN-DIFF preview that shows the rewritten DVM SQL alongside expected delta size. Lowers on-boarding ramp for SQL developers unfamiliar with IVM semantics. | Medium | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
+| POST-OTL | **OpenTelemetry tracing spans.** Emit per-refresh, per-CDC-capture, and per-snapshot spans so OTel collectors can correlate pg_trickle latency with upstream service traces. Minimum viable: `pgtrickle.refresh`, `pgtrickle.cdc_capture`, `pgtrickle.snapshot` spans with standard attributes. | Medium | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.6 |
+| POST-SIGN | **Cosign-sign GHCR release images.** Add `cosign sign` step to the GitHub Actions release workflow for `grove/pg-trickle`, `grove/pgtrickle-relay`, and `pg_trickle-ext` images. Attach signatures to GHCR. Document verification in `SECURITY.md`. | Medium | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.11 |
+| POST-HELM | **First-party Helm chart.** A `charts/pg-trickle` Helm chart that wraps the CNPG ImageVolume deployment pattern. Publishes to a GitHub Pages chart repository at `grove.github.io/pg-trickle`. Supports multi-database cluster deployments via values. | Medium | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.3 |
+| POST-LLM | **LLM-assisted advisor (`pgtrickle.advise()`).** A SQL function backed by a small open model (e.g. Phi-3 via PL/Python) that takes a query and returns recommendations: refresh mode, schedule, source-table index suggestions, and flagged anti-patterns. Onboarding accelerator for users unfamiliar with IVM tuning. | Low | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.9 |
+| POST-GQL | **GraphQL / PostGraphile integration.** A PostGraphile v5 plugin that exposes stream tables as subscription-capable GraphQL types. Clients subscribe to a stream table via GraphQL subscriptions backed by the v1.8.0 `pgtrickle.subscribe()` NOTIFY channel. | Low | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.5 |
+| POST-MDSB | **Multi-database singleton refresh broker.** A cluster-level broker that de-duplicates expensive source-table scans when multiple databases in the same cluster share a source table (e.g. via FDW). Each database's scheduler registers intent with the broker; the broker assigns one scheduler as the "owner" of the scan per cycle. | Low | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §4.7 |
+| POST-PGXN | **PG Extension Network listing.** Submit `pg_trickle` to the [PG Extension Network](https://pgxn.org/) and the [PostgreSQL Extension Directory](https://ext.pgxn.org/). Update `META.json` for PGXN-compatible distribution. | Low | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.12 |
+| POST-POOL | **Pgcat / Odyssey connection pooler compatibility.** Validate and document pg_trickle behaviour under Pgcat (transaction mode) and Odyssey (transaction mode). Fix any incompatibilities. Update `docs/CONFIGURATION.md` pooler matrix. | Low | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.9 |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7357,6 +7357,7 @@ entry can survive a failed apply and be reused in the next statement. Register a
 | PERF-1 | Implement L0 shared-shmem dshash template cache | L | P1 |
 | PERF-2 | Bound parser memory via `max_parse_nodes` GUC + `XactCallback` | M | P1 |
 | PERF-3 | Add missing benchmark suite (SNAP, PLAN, CLUS, IVM apply, WAL decoder) | M | P1 |
+| PERF-4 | Reduce catalog hot-path in `metrics_summary()` / `cluster_worker_summary()` | M | P2 |
 
 **PERF-1 — L0 dshash shared-memory template cache.**
 `src/shmem.rs:680–710` wires `L0_POPULATED_VERSION` as a signal that the L2
@@ -7384,6 +7385,15 @@ apply path, WAL decoder poll loop, multi-database fairness. Add a benchmark
 file or extend `benches/refresh_bench.rs` to cover all seven.
 **Schema change:** No.
 
+**PERF-4 — Reduce catalog hot-path in `metrics_summary()` and `cluster_worker_summary()`.**
+Both new v0.27.0 functions re-query `pgtrickle.pgt_stream_tables` and
+`pg_stat_activity` on every Prometheus scrape (default 5 s interval). At
+200+ stream tables this adds a full catalog scan per database every 5 s, on
+top of the scheduler's own reads. Introduce a short-lived shmem-backed
+snapshot for these read paths that both surfaces share, refreshed once per
+scheduler tick. Controlled by `pg_trickle.metrics_catalog_snapshot_ttl_ms`
+GUC (default 4000 ms). **Schema change:** No.
+
 ---
 
 ### Scalability
@@ -7392,6 +7402,7 @@ file or extend `benches/refresh_bench.rs` to cover all seven.
 |----|-------|--------|----------|
 | SCAL-1 | Replace text-based SPI error classification with SQLSTATE codes | M | P0 |
 | SCAL-2 | Replace `refresh::*` blanket re-exports with explicit `pub use` | XS | P1 |
+| SCAL-3 | Remove dead `#[allow(unused_imports)]` shims in `refresh/orchestrator.rs` | XS | P2 |
 
 **SCAL-1 — SQLSTATE-based error classification.**
 `classify_spi_error_retryable` at `src/error.rs:213–260` matches English text
@@ -7405,6 +7416,13 @@ pgrx (`pg_sys::ErrorData.sqlerrcode`) and classify by 5-character code.
 orchestrator::*;`, promoting every new public symbol automatically. Convert to
 explicit re-export lists to enforce module boundary discipline without breaking
 callers. **Schema change:** No.
+
+**SCAL-3 — Remove dead `#[allow(unused_imports)]` in `refresh/orchestrator.rs`.**
+Every import at `src/refresh/orchestrator.rs:6–26` is annotated
+`#[allow(unused_imports)]` — a maintenance hazard left over from the ARCH-1B
+split. Removing an actually-unused import won't surface a warning, and the
+imports become silently misleading. Convert each `use` to a concrete symbol and
+remove the lint-suppression attribute. **Schema change:** No.
 
 ---
 
@@ -7420,6 +7438,13 @@ callers. **Schema change:** No.
 | UX-6 | Ship first-party Grafana dashboard JSON in `monitoring/grafana/` | M | P1 |
 | UX-7 | Document `pg_trickle_dump` in `BACKUP_AND_RESTORE.md` | XS | P1 |
 | UX-8 | Add snapshot/PITR walkthrough to `GETTING_STARTED.md` | S | P1 |
+| UX-9 | Document `change_buffer_durability` + `frontier_holdback_*` in `PRE_DEPLOYMENT.md` | XS | P1 |
+| UX-10 | Add atomicity-gap warning + concurrent-restore note to `BACKUP_AND_RESTORE.md` | XS | P1 |
+| UX-11 | Add FAQ entries: snapshot how-to, `schedule_recommendation_min_samples` tuning | XS | P2 |
+| UX-12 | Add RELEASE.md checklist item for SNAP/PLAN/CLUS/METR migration script | XS | P2 |
+| UX-13 | Add snapshot demo to `PLAYGROUND.md` | XS | P2 |
+| UX-14 | Track CNPG 1.29 compatibility: update `cnpg/cluster-example.yaml` and CI | S | P1 |
+| UX-15 | Open tracking issue for dbt-core 1.11 upgrade path | XS | P1 |
 
 **UX-1** — `schedule_recommendation_min_samples` (default 20),
 `schedule_alert_cooldown_seconds` (default 300), `metrics_request_timeout_ms`
@@ -7462,6 +7487,48 @@ in `BACKUP_AND_RESTORE.md`.
 `GETTING_STARTED.md` with a worked example: take a snapshot, simulate data
 loss, restore from snapshot, verify.
 
+**UX-9** — `PRE_DEPLOYMENT.md` does not mention `change_buffer_durability`
+(`unlogged|logged|sync`, default `unlogged`) or the `frontier_holdback_lsn_bytes`
+gauge. These are operationally critical: operators setting `sync` for durability
+need to know the write-amplification cost before deployment.
+**Schema change:** No.
+
+**UX-10** — `BACKUP_AND_RESTORE.md` does not warn about the atomicity gap
+in `snapshot_stream_table` / `restore_from_snapshot` identified in §3.2 (no
+subxact bracket; crash between `CREATE TABLE AS` and catalog INSERT leaves
+an orphan table; mid-restore `TRUNCATE` + interrupted `INSERT` leaves
+the storage table truncated). Add an explicit "Known Limitations" callout
+until STAB-1 is fixed. Also document that `restore_from_snapshot` should not
+be called while a concurrent `refresh_stream_table` is in flight.
+**Schema change:** No.
+
+**UX-11** — `FAQ.md` has no entry for "How do I take a snapshot?" or
+"How do I tune `schedule_recommendation_min_samples`?". Add both with links
+to `BACKUP_AND_RESTORE.md` and `CONFIGURATION.md`.
+**Schema change:** No.
+
+**UX-12** — `RELEASE.md` checklist should include a step to verify the
+SNAP/PLAN/CLUS/METR migration script
+(`sql/pg_trickle--0.26.0--0.27.0.sql`) passes
+`scripts/check_upgrade_completeness.sh`. Add to the release runbook.
+**Schema change:** No.
+
+**UX-13** — `PLAYGROUND.md` has no snapshot demo. Add a `snapshot_stream_table`
+→ data loss simulation → `restore_from_snapshot` example that works in the
+`playground/docker-compose.yml` environment.
+**Schema change:** No.
+
+**UX-14** — `cnpg/cluster-example.yaml` targets CNPG 1.28+. CNPG 1.29 ships
+in 2026-Q2. Refresh the manifest, add a CI job using the updated image, and
+verify the ImageVolume mount still works under the new CNPG operator.
+**Schema change:** No.
+
+**UX-15** — `dbt-pgtrickle/AGENTS.md` pins `dbt-core ~=1.10` and notes
+Python 3.13 only (mashumaro dep can't build on 3.14). dbt-core 1.11 is in
+beta. Open a tracking GitHub issue: note the mashumaro blocker, watch the
+1.11 release, and add a CI job testing against 1.11 once the dep resolves.
+**Schema change:** No.
+
 ---
 
 ### Test Coverage
@@ -7479,6 +7546,9 @@ loss, restore from snapshot, verify.
 | TEST-9 | Fuzz: snapshot SQL builder | S | P1 |
 | TEST-10 | Fuzz: DAG SCC graph shapes | S | P2 |
 | TEST-11 | EC-01 deterministic reproducer (replaces flaky `test_tpch_q07_*`) | M | P0 |
+| TEST-12 | E2E: snapshot under concurrent `refresh_stream_table` | S | P1 |
+| TEST-13 | E2E: snapshot → `pg_dump` → `pg_restore` round-trip | M | P1 |
+| TEST-14 | Promote G17-MDB multi-database soak test from `stability-tests.yml` to `ci.yml` | S | P1 |
 
 ---
 
@@ -7495,6 +7565,11 @@ loss, restore from snapshot, verify.
 - **SCAL-1** changes observable retry semantics. Roll out behind a
   `pg_trickle.use_sqlstate_classification` GUC (default `false`) initially,
   flip to `true` in v0.31.0 after one release of parallel validation.
+- **UX-14** (CNPG 1.29) depends on CNPG 1.29 being available; if the release
+  slips past the v0.30.0 window, defer to v1.0.0 but keep the tracking issue
+  open.
+- **UX-15** (dbt 1.11) is purely a tracking concern — no code changes are
+  required in this release.
 
 ### Implementation Phases
 
@@ -7504,11 +7579,12 @@ loss, restore from snapshot, verify.
 | Phase 2 | P0 docs: UX-1, UX-2, TEST-6, TEST-11 | Days 6–9 |
 | Phase 3 | P1 stability + safety: STAB-2, STAB-3, STAB-5, STAB-6, CORR-2, CORR-3 | Days 9–14 |
 | Phase 4 | P1 architecture: SCAL-2, PERF-1, PERF-2 | Days 14–19 |
-| Phase 5 | P1 test coverage: TEST-1 through TEST-9, PERF-3 | Days 19–25 |
-| Phase 6 | P1 docs & UX: UX-3 through UX-8, UX-5 TUI | Days 25–30 |
+| Phase 5 | P1 test coverage: TEST-1 through TEST-14, PERF-3 | Days 19–26 |
+| Phase 6 | P1 docs & UX: UX-3 through UX-15, TUI parity | Days 26–32 |
 
-> **v0.30.0 total: ~5–6 weeks** (correctness-critical path ~10 days;
-> documentation and test coverage ~12 days; architecture improvements ~8 days)
+> **v0.30.0 total: ~6–7 weeks** (correctness-critical path ~10 days;
+> documentation and test coverage ~14 days; architecture improvements ~8 days;
+> new test targets ~6 days)
 
 **Exit criteria:**
 - [ ] CORR-1: `test_tpch_q07_ec01b_combined_delete` passes reliably over 50 runs; IMMEDIATE-mode property tests show zero phantom drift
@@ -7528,7 +7604,15 @@ loss, restore from snapshot, verify.
 - [ ] UX-4: All eight SNAP/PLAN/CLUS/METR functions have full SQL_REFERENCE entries
 - [ ] UX-5: TUI shows SNAP/PLAN/CLUS/METR panels
 - [ ] UX-6: `monitoring/grafana/pg_trickle.json` ships and renders in Grafana 11+
+- [ ] UX-9: `PRE_DEPLOYMENT.md` documents `change_buffer_durability` and `frontier_holdback_lsn_bytes`
+- [ ] UX-10: `BACKUP_AND_RESTORE.md` Known Limitations section added; concurrent-restore warning present
+- [ ] UX-14: `cnpg/cluster-example.yaml` updated to CNPG 1.29; CI job green (or issue opened if 1.29 not yet released)
+- [ ] UX-15: dbt-core 1.11 tracking issue opened with mashumaro blocker documented
 - [ ] TEST-7/8/9: New fuzz targets run in CI; no crashes after 24 h
+- [ ] TEST-12: Snapshot under concurrent refresh test passes
+- [ ] TEST-13: `pg_dump` → `pg_restore` round-trip test passes for snapshot tables
+- [ ] TEST-14: G17-MDB multi-database soak test runs in `ci.yml` on every push to main
+- [ ] SCAL-3: Dead `#[allow(unused_imports)]` removed from `refresh/orchestrator.rs`; `just lint` clean
 - [ ] Extension upgrade path tested (`0.29.0 → 0.30.0`)
 - [ ] `just check-version-sync` passes
 
@@ -7579,8 +7663,11 @@ forward-compatibility.
 | R5 | **Docker Hub official image.** Publish `pgtrickle/pg_trickle:1.0.0-pg18` and `:latest` to Docker Hub. Sync Dockerfile.hub version tag with release. Automate via GitHub Actions release workflow. | 2–4h | — |
 | R6 | **Version sync automation.** Ensure `just check-version-sync` covers all version references (Cargo.toml, extension control files, Dockerfile.hub, dbt_project.yml, CNPG manifests). Add to CI as a blocking check. | 2–3h | — |
 | SAST-SEMGREP | **Elevate Semgrep to blocking in CI.** CodeQL and cargo-deny already block; Semgrep is advisory-only. Flip to blocking for consistent safety gating. Before flipping, verify zero findings across all current rules. | 1–2h | [PLAN_SAST.md](plans/testing/PLAN_SAST.md) |
+| OTL-1 | **OpenTelemetry tracing spans.** Add `pgtrickle.refresh`, `pgtrickle.cdc_capture`, and `pgtrickle.snapshot` spans via the OTel SDK so every pg_trickle operation is visible to OTel collectors. Minimum viable: trace_id propagation through the refresh pipeline; attribute set = `stream_table`, `refresh_mode`, `rows_processed`. | 4–8h | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.6 |
+| SIGN-1 | **Cosign-sign GHCR release images.** Add `cosign sign` step to the GitHub Actions release workflow for `grove/pg-trickle`, `grove/pgtrickle-relay`, and `pg_trickle-ext` GHCR images. Attach Rekor transparency log entry. Document `cosign verify` command in `SECURITY.md`. | 2–4h | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.11 |
+| MDB-1 | **Promote G17-MDB multi-database soak test to `ci.yml`.** The `stability-tests.yml` G17-MDB job runs multi-database scenarios in isolation. Move it to `ci.yml` under the "Push to main" trigger alongside the existing soak test. Gate it on a 30-min wall-clock budget for PR CI; use the full 2-hour run on schedule. | 2–3h | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.10 |
 
-> **v1.0.0 total: ~36–66 hours** (incl. PG 19 compat ~18–36h + release engineering ~18–30h)
+> **v1.0.0 total: ~42–78 hours** (incl. PG 19 compat ~18–36h + release engineering ~18–30h + OTel/cosign/MDB ~8–12h)
 
 **Exit criteria:**
 - [ ] A3: PG 19 builds and passes full E2E suite
@@ -7591,7 +7678,10 @@ forward-compatibility.
 - [x] CNPG cluster-example.yaml validated (Image Volume approach)
 - [ ] `just check-version-sync` passes and blocks CI on mismatch
 - [ ] SAST-SEMGREP: Semgrep elevated to blocking in CI; zero findings verified
-- [ ] Upgrade path from v0.29.0 tested
+- [ ] OTL-1: OTel refresh/CDC/snapshot spans emitted; visible in Jaeger test run
+- [ ] SIGN-1: All GHCR release images cosign-signed; `cosign verify grove/pg-trickle:1.0.0` passes
+- [ ] MDB-1: G17-MDB soak test runs in `ci.yml` on push to main; green
+- [ ] Upgrade path from v0.30.0 tested
 - [ ] Semantic versioning policy in effect
 
 ---
@@ -9646,6 +9736,7 @@ Rewrite the trigger function builders to reference the ENR by name.
 |----|-------|--------|----------|
 | SCAL-1 | Back-pressure signal when change buffer exceeds threshold | S | P2 |
 | SCAL-2 | Multi-DB singleton refresh broker concept (design only) | S | P2 |
+| SCAL-3 | Shared catalog snapshot for `metrics_summary()` / `cluster_worker_summary()` (if deferred from v0.30.0) | M | P2 |
 
 **SCAL-1** — Expose a `pgtrickle_alert change_buffer_backpressure` event
 when a change buffer grows past `pg_trickle.buffer_alert_threshold` for
@@ -9876,8 +9967,6 @@ The following items from [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSES
 |------|-------------|----------|-----|
 | POST-XC | **Cross-cluster fan-out via `pgtrickle-relay`.** A relay mode that reads from one cluster's outbox and applies to another cluster's inbox. Optional CRDT-style conflict resolution for last-write-wins counters. Enables multi-region read-replica patterns without a full replication setup. | Medium | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
 | POST-VIS | **GUI workflow designer + visual DAG editor.** Extend `pgtrickle-tui` with a visual DAG editor and an EXPLAIN-DIFF preview that shows the rewritten DVM SQL alongside expected delta size. Lowers on-boarding ramp for SQL developers unfamiliar with IVM semantics. | Medium | [PLAN_OVERALL_ASSESSMENT_2.md](plans/PLAN_OVERALL_ASSESSMENT_2.md) §7 |
-| POST-OTL | **OpenTelemetry tracing spans.** Emit per-refresh, per-CDC-capture, and per-snapshot spans so OTel collectors can correlate pg_trickle latency with upstream service traces. Minimum viable: `pgtrickle.refresh`, `pgtrickle.cdc_capture`, `pgtrickle.snapshot` spans with standard attributes. | Medium | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.6 |
-| POST-SIGN | **Cosign-sign GHCR release images.** Add `cosign sign` step to the GitHub Actions release workflow for `grove/pg-trickle`, `grove/pgtrickle-relay`, and `pg_trickle-ext` images. Attach signatures to GHCR. Document verification in `SECURITY.md`. | Medium | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.11 |
 | POST-HELM | **First-party Helm chart.** A `charts/pg-trickle` Helm chart that wraps the CNPG ImageVolume deployment pattern. Publishes to a GitHub Pages chart repository at `grove.github.io/pg-trickle`. Supports multi-database cluster deployments via values. | Medium | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.3 |
 | POST-LLM | **LLM-assisted advisor (`pgtrickle.advise()`).** A SQL function backed by a small open model (e.g. Phi-3 via PL/Python) that takes a query and returns recommendations: refresh mode, schedule, source-table index suggestions, and flagged anti-patterns. Onboarding accelerator for users unfamiliar with IVM tuning. | Low | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.9 |
 | POST-GQL | **GraphQL / PostGraphile integration.** A PostGraphile v5 plugin that exposes stream tables as subscription-capable GraphQL types. Clients subscribe to a stream table via GraphQL subscriptions backed by the v1.8.0 `pgtrickle.subscribe()` NOTIFY channel. | Low | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.5 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,9 +44,9 @@ coverage, all in plain language.
 - [v0.25.0 — Scheduler Scalability & Pooler Performance](#v0250--scheduler-scalability--pooler-performance)
 - [v0.26.0 — Test & Concurrency Hardening](#v0260--test--concurrency-hardening)
 - [v0.27.0 — Operability, Observability & DR](#v0270--operability-observability--dr)
-- [v0.28.0 — Transactional Inbox & Outbox Patterns](#v0280--transactional-inbox--outbox-patterns)
-- [v0.29.0 — Relay CLI (`pgtrickle-relay`)](#v0290--relay-cli-pgtrickle-relay)
-- [v0.30.0 — Pre-GA Correctness & Stability Sprint](#v0300--pre-ga-correctness--stability-sprint)
+- [v0.28.0 — Pre-GA Correctness & Stability Sprint](#v0280--pre-ga-correctness--stability-sprint)
+- [v0.29.0 — Transactional Inbox & Outbox Patterns](#v0290--transactional-inbox--outbox-patterns)
+- [v0.30.0 — Relay CLI (`pgtrickle-relay`)](#v0300--relay-cli-pgtrickle-relay)
 - [v1.0.0 — Stable Release](#v100--stable-release)
 - [v1.1.0 — PostgreSQL 17 Support](#v110--postgresql-17-support)
 - [v1.2.0 — PGlite Proof of Concept](#v120--pglite-proof-of-concept)
@@ -103,9 +103,9 @@ from the v0.1.x series to 1.0 and beyond.
 | v0.25.0 | Scheduler scalability & pooler performance | ✅ Released |
 | v0.26.0 | Test & concurrency hardening | ✅ Released |
 | v0.27.0 | Operability, observability & DR — snapshot/PITR, schedule planner, cluster metrics | ✅ Released |
-| v0.28.0 | Transactional inbox & outbox patterns | Planned |
-| v0.29.0 | Relay CLI (`pgtrickle-relay`) | Planned |
-| v0.30.0 | Pre-GA correctness & stability sprint — EC-01 fix, snapshot atomicity, SQLSTATE classifier, caches | Planned |
+| v0.28.0 | Pre-GA correctness & stability sprint — EC-01 fix, snapshot atomicity, SQLSTATE classifier, caches | Planned |
+| v0.29.0 | Transactional inbox & outbox patterns | Planned |
+| v0.30.0 | Relay CLI (`pgtrickle-relay`) | Planned |
 | v1.0.0 | Stable release (incl. PG 19 compatibility) | Planned |
 | v1.1.0 | PostgreSQL 17 support | Planned |
 | v1.2.0 | PGlite proof of concept | Planned |
@@ -6853,384 +6853,7 @@ Phase 1–5 DVM code changes and the TPC-H scaling investigation. Items marked
 
 ---
 
-## v0.28.0 — Transactional Inbox & Outbox Patterns
-
-**Status: Planned.** Driven by [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) and [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md). Outbox helper moved here from v0.22.0 to ship alongside the inbox helper and production-grade advanced features as a complete transactional messaging solution.
-
-> **Release Theme**
-> This release delivers a **complete, production-grade solution** for the two
-> most common event-driven integration patterns in microservice architectures.
-> **Part A (Essential)** ships the Transactional Outbox (reliable atomic event
-> publication) and Transactional Inbox (reliable idempotent event consumption)
-> as zero-boilerplate SQL helpers. **Part B (Advanced)** adds Consumer Groups
-> for coordinated multi-relay outbox polling with Kafka-style offset tracking,
-> visibility timeouts, and lag monitoring — and Ordered Processing for the
-> inbox, including per-aggregate sequence ordering, gap detection, priority
-> queues, and partition-affinity helpers for competing workers. Together,
-> Parts A and B let pg_trickle users build reliable, exactly-once event
-> pipelines that scale from a single relay to multi-instance deployments,
-> using nothing but PostgreSQL.
->
-> See [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md)
-> and [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md)
-> for the full architecture and API design.
-
----
-
-### Known Limitations in v0.28.0
-
-| Limitation | Rationale | Future Path |
-|------------|-----------|-------------|
-| **Outbox requires DIFFERENTIAL mode.** `enable_outbox()` on `IMMEDIATE`-mode stream tables returns `OutboxRequiresNotImmediateMode`. | Outbox writes one row per refresh cycle inside the refresh transaction. IMMEDIATE refreshes fire inside every source transaction; adding an outbox INSERT there imposes that cost on every application write. | Post-1.0 opt-in GUC if demand justifies. |
-| **Ordering and priority are mutually exclusive per inbox.** Calling both `enable_inbox_ordering()` and `enable_inbox_priority()` on the same inbox returns `InboxOrderingPriorityConflict`. | Per-aggregate sequence ordering must surface the next message in sequence regardless of priority level; priority tiers violate that guarantee. | Use separate inboxes per priority class, each with `enable_inbox_ordering()` applied independently. |
-| **Gap detection degrades above ~100K aggregates.** The `gaps_<inbox>` stream table uses `LEAD()` over pending messages, which is O(N log N) in pending message count — not O(sequence range). This is a significant improvement over the `generate_series` approach; however, refresh time still scales with pending message volume. | Acceptable up to ~1M pending messages at 30 s schedule. Above 10M pending messages, auto-refresh may be slow; use `inbox_ordering_gaps()` for on-demand checks. | Post-v0.28.0: delta-based detection scanning only aggregates with recent activity. |
-| **Consumer groups provide at-least-once delivery per consumer instance, not exactly-once globally.** | Exactly-once is achieved by composition: relay uses broker idempotency keys; inbox uses `ON CONFLICT (event_id) DO NOTHING`. Three-layer deduplication is more resilient than a monolithic exactly-once guarantee. | Design decision. Documented in PATTERNS.md and SQL_REFERENCE.md. |
-| **AUTO mode may fall back to FULL refresh while outbox is enabled.** When AUTO refresh falls back to FULL, the outbox header row carries `"full_refresh": true`. If the number of current rows exceeds `outbox_inline_threshold_rows`, the claim-check path applies: rows land in `outbox_delta_rows_<st>` and the relay fetches via cursor. A `pg_trickle_alert outbox_full_refresh` event is emitted regardless of which path is taken. Relays must detect the `full_refresh` flag, apply snapshot semantics (upsert rather than publish-as-new), and handle either inline or claim-check payloads. | AUTO refresh adapts to IVM cost at runtime; blocking the FULL fallback permanently would compromise the adaptation that makes AUTO useful. The sentinel flag preserves correctness; the claim-check path prevents memory exhaustion on large tables. | Reference relay updated in OUTBOX-8 to demonstrate all combinations. Post-v0.28.0: consider a GUC to disable FULL fallback per ST when outbox is enabled. |
-| **`next_<inbox>` ordered ST scans all processed rows.** The `last_processed` CTE in the aggregate-ordered ST runs `MAX(sequence_num) GROUP BY aggregate_id` over every processed row on each refresh. For inboxes with large volumes of processed history this grows without bound. | A partial index `(aggregate_id, sequence_num) WHERE processed_at IS NOT NULL` is created by `enable_inbox_ordering()` to mitigate this at v0.28.0, making it an index-only scan. Scaling thresholds: < 100K rows → < 5 ms at 1 s schedule; 100K–1M → increase schedule to `5s`; > 1M → increase to `10s–30s`; > 10M → use `inbox_ordering_gaps()` on-demand only. | Post-v0.28.0: introduce `pgt_inbox_sequence_state` catalog table updated atomically via `advance_inbox_sequence()`, making the CTE O(changed aggregates). |
-| **Global consumer monitoring STs created once, not reference-counted.** `pgt_consumer_status`, `pgt_consumer_group_lag`, `pgt_consumer_active_leases` are auto-created on the first `create_consumer_group()` call. They must be created idempotently and torn down only when the last consumer group for an outbox is dropped. | A single set of monitoring STs per outbox is correct and cheaper than per-group STs. | Implementation: `create_stream_table()` called with `if_not_exists := true`; `drop_consumer_group()` decrements a reference count and drops STs at zero. |
-| **Outbox relay latency bounded by poll interval.** Relays discover new outbox rows by polling. The pg_trickle extension emits `pg_notify('pgtrickle_outbox_new', outbox_table_name)` after each outbox INSERT (v0.28.0), but the `pgtrickle-relay` binary does not yet use LISTEN — it starts polling on the standard interval. Minimum relay latency today equals the poll interval (`visibility_seconds`). | The NOTIFY is cheap (≈2 µs, inside the existing refresh transaction) and is emitted from v0.28.0 onwards so relay authors can begin using it immediately. The `pgtrickle-relay` CLI will use LISTEN/NOTIFY in v0.29.0. | v0.29.0 relay: subscribe to `pgtrickle_outbox_new` for sub-100 ms wake-up (see E2E latency benchmark in PLAN_RELAY_CLI.md §E.5). |
-| **`replay_inbox_messages()` accepts only explicit event ID lists.** A free-form `where_clause` parameter was removed to eliminate SQL injection risk. | `EXPLAIN`-based validation of dynamic SQL is insufficient; parameterised `WHERE event_id = ANY($1)` is the safe API. | Operators who need filter-based replay should run a parameterised `SELECT ARRAY_AGG(event_id) ... WHERE <condition>` first, then pass the result to `replay_inbox_messages()`. |
-
----
-
-### Part A — Essential Patterns
-
-#### Transactional Outbox Helper (P2 — §9.12)
-
-> **In plain terms:** After each DIFFERENTIAL refresh cycle, pg_trickle
-> writes a row to `pgtrickle.outbox_<st>` within the same transaction as
-> the MERGE — either both succeed or neither does. For small deltas the row
-> carries a versioned inline JSON payload `{"v":1, "inserted":[…],
-> "deleted":[…]}`. For large deltas (above `outbox_inline_threshold_rows`,
-> default 10 000 rows) the row carries a lightweight claim-check header
-> `{"v":1, "claim_check": true, …}` and the actual rows land in the
-> companion table `pgtrickle.outbox_delta_rows_<st>`, which the relay
-> reads via a server-side cursor in bounded batches — constant memory
-> regardless of delta size. Eliminates the dual-write problem for
-> downstream event buses without a CDC connector or external replication
-> slot.
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| OUTBOX-1 | **Catalog + SQL functions.** `pgt_outbox_config` catalog table. `enable_outbox(name, retention_hours)` / `disable_outbox(name, if_exists)` SQL functions. `OutboxAlreadyEnabled`, `OutboxNotEnabled`, `OutboxRequiresNotImmediateMode` error variants. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.1–A.2 |
-| OUTBOX-2 | **Outbox table creation.** `pgtrickle.outbox_<st>` with `id BIGSERIAL`, `pgt_id UUID`, `refresh_id UUID`, `created_at`, `inserted_count INT`, `deleted_count INT`, `is_claim_check BOOLEAN DEFAULT false`, `payload JSONB`. Index on `created_at`. Naming: 7-byte `outbox_` prefix + up to 56-byte stream table name; collision resolution appends 7-char hex suffix derived from `left(md5(name), 7)`. Final name stored in `pgt_outbox_config.outbox_table_name`. Also creates: (a) **latest-row view** `pgtrickle.pgt_outbox_latest_<st>` (`ORDER BY id DESC LIMIT 1`) for quick lag inspection and operational checks; (b) **delta rows table** `pgtrickle.outbox_delta_rows_<st>` with `outbox_id BIGINT REFERENCES outbox_<st>(id)`, `row_num INT`, `op CHAR(1) CHECK (op IN ('I','D'))`, `payload JSONB`, `PRIMARY KEY (outbox_id, row_num)` — populated only for claim-check entries. *(Note: `pgt_consumer_claim_check_acks` is created in Part B / OUTBOX-B1, not here — it has no purpose without consumer groups.)* All objects dropped alongside the outbox table. | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.3 |
-| OUTBOX-3 | **Refresh-path integration.** After successful MERGE, if outbox is enabled, INSERT outbox row within the same transaction — **unless** `outbox_skip_empty_delta = true` (default) and `inserted_count = 0 AND deleted_count = 0`, in which case no INSERT or NOTIFY is issued, saving write amplification on quiet refresh cycles. In-memory `outbox_enabled_set` cache with DDL-triggered invalidation. Hot-path cost < 50 ns when disabled. **Routing:** if `delta_row_count <= outbox_inline_threshold_rows`, serialise `Vec<DeltaRow>` to inline JSONB as before. If `delta_row_count > outbox_inline_threshold_rows`, write `is_claim_check = true` header row first (no payload), then INSERT delta rows into `outbox_delta_rows_<st>` in batches controlled by `outbox_claim_check_batch_size` GUC (default 1 000 rows/call) — keeping Rust heap bounded regardless of delta size. Both writes are in the same transaction. **FULL-refresh fallback:** when AUTO mode falls back to FULL refresh, the outbox header row additionally carries `"full_refresh": true`; if row count exceeds the threshold the claim-check path applies; a `pg_trickle_alert outbox_full_refresh` event is emitted so relays apply snapshot semantics. **NOTIFY:** emit `pg_notify('pgtrickle_outbox_new', outbox_table_name)` inside the same transaction after the outbox INSERT, enabling relay authors to use LISTEN for sub-second wake-up (cost: ~2 µs per refresh; skipped when empty-delta skip applies). | 1.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.4 |
-| OUTBOX-4 | **Versioned payload format — two paths.** **Inline path** (small delta): `{"v":1, "inserted":[…], "deleted":[…]}` with `to_jsonb()` type mapping. **Claim-check path** (large delta): `{"v":1, "claim_check": true, "inserted_count": N, "deleted_count": N, "refresh_id": "…"}` — no row data in the outbox row itself; relay reads `outbox_delta_rows_<st>` via server-side cursor and calls `outbox_rows_consumed(stream_table, outbox_id)` when done. FULL-fallback payloads additionally set `"full_refresh": true` in the header; claim-check applies when the full-refresh row count exceeds the threshold. GUC `outbox_inline_threshold_rows` (default 10 000 rows) controls the routing threshold. **No truncation path** — data is never silently dropped. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.5 |
-| OUTBOX-5 | **Retention drain.** Scheduler cleanup step: batched DELETE on `outbox_<st>` with `outbox_drain_batch_size` GUC (default 10 000). Cascades to `outbox_delta_rows_<st>` via FK `ON DELETE CASCADE` — no separate drain step needed for delta rows. Per-ST or global `outbox_retention_hours` (default 24). `last_drained_at` / `last_drained_count` tracked in catalog. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.6 |
-| OUTBOX-6 | **Lifecycle & cascade.** `drop_stream_table()` cascades to outbox table + delta rows table + metadata. `alter_stream_table()` errors if column set changed while outbox enabled. `outbox_status()` monitoring function (includes `claim_check_pending_count` and `storage_status` fields). `outbox_rows_consumed(stream_table TEXT, outbox_id BIGINT)` SQL function: called by relay after cursor consumption to record per-group completion in `pgt_consumer_claim_check_acks`; idempotent. **Note:** `stream_table` takes the stream table name (as registered in `pgt_stream_tables`), not the outbox table name — the function resolves the outbox table via `pgt_outbox_config`. **8 Part-A GUCs** (`outbox_enabled`, `outbox_retention_hours`, `outbox_drain_batch_size`, `outbox_inline_threshold_rows`, `outbox_claim_check_batch_size`, `outbox_drain_interval_seconds`, `outbox_storage_critical_mb`, `outbox_skip_empty_delta`) + 4 Part-B GUCs (`consumer_dead_threshold_hours`, `consumer_stale_offset_threshold_days`, `consumer_cleanup_enabled`, `outbox_force_retention`). | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.7–A.8 |
-| OUTBOX-7 | **Tests & benchmark.** Unit: enable/disable/validation/naming/cascade. Integration: end-to-end inline outbox write; claim-check triggered at threshold boundary (N = threshold, N = threshold+1); delta rows populated atomically in same transaction; relay cursor-fetch returns all rows in order; `outbox_rows_consumed()` idempotency; retention drain cascades delta rows via FK; rollback on outbox INSERT failure leaves no orphan delta rows; `pg_notify('pgtrickle_outbox_new', ...)` emitted. Benchmark gates: (a) `refresh_no_outbox` vs `refresh_outbox_inline` vs `refresh_outbox_claim_check` — < 10 % overhead at inline threshold, < 25 % at large payloads; (b) `poll_outbox()` < 5 ms at 10K outbox rows; (c) `commit_offset()` < 10 ms with 10 concurrent relays; (d) `consumer_lag()` < 50 ms at 100K outbox rows; (e) E2E latency benchmark `benches/e2e_outbox_latency.rs`: p50 < 1.5 s (polling), p95 < 2.5 s (see PLAN_RELAY_CLI.md §E.5). | 1.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §D |
-| OUTBOX-8 | **Documentation & examples.** SQL_REFERENCE.md: outbox API + both payload formats (inline and claim-check) + `outbox_rows_consumed()` + `pgtrickle_outbox_new` NOTIFY channel. CONFIGURATION.md: 7 GUCs (replacing `outbox_max_payload_bytes` with `outbox_inline_threshold_rows`; adding `outbox_claim_check_batch_size` and `outbox_storage_critical_mb` with tuning table). PATTERNS.md: Transactional Outbox section including claim-check relay pattern; WAL overhead analysis; backpressure guidance for dead consumers (`outbox_storage_critical_mb` alert workflow). Reference Python relay (`examples/relay/outbox_relay.py`) demonstrates both inline and claim-check paths. | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §C, §E |
-
-> **Outbox essential subtotal: ~7 days**
-
-#### Transactional Inbox Helper
-
-> **In plain terms:** `create_inbox('payment_inbox')` creates a
-> production-grade inbox table with auto-managed stream tables for the
-> pending-message queue, dead-letter queue, and processing statistics.
-> Applications write to the inbox (`ON CONFLICT DO NOTHING` for dedup),
-> process messages from the pending stream table, and pg_trickle handles
-> DLQ routing, alerts, retention, and monitoring automatically.
-> `enable_inbox_tracking()` adopts an existing inbox table into pg_trickle's
-> monitoring without schema changes.
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| INBOX-1 | **Catalog + `create_inbox()`.** `pgt_inbox_config` catalog table with column mapping (`id_column`, `processed_at_column`, `retry_count_column`, `error_column`, `received_at_column`, `event_type_column`). `create_inbox(name, schema, max_retries, schedule, with_dead_letter, with_stats, retention_hours)` creates inbox table in the specified schema (default `pgtrickle`) + metadata. `InboxAlreadyExists`, `InboxNotFound`, `InboxTableNotFound`, `InboxColumnMissing` error variants. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.1–A.3 |
-| INBOX-2 | **Inbox table DDL.** Standard schema: `event_id TEXT PK`, `event_type`, `source`, `aggregate_id`, `payload JSONB`, `received_at`, `processed_at`, `error`, `retry_count`, `trace_id`. Partial indexes for pending, DLQ, and processed rows. Autovacuum tuning. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.3 |
-| INBOX-3 | **Auto-created stream tables.** Pending ST (`WHERE processed_at IS NULL AND retry_count < max_retries`, DIFFERENTIAL, user-defined schedule). DLQ ST (`WHERE processed_at IS NULL AND retry_count >= max_retries`, DIFFERENTIAL, 30 s). Stats ST (GROUP BY `event_type` with pending/processed/dead_letter/avg processing time — `max_pending_age_sec` removed from the materialised ST query to enable **DIFFERENTIAL** mode and eliminate the O(N) full scan every 10 s; use `inbox_health()` for `oldest_pending_age_sec` on demand). All STs use column-mapped SQL from `pgt_inbox_config`. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.4 |
-| INBOX-4 | **`enable_inbox_tracking()`.** Adopt existing table: validate columns exist with compatible types, validate PK/UNIQUE on id column, create stream tables using mapped column names, insert metadata with `is_managed = false`. Gracefully omit optional columns (`source`, `aggregate_id`, `trace_id`) if not present. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.6 |
-| INBOX-5 | **DLQ alert mechanism.** Post-refresh hook on DLQ stream table: when `rows_inserted > 0`, emit `pg_trickle_alert` event `inbox_dlq_message` per new entry (capped at `inbox_dlq_alert_max_per_refresh`, default 10; excess batched into summary alert). | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.5 |
-| INBOX-6 | **`inbox_health()` + `inbox_status()`.** `inbox_health(name)` returns JSONB with `pending_count`, `dead_letter_count`, `avg_processing_time_sec`, `oldest_pending_age_sec`, `throughput_per_sec`, `health_status` (`healthy`/`degraded`/`critical`). `inbox_status(name)` returns tabular overview of all inboxes. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.1 |
-| INBOX-7 | **Retention drain + `replay_inbox_messages()`.** Processed message drain via scheduler (batched DELETE, `inbox_processed_retention_hours` default 72 h). DLQ messages kept forever by default (`inbox_dlq_retention_hours` default 0). `replay_inbox_messages(name TEXT, event_ids TEXT[])` resets `processed_at` + `retry_count` for the specified message IDs using a parameterised `WHERE event_id = ANY($1)` — no free-form SQL accepted; eliminates injection surface entirely. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.7–A.8 |
-| INBOX-8 | **`drop_inbox()` + lifecycle.** `drop_inbox(name, if_exists, cascade)`: always drops stream tables + metadata; drops inbox table only if `cascade := true` AND `is_managed = true`. `DROP EXTENSION` cascades managed tables; adopted tables survive. 6 GUCs (`inbox_enabled`, `inbox_processed_retention_hours`, `inbox_dlq_retention_hours`, `inbox_drain_batch_size`, `inbox_drain_interval_seconds`, `inbox_dlq_alert_max_per_refresh`). | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.9–A.10 |
-| INBOX-9 | **Tests & benchmark.** Unit: create/drop/enable_tracking/replay/health. Integration: end-to-end inbox lifecycle, DLQ routing, DLQ alert, retention drain, concurrent processors with `FOR UPDATE SKIP LOCKED`, `enable_inbox_tracking()` with non-standard columns. Benchmark gates: (a) pending ST refresh < 5 ms at 100 pending, < 50 ms at 10K pending; (b) `next_<inbox>` ordered ST refresh at each threshold (100K/1M/10M processed rows) matches documented scaling table; (c) stats ST FULL refresh < 5 ms at 100K rows, < 50 ms at 1M rows; (d) backpressure indicator: `inbox_health()` returns `degraded` within 2 refresh cycles when `oldest_pending_age_sec` exceeds threshold. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §D |
-| INBOX-10 | **Documentation & examples.** SQL_REFERENCE.md: inbox API. CONFIGURATION.md: 6 GUCs. PATTERNS.md: Transactional Inbox section + "Bidirectional Event Pipeline" (inbox → business logic → outbox) worked example. Reference examples: `inbox_writer_nats.py`, `inbox_processor.py`, `webhook_receiver.py`. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §C, §E |
-
-> **Inbox essential subtotal: ~6.5 days**
-
-#### Shared Infrastructure (Part A)
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| SHARED-1 | **Upgrade SQL.** `sql/pg_trickle--0.23.0--0.24.0.sql`: create `pgt_outbox_config` and `pgt_inbox_config` catalog tables, register all new SQL functions. | 0.5d | — |
-| SHARED-2 | **PATTERNS.md integration guide.** New "Event-Driven Integration Patterns" chapter in `docs/PATTERNS.md` covering: when to use outbox vs inbox vs both, transport comparison (NATS/Kafka/pgmq), bidirectional pipeline (inbox → business logic → outbox), and competing consumer patterns (`FOR UPDATE SKIP LOCKED`). | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md), [PLAN_TRANSACTIONAL_INBOX.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX.md) |
-| SHARED-3 | **E2E integration test.** Full pipeline: inbox receives event → processor creates business entity → outbox captures delta → verify end-to-end exactly-once delivery. | 0.5d | — |
-
-> **Part A subtotal: ~15 days**
-
----
-
-### Part B — Production Patterns
-
-#### Consumer Groups for Outbox
-
-> **In plain terms:** Multiple relay processes can share a single outbox
-> table safely using consumer groups — the same concept as Kafka consumer
-> groups or SQS consumer groups, but implemented entirely in PostgreSQL.
-> Each group has its own offset pointer. Relays call `poll_outbox()` to
-> claim a batch under a visibility timeout (like SQS), then call
-> `commit_offset()` when done. If a relay crashes, its lease expires and
-> another relay picks up the batch. `consumer_lag()` shows how far behind
-> each consumer is. Dead relays are reaped automatically after 24 h.
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| OUTBOX-B1 | **Consumer group catalog + lifecycle.** `pgt_consumer_groups` + `pgt_consumer_offsets` + `pgt_consumer_leases` catalog tables. Also creates `pgt_consumer_claim_check_acks` (tracks per-group cursor-consumption completion for claim-check retention drain safety; not created in Part A since it has no purpose without consumer groups). `create_consumer_group(name, outbox, auto_offset_reset)` / `drop_consumer_group(name)` SQL functions; `drop_consumer_group()` decrements a per-outbox reference count and drops per-outbox monitoring STs when count reaches zero. `auto_offset_reset` values: `latest` (default) or `earliest`. `ConsumerGroupAlreadyExists`, `ConsumerGroupNotFound` error variants. | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.2–B.3 |
-| OUTBOX-B2 | **`poll_outbox()` with visibility timeout and lease management.** Returns next batch for `(group, consumer_id)` using `FOR UPDATE SKIP LOCKED`. Acquires lease in `pgt_consumer_leases` with configurable `visibility_seconds` (default 30). Auto-registers new consumer_id on first call based on `auto_offset_reset`. Skips rows already leased by other consumers. | 1.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.4 |
-| OUTBOX-B2a | **`extend_lease()` — lease renewal for long-running relays.** `extend_lease(group, consumer, extension_seconds INT DEFAULT 30)` extends the `visibility_until` of all active leases held by the named consumer, returning the new `visibility_until` timestamp. Prevents spurious re-delivery when broker publish or business logic takes longer than the original `visibility_seconds`. Calling `consumer_heartbeat()` does **not** extend leases — heartbeat and lease lifetime are separate concerns. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.4 |
-| OUTBOX-B3 | **`commit_offset()` + `seek_offset()`.** `commit_offset(group, consumer, last_offset)` monotonically advances offset, releases lease, rejects regression with warning. `seek_offset(group, consumer, new_offset)` resets to any position and clears leases; emits `pg_trickle_alert` event `consumer_seeked`. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.4, §B.6 |
-| OUTBOX-B4 | **Heartbeat + liveness.** `consumer_heartbeat(group, consumer)` updates `last_heartbeat_at` (liveness only — does **not** extend active leases; use `extend_lease()` for that). Consumer is healthy when `last_heartbeat_at > now() - 60 s`. `pg_trickle_alert` event `consumer_unhealthy` when consumer transitions healthy → unhealthy. `consumer_lag()` **live SQL function** (always-fresh, suitable for ad-hoc inspection) exposes per-consumer `healthy` boolean, current lag, and offset. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.5 |
-| OUTBOX-B5 | **Monitoring stream tables.** Three auto-created STs on first `create_consumer_group()`: `pgt_consumer_status` (per-consumer offset + heartbeat timestamp, **FULL mode**, 5 s — FULL because `pgt_consumer_offsets` is updated on every heartbeat and offset commit; at typical relay poll rates most rows change between refreshes, making FULL simpler than DIFFERENTIAL for this small table), `pgt_consumer_group_lag` (per-group aggregate lag, DIFFERENTIAL, 10 s), `pgt_consumer_active_leases` (current leases filtered by `visibility_until > now()`, **FULL mode**, 5 s — FULL because the filter changes every cycle as leases expire). Use `consumer_lag()` for ad-hoc inspection of live health data including `heartbeat_age_sec`; use `pgt_consumer_group_lag` ST for Grafana dashboards and alerting rules (materialized every 10 s). | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.7 |
-| OUTBOX-B6 | **Dead consumer auto-cleanup.** Scheduler step (GUC `consumer_cleanup_enabled`, default `true`): reap consumers with `last_heartbeat_at < now() - consumer_dead_threshold_hours` (GUC, default 24 h), release their leases. Remove from offsets if also `last_commit_at < now() - consumer_stale_offset_threshold_days` (GUC, default 7 d). Emit `pg_trickle_alert` event `consumer_reaped`. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.9 |
-| OUTBOX-B7 | **Retention safety guard.** When consumer groups are enabled, retention drain refuses to delete `outbox_<st>` rows with `id > MIN(last_offset across all consumers)` to prevent silent data loss for slow relays. For claim-check rows, additionally waits until all consumer groups that have polled past that `outbox_id` have called `outbox_rows_consumed()` for it — preventing delta rows from being cascade-deleted via FK before the relay finishes cursor consumption. GUC `outbox_force_retention` (default `false`) allows operator override for permanently abandoned consumers. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.6 |
-| OUTBOX-B8 | **Tests.** Integration: multi-relay group creation, visibility timeout expiry + re-poll, `commit_offset` idempotency, `seek_offset` replay, heartbeat → unhealthy transition, dead consumer reaping, retention guard prevents early drain. Benchmark: `poll_outbox` latency < 5 ms at 10K outbox rows. | 1.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §D |
-| OUTBOX-B9 | **Documentation & reference relay.** SQL_REFERENCE.md: consumer group API + delivery guarantee section (at-least-once per consumer; exactly-once by composition). CONFIGURATION.md: `consumer_cleanup_enabled`, `outbox_force_retention`, `consumer_dead_threshold_hours` (default 24), `consumer_stale_offset_threshold_days` (default 7) GUCs. Reference Python relay with group coordination (`examples/relay/outbox_relay.py`). Rust equivalent (`examples/relay/outbox_relay.rs`). PATTERNS.md: multi-relay competing consumers section + claim-check large delta handling guide (server-side cursor consumption, `outbox_rows_consumed()`, bounded-memory relay loop) + latest-state consumer section (dedup view). | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B, §C |
-
-> **Consumer groups subtotal: ~8 days**
-
-#### Ordered Processing for Inbox
-
-> **In plain terms:** For financial, order management, and audit-trail
-> use-cases, messages about the same entity (customer, order, account)
-> must be processed in the order they were produced. `enable_inbox_ordering()`
-> creates a `next_<inbox>` stream table that surfaces only the *next expected*
-> message per aggregate — preventing out-of-order processing automatically.
-> Gap detection alerts when a message is missing too long. Priority queues
-> let critical messages use a 1-second refresh schedule while background
-> messages use 30 seconds. Worker partition affinity reduces contention when
-> multiple processors share an inbox.
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| INBOX-B1 | **`enable_inbox_ordering()` + aggregate-ordered stream table.** `pgt_inbox_ordering_config` catalog table. `enable_inbox_ordering(inbox, aggregate_id_col, sequence_num_col)` creates `next_<inbox>` ST: `DISTINCT ON (aggregate_id)` selecting only the row where `sequence_num = last_processed_seq + 1`. Ensures only the next expected message per aggregate is surfaced. `disable_inbox_ordering(inbox)` drops the ST + config row. **Mutually exclusive with `enable_inbox_priority()`** — returns `InboxOrderingPriorityConflict` if priority is already enabled on this inbox (and vice versa). | 1.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B.2–B.3 |
-| INBOX-B2 | **Gap detection stream table + alert.** `gaps_<inbox>` ST uses a `LEAD()` window function (O(N log N)) to detect missing sequence numbers by comparing adjacent sequences in the pending-only messages. Uses `FULL` refresh mode (contains `now()` in `gap_age_sec`). Emits `pg_trickle_alert` event `inbox_ordering_gap` when new gaps appear. `inbox_ordering_gaps(inbox_name)` SQL function for ad-hoc inspection. 30 s refresh schedule. Scales to 1M+ pending messages without the O(sequence_range) blowup of `generate_series`. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B.4 |
-| INBOX-B3 | **`enable_inbox_priority()` + tier-based stream tables.** `pgt_inbox_priority_config` catalog table. `enable_inbox_priority(inbox, priority_col, tiers JSONB)` creates one `pending_<inbox>_<tier>` ST per priority tier with per-tier `schedule` and `WHERE priority BETWEEN min AND max`. Default 3 tiers: critical (1–2, 1 s), normal (3–6, 5 s), background (7–9, 30 s). Original `pending_<inbox>` preserved as unified view. `disable_inbox_priority(inbox, if_exists)` drops all tier STs + config row; original unified `pending_<inbox>` is restored. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B.5 |
-| INBOX-B4 | **`inbox_is_my_partition()` helper.** Boolean-returning SQL function with signature `inbox_is_my_partition(aggregate_id TEXT, worker_id INT, total_workers INT) RETURNS BOOLEAN`. Evaluates `abs(hashtext(aggregate_id)) % total_workers = worker_id` inline in the WHERE clause. Advisory only — workers can still process any message; the condition makes each worker prefer its subset for cache locality. Composable with prepared statements and ORMs without SQL string interpolation. Documented in PATTERNS.md with Python + SQL usage example. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B.6 |
-| INBOX-B5 | **Tests.** Integration: ordered ST surfaces only next-sequence messages; out-of-order arrivals withheld until preceding sequence processed; gap detection fires alert after configurable delay; priority tier routing; partition affinity correctness (no messages lost). Benchmark gate: `gaps_<inbox>` ST refresh at 1M messages across 10K aggregates must complete in < 1 s at 30 s schedule (uses `LEAD()` window function; O(N log N) not O(sequence_range)). Chaos: processor crash mid-processing + replay recovery; concurrent processors with `FOR UPDATE SKIP LOCKED` (no duplicate processing at 10 concurrent workers). | 1.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §D |
-| INBOX-B6 | **Documentation & examples.** SQL_REFERENCE.md: ordering + priority API. CONFIGURATION.md: ordering GUCs. PATTERNS.md: per-aggregate ordering, gap recovery, priority queue, and competing workers with partition affinity sections. Reference `examples/inbox/inbox_processor_ordered.py`. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B, §C |
-
-> **Ordered processing subtotal: ~6 days**
-
-#### Shared Infrastructure (Part B)
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| SHARED-B1 | **Upgrade SQL additions.** Extend `sql/pg_trickle--0.23.0--0.24.0.sql`: create `pgt_consumer_groups`, `pgt_consumer_offsets`, `pgt_consumer_leases`, `pgt_inbox_ordering_config`, `pgt_inbox_priority_config` tables; register all Part B SQL functions. *(Note: `pgt_consumer_claim_check_acks` is created dynamically by `create_consumer_group()` at runtime, not in the upgrade script — it has no purpose without consumer groups.)* | 0.5d | — |
-| SHARED-B2 | **Advanced PATTERNS.md sections.** Add to "Event-Driven Integration Patterns" chapter: competing relays with consumer groups, ordered inbox processing end-to-end, priority queues (when to use), partition-affinity for high-throughput inboxes, claim-check large delta handling guide (when triggered, cursor consumption loop, `outbox_rows_consumed()`, interaction with `full_refresh` flag), latest-state consumer pattern (dedup view), and FULL-refresh fallback handling for relay authors. Note in PATTERNS.md: add Grafana dashboard panel recommendations for consumer lag (`pgt_consumer_group_lag` ST), DLQ growth rate (`dlq_<inbox>` ST), inbox pending backlog (`pending_<inbox>` ST), and inbox throughput (`stats_<inbox>` ST). | 0.5d | — |
-| SHARED-B3 | **Advanced E2E tests.** (1) Multi-relay group test: 3 relays share one outbox group, verify each row published exactly once, simulate relay crash + visibility timeout redelivery. (2) Ordered inbox test: publish 10 messages out-of-order per aggregate, verify processor receives them in sequence order. (3) Concurrent stress: 10 relay workers + 100K outbox rows; verify < 0.1% duplicate rate at broker. | 1d | — |
-| SHARED-B4 | **dbt adapter updates.** Add `outbox_enabled`, `consumer_group` and `inbox_config` properties to dbt model config; add `pgtrickle_outbox_config` and `pgtrickle_create_inbox` macros; update dbt-pgtrickle docs and integration tests. | 0.5d | [dbt-pgtrickle/AGENTS.md](dbt-pgtrickle/AGENTS.md) |
-
-> **Part B subtotal: ~17.5 days**
-
----
-
-### Implementation Phases
-
-| Phase | Description | Duration |
-|-------|-------------|----------|
-| A-SHARED | Upgrade SQL, shared Part A catalog infrastructure | Day 1 |
-| A-OUTBOX | Outbox helper: catalog, table DDL, refresh-path hook, payload format, retention, lifecycle, GUCs | Days 1–5 |
-| A-INBOX | Inbox helper: catalog, table DDL, stream tables, `enable_inbox_tracking`, DLQ alerts, health, replay, retention, lifecycle, GUCs | Days 5–11 |
-| A-TEST | Part A integration tests, E2E pipeline test, benchmarks | Days 11–13 |
-| A-DOC | Part A documentation, PATTERNS.md guide, reference examples | Days 13–14 |
-| B-OUTBOX | Consumer groups: catalog, `poll_outbox`, `commit_offset`, `seek_offset`, heartbeat, monitoring STs, dead consumer cleanup, retention guard | Days 14–22 |
-| B-INBOX | Ordered processing: `enable_inbox_ordering`, gap detection, priority queues, worker partition helper | Days 22–28 |
-| B-TEST | Part B integration tests, multi-relay E2E, ordered inbox E2E | Days 28–31 |
-| B-DOC | Part B documentation, advanced PATTERNS.md sections, reference relay implementations | Days 31–33 |
-
-> **v0.28.0 total: ~6–7 weeks solo / ~4–5 weeks with two developers working Part A and Part B tracks in parallel** (Part A: essential patterns + Part B: production patterns)
-
-**Exit criteria:**
-- [ ] OUTBOX-1/2: `enable_outbox()` creates outbox table + `pgt_outbox_latest_<st>` view with correct schema; catalog row present
-- [ ] OUTBOX-1: `enable_outbox()` on IMMEDIATE-mode stream table returns `OutboxRequiresNotImmediateMode` with clear message
-- [ ] OUTBOX-2: Naming collision resolution: truncation + hex suffix tested end-to-end; final name stored in catalog
-- [ ] OUTBOX-3/CC: Initial load (first refresh, all rows as `"inserted"`) above `outbox_inline_threshold_rows` uses claim-check path; `outbox_delta_rows_<st>` populated atomically; no data loss
-- [ ] OUTBOX-3/CC: Bulk source update (many rows changed in one cycle) above threshold uses claim-check path; relay cursor returns all inserted + deleted rows correctly
-- [ ] OUTBOX-3: Refresh populates outbox payload within same transaction; rollback on outbox INSERT failure leaves no orphan delta rows
-- [ ] OUTBOX-4: Small deltas (≤ `outbox_inline_threshold_rows`) produce inline `{"v":1, "inserted":[…], "deleted":[…]}`; large deltas produce claim-check header `{"v":1, "claim_check": true, …}` with rows in `outbox_delta_rows_<st>`; relay cursor consumption + `outbox_rows_consumed()` documented + tested; no truncation path exists
-- [ ] OUTBOX-5: Retention drain removes rows older than `outbox_retention_hours`; respects batch size
-- [ ] OUTBOX-6: `drop_stream_table()` cascades to outbox + latest-row view; `outbox_status()` returns correct data
-- [ ] OUTBOX-7: Benchmark shows < 10 % overhead vs baseline at small payloads
-- [ ] INBOX-1/2: `create_inbox()` creates inbox table + 3 stream tables + metadata
-- [ ] INBOX-3: Pending ST reflects unprocessed messages; DLQ ST reflects poisoned messages
-- [ ] INBOX-4: `enable_inbox_tracking()` works with non-standard column names on existing tables
-- [ ] INBOX-5: `pg_trickle_alert` fires when new DLQ entries appear
-- [ ] INBOX-6: `inbox_health()` returns correct health status; `inbox_status()` lists all inboxes
-- [ ] INBOX-7: `replay_inbox_messages()` resets messages by explicit `event_ids` array (no `where_clause`); uses parameterised `WHERE event_id = ANY($1)` — no dynamic SQL; retention drain respects DLQ; processor crash + replay recovery path documented
-- [ ] INBOX-8: `drop_inbox(cascade := true)` drops managed table; preserves adopted tables
-- [ ] SHARED-3: End-to-end inbox → business logic → outbox pipeline test passes
-- [ ] SHARED-4: dbt adapter updated with `outbox_enabled` and `inbox_config` properties; integration tests pass
-- [ ] OUTBOX-B1: `create_consumer_group()` creates group + offset + lease tables; idempotent re-create
-- [ ] OUTBOX-3/4: FULL-refresh fallback writes `"full_refresh": true` in header; claim-check applies when row count exceeds `outbox_inline_threshold_rows`; reference relay handles all four combinations (inline/claim-check × differential/full-refresh) correctly
-- [ ] OUTBOX-B2: `poll_outbox()` returns correct batch; no overlap between concurrent relays; visibility timeout expires and row re-delivered
-- [ ] OUTBOX-B2a: `extend_lease()` extends visibility_until for all active consumer leases; re-delivery does not occur when relay calls extend_lease before timeout
-- [ ] OUTBOX-B3: `commit_offset()` advances monotonically; `seek_offset()` enables replay from any position
-- [ ] OUTBOX-B4: Heartbeat tracks liveness; `consumer_unhealthy` alert fires on timeout
-- [ ] OUTBOX-B5: Three monitoring STs (status/FULL, group lag/DIFFERENTIAL, active leases/FULL) created idempotently (second `create_consumer_group()` does not fail); refreshed correctly; dropped when last group is dropped (reference count reaches zero)
-- [ ] OUTBOX-B6: Dead relay reaped after `consumer_dead_threshold_hours` (default 24 h, configurable); leases released; `consumer_reaped` alert emitted
-- [ ] OUTBOX-B7: Retention drain respects `MIN(last_offset)`; `outbox_force_retention` override works
-- [ ] OUTBOX-B8: Multi-relay group E2E: each outbox row published exactly once across 3 concurrent relays
-- [ ] OUTBOX-B8b: Concurrent relay stress test: 10 relays, 100K outbox rows, < 0.1% duplicate rate before broker dedup; 0% after
-- [ ] INBOX-B1: `next_<inbox>` ST surfaces only next expected sequence per aggregate; withholds future sequences; partial index `(aggregate_id, sequence_num) WHERE processed_at IS NOT NULL` created by `enable_inbox_ordering()`
-- [ ] INBOX-B1: `enable_inbox_ordering()` + `enable_inbox_priority()` together returns `InboxOrderingPriorityConflict` with clear message
-- [ ] INBOX-B2: `gaps_<inbox>` ST detects missing sequences using `LEAD()` window function; `inbox_ordering_gap` alert fires; gap detection benchmark passes (< 1 s at 10K aggregates, 1M messages; O(N log N) not O(sequence_range))
-- [ ] INBOX-B3: Priority tier STs refresh at configured schedules; messages route to correct tier
-- [ ] INBOX-B3: `disable_inbox_priority()` drops all tier STs + config row; unified `pending_<inbox>` is restored
-- [ ] INBOX-B1: `disable_inbox_ordering()` drops `next_<inbox>` ST + config row; inbox resumes normal pending behaviour
-- [ ] INBOX-B4: `inbox_is_my_partition(aggregate_id, worker_id, total_workers)` returns BOOLEAN; no messages lost across N workers; usable in prepared statements without SQL interpolation
-- [ ] SHARED-B3: Ordered inbox E2E: 10 out-of-order arrivals per aggregate delivered to processor in order
-- [ ] SHARED-B4: dbt adapter updated with consumer group and inbox ordering properties
-- [ ] Extension upgrade path tested (`0.27.0 → 0.28.0`) — `sql/pg_trickle--0.27.0--0.28.0.sql` validated by `scripts/check_upgrade_completeness.sh`
-- [ ] `just check-version-sync` passes
-
----
-
-## v0.29.0 — Relay CLI (`pgtrickle-relay`)
-
-**Status: Planned.** See [plans/relay/PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) for the full design.
-
-> **Release Theme**
-> This release ships `pgtrickle-relay` — a standalone bidirectional Rust CLI
-> binary that bridges pg-trickle outboxes and inboxes with popular messaging
-> systems. In **forward mode** it polls outbox tables and publishes deltas to
-> external sinks; in **reverse mode** it consumes messages from external
-> sources and writes them into pg-trickle inbox tables. Both directions share
-> symmetric Source/Sink trait abstractions, config system, observability, and
-> error handling. Implemented as a workspace member alongside `pgtrickle-tui`,
-> with 8 backends behind Cargo feature flags. The relay makes the v0.28.0
-> outbox and inbox immediately usable — zero custom relay code required.
->
-> See [plans/relay/PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md)
-> for the full architecture, backend specifications, and phased implementation plan.
-
-### Phase 1 — Core Framework + Forward Tier 1 Sinks
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| RELAY-CAT | **Catalog schema + SQL API.** `sql/pg_trickle--0.23.0--0.24.0.sql`: create `pgtrickle.relay_outbox_config` + `pgtrickle.relay_inbox_config` tables, shared `relay_config_notify()` trigger (uses `TG_TABLE_NAME` to identify direction), and 7 `SECURITY DEFINER` SQL wrapper functions: `set_relay_outbox`, `set_relay_inbox`, `enable_relay`, `disable_relay`, `delete_relay`, `get_relay_config`, `list_relay_configs`. Functions validate required JSONB keys and raise clear exceptions. Direct table access is revoked from `pgtrickle_relay`; only `EXECUTE` on the API functions is granted — tables are an internal implementation detail. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.14 |
-| RELAY-1 | **Crate scaffold.** Workspace member `pgtrickle-relay/` with `Cargo.toml`, feature flags per backend, CLI parsing via `clap` (`--postgres-url`, `--metrics-addr`, `--log-format`, `--log-level`; no config subcommands — pipeline management is SQL-only), DB bootstrap (connect to PG, load `relay_outbox_config` + `relay_inbox_config`, `LISTEN pgtrickle_relay_config`), `RelayError` enum, `RelayMessage` envelope type. | 1.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.1–A.3, §A.7 |
-| RELAY-2 | **Source + Sink traits + relay loop.** `async trait Source` with `poll`/`acknowledge`, `async trait Sink` with `publish`/`is_healthy`. Generic relay loop composing any source with any sink via `CancellationToken`. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.4–A.6 |
-| RELAY-3 | **Outbox poller source.** Simple mode (offset tracked in memory) and consumer group mode (`poll_outbox()` + `commit_offset()`). Heartbeat background task. Lease renewal via `extend_lease()`. | 2d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.8 |
-| RELAY-4 | **Payload decoder.** All four modes: inline differential, inline full-refresh, claim-check differential, claim-check full-refresh. Server-side cursor for claim-check rows. `outbox_rows_consumed()` called after cursor consumption. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.9 |
-| RELAY-5 | **Sink: stdout/file.** `jsonl`, `json_pretty`, `csv` formats. File rotation. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.4 |
-| RELAY-6 | **Sink: NATS JetStream.** `async-nats`. Subject template. `Nats-Msg-Id` dedup header. `Pgtrickle-Full-Refresh` header. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.1 |
-| RELAY-7 | **Sink: HTTP webhook.** `reqwest`. Batch and per-event mode. `Idempotency-Key` header. Configurable timeout, custom headers, retry-on-status. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.2 |
-| RELAY-8 | **Sink: Apache Kafka.** `rdkafka`. Idempotent producer. Dedup key as record key. Topic template. Compression, acks, SASL/SSL. | 1.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.3 |
-| RELAY-9 | **Observability + shutdown.** `axum` at `:9090/metrics` + `GET /health`. Prometheus counters for both modes. SIGTERM/SIGINT graceful shutdown. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.11–A.12 |
-
-> **Phase 1 subtotal: ~10.5 days**
-
-### Phase 2 — Forward Tier 2 Sinks
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| RELAY-10 | **Sink: Redis Streams.** `redis` crate. `XADD` with `MAXLEN ~`. Stream key template. Dedup key field. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.5 |
-| RELAY-11 | **Sink: Amazon SQS.** `aws-sdk-sqs`. `SendMessageBatch`. `MessageDeduplicationId` for FIFO queues. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.6 |
-| RELAY-12 | **Sink: PostgreSQL inbox (remote).** `tokio-postgres`. Inserts into compatible inbox table on different PG. `ON CONFLICT (event_id) DO NOTHING`. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.7 |
-| RELAY-13 | **Sink: RabbitMQ AMQP.** `lapin`. Exchange + routing key template. `message-id` AMQP property. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.8 |
-| RELAY-14 | **Subject/topic routing templates.** Variables: `{stream_table}`, `{op}`, `{outbox_id}`, `{refresh_id}`. Per-event-type override map. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.3 |
-
-> **Phase 2 subtotal: ~5 days**
-
-### Phase 3 — Reverse Mode (Sources + Inbox Sink)
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| RELAY-22 | **Inbox sink.** pg-trickle inbox writer with batch insert, `ON CONFLICT (event_id) DO NOTHING`, dedup tracking metric, configurable column mapping. | 1.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §D |
-| RELAY-23 | **Source: NATS JetStream consumer.** Durable pull consumer, ack after inbox write. Dedup key from `Nats-Msg-Id` header or stream sequence. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.1 |
-| RELAY-24 | **Source: Apache Kafka consumer.** `rdkafka` `StreamConsumer`, manual offset commit after inbox write. Dedup key from record key or partition:offset. | 1.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.3 |
-| RELAY-25 | **Source: HTTP webhook receiver.** `axum` server, synchronous ack (200 after inbox write). Dedup key from `Idempotency-Key` header. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.2 |
-| RELAY-26 | **Source: Redis Streams consumer.** `XREADGROUP` + `XACK`. Dedup key from `pgt_dedup_key` field or entry ID. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.5 |
-| RELAY-27 | **Source: Amazon SQS consumer.** `ReceiveMessage` + `DeleteMessage`. Dedup key from `MessageDeduplicationId` (FIFO) or `MessageId`. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.6 |
-| RELAY-28 | **Source: RabbitMQ consumer.** `basic_consume` + manual ack/nack. Dedup key from `message-id` AMQP property. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.7 |
-| RELAY-29 | **Source: stdin/file reader.** JSONL format. Dedup key from `dedup_key` field or generated UUID. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.4 |
-| RELAY-30 | **Reverse-mode config.** Dedup key mapping, event type extraction, inbox column mapping. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §D |
-
-> **Phase 3 subtotal: ~10 days**
-
-### Phase 4 — Testing & Polish
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| RELAY-15 | **Unit tests.** Payload decoder (all 4 modes), config merging, subject templates, dedup key generation, retry backoff, envelope round-trip, mock source→sink. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.1 |
-| RELAY-16 | **Forward integration tests (Testcontainers).** NATS, Kafka (Redpanda), webhook (WireMock), Redis, PG inbox — end-to-end per sink with dedup verification. | 2d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.2 |
-| RELAY-17 | **Forward consumer group E2E.** 2 relay instances share one consumer group; zero duplicates; crash recovery; claim-check large delta. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.2 |
-| RELAY-31 | **Reverse integration tests (Testcontainers).** NATS→inbox, Kafka→inbox, webhook→inbox, Redis→inbox, SQS→inbox, RabbitMQ→inbox, stdin→inbox — dedup verification per source. | 2d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.3 |
-| RELAY-32 | **Reverse dedup + crash recovery E2E.** Duplicate messages produce 1 inbox row; kill relay mid-batch → restart → zero lost messages. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.3 |
-| RELAY-18 | **Benchmarks.** Forward + reverse throughput (100K events), latency p50/p95/p99, memory bounded during claim-check. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.4 |
-
-> **Phase 4 subtotal: ~7 days**
-
-### Phase 5 — Documentation & Distribution
-
-| Item | Description | Effort | Ref |
-|------|-------------|--------|-----|
-| RELAY-19 | **Documentation.** `pgtrickle-relay/README.md` quick start (forward + reverse). `docs/RELAY.md` comprehensive guide. `docs/PATTERNS.md` relay section with worked examples per backend. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §F.1 |
-| RELAY-20 | **Dockerfile + GitHub Actions.** Distroless container image `grove/pgtrickle-relay`. CI matrix: Linux amd64/arm64, macOS amd64/arm64. Pre-built binaries on GitHub Releases. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §F.2 |
-| RELAY-21 | **Release automation.** Docker Hub publish, Homebrew formula (`brew install grove/tap/pgtrickle-relay`), `cargo publish pgtrickle-relay`. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §F.2 |
-
-> **Phase 5 subtotal: ~2.5 days**
-
-### Implementation Phases
-
-| Phase | Description | Duration |
-|-------|-------------|----------|
-| Phase 1 | Core framework: Source/Sink traits, outbox poller, payload decoder, NATS/webhook/Kafka sinks, metrics, shutdown | Days 1–10 |
-| Phase 2 | Tier 2 sinks: Redis, SQS, PG inbox, RabbitMQ + routing templates | Days 10–15 |
-| Phase 3 | Reverse mode: inbox sink, NATS/Kafka/webhook/Redis/SQS/RabbitMQ/stdin sources + reverse config | Days 15–25 |
-| Phase 4 | Tests: unit, Testcontainers integration (forward + reverse), consumer group E2E, benchmarks | Days 25–32 |
-| Phase 5 | Distribution: Docker, CI binaries, Homebrew, docs, cargo publish | Days 32–34.5 |
-
-> **v0.29.0 total: ~36.5 days solo / ~23 days with two developers**
-> (Phases 1–2 forward sinks and Phase 3 reverse sources can be parallelised.
-> Requires v0.28.0 outbox + consumer groups for full forward E2E; reverse
-> mode only needs inbox table schema.)
-
-**Exit criteria:**
-- [ ] RELAY-CAT: Migration `sql/pg_trickle--0.23.0--0.24.0.sql` creates `relay_outbox_config` + `relay_inbox_config` tables and `relay_config_notify()` trigger
-- [ ] RELAY-CAT: `set_relay_outbox()` validates `source_type = 'outbox'`; `set_relay_inbox()` validates `sink_type = 'pg-inbox'`; missing keys raise clear exception
-- [ ] RELAY-CAT: `enable_relay()`/`disable_relay()`/`delete_relay()` search both tables; raise exception on missing name
-- [ ] RELAY-CAT: `list_relay_configs()` returns all pipelines with `direction` column; `get_relay_config()` raises on missing name
-- [ ] RELAY-CAT: functions are `SECURITY DEFINER`; `pgtrickle_relay` role has no direct table access; `SELECT * FROM pgtrickle.relay_outbox_config` fails with permission denied for relay role
-- [ ] RELAY-1: `pgtrickle-relay` crate builds with `--features default` and `--features nats,webhook,kafka`
-- [ ] RELAY-2: Source + Sink traits compose correctly; relay loop runs with mock source/sink
-- [ ] RELAY-3: Simple mode polls and forwards events; consumer group mode uses `poll_outbox()` + `commit_offset()` correctly
-- [ ] RELAY-4: Inline payload decoded and published; claim-check cursor fetch returns all rows; `outbox_rows_consumed()` called; full-refresh flag triggers upsert semantics
-- [ ] RELAY-5: stdout/file backend writes valid JSONL; all 3 formats tested
-- [ ] RELAY-6: NATS E2E: relay publishes; consumer verifies dedup via `Nats-Msg-Id`
-- [ ] RELAY-7: Webhook E2E: relay POSTs batch; WireMock verifies `Idempotency-Key` header
-- [ ] RELAY-8: Kafka E2E: relay produces records; consumer group verifies zero duplicates
-- [ ] RELAY-9: `/metrics` returns valid Prometheus exposition; `/health` returns 200 healthy, 503 degraded
-- [ ] RELAY-10: Redis E2E: `XRANGE` returns all relayed events in order
-- [ ] RELAY-11: SQS E2E: `SendMessageBatch` used; FIFO dedup verified
-- [ ] RELAY-12: PG inbox E2E: events appear in target inbox; duplicate publish does not duplicate row
-- [ ] RELAY-13: RabbitMQ E2E: events delivered to bound queue; `message-id` property set
-- [ ] RELAY-14: Subject template `pgtrickle.{stream_table}.{op}` resolves correctly
-- [ ] RELAY-15: All unit tests pass
-- [ ] RELAY-16: All forward Testcontainers integration tests pass per sink
-- [ ] RELAY-17: Forward consumer group E2E: 2 relays, 0 duplicates; crash recovery verified
-- [ ] RELAY-18: Forward throughput > 10K events/sec inline → NATS; reverse throughput > 10K events/sec Kafka → inbox; memory bounded during claim-check
-- [ ] RELAY-19: `docs/RELAY.md` published; quick start covers forward + reverse with NATS, webhook, Kafka
-- [ ] RELAY-20: Docker image `grove/pgtrickle-relay:0.24.0` published; distroless < 50 MB
-- [ ] RELAY-21: `cargo install pgtrickle-relay` works; Homebrew formula passes `brew audit`
-- [ ] RELAY-22: Inbox sink writes events with `ON CONFLICT` dedup; batch insert verified
-- [ ] RELAY-23: NATS→inbox E2E: durable consumer delivers to inbox; ack only after write
-- [ ] RELAY-24: Kafka→inbox E2E: offset committed only after inbox write; crash recovery verified
-- [ ] RELAY-25: Webhook→inbox E2E: POST returns 200 only after inbox write
-- [ ] RELAY-26: Redis→inbox E2E: XACK sent only after inbox write
-- [ ] RELAY-27: SQS→inbox E2E: DeleteMessage after inbox write; visibility timeout re-poll verified
-- [ ] RELAY-28: RabbitMQ→inbox E2E: manual ack after inbox write; nack+requeue on failure
-- [ ] RELAY-29: stdin→inbox: piped JSONL arrives in inbox; dedup key extracted
-- [ ] RELAY-30: Reverse config: event type extraction + column mapping works
-- [ ] RELAY-31: All reverse Testcontainers integration tests pass per source
-- [ ] RELAY-32: Reverse dedup: duplicate source message produces 1 inbox row; crash recovery zero loss
-- [ ] Extension upgrade path tested (`0.28.0 → 0.29.0`)
-- [ ] `just check-version-sync` passes
-
----
-
-## v0.30.0 — Pre-GA Correctness & Stability Sprint
+## v0.28.0 — Pre-GA Correctness & Stability Sprint
 
 **Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §3, §4, §7, §8.
 This release must land **before** v1.0.0 GA. Its purpose is to close every
@@ -7238,7 +6861,7 @@ P0 and P1 gap identified in the v0.27.0 assessment so that the stable
 release inherits a clean correctness baseline.
 
 > **Release Theme**
-> v0.30.0 is the quality gate between the feature-rich v0.28–v0.29 arc and
+> v0.28.0 is the quality gate before the feature-rich v0.29–v0.30 arc and
 > the v1.0 stable release. It fixes the remaining correctness defects that
 > could produce silent wrong answers (EC-01 phantom drift, snapshot
 > non-atomicity), eliminates the operational failure modes that could
@@ -7590,7 +7213,7 @@ it is tested against. Add a compatibility matrix row (e.g.
   `pg_trickle.use_sqlstate_classification` GUC (default `false`) initially,
   flip to `true` in v0.31.0 after one release of parallel validation.
 - **UX-14** (CNPG 1.29) depends on CNPG 1.29 being available; if the release
-  slips past the v0.30.0 window, defer to v1.0.0 but keep the tracking issue
+  slips past the v0.28.0 window, defer to v1.0.0 but keep the tracking issue
   open.
 - **UX-15** (dbt 1.11) is purely a tracking concern — no code changes are
   required in this release.
@@ -7606,7 +7229,7 @@ it is tested against. Add a compatibility matrix row (e.g.
 | Phase 5 | P1/P2 test coverage: TEST-1 through TEST-19, PERF-3 | Days 19–27 |
 | Phase 6 | P1/P2/P3 docs & UX: UX-3 through UX-18, TUI parity | Days 27–34 |
 
-> **v0.30.0 total: ~7–8 weeks** (correctness-critical path ~10 days;
+> **v0.28.0 total: ~7–8 weeks** (correctness-critical path ~10 days;
 > documentation and test coverage ~14 days; architecture improvements ~8 days;
 > new test targets ~8 days; Low-priority doc polish ~4 days)
 
@@ -7638,6 +7261,383 @@ it is tested against. Add a compatibility matrix row (e.g.
 - [ ] TEST-14: G17-MDB multi-database soak test runs in `ci.yml` on every push to main
 - [ ] SCAL-3: Dead `#[allow(unused_imports)]` removed from `refresh/orchestrator.rs`; `just lint` clean
 - [ ] Extension upgrade path tested (`0.29.0 → 0.30.0`)
+- [ ] `just check-version-sync` passes
+
+---
+
+## v0.29.0 — Transactional Inbox & Outbox Patterns
+
+**Status: Planned.** Driven by [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) and [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md). Outbox helper moved here from v0.22.0 to ship alongside the inbox helper and production-grade advanced features as a complete transactional messaging solution.
+
+> **Release Theme**
+> This release delivers a **complete, production-grade solution** for the two
+> most common event-driven integration patterns in microservice architectures.
+> **Part A (Essential)** ships the Transactional Outbox (reliable atomic event
+> publication) and Transactional Inbox (reliable idempotent event consumption)
+> as zero-boilerplate SQL helpers. **Part B (Advanced)** adds Consumer Groups
+> for coordinated multi-relay outbox polling with Kafka-style offset tracking,
+> visibility timeouts, and lag monitoring — and Ordered Processing for the
+> inbox, including per-aggregate sequence ordering, gap detection, priority
+> queues, and partition-affinity helpers for competing workers. Together,
+> Parts A and B let pg_trickle users build reliable, exactly-once event
+> pipelines that scale from a single relay to multi-instance deployments,
+> using nothing but PostgreSQL.
+>
+> See [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md)
+> and [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md)
+> for the full architecture and API design.
+
+---
+
+### Known Limitations in v0.29.0
+
+| Limitation | Rationale | Future Path |
+|------------|-----------|-------------|
+| **Outbox requires DIFFERENTIAL mode.** `enable_outbox()` on `IMMEDIATE`-mode stream tables returns `OutboxRequiresNotImmediateMode`. | Outbox writes one row per refresh cycle inside the refresh transaction. IMMEDIATE refreshes fire inside every source transaction; adding an outbox INSERT there imposes that cost on every application write. | Post-1.0 opt-in GUC if demand justifies. |
+| **Ordering and priority are mutually exclusive per inbox.** Calling both `enable_inbox_ordering()` and `enable_inbox_priority()` on the same inbox returns `InboxOrderingPriorityConflict`. | Per-aggregate sequence ordering must surface the next message in sequence regardless of priority level; priority tiers violate that guarantee. | Use separate inboxes per priority class, each with `enable_inbox_ordering()` applied independently. |
+| **Gap detection degrades above ~100K aggregates.** The `gaps_<inbox>` stream table uses `LEAD()` over pending messages, which is O(N log N) in pending message count — not O(sequence range). This is a significant improvement over the `generate_series` approach; however, refresh time still scales with pending message volume. | Acceptable up to ~1M pending messages at 30 s schedule. Above 10M pending messages, auto-refresh may be slow; use `inbox_ordering_gaps()` for on-demand checks. | Post-v0.29.0: delta-based detection scanning only aggregates with recent activity. |
+| **Consumer groups provide at-least-once delivery per consumer instance, not exactly-once globally.** | Exactly-once is achieved by composition: relay uses broker idempotency keys; inbox uses `ON CONFLICT (event_id) DO NOTHING`. Three-layer deduplication is more resilient than a monolithic exactly-once guarantee. | Design decision. Documented in PATTERNS.md and SQL_REFERENCE.md. |
+| **AUTO mode may fall back to FULL refresh while outbox is enabled.** When AUTO refresh falls back to FULL, the outbox header row carries `"full_refresh": true`. If the number of current rows exceeds `outbox_inline_threshold_rows`, the claim-check path applies: rows land in `outbox_delta_rows_<st>` and the relay fetches via cursor. A `pg_trickle_alert outbox_full_refresh` event is emitted regardless of which path is taken. Relays must detect the `full_refresh` flag, apply snapshot semantics (upsert rather than publish-as-new), and handle either inline or claim-check payloads. | AUTO refresh adapts to IVM cost at runtime; blocking the FULL fallback permanently would compromise the adaptation that makes AUTO useful. The sentinel flag preserves correctness; the claim-check path prevents memory exhaustion on large tables. | Reference relay updated in OUTBOX-8 to demonstrate all combinations. Post-v0.29.0: consider a GUC to disable FULL fallback per ST when outbox is enabled. |
+| **`next_<inbox>` ordered ST scans all processed rows.** The `last_processed` CTE in the aggregate-ordered ST runs `MAX(sequence_num) GROUP BY aggregate_id` over every processed row on each refresh. For inboxes with large volumes of processed history this grows without bound. | A partial index `(aggregate_id, sequence_num) WHERE processed_at IS NOT NULL` is created by `enable_inbox_ordering()` to mitigate this at v0.29.0, making it an index-only scan. Scaling thresholds: < 100K rows → < 5 ms at 1 s schedule; 100K–1M → increase schedule to `5s`; > 1M → increase to `10s–30s`; > 10M → use `inbox_ordering_gaps()` on-demand only. | Post-v0.29.0: introduce `pgt_inbox_sequence_state` catalog table updated atomically via `advance_inbox_sequence()`, making the CTE O(changed aggregates). |
+| **Global consumer monitoring STs created once, not reference-counted.** `pgt_consumer_status`, `pgt_consumer_group_lag`, `pgt_consumer_active_leases` are auto-created on the first `create_consumer_group()` call. They must be created idempotently and torn down only when the last consumer group for an outbox is dropped. | A single set of monitoring STs per outbox is correct and cheaper than per-group STs. | Implementation: `create_stream_table()` called with `if_not_exists := true`; `drop_consumer_group()` decrements a reference count and drops STs at zero. |
+| **Outbox relay latency bounded by poll interval.** Relays discover new outbox rows by polling. The pg_trickle extension emits `pg_notify('pgtrickle_outbox_new', outbox_table_name)` after each outbox INSERT (v0.29.0), but the `pgtrickle-relay` binary does not yet use LISTEN — it starts polling on the standard interval. Minimum relay latency today equals the poll interval (`visibility_seconds`). | The NOTIFY is cheap (≈2 µs, inside the existing refresh transaction) and is emitted from v0.29.0 onwards so relay authors can begin using it immediately. The `pgtrickle-relay` CLI will use LISTEN/NOTIFY in v0.30.0. | v0.30.0 relay: subscribe to `pgtrickle_outbox_new` for sub-100 ms wake-up (see E2E latency benchmark in PLAN_RELAY_CLI.md §E.5). |
+| **`replay_inbox_messages()` accepts only explicit event ID lists.** A free-form `where_clause` parameter was removed to eliminate SQL injection risk. | `EXPLAIN`-based validation of dynamic SQL is insufficient; parameterised `WHERE event_id = ANY($1)` is the safe API. | Operators who need filter-based replay should run a parameterised `SELECT ARRAY_AGG(event_id) ... WHERE <condition>` first, then pass the result to `replay_inbox_messages()`. |
+
+---
+
+### Part A — Essential Patterns
+
+#### Transactional Outbox Helper (P2 — §9.12)
+
+> **In plain terms:** After each DIFFERENTIAL refresh cycle, pg_trickle
+> writes a row to `pgtrickle.outbox_<st>` within the same transaction as
+> the MERGE — either both succeed or neither does. For small deltas the row
+> carries a versioned inline JSON payload `{"v":1, "inserted":[…],
+> "deleted":[…]}`. For large deltas (above `outbox_inline_threshold_rows`,
+> default 10 000 rows) the row carries a lightweight claim-check header
+> `{"v":1, "claim_check": true, …}` and the actual rows land in the
+> companion table `pgtrickle.outbox_delta_rows_<st>`, which the relay
+> reads via a server-side cursor in bounded batches — constant memory
+> regardless of delta size. Eliminates the dual-write problem for
+> downstream event buses without a CDC connector or external replication
+> slot.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| OUTBOX-1 | **Catalog + SQL functions.** `pgt_outbox_config` catalog table. `enable_outbox(name, retention_hours)` / `disable_outbox(name, if_exists)` SQL functions. `OutboxAlreadyEnabled`, `OutboxNotEnabled`, `OutboxRequiresNotImmediateMode` error variants. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.1–A.2 |
+| OUTBOX-2 | **Outbox table creation.** `pgtrickle.outbox_<st>` with `id BIGSERIAL`, `pgt_id UUID`, `refresh_id UUID`, `created_at`, `inserted_count INT`, `deleted_count INT`, `is_claim_check BOOLEAN DEFAULT false`, `payload JSONB`. Index on `created_at`. Naming: 7-byte `outbox_` prefix + up to 56-byte stream table name; collision resolution appends 7-char hex suffix derived from `left(md5(name), 7)`. Final name stored in `pgt_outbox_config.outbox_table_name`. Also creates: (a) **latest-row view** `pgtrickle.pgt_outbox_latest_<st>` (`ORDER BY id DESC LIMIT 1`) for quick lag inspection and operational checks; (b) **delta rows table** `pgtrickle.outbox_delta_rows_<st>` with `outbox_id BIGINT REFERENCES outbox_<st>(id)`, `row_num INT`, `op CHAR(1) CHECK (op IN ('I','D'))`, `payload JSONB`, `PRIMARY KEY (outbox_id, row_num)` — populated only for claim-check entries. *(Note: `pgt_consumer_claim_check_acks` is created in Part B / OUTBOX-B1, not here — it has no purpose without consumer groups.)* All objects dropped alongside the outbox table. | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.3 |
+| OUTBOX-3 | **Refresh-path integration.** After successful MERGE, if outbox is enabled, INSERT outbox row within the same transaction — **unless** `outbox_skip_empty_delta = true` (default) and `inserted_count = 0 AND deleted_count = 0`, in which case no INSERT or NOTIFY is issued, saving write amplification on quiet refresh cycles. In-memory `outbox_enabled_set` cache with DDL-triggered invalidation. Hot-path cost < 50 ns when disabled. **Routing:** if `delta_row_count <= outbox_inline_threshold_rows`, serialise `Vec<DeltaRow>` to inline JSONB as before. If `delta_row_count > outbox_inline_threshold_rows`, write `is_claim_check = true` header row first (no payload), then INSERT delta rows into `outbox_delta_rows_<st>` in batches controlled by `outbox_claim_check_batch_size` GUC (default 1 000 rows/call) — keeping Rust heap bounded regardless of delta size. Both writes are in the same transaction. **FULL-refresh fallback:** when AUTO mode falls back to FULL refresh, the outbox header row additionally carries `"full_refresh": true`; if row count exceeds the threshold the claim-check path applies; a `pg_trickle_alert outbox_full_refresh` event is emitted so relays apply snapshot semantics. **NOTIFY:** emit `pg_notify('pgtrickle_outbox_new', outbox_table_name)` inside the same transaction after the outbox INSERT, enabling relay authors to use LISTEN for sub-second wake-up (cost: ~2 µs per refresh; skipped when empty-delta skip applies). | 1.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.4 |
+| OUTBOX-4 | **Versioned payload format — two paths.** **Inline path** (small delta): `{"v":1, "inserted":[…], "deleted":[…]}` with `to_jsonb()` type mapping. **Claim-check path** (large delta): `{"v":1, "claim_check": true, "inserted_count": N, "deleted_count": N, "refresh_id": "…"}` — no row data in the outbox row itself; relay reads `outbox_delta_rows_<st>` via server-side cursor and calls `outbox_rows_consumed(stream_table, outbox_id)` when done. FULL-fallback payloads additionally set `"full_refresh": true` in the header; claim-check applies when the full-refresh row count exceeds the threshold. GUC `outbox_inline_threshold_rows` (default 10 000 rows) controls the routing threshold. **No truncation path** — data is never silently dropped. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.5 |
+| OUTBOX-5 | **Retention drain.** Scheduler cleanup step: batched DELETE on `outbox_<st>` with `outbox_drain_batch_size` GUC (default 10 000). Cascades to `outbox_delta_rows_<st>` via FK `ON DELETE CASCADE` — no separate drain step needed for delta rows. Per-ST or global `outbox_retention_hours` (default 24). `last_drained_at` / `last_drained_count` tracked in catalog. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.6 |
+| OUTBOX-6 | **Lifecycle & cascade.** `drop_stream_table()` cascades to outbox table + delta rows table + metadata. `alter_stream_table()` errors if column set changed while outbox enabled. `outbox_status()` monitoring function (includes `claim_check_pending_count` and `storage_status` fields). `outbox_rows_consumed(stream_table TEXT, outbox_id BIGINT)` SQL function: called by relay after cursor consumption to record per-group completion in `pgt_consumer_claim_check_acks`; idempotent. **Note:** `stream_table` takes the stream table name (as registered in `pgt_stream_tables`), not the outbox table name — the function resolves the outbox table via `pgt_outbox_config`. **8 Part-A GUCs** (`outbox_enabled`, `outbox_retention_hours`, `outbox_drain_batch_size`, `outbox_inline_threshold_rows`, `outbox_claim_check_batch_size`, `outbox_drain_interval_seconds`, `outbox_storage_critical_mb`, `outbox_skip_empty_delta`) + 4 Part-B GUCs (`consumer_dead_threshold_hours`, `consumer_stale_offset_threshold_days`, `consumer_cleanup_enabled`, `outbox_force_retention`). | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §A.7–A.8 |
+| OUTBOX-7 | **Tests & benchmark.** Unit: enable/disable/validation/naming/cascade. Integration: end-to-end inline outbox write; claim-check triggered at threshold boundary (N = threshold, N = threshold+1); delta rows populated atomically in same transaction; relay cursor-fetch returns all rows in order; `outbox_rows_consumed()` idempotency; retention drain cascades delta rows via FK; rollback on outbox INSERT failure leaves no orphan delta rows; `pg_notify('pgtrickle_outbox_new', ...)` emitted. Benchmark gates: (a) `refresh_no_outbox` vs `refresh_outbox_inline` vs `refresh_outbox_claim_check` — < 10 % overhead at inline threshold, < 25 % at large payloads; (b) `poll_outbox()` < 5 ms at 10K outbox rows; (c) `commit_offset()` < 10 ms with 10 concurrent relays; (d) `consumer_lag()` < 50 ms at 100K outbox rows; (e) E2E latency benchmark `benches/e2e_outbox_latency.rs`: p50 < 1.5 s (polling), p95 < 2.5 s (see PLAN_RELAY_CLI.md §E.5). | 1.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §D |
+| OUTBOX-8 | **Documentation & examples.** SQL_REFERENCE.md: outbox API + both payload formats (inline and claim-check) + `outbox_rows_consumed()` + `pgtrickle_outbox_new` NOTIFY channel. CONFIGURATION.md: 7 GUCs (replacing `outbox_max_payload_bytes` with `outbox_inline_threshold_rows`; adding `outbox_claim_check_batch_size` and `outbox_storage_critical_mb` with tuning table). PATTERNS.md: Transactional Outbox section including claim-check relay pattern; WAL overhead analysis; backpressure guidance for dead consumers (`outbox_storage_critical_mb` alert workflow). Reference Python relay (`examples/relay/outbox_relay.py`) demonstrates both inline and claim-check paths. | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §C, §E |
+
+> **Outbox essential subtotal: ~7 days**
+
+#### Transactional Inbox Helper
+
+> **In plain terms:** `create_inbox('payment_inbox')` creates a
+> production-grade inbox table with auto-managed stream tables for the
+> pending-message queue, dead-letter queue, and processing statistics.
+> Applications write to the inbox (`ON CONFLICT DO NOTHING` for dedup),
+> process messages from the pending stream table, and pg_trickle handles
+> DLQ routing, alerts, retention, and monitoring automatically.
+> `enable_inbox_tracking()` adopts an existing inbox table into pg_trickle's
+> monitoring without schema changes.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| INBOX-1 | **Catalog + `create_inbox()`.** `pgt_inbox_config` catalog table with column mapping (`id_column`, `processed_at_column`, `retry_count_column`, `error_column`, `received_at_column`, `event_type_column`). `create_inbox(name, schema, max_retries, schedule, with_dead_letter, with_stats, retention_hours)` creates inbox table in the specified schema (default `pgtrickle`) + metadata. `InboxAlreadyExists`, `InboxNotFound`, `InboxTableNotFound`, `InboxColumnMissing` error variants. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.1–A.3 |
+| INBOX-2 | **Inbox table DDL.** Standard schema: `event_id TEXT PK`, `event_type`, `source`, `aggregate_id`, `payload JSONB`, `received_at`, `processed_at`, `error`, `retry_count`, `trace_id`. Partial indexes for pending, DLQ, and processed rows. Autovacuum tuning. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.3 |
+| INBOX-3 | **Auto-created stream tables.** Pending ST (`WHERE processed_at IS NULL AND retry_count < max_retries`, DIFFERENTIAL, user-defined schedule). DLQ ST (`WHERE processed_at IS NULL AND retry_count >= max_retries`, DIFFERENTIAL, 30 s). Stats ST (GROUP BY `event_type` with pending/processed/dead_letter/avg processing time — `max_pending_age_sec` removed from the materialised ST query to enable **DIFFERENTIAL** mode and eliminate the O(N) full scan every 10 s; use `inbox_health()` for `oldest_pending_age_sec` on demand). All STs use column-mapped SQL from `pgt_inbox_config`. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.4 |
+| INBOX-4 | **`enable_inbox_tracking()`.** Adopt existing table: validate columns exist with compatible types, validate PK/UNIQUE on id column, create stream tables using mapped column names, insert metadata with `is_managed = false`. Gracefully omit optional columns (`source`, `aggregate_id`, `trace_id`) if not present. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.6 |
+| INBOX-5 | **DLQ alert mechanism.** Post-refresh hook on DLQ stream table: when `rows_inserted > 0`, emit `pg_trickle_alert` event `inbox_dlq_message` per new entry (capped at `inbox_dlq_alert_max_per_refresh`, default 10; excess batched into summary alert). | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.5 |
+| INBOX-6 | **`inbox_health()` + `inbox_status()`.** `inbox_health(name)` returns JSONB with `pending_count`, `dead_letter_count`, `avg_processing_time_sec`, `oldest_pending_age_sec`, `throughput_per_sec`, `health_status` (`healthy`/`degraded`/`critical`). `inbox_status(name)` returns tabular overview of all inboxes. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.1 |
+| INBOX-7 | **Retention drain + `replay_inbox_messages()`.** Processed message drain via scheduler (batched DELETE, `inbox_processed_retention_hours` default 72 h). DLQ messages kept forever by default (`inbox_dlq_retention_hours` default 0). `replay_inbox_messages(name TEXT, event_ids TEXT[])` resets `processed_at` + `retry_count` for the specified message IDs using a parameterised `WHERE event_id = ANY($1)` — no free-form SQL accepted; eliminates injection surface entirely. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.7–A.8 |
+| INBOX-8 | **`drop_inbox()` + lifecycle.** `drop_inbox(name, if_exists, cascade)`: always drops stream tables + metadata; drops inbox table only if `cascade := true` AND `is_managed = true`. `DROP EXTENSION` cascades managed tables; adopted tables survive. 6 GUCs (`inbox_enabled`, `inbox_processed_retention_hours`, `inbox_dlq_retention_hours`, `inbox_drain_batch_size`, `inbox_drain_interval_seconds`, `inbox_dlq_alert_max_per_refresh`). | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §A.9–A.10 |
+| INBOX-9 | **Tests & benchmark.** Unit: create/drop/enable_tracking/replay/health. Integration: end-to-end inbox lifecycle, DLQ routing, DLQ alert, retention drain, concurrent processors with `FOR UPDATE SKIP LOCKED`, `enable_inbox_tracking()` with non-standard columns. Benchmark gates: (a) pending ST refresh < 5 ms at 100 pending, < 50 ms at 10K pending; (b) `next_<inbox>` ordered ST refresh at each threshold (100K/1M/10M processed rows) matches documented scaling table; (c) stats ST FULL refresh < 5 ms at 100K rows, < 50 ms at 1M rows; (d) backpressure indicator: `inbox_health()` returns `degraded` within 2 refresh cycles when `oldest_pending_age_sec` exceeds threshold. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §D |
+| INBOX-10 | **Documentation & examples.** SQL_REFERENCE.md: inbox API. CONFIGURATION.md: 6 GUCs. PATTERNS.md: Transactional Inbox section + "Bidirectional Event Pipeline" (inbox → business logic → outbox) worked example. Reference examples: `inbox_writer_nats.py`, `inbox_processor.py`, `webhook_receiver.py`. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §C, §E |
+
+> **Inbox essential subtotal: ~6.5 days**
+
+#### Shared Infrastructure (Part A)
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| SHARED-1 | **Upgrade SQL.** `sql/pg_trickle--0.23.0--0.24.0.sql`: create `pgt_outbox_config` and `pgt_inbox_config` catalog tables, register all new SQL functions. | 0.5d | — |
+| SHARED-2 | **PATTERNS.md integration guide.** New "Event-Driven Integration Patterns" chapter in `docs/PATTERNS.md` covering: when to use outbox vs inbox vs both, transport comparison (NATS/Kafka/pgmq), bidirectional pipeline (inbox → business logic → outbox), and competing consumer patterns (`FOR UPDATE SKIP LOCKED`). | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX.md), [PLAN_TRANSACTIONAL_INBOX.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX.md) |
+| SHARED-3 | **E2E integration test.** Full pipeline: inbox receives event → processor creates business entity → outbox captures delta → verify end-to-end exactly-once delivery. | 0.5d | — |
+
+> **Part A subtotal: ~15 days**
+
+---
+
+### Part B — Production Patterns
+
+#### Consumer Groups for Outbox
+
+> **In plain terms:** Multiple relay processes can share a single outbox
+> table safely using consumer groups — the same concept as Kafka consumer
+> groups or SQS consumer groups, but implemented entirely in PostgreSQL.
+> Each group has its own offset pointer. Relays call `poll_outbox()` to
+> claim a batch under a visibility timeout (like SQS), then call
+> `commit_offset()` when done. If a relay crashes, its lease expires and
+> another relay picks up the batch. `consumer_lag()` shows how far behind
+> each consumer is. Dead relays are reaped automatically after 24 h.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| OUTBOX-B1 | **Consumer group catalog + lifecycle.** `pgt_consumer_groups` + `pgt_consumer_offsets` + `pgt_consumer_leases` catalog tables. Also creates `pgt_consumer_claim_check_acks` (tracks per-group cursor-consumption completion for claim-check retention drain safety; not created in Part A since it has no purpose without consumer groups). `create_consumer_group(name, outbox, auto_offset_reset)` / `drop_consumer_group(name)` SQL functions; `drop_consumer_group()` decrements a per-outbox reference count and drops per-outbox monitoring STs when count reaches zero. `auto_offset_reset` values: `latest` (default) or `earliest`. `ConsumerGroupAlreadyExists`, `ConsumerGroupNotFound` error variants. | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.2–B.3 |
+| OUTBOX-B2 | **`poll_outbox()` with visibility timeout and lease management.** Returns next batch for `(group, consumer_id)` using `FOR UPDATE SKIP LOCKED`. Acquires lease in `pgt_consumer_leases` with configurable `visibility_seconds` (default 30). Auto-registers new consumer_id on first call based on `auto_offset_reset`. Skips rows already leased by other consumers. | 1.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.4 |
+| OUTBOX-B2a | **`extend_lease()` — lease renewal for long-running relays.** `extend_lease(group, consumer, extension_seconds INT DEFAULT 30)` extends the `visibility_until` of all active leases held by the named consumer, returning the new `visibility_until` timestamp. Prevents spurious re-delivery when broker publish or business logic takes longer than the original `visibility_seconds`. Calling `consumer_heartbeat()` does **not** extend leases — heartbeat and lease lifetime are separate concerns. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.4 |
+| OUTBOX-B3 | **`commit_offset()` + `seek_offset()`.** `commit_offset(group, consumer, last_offset)` monotonically advances offset, releases lease, rejects regression with warning. `seek_offset(group, consumer, new_offset)` resets to any position and clears leases; emits `pg_trickle_alert` event `consumer_seeked`. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.4, §B.6 |
+| OUTBOX-B4 | **Heartbeat + liveness.** `consumer_heartbeat(group, consumer)` updates `last_heartbeat_at` (liveness only — does **not** extend active leases; use `extend_lease()` for that). Consumer is healthy when `last_heartbeat_at > now() - 60 s`. `pg_trickle_alert` event `consumer_unhealthy` when consumer transitions healthy → unhealthy. `consumer_lag()` **live SQL function** (always-fresh, suitable for ad-hoc inspection) exposes per-consumer `healthy` boolean, current lag, and offset. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.5 |
+| OUTBOX-B5 | **Monitoring stream tables.** Three auto-created STs on first `create_consumer_group()`: `pgt_consumer_status` (per-consumer offset + heartbeat timestamp, **FULL mode**, 5 s — FULL because `pgt_consumer_offsets` is updated on every heartbeat and offset commit; at typical relay poll rates most rows change between refreshes, making FULL simpler than DIFFERENTIAL for this small table), `pgt_consumer_group_lag` (per-group aggregate lag, DIFFERENTIAL, 10 s), `pgt_consumer_active_leases` (current leases filtered by `visibility_until > now()`, **FULL mode**, 5 s — FULL because the filter changes every cycle as leases expire). Use `consumer_lag()` for ad-hoc inspection of live health data including `heartbeat_age_sec`; use `pgt_consumer_group_lag` ST for Grafana dashboards and alerting rules (materialized every 10 s). | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.7 |
+| OUTBOX-B6 | **Dead consumer auto-cleanup.** Scheduler step (GUC `consumer_cleanup_enabled`, default `true`): reap consumers with `last_heartbeat_at < now() - consumer_dead_threshold_hours` (GUC, default 24 h), release their leases. Remove from offsets if also `last_commit_at < now() - consumer_stale_offset_threshold_days` (GUC, default 7 d). Emit `pg_trickle_alert` event `consumer_reaped`. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.9 |
+| OUTBOX-B7 | **Retention safety guard.** When consumer groups are enabled, retention drain refuses to delete `outbox_<st>` rows with `id > MIN(last_offset across all consumers)` to prevent silent data loss for slow relays. For claim-check rows, additionally waits until all consumer groups that have polled past that `outbox_id` have called `outbox_rows_consumed()` for it — preventing delta rows from being cascade-deleted via FK before the relay finishes cursor consumption. GUC `outbox_force_retention` (default `false`) allows operator override for permanently abandoned consumers. | 0.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B.6 |
+| OUTBOX-B8 | **Tests.** Integration: multi-relay group creation, visibility timeout expiry + re-poll, `commit_offset` idempotency, `seek_offset` replay, heartbeat → unhealthy transition, dead consumer reaping, retention guard prevents early drain. Benchmark: `poll_outbox` latency < 5 ms at 10K outbox rows. | 1.5d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §D |
+| OUTBOX-B9 | **Documentation & reference relay.** SQL_REFERENCE.md: consumer group API + delivery guarantee section (at-least-once per consumer; exactly-once by composition). CONFIGURATION.md: `consumer_cleanup_enabled`, `outbox_force_retention`, `consumer_dead_threshold_hours` (default 24), `consumer_stale_offset_threshold_days` (default 7) GUCs. Reference Python relay with group coordination (`examples/relay/outbox_relay.py`). Rust equivalent (`examples/relay/outbox_relay.rs`). PATTERNS.md: multi-relay competing consumers section + claim-check large delta handling guide (server-side cursor consumption, `outbox_rows_consumed()`, bounded-memory relay loop) + latest-state consumer section (dedup view). | 1d | [PLAN_TRANSACTIONAL_OUTBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_OUTBOX_HELPER.md) §B, §C |
+
+> **Consumer groups subtotal: ~8 days**
+
+#### Ordered Processing for Inbox
+
+> **In plain terms:** For financial, order management, and audit-trail
+> use-cases, messages about the same entity (customer, order, account)
+> must be processed in the order they were produced. `enable_inbox_ordering()`
+> creates a `next_<inbox>` stream table that surfaces only the *next expected*
+> message per aggregate — preventing out-of-order processing automatically.
+> Gap detection alerts when a message is missing too long. Priority queues
+> let critical messages use a 1-second refresh schedule while background
+> messages use 30 seconds. Worker partition affinity reduces contention when
+> multiple processors share an inbox.
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| INBOX-B1 | **`enable_inbox_ordering()` + aggregate-ordered stream table.** `pgt_inbox_ordering_config` catalog table. `enable_inbox_ordering(inbox, aggregate_id_col, sequence_num_col)` creates `next_<inbox>` ST: `DISTINCT ON (aggregate_id)` selecting only the row where `sequence_num = last_processed_seq + 1`. Ensures only the next expected message per aggregate is surfaced. `disable_inbox_ordering(inbox)` drops the ST + config row. **Mutually exclusive with `enable_inbox_priority()`** — returns `InboxOrderingPriorityConflict` if priority is already enabled on this inbox (and vice versa). | 1.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B.2–B.3 |
+| INBOX-B2 | **Gap detection stream table + alert.** `gaps_<inbox>` ST uses a `LEAD()` window function (O(N log N)) to detect missing sequence numbers by comparing adjacent sequences in the pending-only messages. Uses `FULL` refresh mode (contains `now()` in `gap_age_sec`). Emits `pg_trickle_alert` event `inbox_ordering_gap` when new gaps appear. `inbox_ordering_gaps(inbox_name)` SQL function for ad-hoc inspection. 30 s refresh schedule. Scales to 1M+ pending messages without the O(sequence_range) blowup of `generate_series`. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B.4 |
+| INBOX-B3 | **`enable_inbox_priority()` + tier-based stream tables.** `pgt_inbox_priority_config` catalog table. `enable_inbox_priority(inbox, priority_col, tiers JSONB)` creates one `pending_<inbox>_<tier>` ST per priority tier with per-tier `schedule` and `WHERE priority BETWEEN min AND max`. Default 3 tiers: critical (1–2, 1 s), normal (3–6, 5 s), background (7–9, 30 s). Original `pending_<inbox>` preserved as unified view. `disable_inbox_priority(inbox, if_exists)` drops all tier STs + config row; original unified `pending_<inbox>` is restored. | 1d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B.5 |
+| INBOX-B4 | **`inbox_is_my_partition()` helper.** Boolean-returning SQL function with signature `inbox_is_my_partition(aggregate_id TEXT, worker_id INT, total_workers INT) RETURNS BOOLEAN`. Evaluates `abs(hashtext(aggregate_id)) % total_workers = worker_id` inline in the WHERE clause. Advisory only — workers can still process any message; the condition makes each worker prefer its subset for cache locality. Composable with prepared statements and ORMs without SQL string interpolation. Documented in PATTERNS.md with Python + SQL usage example. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B.6 |
+| INBOX-B5 | **Tests.** Integration: ordered ST surfaces only next-sequence messages; out-of-order arrivals withheld until preceding sequence processed; gap detection fires alert after configurable delay; priority tier routing; partition affinity correctness (no messages lost). Benchmark gate: `gaps_<inbox>` ST refresh at 1M messages across 10K aggregates must complete in < 1 s at 30 s schedule (uses `LEAD()` window function; O(N log N) not O(sequence_range)). Chaos: processor crash mid-processing + replay recovery; concurrent processors with `FOR UPDATE SKIP LOCKED` (no duplicate processing at 10 concurrent workers). | 1.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §D |
+| INBOX-B6 | **Documentation & examples.** SQL_REFERENCE.md: ordering + priority API. CONFIGURATION.md: ordering GUCs. PATTERNS.md: per-aggregate ordering, gap recovery, priority queue, and competing workers with partition affinity sections. Reference `examples/inbox/inbox_processor_ordered.py`. | 0.5d | [PLAN_TRANSACTIONAL_INBOX_HELPER.md](plans/patterns/PLAN_TRANSACTIONAL_INBOX_HELPER.md) §B, §C |
+
+> **Ordered processing subtotal: ~6 days**
+
+#### Shared Infrastructure (Part B)
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| SHARED-B1 | **Upgrade SQL additions.** Extend `sql/pg_trickle--0.23.0--0.24.0.sql`: create `pgt_consumer_groups`, `pgt_consumer_offsets`, `pgt_consumer_leases`, `pgt_inbox_ordering_config`, `pgt_inbox_priority_config` tables; register all Part B SQL functions. *(Note: `pgt_consumer_claim_check_acks` is created dynamically by `create_consumer_group()` at runtime, not in the upgrade script — it has no purpose without consumer groups.)* | 0.5d | — |
+| SHARED-B2 | **Advanced PATTERNS.md sections.** Add to "Event-Driven Integration Patterns" chapter: competing relays with consumer groups, ordered inbox processing end-to-end, priority queues (when to use), partition-affinity for high-throughput inboxes, claim-check large delta handling guide (when triggered, cursor consumption loop, `outbox_rows_consumed()`, interaction with `full_refresh` flag), latest-state consumer pattern (dedup view), and FULL-refresh fallback handling for relay authors. Note in PATTERNS.md: add Grafana dashboard panel recommendations for consumer lag (`pgt_consumer_group_lag` ST), DLQ growth rate (`dlq_<inbox>` ST), inbox pending backlog (`pending_<inbox>` ST), and inbox throughput (`stats_<inbox>` ST). | 0.5d | — |
+| SHARED-B3 | **Advanced E2E tests.** (1) Multi-relay group test: 3 relays share one outbox group, verify each row published exactly once, simulate relay crash + visibility timeout redelivery. (2) Ordered inbox test: publish 10 messages out-of-order per aggregate, verify processor receives them in sequence order. (3) Concurrent stress: 10 relay workers + 100K outbox rows; verify < 0.1% duplicate rate at broker. | 1d | — |
+| SHARED-B4 | **dbt adapter updates.** Add `outbox_enabled`, `consumer_group` and `inbox_config` properties to dbt model config; add `pgtrickle_outbox_config` and `pgtrickle_create_inbox` macros; update dbt-pgtrickle docs and integration tests. | 0.5d | [dbt-pgtrickle/AGENTS.md](dbt-pgtrickle/AGENTS.md) |
+
+> **Part B subtotal: ~17.5 days**
+
+---
+
+### Implementation Phases
+
+| Phase | Description | Duration |
+|-------|-------------|----------|
+| A-SHARED | Upgrade SQL, shared Part A catalog infrastructure | Day 1 |
+| A-OUTBOX | Outbox helper: catalog, table DDL, refresh-path hook, payload format, retention, lifecycle, GUCs | Days 1–5 |
+| A-INBOX | Inbox helper: catalog, table DDL, stream tables, `enable_inbox_tracking`, DLQ alerts, health, replay, retention, lifecycle, GUCs | Days 5–11 |
+| A-TEST | Part A integration tests, E2E pipeline test, benchmarks | Days 11–13 |
+| A-DOC | Part A documentation, PATTERNS.md guide, reference examples | Days 13–14 |
+| B-OUTBOX | Consumer groups: catalog, `poll_outbox`, `commit_offset`, `seek_offset`, heartbeat, monitoring STs, dead consumer cleanup, retention guard | Days 14–22 |
+| B-INBOX | Ordered processing: `enable_inbox_ordering`, gap detection, priority queues, worker partition helper | Days 22–28 |
+| B-TEST | Part B integration tests, multi-relay E2E, ordered inbox E2E | Days 28–31 |
+| B-DOC | Part B documentation, advanced PATTERNS.md sections, reference relay implementations | Days 31–33 |
+
+> **v0.29.0 total: ~6–7 weeks solo / ~4–5 weeks with two developers working Part A and Part B tracks in parallel** (Part A: essential patterns + Part B: production patterns)
+
+**Exit criteria:**
+- [ ] OUTBOX-1/2: `enable_outbox()` creates outbox table + `pgt_outbox_latest_<st>` view with correct schema; catalog row present
+- [ ] OUTBOX-1: `enable_outbox()` on IMMEDIATE-mode stream table returns `OutboxRequiresNotImmediateMode` with clear message
+- [ ] OUTBOX-2: Naming collision resolution: truncation + hex suffix tested end-to-end; final name stored in catalog
+- [ ] OUTBOX-3/CC: Initial load (first refresh, all rows as `"inserted"`) above `outbox_inline_threshold_rows` uses claim-check path; `outbox_delta_rows_<st>` populated atomically; no data loss
+- [ ] OUTBOX-3/CC: Bulk source update (many rows changed in one cycle) above threshold uses claim-check path; relay cursor returns all inserted + deleted rows correctly
+- [ ] OUTBOX-3: Refresh populates outbox payload within same transaction; rollback on outbox INSERT failure leaves no orphan delta rows
+- [ ] OUTBOX-4: Small deltas (≤ `outbox_inline_threshold_rows`) produce inline `{"v":1, "inserted":[…], "deleted":[…]}`; large deltas produce claim-check header `{"v":1, "claim_check": true, …}` with rows in `outbox_delta_rows_<st>`; relay cursor consumption + `outbox_rows_consumed()` documented + tested; no truncation path exists
+- [ ] OUTBOX-5: Retention drain removes rows older than `outbox_retention_hours`; respects batch size
+- [ ] OUTBOX-6: `drop_stream_table()` cascades to outbox + latest-row view; `outbox_status()` returns correct data
+- [ ] OUTBOX-7: Benchmark shows < 10 % overhead vs baseline at small payloads
+- [ ] INBOX-1/2: `create_inbox()` creates inbox table + 3 stream tables + metadata
+- [ ] INBOX-3: Pending ST reflects unprocessed messages; DLQ ST reflects poisoned messages
+- [ ] INBOX-4: `enable_inbox_tracking()` works with non-standard column names on existing tables
+- [ ] INBOX-5: `pg_trickle_alert` fires when new DLQ entries appear
+- [ ] INBOX-6: `inbox_health()` returns correct health status; `inbox_status()` lists all inboxes
+- [ ] INBOX-7: `replay_inbox_messages()` resets messages by explicit `event_ids` array (no `where_clause`); uses parameterised `WHERE event_id = ANY($1)` — no dynamic SQL; retention drain respects DLQ; processor crash + replay recovery path documented
+- [ ] INBOX-8: `drop_inbox(cascade := true)` drops managed table; preserves adopted tables
+- [ ] SHARED-3: End-to-end inbox → business logic → outbox pipeline test passes
+- [ ] SHARED-4: dbt adapter updated with `outbox_enabled` and `inbox_config` properties; integration tests pass
+- [ ] OUTBOX-B1: `create_consumer_group()` creates group + offset + lease tables; idempotent re-create
+- [ ] OUTBOX-3/4: FULL-refresh fallback writes `"full_refresh": true` in header; claim-check applies when row count exceeds `outbox_inline_threshold_rows`; reference relay handles all four combinations (inline/claim-check × differential/full-refresh) correctly
+- [ ] OUTBOX-B2: `poll_outbox()` returns correct batch; no overlap between concurrent relays; visibility timeout expires and row re-delivered
+- [ ] OUTBOX-B2a: `extend_lease()` extends visibility_until for all active consumer leases; re-delivery does not occur when relay calls extend_lease before timeout
+- [ ] OUTBOX-B3: `commit_offset()` advances monotonically; `seek_offset()` enables replay from any position
+- [ ] OUTBOX-B4: Heartbeat tracks liveness; `consumer_unhealthy` alert fires on timeout
+- [ ] OUTBOX-B5: Three monitoring STs (status/FULL, group lag/DIFFERENTIAL, active leases/FULL) created idempotently (second `create_consumer_group()` does not fail); refreshed correctly; dropped when last group is dropped (reference count reaches zero)
+- [ ] OUTBOX-B6: Dead relay reaped after `consumer_dead_threshold_hours` (default 24 h, configurable); leases released; `consumer_reaped` alert emitted
+- [ ] OUTBOX-B7: Retention drain respects `MIN(last_offset)`; `outbox_force_retention` override works
+- [ ] OUTBOX-B8: Multi-relay group E2E: each outbox row published exactly once across 3 concurrent relays
+- [ ] OUTBOX-B8b: Concurrent relay stress test: 10 relays, 100K outbox rows, < 0.1% duplicate rate before broker dedup; 0% after
+- [ ] INBOX-B1: `next_<inbox>` ST surfaces only next expected sequence per aggregate; withholds future sequences; partial index `(aggregate_id, sequence_num) WHERE processed_at IS NOT NULL` created by `enable_inbox_ordering()`
+- [ ] INBOX-B1: `enable_inbox_ordering()` + `enable_inbox_priority()` together returns `InboxOrderingPriorityConflict` with clear message
+- [ ] INBOX-B2: `gaps_<inbox>` ST detects missing sequences using `LEAD()` window function; `inbox_ordering_gap` alert fires; gap detection benchmark passes (< 1 s at 10K aggregates, 1M messages; O(N log N) not O(sequence_range))
+- [ ] INBOX-B3: Priority tier STs refresh at configured schedules; messages route to correct tier
+- [ ] INBOX-B3: `disable_inbox_priority()` drops all tier STs + config row; unified `pending_<inbox>` is restored
+- [ ] INBOX-B1: `disable_inbox_ordering()` drops `next_<inbox>` ST + config row; inbox resumes normal pending behaviour
+- [ ] INBOX-B4: `inbox_is_my_partition(aggregate_id, worker_id, total_workers)` returns BOOLEAN; no messages lost across N workers; usable in prepared statements without SQL interpolation
+- [ ] SHARED-B3: Ordered inbox E2E: 10 out-of-order arrivals per aggregate delivered to processor in order
+- [ ] SHARED-B4: dbt adapter updated with consumer group and inbox ordering properties
+- [ ] Extension upgrade path tested (`0.27.0 → 0.28.0`) — `sql/pg_trickle--0.27.0--0.28.0.sql` validated by `scripts/check_upgrade_completeness.sh`
+- [ ] `just check-version-sync` passes
+
+---
+
+## v0.30.0 — Relay CLI (`pgtrickle-relay`)
+
+**Status: Planned.** See [plans/relay/PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) for the full design.
+
+> **Release Theme**
+> This release ships `pgtrickle-relay` — a standalone bidirectional Rust CLI
+> binary that bridges pg-trickle outboxes and inboxes with popular messaging
+> systems. In **forward mode** it polls outbox tables and publishes deltas to
+> external sinks; in **reverse mode** it consumes messages from external
+> sources and writes them into pg-trickle inbox tables. Both directions share
+> symmetric Source/Sink trait abstractions, config system, observability, and
+> error handling. Implemented as a workspace member alongside `pgtrickle-tui`,
+> with 8 backends behind Cargo feature flags. The relay makes the v0.29.0
+> outbox and inbox immediately usable — zero custom relay code required.
+>
+> See [plans/relay/PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md)
+> for the full architecture, backend specifications, and phased implementation plan.
+
+### Phase 1 — Core Framework + Forward Tier 1 Sinks
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| RELAY-CAT | **Catalog schema + SQL API.** `sql/pg_trickle--0.23.0--0.24.0.sql`: create `pgtrickle.relay_outbox_config` + `pgtrickle.relay_inbox_config` tables, shared `relay_config_notify()` trigger (uses `TG_TABLE_NAME` to identify direction), and 7 `SECURITY DEFINER` SQL wrapper functions: `set_relay_outbox`, `set_relay_inbox`, `enable_relay`, `disable_relay`, `delete_relay`, `get_relay_config`, `list_relay_configs`. Functions validate required JSONB keys and raise clear exceptions. Direct table access is revoked from `pgtrickle_relay`; only `EXECUTE` on the API functions is granted — tables are an internal implementation detail. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.14 |
+| RELAY-1 | **Crate scaffold.** Workspace member `pgtrickle-relay/` with `Cargo.toml`, feature flags per backend, CLI parsing via `clap` (`--postgres-url`, `--metrics-addr`, `--log-format`, `--log-level`; no config subcommands — pipeline management is SQL-only), DB bootstrap (connect to PG, load `relay_outbox_config` + `relay_inbox_config`, `LISTEN pgtrickle_relay_config`), `RelayError` enum, `RelayMessage` envelope type. | 1.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.1–A.3, §A.7 |
+| RELAY-2 | **Source + Sink traits + relay loop.** `async trait Source` with `poll`/`acknowledge`, `async trait Sink` with `publish`/`is_healthy`. Generic relay loop composing any source with any sink via `CancellationToken`. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.4–A.6 |
+| RELAY-3 | **Outbox poller source.** Simple mode (offset tracked in memory) and consumer group mode (`poll_outbox()` + `commit_offset()`). Heartbeat background task. Lease renewal via `extend_lease()`. | 2d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.8 |
+| RELAY-4 | **Payload decoder.** All four modes: inline differential, inline full-refresh, claim-check differential, claim-check full-refresh. Server-side cursor for claim-check rows. `outbox_rows_consumed()` called after cursor consumption. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.9 |
+| RELAY-5 | **Sink: stdout/file.** `jsonl`, `json_pretty`, `csv` formats. File rotation. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.4 |
+| RELAY-6 | **Sink: NATS JetStream.** `async-nats`. Subject template. `Nats-Msg-Id` dedup header. `Pgtrickle-Full-Refresh` header. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.1 |
+| RELAY-7 | **Sink: HTTP webhook.** `reqwest`. Batch and per-event mode. `Idempotency-Key` header. Configurable timeout, custom headers, retry-on-status. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.2 |
+| RELAY-8 | **Sink: Apache Kafka.** `rdkafka`. Idempotent producer. Dedup key as record key. Topic template. Compression, acks, SASL/SSL. | 1.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.3 |
+| RELAY-9 | **Observability + shutdown.** `axum` at `:9090/metrics` + `GET /health`. Prometheus counters for both modes. SIGTERM/SIGINT graceful shutdown. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.11–A.12 |
+
+> **Phase 1 subtotal: ~10.5 days**
+
+### Phase 2 — Forward Tier 2 Sinks
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| RELAY-10 | **Sink: Redis Streams.** `redis` crate. `XADD` with `MAXLEN ~`. Stream key template. Dedup key field. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.5 |
+| RELAY-11 | **Sink: Amazon SQS.** `aws-sdk-sqs`. `SendMessageBatch`. `MessageDeduplicationId` for FIFO queues. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.6 |
+| RELAY-12 | **Sink: PostgreSQL inbox (remote).** `tokio-postgres`. Inserts into compatible inbox table on different PG. `ON CONFLICT (event_id) DO NOTHING`. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.7 |
+| RELAY-13 | **Sink: RabbitMQ AMQP.** `lapin`. Exchange + routing key template. `message-id` AMQP property. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §B.8 |
+| RELAY-14 | **Subject/topic routing templates.** Variables: `{stream_table}`, `{op}`, `{outbox_id}`, `{refresh_id}`. Per-event-type override map. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §A.3 |
+
+> **Phase 2 subtotal: ~5 days**
+
+### Phase 3 — Reverse Mode (Sources + Inbox Sink)
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| RELAY-22 | **Inbox sink.** pg-trickle inbox writer with batch insert, `ON CONFLICT (event_id) DO NOTHING`, dedup tracking metric, configurable column mapping. | 1.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §D |
+| RELAY-23 | **Source: NATS JetStream consumer.** Durable pull consumer, ack after inbox write. Dedup key from `Nats-Msg-Id` header or stream sequence. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.1 |
+| RELAY-24 | **Source: Apache Kafka consumer.** `rdkafka` `StreamConsumer`, manual offset commit after inbox write. Dedup key from record key or partition:offset. | 1.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.3 |
+| RELAY-25 | **Source: HTTP webhook receiver.** `axum` server, synchronous ack (200 after inbox write). Dedup key from `Idempotency-Key` header. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.2 |
+| RELAY-26 | **Source: Redis Streams consumer.** `XREADGROUP` + `XACK`. Dedup key from `pgt_dedup_key` field or entry ID. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.5 |
+| RELAY-27 | **Source: Amazon SQS consumer.** `ReceiveMessage` + `DeleteMessage`. Dedup key from `MessageDeduplicationId` (FIFO) or `MessageId`. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.6 |
+| RELAY-28 | **Source: RabbitMQ consumer.** `basic_consume` + manual ack/nack. Dedup key from `message-id` AMQP property. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.7 |
+| RELAY-29 | **Source: stdin/file reader.** JSONL format. Dedup key from `dedup_key` field or generated UUID. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §C.4 |
+| RELAY-30 | **Reverse-mode config.** Dedup key mapping, event type extraction, inbox column mapping. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §D |
+
+> **Phase 3 subtotal: ~10 days**
+
+### Phase 4 — Testing & Polish
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| RELAY-15 | **Unit tests.** Payload decoder (all 4 modes), config merging, subject templates, dedup key generation, retry backoff, envelope round-trip, mock source→sink. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.1 |
+| RELAY-16 | **Forward integration tests (Testcontainers).** NATS, Kafka (Redpanda), webhook (WireMock), Redis, PG inbox — end-to-end per sink with dedup verification. | 2d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.2 |
+| RELAY-17 | **Forward consumer group E2E.** 2 relay instances share one consumer group; zero duplicates; crash recovery; claim-check large delta. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.2 |
+| RELAY-31 | **Reverse integration tests (Testcontainers).** NATS→inbox, Kafka→inbox, webhook→inbox, Redis→inbox, SQS→inbox, RabbitMQ→inbox, stdin→inbox — dedup verification per source. | 2d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.3 |
+| RELAY-32 | **Reverse dedup + crash recovery E2E.** Duplicate messages produce 1 inbox row; kill relay mid-batch → restart → zero lost messages. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.3 |
+| RELAY-18 | **Benchmarks.** Forward + reverse throughput (100K events), latency p50/p95/p99, memory bounded during claim-check. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §E.4 |
+
+> **Phase 4 subtotal: ~7 days**
+
+### Phase 5 — Documentation & Distribution
+
+| Item | Description | Effort | Ref |
+|------|-------------|--------|-----|
+| RELAY-19 | **Documentation.** `pgtrickle-relay/README.md` quick start (forward + reverse). `docs/RELAY.md` comprehensive guide. `docs/PATTERNS.md` relay section with worked examples per backend. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §F.1 |
+| RELAY-20 | **Dockerfile + GitHub Actions.** Distroless container image `grove/pgtrickle-relay`. CI matrix: Linux amd64/arm64, macOS amd64/arm64. Pre-built binaries on GitHub Releases. | 1d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §F.2 |
+| RELAY-21 | **Release automation.** Docker Hub publish, Homebrew formula (`brew install grove/tap/pgtrickle-relay`), `cargo publish pgtrickle-relay`. | 0.5d | [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) §F.2 |
+
+> **Phase 5 subtotal: ~2.5 days**
+
+### Implementation Phases
+
+| Phase | Description | Duration |
+|-------|-------------|----------|
+| Phase 1 | Core framework: Source/Sink traits, outbox poller, payload decoder, NATS/webhook/Kafka sinks, metrics, shutdown | Days 1–10 |
+| Phase 2 | Tier 2 sinks: Redis, SQS, PG inbox, RabbitMQ + routing templates | Days 10–15 |
+| Phase 3 | Reverse mode: inbox sink, NATS/Kafka/webhook/Redis/SQS/RabbitMQ/stdin sources + reverse config | Days 15–25 |
+| Phase 4 | Tests: unit, Testcontainers integration (forward + reverse), consumer group E2E, benchmarks | Days 25–32 |
+| Phase 5 | Distribution: Docker, CI binaries, Homebrew, docs, cargo publish | Days 32–34.5 |
+
+> **v0.30.0 total: ~36.5 days solo / ~23 days with two developers**
+> (Phases 1–2 forward sinks and Phase 3 reverse sources can be parallelised.
+> Requires v0.29.0 outbox + consumer groups for full forward E2E; reverse
+> mode only needs inbox table schema.)
+
+**Exit criteria:**
+- [ ] RELAY-CAT: Migration `sql/pg_trickle--0.23.0--0.24.0.sql` creates `relay_outbox_config` + `relay_inbox_config` tables and `relay_config_notify()` trigger
+- [ ] RELAY-CAT: `set_relay_outbox()` validates `source_type = 'outbox'`; `set_relay_inbox()` validates `sink_type = 'pg-inbox'`; missing keys raise clear exception
+- [ ] RELAY-CAT: `enable_relay()`/`disable_relay()`/`delete_relay()` search both tables; raise exception on missing name
+- [ ] RELAY-CAT: `list_relay_configs()` returns all pipelines with `direction` column; `get_relay_config()` raises on missing name
+- [ ] RELAY-CAT: functions are `SECURITY DEFINER`; `pgtrickle_relay` role has no direct table access; `SELECT * FROM pgtrickle.relay_outbox_config` fails with permission denied for relay role
+- [ ] RELAY-1: `pgtrickle-relay` crate builds with `--features default` and `--features nats,webhook,kafka`
+- [ ] RELAY-2: Source + Sink traits compose correctly; relay loop runs with mock source/sink
+- [ ] RELAY-3: Simple mode polls and forwards events; consumer group mode uses `poll_outbox()` + `commit_offset()` correctly
+- [ ] RELAY-4: Inline payload decoded and published; claim-check cursor fetch returns all rows; `outbox_rows_consumed()` called; full-refresh flag triggers upsert semantics
+- [ ] RELAY-5: stdout/file backend writes valid JSONL; all 3 formats tested
+- [ ] RELAY-6: NATS E2E: relay publishes; consumer verifies dedup via `Nats-Msg-Id`
+- [ ] RELAY-7: Webhook E2E: relay POSTs batch; WireMock verifies `Idempotency-Key` header
+- [ ] RELAY-8: Kafka E2E: relay produces records; consumer group verifies zero duplicates
+- [ ] RELAY-9: `/metrics` returns valid Prometheus exposition; `/health` returns 200 healthy, 503 degraded
+- [ ] RELAY-10: Redis E2E: `XRANGE` returns all relayed events in order
+- [ ] RELAY-11: SQS E2E: `SendMessageBatch` used; FIFO dedup verified
+- [ ] RELAY-12: PG inbox E2E: events appear in target inbox; duplicate publish does not duplicate row
+- [ ] RELAY-13: RabbitMQ E2E: events delivered to bound queue; `message-id` property set
+- [ ] RELAY-14: Subject template `pgtrickle.{stream_table}.{op}` resolves correctly
+- [ ] RELAY-15: All unit tests pass
+- [ ] RELAY-16: All forward Testcontainers integration tests pass per sink
+- [ ] RELAY-17: Forward consumer group E2E: 2 relays, 0 duplicates; crash recovery verified
+- [ ] RELAY-18: Forward throughput > 10K events/sec inline → NATS; reverse throughput > 10K events/sec Kafka → inbox; memory bounded during claim-check
+- [ ] RELAY-19: `docs/RELAY.md` published; quick start covers forward + reverse with NATS, webhook, Kafka
+- [ ] RELAY-20: Docker image `grove/pgtrickle-relay:0.24.0` published; distroless < 50 MB
+- [ ] RELAY-21: `cargo install pgtrickle-relay` works; Homebrew formula passes `brew audit`
+- [ ] RELAY-22: Inbox sink writes events with `ON CONFLICT` dedup; batch insert verified
+- [ ] RELAY-23: NATS→inbox E2E: durable consumer delivers to inbox; ack only after write
+- [ ] RELAY-24: Kafka→inbox E2E: offset committed only after inbox write; crash recovery verified
+- [ ] RELAY-25: Webhook→inbox E2E: POST returns 200 only after inbox write
+- [ ] RELAY-26: Redis→inbox E2E: XACK sent only after inbox write
+- [ ] RELAY-27: SQS→inbox E2E: DeleteMessage after inbox write; visibility timeout re-poll verified
+- [ ] RELAY-28: RabbitMQ→inbox E2E: manual ack after inbox write; nack+requeue on failure
+- [ ] RELAY-29: stdin→inbox: piped JSONL arrives in inbox; dedup key extracted
+- [ ] RELAY-30: Reverse config: event type extraction + column mapping works
+- [ ] RELAY-31: All reverse Testcontainers integration tests pass per source
+- [ ] RELAY-32: Reverse dedup: duplicate source message produces 1 inbox row; crash recovery zero loss
+- [ ] Extension upgrade path tested (`0.28.0 → 0.29.0`)
 - [ ] `just check-version-sync` passes
 
 ---
@@ -7715,7 +7715,7 @@ forward-compatibility.
 > **Release Theme**
 > This release adds PostgreSQL 17 as a supported target alongside
 > PostgreSQL 18. PGlite is built on PostgreSQL 17, so this is a hard
-> prerequisite for the PGlite proof of concept (v0.28.0). The pgrx 0.17.x
+> prerequisite for the PGlite proof of concept (v0.29.0). The pgrx 0.17.x
 > framework already supports PG 17 — the work is enabling the feature flag,
 > adapting version-sensitive code paths, expanding the CI matrix, and
 > validating the full test suite against a PG 17 instance.
@@ -7818,7 +7818,7 @@ Low-hanging PostgreSQL feature opportunities identified in [plans/sql/PLAN_POSTG
 > simple patterns — single-table aggregates, two-table inner joins, and
 > filtered scans. It deliberately limits scope to 3–5 SQL patterns to
 > keep effort low while generating a concrete demand signal. If adoption
-> materialises, the full core extraction (v0.29.0) and WASM build (v0.30.0)
+> materialises, the full core extraction (v0.30.0) and WASM build (v0.28.0)
 > proceed. The main pg_trickle PostgreSQL extension ships no functional
 > changes in this release — only version bumps and upgrade migration
 > plumbing.
@@ -8042,7 +8042,7 @@ Dependencies: PGL-0-4. Schema change: No.
 
 > **In plain terms:** A clear table showing which SQL patterns are and are
 > not supported, what error you get for unsupported patterns, and when full
-> support is expected (v0.29.0). This prevents user frustration and sets
+> support is expected (v0.30.0). This prevents user frustration and sets
 > expectations.
 
 Verify: decision table in README and npm page lists all tested patterns with
@@ -8054,7 +8054,7 @@ Dependencies: None. Schema change: No.
 > **In plain terms:** Every error thrown by the plugin must include the
 > table name, the failing operation, and a one-sentence hint. Example:
 > `"LEFT JOIN is not supported in pglite-lite. Use @pgtrickle/pglite
-> (v0.29.0+) for full SQL support, or rewrite as INNER JOIN."` 
+> (v0.30.0+) for full SQL support, or rewrite as INNER JOIN."` 
 
 Verify: all error paths tested; every error message includes a remediation
 sentence.
@@ -8134,7 +8134,7 @@ Dependencies: PGL-0-4. Schema change: No.
 **TEST-5 — Extension upgrade path (0.18 to 0.19)**
 
 > **In plain terms:** The main pg_trickle PostgreSQL extension ships no
-> functional changes in v0.28.0, but the upgrade migration path must still
+> functional changes in v0.29.0, but the upgrade migration path must still
 > be tested. `ALTER EXTENSION pg_trickle UPDATE` from 0.26.0 to 0.27.0
 > must leave existing stream tables intact.
 
@@ -8146,10 +8146,10 @@ Dependencies: None. Schema change: No (PG extension unchanged).
 
 1. **Demand uncertainty is the primary risk.** This entire milestone is a bet
    that PGlite users want IVM beyond what pg_ivm provides. If Phase 0
-   generates no adoption signal, v0.29.0–v0.31.0 should be deprioritised and
+   generates no adoption signal, v0.30.0–v0.31.0 should be deprioritised and
    v1.0.0 proceeds without PGlite. Define a concrete adoption threshold
    (e.g., > 100 npm weekly downloads within 60 days of publication) as a
-   go/no-go gate for v0.28.0.
+   go/no-go gate for v0.29.0.
 
 2. **PGlite trigger infrastructure is unverified.** PGL-0-1 (trigger
    validation) is a hard prerequisite for everything else. If statement-level
@@ -8214,7 +8214,7 @@ Dependencies: None. Schema change: No (PG extension unchanged).
 > The extraction touches ~51,000 lines of code across 30+ source files but
 > produces zero user-visible behavior change: every existing test must pass
 > unchanged. The payoff is threefold: the core crate compiles to WASM
-> (enabling the PGlite extension in v0.29.0), pure-logic unit tests run
+> (enabling the PGlite extension in v0.30.0), pure-logic unit tests run
 > without a PostgreSQL instance (10x faster CI), and the main extension
 > gains a cleaner internal architecture. Approximately 500 unsafe blocks in
 > the parser require an abstraction layer over raw `pg_sys` node traversal,
@@ -8355,7 +8355,7 @@ Dependencies: PGL-1-1. Schema change: No.
 
 **STAB-4 — Extension upgrade path (0.19 to 0.20)**
 
-> **In plain terms:** v0.28.0 makes no SQL-visible changes (same functions,
+> **In plain terms:** v0.29.0 makes no SQL-visible changes (same functions,
 > same catalog schema), but the upgrade migration must still be tested.
 > `ALTER EXTENSION pg_trickle UPDATE` from 0.27.0 to 0.28.0 must leave
 > existing stream tables intact and refreshable.
@@ -8437,7 +8437,7 @@ Dependencies: PGL-1-1. Schema change: No.
 
 **SCAL-2 — Core crate binary size for WASM budget**
 
-> **In plain terms:** v0.29.0 targets < 2 MB WASM bundle. Measure the
+> **In plain terms:** v0.30.0 targets < 2 MB WASM bundle. Measure the
 > compiled size of `pg_trickle_core` for the WASM target now so the budget
 > is known before Phase 2. If > 5 MB, investigate `wasm-opt` stripping and
 > feature-gating large operator modules.
@@ -8568,8 +8568,8 @@ Dependencies: PGL-1-1. Schema change: No.
    item. If the abstraction proves too leaky (e.g., too many pg_sys node
    types to wrap), consider leaving `rewrites.rs` and `sublinks.rs` in the
    extension crate and extracting only operators + DAG + types to the core
-   crate. This reduces v0.28.0 scope but still delivers the WASM-compilable
-   operator engine for v0.29.0.
+   crate. This reduces v0.29.0 scope but still delivers the WASM-compilable
+   operator engine for v0.30.0.
 
 2. **PERF-1 must be validated before merging.** Introducing a
    `trait DatabaseBackend` could add vtable dispatch overhead on the hot
@@ -8636,7 +8636,7 @@ Dependencies: PGL-1-1. Schema change: No.
 > **Release Theme**
 > This release delivers the first working PGlite extension — the moment
 > pg_trickle's incremental view maintenance runs in the browser. By
-> wrapping `pg_trickle_core` (extracted in v0.28.0) in a thin C/FFI shim
+> wrapping `pg_trickle_core` (extracted in v0.29.0) in a thin C/FFI shim
 > and compiling to WASM via PGlite's Emscripten toolchain, we ship an npm
 > package (`@pgtrickle/pglite`) that gives PGlite users the full DVM
 > operator vocabulary — outer joins, window functions, subqueries,
@@ -8651,7 +8651,7 @@ Phase 2 for the full architecture.
 ### PGlite WASM Build (Phase 2)
 
 > **In plain terms:** This takes the `pg_trickle_core` crate extracted in
-> v0.28.0 and wraps it in a thin C shim that PGlite's Emscripten-based
+> v0.29.0 and wraps it in a thin C shim that PGlite's Emscripten-based
 > extension build system can compile to WASM. The result is a PGlite
 > extension package (`@pgtrickle/pglite`) that provides
 > `create_stream_table()`, `drop_stream_table()`, and `alter_stream_table()`
@@ -8782,7 +8782,7 @@ Dependencies: PGL-2-1, PGL-2-4. Schema change: No.
 
 **STAB-4 — Native extension upgrade path (0.27 → 0.28)**
 
-> **In plain terms:** v0.29.0 adds PGlite support but makes no SQL-visible
+> **In plain terms:** v0.30.0 adds PGlite support but makes no SQL-visible
 > changes to the native extension. The upgrade migration from 0.27.0 to
 > 0.28.0 must leave existing stream tables intact and refreshable.
 
@@ -9445,11 +9445,11 @@ Dependencies: PGL-3-4, PERF-1. Schema change: No.
 > `live.changes()` bridge emits the correct change events for INSERT,
 > UPDATE, and DELETE on the source table. Replay events into an
 > accumulator and assert it matches `SELECT * FROM stream_table`. This
-> extends v0.29.0 TEST-1 (operator E2E) by adding the reactive layer.
+> extends v0.30.0 TEST-1 (operator E2E) by adding the reactive layer.
 
 Verify: ≥ 69 tests (23 operators × 3 DML types). Accumulator matches
 `SELECT *` for every test case.
-Dependencies: PGL-3-1, v0.29.0 TEST-1. Schema change: No.
+Dependencies: PGL-3-1, v0.30.0 TEST-1. Schema change: No.
 
 **TEST-2 — React hook lifecycle tests**
 
@@ -9502,7 +9502,7 @@ Dependencies: STAB-1, PGL-3-2. Schema change: No.
    relatively new and its event format may change between PGlite releases.
    Pin the PGlite version and add an adapter layer so the bridge can
    accommodate event format changes without rewriting the React/Vue hooks.
-   If PGlite deprecates `live.changes()` before v0.30.0 ships, fall back
+   If PGlite deprecates `live.changes()` before v0.28.0 ships, fall back
    to `LISTEN/NOTIFY` with a custom channel.
 
 2. **CORR-2 (batch atomicity) and PERF-2 (single re-render) are coupled.**
@@ -9529,7 +9529,7 @@ Dependencies: STAB-1, PGL-3-2. Schema change: No.
    and scope it to documentation + a proof-of-concept, not production-grade
    support.
 
-6. **No native extension changes in v0.30.0.** This release is entirely
+6. **No native extension changes in v0.28.0.** This release is entirely
    in the TypeScript/npm layer. Any temptation to add native features
    (e.g., `LISTEN/NOTIFY` bridge, WebSocket push) should be deferred to
    post-1.0. Keep the scope tight: reactive bindings + examples + docs.
@@ -9698,7 +9698,7 @@ TUI/CLI visualization enhancement for the self-monitoring views. Recommended fro
 > is paid once per source per cycle; plan-aware delta routing selects
 > `merge_strategy` per-refresh from `EXPLAIN ANALYZE` output instead of
 > requiring per-stream-table tuning; and the L0 shared-shmem dshash cache
-> (if not completed in v0.30.0) finishes the three-tier caching story by
+> (if not completed in v0.28.0) finishes the three-tier caching story by
 > placing hot delta SQL in shared memory, making cold backends
 > indistinguishable from warm ones. Each improvement is independently
 > deployable and hidden behind a GUC, so operators can adopt them
@@ -9714,7 +9714,7 @@ TUI/CLI visualization enhancement for the self-monitoring views. Recommended fro
 | PERF-2 | Plan-aware delta routing: auto-select `merge_strategy` | M | P1 |
 | PERF-3 | IVM lock-mode observability counter | XS | P1 |
 | PERF-4 | Switch IVM transition tables to ENR (drop temp tables) | M | P1 |
-| PERF-5 | L0 dshash shared-shmem cache (if deferred from v0.30.0) | L | P1 |
+| PERF-5 | L0 dshash shared-shmem cache (if deferred from v0.28.0) | L | P1 |
 
 **PERF-1 — Adaptive batching.**
 The scheduler currently dispatches each ready stream table independently.
@@ -9760,7 +9760,7 @@ Rewrite the trigger function builders to reference the ENR by name.
 |----|-------|--------|----------|
 | SCAL-1 | Back-pressure signal when change buffer exceeds threshold | S | P2 |
 | SCAL-2 | Multi-DB singleton refresh broker concept (design only) | S | P2 |
-| SCAL-3 | Shared catalog snapshot for `metrics_summary()` / `cluster_worker_summary()` (if deferred from v0.30.0) | M | P2 |
+| SCAL-3 | Shared catalog snapshot for `metrics_summary()` / `cluster_worker_summary()` (if deferred from v0.28.0) | M | P2 |
 
 **SCAL-1** — Expose a `pgtrickle_alert change_buffer_backpressure` event
 when a change buffer grows past `pg_trickle.buffer_alert_threshold` for
@@ -9843,7 +9843,7 @@ table listener: after every successful differential or full refresh, if the
 delta is non-empty, the refresh path emits `pg_notify(channel, payload_jsonb::text)`
 within the same transaction. The payload carries `{"name": …, "refresh_id": …,
 "inserted_count": N, "deleted_count": N}`. Build on the `pg_notify`
-infrastructure already wired by the v0.28.0 outbox. `pgtrickle.unsubscribe(name, channel)`
+infrastructure already wired by the v0.29.0 outbox. `pgtrickle.unsubscribe(name, channel)`
 removes the registration; `pgtrickle.list_subscriptions()` returns all active
 registrations. **Schema change:** Yes — new `pgtrickle.pgt_subscriptions`
 catalog table.

--- a/plans/PLAN_OVERALL_ASSESSMENT_3.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT_3.md
@@ -1,0 +1,1048 @@
+# pg_trickle — Overall Project Assessment v3
+
+> **Status:** Draft (review-ready)
+> **Type:** Audit / project-wide gap analysis
+> **Last updated:** 2026-04-22
+> **Scope:** Branch `feat/v0.27.0`, codebase as of v0.27.0 (released
+> 2026-04-21). Compares v0.27.0 against the two prior assessments.
+> **Target audience:** Maintainers, release managers, and senior contributors
+> planning v0.28.0 → v1.0.0.
+> **Sibling documents:**
+> - [PLAN_OVERALL_ASSESSMENT.md](PLAN_OVERALL_ASSESSMENT.md) — v0.20.0 baseline
+> - [PLAN_OVERALL_ASSESSMENT_2.md](PLAN_OVERALL_ASSESSMENT_2.md) — v0.23.0
+>   follow-up
+> - [ROADMAP.md](../ROADMAP.md) — current release roadmap
+> - [plans/PLAN.md](PLAN.md) — overall design plan
+> - [AGENTS.md](../AGENTS.md) — engineering conventions
+
+---
+
+## Executive Summary
+
+pg_trickle has matured substantially since v0.23.0. The architectural
+re-shaping promised in the previous assessment (`refresh.rs` decomposition,
+shared-memory lock split, CDC `unwrap()` removal, snapshot/PITR API,
+predictive schedule planner, cluster-wide observability) has shipped. The
+codebase is now organised into purposeful sub-modules
+([`refresh/mod.rs`](../src/refresh/mod.rs) is a 187-line shim, with
+`orchestrator.rs`/`codegen.rs`/`merge.rs`/`phd1.rs` carrying the weight); the
+old `PGS_STATE` mega-lock has been split into three dedicated `PgLwLock`s
+(`SCHEDULER_META_STATE`, `TICK_WATERMARK_STATE`); CDC error paths now produce
+typed `PgTrickleError::ChangedColsBitmaskFailed` instead of panicking; and a
+two-tier template cache (L1 thread-local + L2 catalog table
+`pgtrickle.pgt_template_cache`) backs cross-backend reuse. The pgrx 0.18
+upgrade landed without an extension-version bump, the SNAP/PLAN/CLUS/METR
+families ship with SQL surface, and OpenMetrics now emits `db_oid` / `db_name`
+labels for cluster-wide Prometheus aggregation.
+
+The remaining risks are concentrated in five areas. **(1)** EC-01 is **still
+incomplete** in production: the v0.24.0 “PKs are immutable, so hash hashes
+match” fix at [`src/dvm/operators/join.rs:220-260`](../src/dvm/operators/join.rs)
+is sound for INNER joins on stable PKs, but `is_deduplicated: false` at
+[`src/dvm/operators/join.rs:657-668`](../src/dvm/operators/join.rs) means the
+MERGE pipeline still groups by row-id, and repo memory
+(`/memories/repo/join-delta-phantom-rows.md`) confirms `test_tpch_q07_*` and
+the IMMEDIATE-mode property tests still occasionally drift; PH-D1 cross-cycle
+cleanup ([`src/refresh/phd1.rs`](../src/refresh/phd1.rs)) is opt-in per cycle
+and not always invoked. **(2)** `snapshot_stream_table` /
+`restore_from_snapshot`
+([`src/api/snapshot.rs`](../src/api/snapshot.rs)) are **not transaction
+bracketed** — the `CREATE TABLE AS` and the catalog `INSERT INTO
+pgtrickle.pgt_snapshots` are independent statements, so a backend crash
+between them leaves orphan tables; `restore_from_snapshot` issues a
+non-locked `TRUNCATE` followed by an unguarded bulk `INSERT`, so concurrent
+writers see partial state. **(3)** The `IVM_DELTA_CACHE` thread-local
+HashMap in [`src/ivm.rs`](../src/ivm.rs) has **no eviction policy**, growing
+unbounded per backend in IMMEDIATE-mode workloads with churn. **(4)**
+`classify_spi_error_retryable` ([`src/error.rs`](../src/error.rs)) still
+relies on **English-text pattern matching** (no SQLSTATE inspection) and
+will misclassify localised Postgres builds. **(5)** The L2 template-cache
+catalog table has no size cap, no LRU/age eviction; over the lifetime of a
+high-DDL deployment it grows unbounded.
+
+The top three opportunities for v0.28.0+ are **(1)** completing the
+shared-memory dshash L0 template cache (today only the
+`L0_POPULATED_VERSION` signal is wired — see
+[`src/shmem.rs:680-710`](../src/shmem.rs)); **(2)** building the reactive
+subscription primitive that v0.27.0's publication infrastructure now makes
+trivially achievable; and **(3)** starting the PGlite/WASM port investment
+ahead of the v1.4 milestone, since the recently-cleaned core (no more giant
+`refresh.rs`, no more lock megastruct) is finally ready to be carved out.
+
+The overall project has moved decisively from “experimental extension” to
+“production-ready streaming engine for PostgreSQL 18”. The remaining gaps
+are well-bounded. If the P0/P1 items in §11 land before v0.30.0, the
+project is on track for a credible v1.0 GA.
+
+---
+
+## Table of Contents
+
+1. [Method & Scope](#1-method--scope)
+2. [What Has Improved Since v0.23.0](#2-what-has-improved-since-v0230)
+3. [Critical Bugs](#3-critical-bugs)
+4. [Architecture Gaps](#4-architecture-gaps)
+5. [Performance](#5-performance)
+6. [Security](#6-security-owasp-mapped)
+7. [Test Coverage Gaps](#7-test-coverage-gaps)
+8. [Documentation Gaps](#8-documentation-gaps)
+9. [Operational / Ecosystem](#9-operational--ecosystem)
+10. [Recommended New Features](#10-recommended-new-features)
+11. [Prioritised Action Plan](#11-prioritised-action-plan)
+12. [Risk Register](#12-risk-register)
+13. [Appendix A — Unsafe Block Inventory](#appendix-a--unsafe-block-inventory)
+14. [Appendix B — Undocumented SQL Functions](#appendix-b--undocumented-sql-functions)
+15. [Appendix C — Undocumented GUCs](#appendix-c--undocumented-gucs)
+
+---
+
+## 1. Method & Scope
+
+This assessment was produced by a single audit pass over the
+`feat/v0.27.0` branch (head as of 2026-04-22) using a combination of
+file-level read passes, targeted `grep` queries, and inspection of
+`docs/`, `plans/`, `cnpg/`, `dbt-pgtrickle/`, `benches/`, `fuzz/` and
+`tests/`.
+
+### 1.1 Inputs
+
+- The two prior assessments
+  ([PLAN_OVERALL_ASSESSMENT.md](PLAN_OVERALL_ASSESSMENT.md),
+  [PLAN_OVERALL_ASSESSMENT_2.md](PLAN_OVERALL_ASSESSMENT_2.md)) — used to
+  identify which findings persisted, which were resolved, and which
+  regressed.
+- The CHANGELOG ([CHANGELOG.md](../CHANGELOG.md)) — top sections covering
+  v0.24.0 through v0.27.0 inclusive.
+- Repo-scoped memory files
+  (`/memories/repo/df-cdc-buffer-trends-fix.md`,
+  `/memories/repo/join-delta-phantom-rows.md`,
+  `/memories/repo/tpch-dvm-scaling-analysis.md`) — to anchor any “fixed?”
+  claims against actual recent debugging history.
+- The roadmap ([ROADMAP.md](../ROADMAP.md)).
+- The migration script
+  [`sql/pg_trickle--0.26.0--0.27.0.sql`](../sql/pg_trickle--0.26.0--0.27.0.sql).
+- Source files; the largest examined include
+  [`src/scheduler.rs`](../src/scheduler.rs) (7,392 LOC),
+  [`src/dvm/parser/sublinks.rs`](../src/dvm/parser/sublinks.rs) (6,485 LOC),
+  [`src/api/mod.rs`](../src/api/mod.rs) (6,127 LOC),
+  [`src/dvm/parser/rewrites.rs`](../src/dvm/parser/rewrites.rs) (6,104 LOC),
+  [`src/dvm/parser/mod.rs`](../src/dvm/parser/mod.rs) (5,526 LOC),
+  [`src/dvm/operators/aggregate.rs`](../src/dvm/operators/aggregate.rs) (5,399 LOC),
+  [`src/dag.rs`](../src/dag.rs) (4,295 LOC),
+  [`src/dvm/operators/recursive_cte.rs`](../src/dvm/operators/recursive_cte.rs) (4,043 LOC),
+  [`src/cdc.rs`](../src/cdc.rs) (3,970 LOC),
+  [`src/monitor.rs`](../src/monitor.rs) (3,633 LOC),
+  [`src/refresh/merge.rs`](../src/refresh/merge.rs) (3,393 LOC),
+  [`src/config.rs`](../src/config.rs) (3,270 LOC),
+  [`src/catalog.rs`](../src/catalog.rs) (3,135 LOC),
+  [`src/dvm/parser/types.rs`](../src/dvm/parser/types.rs) (3,082 LOC),
+  [`src/refresh/codegen.rs`](../src/refresh/codegen.rs) (2,383 LOC),
+  [`src/wal_decoder.rs`](../src/wal_decoder.rs) (2,118 LOC),
+  [`src/diagnostics.rs`](../src/diagnostics.rs) (2,049 LOC),
+  [`src/hooks.rs`](../src/hooks.rs) (1,961 LOC),
+  [`src/ivm.rs`](../src/ivm.rs) (1,414 LOC),
+  [`src/dvm/parser/validation.rs`](../src/dvm/parser/validation.rs) (1,177 LOC),
+  [`src/shmem.rs`](../src/shmem.rs) (1,079 LOC),
+  [`src/dvm/diff.rs`](../src/dvm/diff.rs) (1,057 LOC),
+  [`src/api/snapshot.rs`](../src/api/snapshot.rs) (440 LOC),
+  [`src/refresh/orchestrator.rs`](../src/refresh/orchestrator.rs) (404 LOC),
+  [`src/api/planner.rs`](../src/api/planner.rs) (341 LOC),
+  [`src/api/cluster.rs`](../src/api/cluster.rs) (153 LOC),
+  [`src/template_cache.rs`](../src/template_cache.rs) (158 LOC),
+  [`src/refresh/mod.rs`](../src/refresh/mod.rs) (187 LOC),
+  [`src/refresh/phd1.rs`](../src/refresh/phd1.rs) (108 LOC).
+- Documentation: `docs/` (29 files), `cnpg/` manifests, `dbt-pgtrickle/`
+  subproject.
+- Benchmark inventory: [`benches/diff_operators.rs`](../benches/diff_operators.rs),
+  [`benches/refresh_bench.rs`](../benches/refresh_bench.rs),
+  [`benches/scheduler_bench.rs`](../benches/scheduler_bench.rs).
+- Fuzz inventory: [`fuzz/fuzz_targets/`](../fuzz/fuzz_targets/) — `cdc_fuzz`,
+  `cron_fuzz`, `guc_fuzz`, `parser_fuzz`.
+
+### 1.2 Method
+
+For every finding I cite a file path and a line number, and where possible
+quote a few characters of context. I do **not** reproduce findings already
+resolved in v0.24.0–v0.27.0; those go into §2 instead. I have made no source
+modifications during this audit. Where this assessment disagrees with the
+ROADMAP about whether something is delivered, the source code wins.
+
+### 1.3 Out of scope
+
+- Performance microbenchmarks (numbers reported in §5 are existing CHANGELOG
+  numbers, not reproduced).
+- Patent / IP review — already covered in `src/cdc.rs` prior-art note.
+- Detailed dbt-pgtrickle macro audit — covered separately by
+  [dbt-pgtrickle/AGENTS.md](../dbt-pgtrickle/AGENTS.md) and
+  [plans/dbt/](dbt/).
+- Marketing / website assets.
+- Deep TUI ([pgtrickle-tui/](../pgtrickle-tui/)) audit beyond noting parity
+  gaps with the new SNAP/PLAN/CLUS/METR functions.
+
+---
+
+## 2. What Has Improved Since v0.23.0
+
+The single most important change since the previous assessment is that
+**the architecture is no longer the dominant risk**. The structural
+liabilities flagged in
+[PLAN_OVERALL_ASSESSMENT_2.md](PLAN_OVERALL_ASSESSMENT_2.md) — the 5,400-line
+`refresh.rs`, the single mega-lock `PGS_STATE`, the panicking CDC code path,
+the missing snapshot story, the missing predictive scheduling story, the
+fragmented per-database observability — have all been addressed in some
+form. The table below maps each item from the v0.23 assessment to its
+current state.
+
+| v0.23 finding | Identifier | Current state (v0.27.0) | Evidence |
+|---|---|---|---|
+| `refresh.rs` is 5,400 LOC, dominates change risk | ARCH-1B | **Resolved.** Split into `mod.rs` (187 LOC re-export shim), `orchestrator.rs` (404), `codegen.rs` (2,383), `merge.rs` (3,393), `phd1.rs` (108). | [`src/refresh/mod.rs:1-30`](../src/refresh/mod.rs) |
+| `PGS_STATE` PgLwLock guards everything | SCAL-3 | **Resolved.** Three locks: `PGS_STATE` (DAG state), `SCHEDULER_META_STATE` (PID/wake), `TICK_WATERMARK_STATE` (xmin/safe LSN). | [`src/shmem.rs:100-118`](../src/shmem.rs) |
+| Two `unwrap()`s in `cdc.rs` changed-cols bitmask path | CDC-1 | **Resolved.** New typed variant `ChangedColsBitmaskFailed(String)` propagates instead. | [`src/error.rs:127-131`](../src/error.rs) and [`src/error.rs:147-152`](../src/error.rs) (variant) |
+| Partitioned source publication rebuild fragile | CDC-2 | **Resolved.** Typed `PublicationRebuildFailed` variant + `PublicationRebuildFailed` error path in `src/api/mod.rs:421`. | [`src/error.rs:153-156`](../src/error.rs) |
+| Refresh history retention unbounded | OBS-1 | **Resolved.** `pg_trickle.history_retention_days` GUC + scheduler auto-prune. | [`docs/CONFIGURATION.md`](../docs/CONFIGURATION.md) (TOC entry “History & Retention”) |
+| TOAST-aware change-buffer durability missing | DUR-1 | **Resolved.** `change_buffer_durability` GUC with `unlogged|logged|sync`. | [`docs/CONFIGURATION.md`](../docs/CONFIGURATION.md) Guardrails section |
+| Predictive cost-model has no warm-up / outlier guard | PRED-1 | **Resolved.** v0.25 60s warmup + outlier removal. | [`src/refresh/orchestrator.rs:160-260`](../src/refresh/orchestrator.rs) `query_refresh_history_stats` requires ≥3 differential and ≥1 full sample. |
+| Subscriber LSN tracking absent | SUB-1 | **Resolved.** Tracking shipped v0.25; surfaced via `pgtrickle.pgt_status()`. | (CHANGELOG v0.25.0) |
+| Frontier two-phase commit missing | FRONT-1 | **Resolved.** `change_buffer_durability=logged|sync` enables tentative→finalize commit. | (CHANGELOG v0.24.0) |
+| L1 template cache only — cold backends pay 45 ms | CACHE-1 | **Partially resolved.** L2 catalog cache shipped (`pgtrickle.pgt_template_cache`); L0 dshash signal exists but the actual shared-memory data structure is **not** populated. | [`src/template_cache.rs:1-159`](../src/template_cache.rs); [`src/shmem.rs:680-710`](../src/shmem.rs) |
+| `template_cache_max_entries` LRU not enforced | CACHE-2 | **Resolved for L1.** GUC honoured by thread-local cache. **Not enforced for L2** (catalog table grows unbounded). | (See §3.5 below.) |
+| No per-database Prometheus labels | OBS-CLUS | **Resolved.** v0.27.0 CLUS-2 — every metric tagged `db_oid`/`db_name`. | [`docs/integrations/multi-tenant.md`](../docs/integrations/multi-tenant.md) |
+| No snapshot/PITR API | SNAP | **Resolved (initial).** `snapshot_stream_table`, `restore_from_snapshot`, `list_snapshots`, `drop_snapshot` shipped. **But — see §3.2 for atomicity bug.** | [`src/api/snapshot.rs`](../src/api/snapshot.rs) |
+| No predictive scheduler hint | PLAN | **Resolved.** `recommend_schedule` and `schedule_recommendations` SQL functions shipped. | [`src/api/planner.rs`](../src/api/planner.rs); [`sql/pg_trickle--0.26.0--0.27.0.sql:104-130`](../sql/pg_trickle--0.26.0--0.27.0.sql) |
+| No cluster-wide worker visibility | CLUS-1 | **Resolved.** `pgtrickle.cluster_worker_summary()` reads from shmem + `pg_stat_activity`. | [`src/api/cluster.rs`](../src/api/cluster.rs) |
+| No metrics_summary aggregation | METR-3 | **Resolved.** `pgtrickle.metrics_summary()` shipped. | [`src/api/metrics_ext.rs`](../src/api/metrics_ext.rs) |
+| pgrx 0.17 vendor lock | DEP-1 | **Resolved.** `Cargo.toml` is now pgrx 0.18.0 across the workspace, including [pgtrickle-tui/](../pgtrickle-tui/) and [fuzz/](../fuzz/). | [`Cargo.toml`](../Cargo.toml) |
+| Recursion in DVM parser unbounded | G13-SD | **Resolved.** `cte_ctx.descend()/ascend()` enforced via `pg_trickle.max_parse_depth` GUC; rejection emits `QueryTooComplex`. | [`src/dvm/parser/mod.rs`](../src/dvm/parser/mod.rs) (called in `parse_select_stmt`, `parse_set_operation`, `parse_from_item`); [`src/error.rs:65-67`](../src/error.rs) |
+| `lib.rs` not denying clippy::unwrap_used in non-test | SAF-3 | **Resolved.** [`src/lib.rs:23`](../src/lib.rs) sets `#![cfg_attr(not(test), deny(clippy::unwrap_used))]`. |
+| SCC `.unwrap()` in tarjan algorithm | DAG-PANIC | **Mitigated.** Three `.unwrap()` sites at [`src/dag.rs:1093, 1100, 1112`](../src/dag.rs) carry explicit `nosemgrep` justifications referencing the SCC invariant. Sound but worth a final audit. |
+| Per-DB IVM memory leak risk (early v0.23 IVM) | IVM-1 | **Partially resolved.** IVM lock-mode parser now defaults to `Exclusive` on parse failure (correct, fail-closed); but the `IVM_DELTA_CACHE` is **still unbounded** (see §3.3). | [`src/ivm.rs:48-91`](../src/ivm.rs) lock mode; [`src/ivm.rs:107-143`](../src/ivm.rs) cache |
+
+In addition, the v0.27.0 release ships several improvements not flagged in
+the v0.23 assessment:
+
+- **Statement-level CDC triggers** with `REFERENCING NEW/OLD TABLE`
+  ([`src/cdc.rs:124-219`](../src/cdc.rs)) — gives the “50–80% less write
+  overhead for bulk DML” claim its production teeth.
+- **INSERT-only CORR-4 invariant** for `pgt_refresh_history` enforced at
+  [`src/cdc.rs:71-83`](../src/cdc.rs) — prevents UPDATE/DELETE CDC trigger
+  registration on the audit table itself.
+- **`pg_current_wal_insert_lsn()`** documented as the **only** WAL position
+  function used by CDC ([`src/cdc.rs:104-114`](../src/cdc.rs)) — eliminates
+  the silent-no-op refresh class of bug.
+- **Sub-transaction RAII helper** ([`src/scheduler.rs:250-308`](../src/scheduler.rs))
+  with auto-rollback on `Drop` — replaces ad-hoc
+  `BeginInternalSubTransaction` / `RollbackAndReleaseCurrentSubTransaction`
+  pairs and gives panic-safe per-job isolation.
+- **Cross-cycle PH-D1 phantom cleanup** ([`src/refresh/phd1.rs:34-100`](../src/refresh/phd1.rs))
+  — anti-join `NOT EXISTS` against the full-refresh result, batched.
+
+The rest of this document focuses on what *remains* to do.
+
+---
+
+## 3. Critical Bugs
+
+This section enumerates issues that should block a v1.0 release. Each is
+classified P0 (must fix before v0.30.0), P1 (must fix before v1.0), or P2
+(should fix before v1.0 but workarounds exist).
+
+### 3.1 EC-01 phantom rows still drift in production tests *(P0)*
+
+**Where:** [`src/dvm/operators/join.rs:220-260`](../src/dvm/operators/join.rs)
+(Part 1a/1b hash formula); [`src/dvm/operators/join.rs:657-668`](../src/dvm/operators/join.rs)
+(`is_deduplicated: false`); cross-cycle cleanup in
+[`src/refresh/phd1.rs:34-99`](../src/refresh/phd1.rs).
+
+The v0.24.0 fix made Part 1a (`ΔL_I ⋈ R₁`) and Part 1b (`ΔL_D ⋈ R₀`) emit
+the same `__pgt_row_id` for the same logical row by always hashing
+`(left_pks, right_pks)`. The premise — that PKs are immutable — is correct
+in the steady state, but the surrounding pipeline still emits
+`is_deduplicated: false` (line 668), forcing the MERGE to aggregate by row
+id. The repository memory note in
+[`/memories/repo/join-delta-phantom-rows.md`](/memories/repo/join-delta-phantom-rows.md)
+records that `test_tpch_q07_ec01b_combined_delete` and
+`test_tpch_immediate_correctness` continue to flake with one or two
+phantom rows when an insert-then-delete pair on the left collides with a
+delete on the right within the same cycle. PH-D1 cross-cycle cleanup
+([`src/refresh/phd1.rs:34`](../src/refresh/phd1.rs))
+is **opt-in** per refresh and is not invoked by the default code path; the
+caller is supposed to invoke it conditionally when prior refresh reported
+non-zero phantom residuals (see comments at
+[`src/refresh/phd1.rs:18-32`](../src/refresh/phd1.rs)), but as of v0.27.0
+the wiring that actually flips this conditional is incomplete.
+
+**Risk:** Stream tables with multi-table joins can accumulate spurious rows
+across cycles, causing `UNIQUE_VIOLATION` in the soak test
+(`tests/e2e_soak_*`) and incorrect business metrics in production. This is
+the single highest-priority correctness defect remaining.
+
+**Recommendation:** Either (a) prove convergence by routing all cycles
+through unconditional PH-D1 cleanup with a small batch size, or (b)
+re-engineer Part 2 to derive its row-id from the *retained* base-table
+key snapshot rather than mixing pre- and post-image hashes. Option (a) is
+cheap in CPU and safe; option (b) is the principled fix and would let
+`is_deduplicated: true` flip on for INNER joins.
+
+### 3.2 Snapshot/restore is not atomic *(P0)*
+
+**Where:** [`src/api/snapshot.rs:90-180`](../src/api/snapshot.rs)
+(`snapshot_stream_table_impl`); [`src/api/snapshot.rs:200-260`](../src/api/snapshot.rs)
+(`restore_from_snapshot_impl`).
+
+The implementation runs three separate statements without bracketing:
+
+1. `CREATE TABLE … AS SELECT *, $1, $2, now() FROM <storage>` — the
+   archival table.
+2. `INSERT INTO pgtrickle.pgt_snapshots …` — the catalog row tracking the
+   snapshot.
+3. (Restore path) `TRUNCATE <storage>` followed by `INSERT INTO <storage>
+   SELECT * EXCEPT(...) FROM <source>` followed by `UPDATE
+   pgtrickle.pgt_stream_tables SET frontier=…`.
+
+**Failure modes:**
+
+- *Snapshot path:* If the connection dies between (1) and (2), the
+  archival table exists but has **no catalog row** —
+  `pgtrickle.list_snapshots()` won't find it, but it still consumes
+  storage. Worse, a future snapshot with the same auto-generated name
+  (very unlikely given the millisecond-epoch suffix, but possible across
+  clock skew) returns `SnapshotAlreadyExists` from
+  [`src/api/snapshot.rs:113`](../src/api/snapshot.rs).
+- *Restore path:* The `TRUNCATE` takes an `AccessExclusiveLock`, but the
+  subsequent `INSERT` runs in the same transaction with no additional
+  guard. **However** `Spi::run` issues a separate command — there is no
+  explicit `BEGIN; … COMMIT;` framing in the function body. If
+  `INSERT … SELECT *` is interrupted (statement timeout, OOM, deadlock
+  with another `pgtrickle.refresh_stream_table` call), the storage table
+  is left **truncated** with zero rows but the catalog still records the
+  stream table as `is_populated = true` (the `UPDATE` later sets it
+  again, but only if the INSERT succeeded). The subsequent automatic
+  refresh will fall back to `Differential` against an empty storage and
+  apply only the new delta rows, producing a permanently truncated
+  result.
+- *Restore path again:* The `__pgt_snapshot_version` major-version
+  comparison at
+  [`src/api/snapshot.rs:215-230`](../src/api/snapshot.rs) is correct in
+  spirit, but `Spi::get_one_with_args::<String>` returns `None` if the
+  first SPI call fails for any reason (permissions, missing column),
+  which is then silently treated as “no version stored” — letting the
+  restore proceed against an actually-incompatible snapshot.
+
+**Recommendation:** Wrap the entire snapshot operation in
+`BeginInternalSubTransaction` / `ReleaseCurrentSubTransaction` (the same
+RAII helper as in [`src/scheduler.rs:250-308`](../src/scheduler.rs)).
+For restore, take an exclusive lock on the storage table at the start
+(`LOCK TABLE <storage> IN ACCESS EXCLUSIVE MODE`) and propagate snapshot
+version-check failures as `SnapshotSchemaVersionMismatch` rather than
+returning `None`.
+
+### 3.3 `IVM_DELTA_CACHE` grows without bound *(P1)*
+
+**Where:** [`src/ivm.rs:107-143`](../src/ivm.rs).
+
+The cache is a `thread_local! { static IVM_DELTA_CACHE:
+RefCell<HashMap<IvmCacheKey, CachedIvmDelta>> = RefCell::new(HashMap::new()) }`.
+The key is `(pgt_id, source_oid, has_new, has_old)`, which is bounded per
+session, but the `CachedIvmDelta { delta_sql, user_columns, .. }` payload
+can be tens of kilobytes per IMMEDIATE-mode stream table. The only
+eviction path is `invalidate_ivm_delta_cache(pgt_id)` (called on ALTER
+QUERY / DROP / reinitialize) and the `LOCAL_IVM_CACHE_GEN` generation
+counter (called on global cache flush). There is **no LRU**, no size cap,
+and no time-based eviction. A long-lived backend that touches many
+IMMEDIATE-mode stream tables (e.g. a reporting connection that ranges
+over the catalog) will pay the cache memory cost forever.
+
+**Recommendation:** Honour `pg_trickle.template_cache_max_entries` for the
+IVM cache as well as the L1 delta-template cache. Implement a simple
+clock-style eviction.
+
+### 3.4 `classify_spi_error_retryable` is text-based *(P1)*
+
+**Where:** [`src/error.rs:213-260`](../src/error.rs) (and the
+documentation comment above it).
+
+The function explicitly admits SQLSTATE codes do not appear in pgrx SPI
+error messages, and matches against English text fragments such as
+`"does not exist"`, `"syntax error"`, `"permission denied"`,
+`"violates"`, `"division by zero"`. On a PostgreSQL build with a
+non-English `lc_messages`, **all** of these patterns silently break and
+every SPI error becomes retryable. Even on an English build, future
+PostgreSQL message rewordings (which happen between major releases)
+could regress this without any compile error.
+
+**Recommendation:** Push SQLSTATE through pgrx (it's available in
+`pg_sys::ErrorData.sqlerrcode`); update [`error.rs`](../src/error.rs) to
+classify by 5-character code instead of text. As a stopgap, set
+`PGOPTIONS='-c client_messages_locale=en_US.UTF-8'` in CI.
+
+### 3.5 L2 template-cache catalog table is unbounded *(P1)*
+
+**Where:** [`src/template_cache.rs:79-118`](../src/template_cache.rs)
+(`store`); [`src/template_cache.rs:124-142`](../src/template_cache.rs)
+(`invalidate`/`invalidate_all`).
+
+`store()` does an `INSERT ... ON CONFLICT (pgt_id) DO UPDATE`, which keeps
+the catalog at one row per stream table — bounded by the number of stream
+tables. So far so good. **But:** `invalidate()` only deletes for a single
+`pgt_id`, and there is no purger for stale entries left behind by ALTER
+QUERY without DROP, by source-table OID renumbering, or by
+extension-version migration. The catalog table is `UNLOGGED`, so a crash
+flushes it — but that simply moves the problem from durability to cold
+boot.
+
+**Recommendation:** Add a `cached_at TIMESTAMPTZ` aware purge inside the
+scheduler's tick (one DELETE per launcher cycle, age-bounded) and respect
+`pg_trickle.template_cache_max_entries` for the L2 table as well as L1.
+
+### 3.6 SubLink extraction inside OR is silently rejected, but not for all shapes *(P2)*
+
+**Where:** [`src/dvm/parser/sublinks.rs:101-145`](../src/dvm/parser/sublinks.rs)
+(`extract_where_sublinks`).
+
+The error path correctly rejects `SubLink` inside `OR` with a
+`UnsupportedOperator`, but the check uses `node_tree_contains_sublink`
+which only recurses into `T_BoolExpr` arguments. SubLinks nested inside
+`T_CaseExpr`, `T_CoalesceExpr`, or function arguments can slip past the
+check and end up in `safe_node_to_expr` as opaque `Expr::Raw`. That is
+correct *for execution* (the raw SQL still runs), but it silently
+disables differential refresh for those queries — they fall back to
+FULL — without any user-visible explanation.
+
+**Recommendation:** Either generalise `node_tree_contains_sublink` to
+recurse via `expression_tree_walker_impl`, or emit a `NOTICE` when the
+parser silently downgrades an OR-with-CASE to FULL.
+
+### 3.7 `restore_from_snapshot` SELECT * EXCEPT requires PG ≥ 18 with the patch *(P2)*
+
+**Where:** [`src/api/snapshot.rs:243-251`](../src/api/snapshot.rs).
+
+The comment claims “PostgreSQL 18+ supports `SELECT * EXCEPT (...)` — fall
+back to explicit column list if it fails (older PG in tests).” The
+fallback is **not implemented** — the code unconditionally emits
+`SELECT * EXCEPT(...)` and returns `SpiError("restore insert failed: ...")`
+on older minor versions or non-mainstream PG distributions that have not
+yet picked up the EXCEPT support.
+
+**Recommendation:** Catalog-walk `pg_attribute` for the storage table,
+build the explicit column list, and use that instead. Removes the PG-minor
+sensitivity entirely.
+
+### 3.8 `snapshot_stream_table` returns the snapshot name even when the catalog INSERT fails *(P2)*
+
+**Where:** [`src/api/snapshot.rs:152-167`](../src/api/snapshot.rs).
+
+The comment says the catalog INSERT is “best-effort” and the result
+discards the `Result`. If the user later calls
+`pgtrickle.list_snapshots(...)` they will not see the snapshot, even
+though the function returned a path. This is a UX trap — surface the
+INSERT failure as a `WARNING` so the caller knows the snapshot is not
+tracked.
+
+### 3.9 SCC tarjan `.unwrap()` are sound but un-tested at scale *(P2)*
+
+**Where:** [`src/dag.rs:1093, 1100, 1112`](../src/dag.rs).
+
+The three `.unwrap()`s carry `nosemgrep` justifications and are correct by
+the SCC algorithm invariant. But they have no fuzz coverage — a
+graph-shape fuzzer (the moral equivalent of `parser_fuzz` for DAG
+operations) would close the residual risk and make a change in the
+recursion easy to spot.
+
+### 3.10 `wal_decoder.rs` `.expect("'test_decoding' contains no NUL bytes")` *(P2)*
+
+**Where:** [`src/wal_decoder.rs:307`](../src/wal_decoder.rs).
+
+`CString::new("test_decoding").expect("'test_decoding' contains no NUL bytes")`
+is sound (the literal has no NUL bytes), but it is the **only remaining
+`.expect()` in production code** outside `api/mod.rs`'s `unreachable!()`
+post-`report()` calls. Replace with `c"test_decoding"` (compile-time
+guarantee) or with `?` and a typed error to set the precedent for the
+rest of the WAL decoder.
+
+---
+
+## 4. Architecture Gaps
+
+### 4.1 The L0 shared-shmem template cache is a signal, not a store
+
+**Where:** [`src/shmem.rs:680-710`](../src/shmem.rs).
+
+`L0_POPULATED_VERSION` and `signal_l0_cache_populated()` /
+`is_l0_cache_available()` only **broadcast** that *someone* populated the
+L2 catalog cache at the current generation. They do not actually store any
+delta SQL in shared memory. So a cold backend pays:
+
+- L1 thread-local lookup → miss (cold backend)
+- L2 catalog SELECT → ~1 ms hit, cached by PG buffer cache
+
+The promised dshash-backed L0 cache from the
+[PLAN_OVERALL_ASSESSMENT_2.md](PLAN_OVERALL_ASSESSMENT_2.md) §4 design is
+not implemented. Building it would erase the remaining ~1 ms cold-path
+penalty and make a many-database deployment scale linearly.
+
+### 4.2 Refresh sub-modules still reach into each other via `pub use codegen::*`
+
+**Where:** [`src/refresh/mod.rs:33-43`](../src/refresh/mod.rs).
+
+The migration to ARCH-1B preserved binary compatibility by re-exporting
+everything (`pub use codegen::*; pub use merge::*; pub use orchestrator::*;`).
+This means a function moved between sub-modules still appears to live in
+`refresh::`, which is good for caller stability but bad for module
+discipline — any new function in any sub-module is automatically promoted
+to the top-level `refresh` namespace, with no curation. Recommend
+introducing an explicit re-export list (`pub use codegen::{A, B, C, …};`)
+within v0.30.0.
+
+### 4.3 IVM lock-mode parser is conservative but undocumented
+
+**Where:** [`src/ivm.rs:48-91`](../src/ivm.rs).
+
+`IvmLockMode::for_query` walks the parsed OpTree and returns
+`RowExclusive` only when the tree is `Scan → Filter? → Project?` —
+everything else gets `Exclusive`. This is correct but **fail-closed**:
+any parse failure also returns `Exclusive`. There is no observability
+into how often the IVM path runs in `Exclusive` because of a parser
+giving up on a query the rest of the engine handles fine.
+
+**Recommendation:** Add a counter
+`pgtrickle_ivm_lock_mode{mode="exclusive_due_to_parse_error"}` and emit
+it via the metrics_summary aggregation.
+
+### 4.4 No bounded-memory protection for the parser itself
+
+**Where:** [`src/dvm/parser/mod.rs:120-230`](../src/dvm/parser/mod.rs).
+
+`pg_trickle.max_parse_depth` (G13-SD) bounds recursion *depth* but not
+total *memory*. A large `IN (1, 2, 3, …, 1_000_000)` list still allocates
+proportionally. PostgreSQL itself bounds these via memory contexts, but
+the Rust-side parse caches (`PARSE_ADVISORY_WARNINGS`,
+`cte_ctx.registry`) live in the backend heap, not in a memory context,
+and never shrink within a long-running session.
+
+**Recommendation:** Track aggregate node count per parse, reject above
+`pg_trickle.max_parse_nodes` (new GUC, default 100k), and clear
+thread-locals at end-of-statement via a `XactCallback`.
+
+### 4.5 Catalog reads remain hot-path
+
+The scheduler reads `pgtrickle.pgt_stream_tables` on every tick (already
+known and partly mitigated by v0.25's cached snapshot). The new
+`metrics_summary()` and `cluster_worker_summary()` re-query the catalog
+on every Prometheus scrape. At 200+ stream tables and a 5-second scrape
+interval, this is one full table scan per database every 5 s on top of
+the scheduler's own reads. A shared snapshot that both surfaces
+write would eliminate redundant reads.
+
+### 4.6 `ivm.rs` still re-uses statement-level transition tables via temp tables
+
+**Where:** [`src/ivm.rs:30-37`](../src/ivm.rs) (comments) and the trigger
+function builders below.
+
+The comments admit “Uses temp tables for transition table access (ENR-based
+access is a future optimization).” PostgreSQL 18 supports referencing
+ephemeral named relations directly inside trigger bodies, so the
+intermediate temp table is unnecessary overhead.
+
+### 4.7 No multi-database singleton for the scheduler
+
+The launcher spawns one scheduler per database. If two databases share a
+high-cost source table (e.g., a foreign-data-wrapper view), each schedules
+its own refresh, doubling the work. There is no notion of a “refresh
+broker” at the cluster level.
+
+### 4.8 No back-pressure between change capture and refresh
+
+If `pgtrickle.refresh_stream_table` falls behind under a write spike, the
+change buffer (`pgtrickle_changes.changes_<oid>`) grows monotonically.
+`pg_trickle.buffer_alert_threshold` warns but does not throttle the source
+DML. A real back-pressure design (RAISE NOTICE → application slow-down) is
+out of scope here, but the absence is worth flagging.
+
+### 4.9 ARCH-1B left dead `#[allow(unused_imports)]` shims
+
+**Where:** [`src/refresh/orchestrator.rs:6-26`](../src/refresh/orchestrator.rs).
+
+Every import is `#[allow(unused_imports)]`. This is a maintenance hazard:
+removing a dependency from a function will not produce a clippy warning,
+and the imports become silently misleading. Recommend converting to
+specific `pub use` clauses now that the module split has stabilised.
+
+### 4.10 No `Drop` guards on `Spi::run_with_args` failure inside ivm.rs
+
+If an IVM trigger function fails mid-statement, the `__pgt_newtable_<oid>`
+/ `__pgt_oldtable_<oid>` temp tables are normally cleaned up by PG's
+sub-transaction abort, but the thread-local `IVM_DELTA_CACHE` is **not**
+cleared. A stale entry can survive a failed apply and be reused in the
+next statement. Mitigation: clear the thread-local in a `XactCallback`
+on subxact abort.
+
+---
+
+## 5. Performance
+
+### 5.1 Existing benchmarks
+
+Three Criterion benches:
+
+- [`benches/diff_operators.rs`](../benches/diff_operators.rs) — covers
+  `Scan`, `Filter`, `Project`, `Aggregate`, `Join`, `Distinct`, `Window`
+  via `DiffContext::new_standalone`.
+- [`benches/refresh_bench.rs`](../benches/refresh_bench.rs) — covers
+  `quote_ident`, `col_list`, `Expr::to_sql`, `OpTree::output_columns`,
+  `OpTree::source_oids`, `Frontier::lsn_gt`,
+  `select_canonical_period_secs`.
+- [`benches/scheduler_bench.rs`](../benches/scheduler_bench.rs) — covers
+  500-stream-table dispatch (PERF-5).
+
+### 5.2 Performance gaps
+
+| Area | Bench? | Notes |
+|---|---|---|
+| Snapshot/restore round-trip | ❌ | New SNAP API has zero benchmark coverage. |
+| Predictive scheduler `recommend_schedule` | ❌ | PLAN-1 reads refresh history via SPI; cost grows with retention window. |
+| Cluster-wide observability | ❌ | `cluster_worker_summary()` and `metrics_summary()` re-query the catalog per scrape. |
+| L2 template-cache lookup hit-rate at scale | ❌ | No microbench measuring 1ms vs 45ms cold cost. |
+| IVM apply path | ❌ | `pgt_ivm_apply_delta` has no bench. Repo memory says IVM is on the hot path for some users. |
+| WAL decoder throughput | ❌ | No bench for the polling loop. |
+| Multi-database fairness | ❌ | Quota formula is documented but unmeasured under contention. |
+
+### 5.3 Known wins shipped since v0.23
+
+- 50-80% write-path overhead reduction via statement-level CDC triggers
+  (v0.27.0).
+- Cold-backend ~45 ms → ~1 ms via L2 template cache (v0.25.0).
+- Differential refresh adaptive threshold (`differential_max_change_ratio`)
+  prevents pathological FULL fallback cycles.
+- Frontier two-phase commit removes the “silent stale frontier” class of
+  no-op refreshes.
+
+### 5.4 Recommendation
+
+Add one benchmark per missing row in §5.2 before v1.0. Priority: SNAP and
+predictive planner, which are the newest code paths.
+
+---
+
+## 6. Security (OWASP Mapped)
+
+| OWASP Top 10 (2021) | Status | Notes |
+|---|---|---|
+| A01 — Broken Access Control | **Hardened.** v0.13 SECURITY DEFINER triggers + `SET search_path`; `PgTrickleError::PermissionDenied` separates SEC-1 from SPI permission errors. | [`src/error.rs:65-67`](../src/error.rs) (`PermissionDenied`); [`src/error.rs:88-93`](../src/error.rs) (`SpiPermissionError`). |
+| A02 — Cryptographic Failures | N/A — extension does not handle credentials. |
+| A03 — Injection | **Mostly hardened.** All user-table identifiers go through `quote_ident`; the few `Spi::run(&dynamic_format)` sites carry `nosemgrep` justifications and pass only catalog-resolved double-quoted identifiers ([`src/api/snapshot.rs:240, 252`](../src/api/snapshot.rs)). **Risk:** the L2 template cache stores SQL strings; if an attacker can control `defining_query`, they control what's later replayed at refresh time — but creating a stream table requires elevated privileges. |
+| A04 — Insecure Design | **Watch.** Snapshot/restore (§3.2) is not transaction-safe by design. |
+| A05 — Security Misconfiguration | **Watch.** New v0.27.0 GUCs (`schedule_recommendation_min_samples`, `schedule_alert_cooldown_seconds`, `metrics_request_timeout_ms`) are not yet documented in CONFIGURATION.md (see §8 / Appendix C). Operators may not know what they default to. |
+| A06 — Vulnerable Components | **Watch.** pgrx 0.18 is current; `cargo deny` is configured ([`deny.toml`](../deny.toml)). Recommend a scheduled `cargo audit` job. |
+| A07 — Identification & Auth Failures | N/A. |
+| A08 — Software & Data Integrity | **Risk.** Snapshot files include `__pgt_snapshot_version` for compatibility, but no checksum or signature; a tampered snapshot can be restored without detection. |
+| A09 — Logging & Monitoring | **Hardened.** OpenMetrics + per-DB labels (CLUS-2). |
+| A10 — SSRF | N/A. |
+
+**Additional security observations:**
+
+- Trigger functions are `SECURITY DEFINER` (v0.13). Source-table DDL is
+  blocked by `pg_trickle.block_source_ddl` (configurable). The audit table
+  `pgtrickle.pgt_refresh_history` is INSERT-only by enforcement at
+  [`src/cdc.rs:71-83`](../src/cdc.rs).
+- The TUI binary ([pgtrickle-tui/](../pgtrickle-tui/)) connects via
+  ordinary libpq; it does not embed credentials. Good.
+- Fuzz coverage exists for `cdc_fuzz`, `cron_fuzz`, `guc_fuzz`,
+  `parser_fuzz` ([`fuzz/fuzz_targets/`](../fuzz/fuzz_targets/)). **Missing:**
+  WAL-decoder fuzz target, MERGE-template fuzz, snapshot/restore fuzz.
+
+---
+
+## 7. Test Coverage Gaps
+
+The repository ships six test tiers
+([AGENTS.md](../AGENTS.md) §Testing). The table below maps the tier to
+the gap.
+
+| Area | Tier | Gap |
+|---|---|---|
+| Snapshot / restore atomicity | E2E | No test asserts that a mid-snapshot crash leaves no orphan tables (cf. §3.2). |
+| Snapshot version mismatch | E2E | No test feeds a version-mismatched snapshot to `restore_from_snapshot`. |
+| Predictive planner under sparse history | Integration | No test asserts `recommend_schedule` returns confidence=0 when N < `schedule_recommendation_min_samples`. |
+| IVM cache memory growth | Soak | No long-running test asserts `IVM_DELTA_CACHE.len()` is bounded over many ALTER QUERY cycles. |
+| L2 template cache eviction | Integration | No test asserts the L2 catalog table size stays bounded across 1000 stream-table churn cycles. |
+| Multi-database worker fairness | E2E | No test asserts the per-DB quota under contention from N parallel writer connections. |
+| WAL decoder failure injection | E2E | No test asserts behaviour when the replication slot is missing or has wrong plugin. |
+| Statement-level CDC with mixed INSERT/UPDATE/DELETE in one transaction | E2E | The new triggers split into 3 functions; assert ordering invariants. |
+| `classify_spi_error_retryable` localised messages | Unit | No test runs with `lc_messages=fr_FR.UTF-8`; the heuristic silently regresses. |
+| Snapshot under concurrent refresh | E2E | No test runs `snapshot_stream_table` while a refresh is in flight. |
+| `restore_from_snapshot` rollback on partial INSERT failure | E2E | No test injects a constraint violation mid-restore. |
+| SubLink-in-CASE silently downgraded to FULL | Integration | No test surfaces this as a NOTICE. |
+| EC-01 cross-cycle phantom convergence | E2E + soak | The existing `test_tpch_q07_*` is flaky per repo memory; needs a deterministic reproducer. |
+| Snapshot interaction with `pg_dump` / `pg_restore` | E2E | No test pipes a snapshot through `pg_dump` and asserts round-trip. |
+| Fuzz: WAL decoder | Fuzz | Not present. |
+| Fuzz: MERGE template generator | Fuzz | Not present. |
+| Fuzz: snapshot SQL builder | Fuzz | Not present. |
+| Fuzz: DAG SCC graphs | Fuzz | Not present. |
+| Property test: cluster_worker_summary consistency under crash | Property | None. |
+| Property test: predictive planner monotone in history length | Property | None. |
+| dbt 1.11 compatibility | Integration | dbt-pgtrickle pins `dbt-core ~=1.10`; no test runs against 1.11+ (CI gate?). |
+| CNPG 1.29 manifest | Integration | `cnpg/cluster-example.yaml` declares 1.28+; no test runs against 1.29. |
+
+**Recommendation:** Open a `tests/e2e_snap_atomicity_tests.rs` to cover §3.2,
+a `tests/e2e_ivm_cache_growth_tests.rs` to cover §3.3, and add four new
+fuzz targets.
+
+---
+
+## 8. Documentation Gaps
+
+| Doc | Gap | Severity |
+|---|---|---|
+| [`docs/UPGRADING.md`](../docs/UPGRADING.md) | The TOC and “Supported Upgrade Paths” table stop at 0.13.0 → 0.14.0. v0.15.0–v0.27.0 upgrade notes are entirely missing. The table at line 502 ends at `0.13.0 | 0.14.0`. | **High** |
+| [`docs/CONFIGURATION.md`](../docs/CONFIGURATION.md) | New v0.27.0 GUCs (`schedule_recommendation_min_samples`, `schedule_alert_cooldown_seconds`, `metrics_request_timeout_ms`) are not in the TOC and have no individual sections. The deprecated `merge_planner_hints`/`merge_work_mem_mb` are listed but the deprecation warning text is not documented. | **High** |
+| [`docs/SQL_REFERENCE.md`](../docs/SQL_REFERENCE.md) | New v0.27.0 functions (`snapshot_stream_table`, `restore_from_snapshot`, `list_snapshots`, `drop_snapshot`, `recommend_schedule`, `schedule_recommendations`, `cluster_worker_summary`, `metrics_summary`) — verify each has its own section. Spot check shows `cluster_worker_summary` and `metrics_summary` are referenced from SCALING.md but not necessarily fully documented in SQL_REFERENCE.md. | **High** |
+| [`docs/BACKUP_AND_RESTORE.md`](../docs/BACKUP_AND_RESTORE.md) | Snapshot section present; **does not warn** about §3.2 atomicity gap or about concurrent restore. | **Medium** |
+| [`docs/SCALING.md`](../docs/SCALING.md) | Has the new v0.27.0 “Cluster-wide Worker Fairness” section; the per-DB Prometheus example is correct. **Missing:** numerical guidance for `schedule_recommendation_min_samples` and `metrics_request_timeout_ms`. | **Medium** |
+| [`docs/integrations/multi-tenant.md`](../docs/integrations/multi-tenant.md) | Excellent. **Add:** worked example of a noisy-neighbour scenario and the corresponding alert. | **Low** |
+| [`docs/GETTING_STARTED.md`](../docs/GETTING_STARTED.md) | Comprehensive (1,491 LOC). **Missing:** snapshot/PITR walkthrough; predictive planner advice. | **Medium** |
+| [`docs/PERFORMANCE_COOKBOOK.md`](../docs/PERFORMANCE_COOKBOOK.md) | Should add a recipe: “use `recommend_schedule` to right-size a 100-table dbt project.” | **Low** |
+| [`docs/TUI.md`](../docs/TUI.md) | Does not mention SNAP / PLAN / CLUS / METR functions. | **Medium** |
+| [`docs/PRE_DEPLOYMENT.md`](../docs/PRE_DEPLOYMENT.md) | Does not mention `change_buffer_durability` or `frontier_holdback_*` GUCs. | **Medium** |
+| [`docs/FAQ.md`](../docs/FAQ.md) | No entry for “How do I take a snapshot?” or “How do I tune `schedule_recommendation_min_samples`?” | **Low** |
+| [ROADMAP.md](../ROADMAP.md) | The v0.29.0 row in the milestone table at line 89 contains a copy-paste typo: it repeats v0.27.0's description (“Operability, observability & DR”) instead of describing the Relay CLI. | **Low** |
+| [`docs/ERRORS.md`](../docs/ERRORS.md) | New error variants (SnapshotAlreadyExists, SnapshotSourceNotFound, SnapshotSchemaVersionMismatch, DiagnosticError, PublicationAlreadyExists, PublicationNotFound, PublicationRebuildFailed, SlaTooSmall, ChangedColsBitmaskFailed) need documented HINT/DETAIL guidance. | **High** |
+| [`docs/RELEASE.md`](../docs/RELEASE.md) | Should now include the SNAP/PLAN/CLUS/METR migration script as a checklist item. | **Low** |
+| [`docs/PLAYGROUND.md`](../docs/PLAYGROUND.md) | Should add a snapshot demo. | **Low** |
+| [`dbt-pgtrickle/README.md`](../dbt-pgtrickle/README.md) | Macro library is unchanged in v0.27 — but the README does not say which extension version it is tested against. | **Low** |
+
+---
+
+## 9. Operational / Ecosystem
+
+1. **CNPG manifest version bump.** [`cnpg/cluster-example.yaml`](../cnpg/cluster-example.yaml)
+   targets CNPG 1.28+. CNPG 1.29 ships in 2026-Q2; the example should be
+   refreshed and re-tested in CI before v1.0.
+2. **dbt-pgtrickle dbt-core compatibility.**
+   [`dbt-pgtrickle/AGENTS.md`](../dbt-pgtrickle/AGENTS.md) pins `~=1.10`
+   and explicitly notes Python 3.13 only because dbt 1.10's mashumaro
+   dep cannot build on 3.14. dbt-core 1.11 is in beta. Open an issue
+   tracking the upgrade path.
+3. **Helm chart.** No first-party Helm chart yet; the CNPG path is the
+   only documented K8s deployment.
+4. **`pgtrickle-tui` parity.** TUI does not surface
+   `snapshot_stream_table`, `restore_from_snapshot`, `list_snapshots`,
+   `recommend_schedule`, `schedule_recommendations`,
+   `cluster_worker_summary`, `metrics_summary`. The new SNAP/PLAN/CLUS
+   functions exist only via SQL.
+5. **Grafana dashboards.** Per-DB `db_oid` / `db_name` labels (CLUS-2)
+   are documented but no first-party Grafana dashboard JSON ships in
+   `monitoring/grafana/`. The dashboard snippets in
+   [docs/integrations/multi-tenant.md](../docs/integrations/multi-tenant.md)
+   are the only artefact.
+6. **OpenTelemetry.** No tracing spans yet — every pg_trickle operation
+   is opaque to OTel collectors. v1.0 should at minimum emit per-refresh
+   spans.
+7. **Backup tooling.** The bin target [`src/bin/pg_trickle_dump.rs`](../src/bin/pg_trickle_dump.rs)
+   (458 LOC) is the only out-of-database backup tool; it is not yet
+   documented in `docs/BACKUP_AND_RESTORE.md`.
+8. **Multi-version test matrix.** The CI matrix runs PostgreSQL 18.x; PG
+   17 support is on the v1.1 roadmap but not in CI today.
+9. **Connection pooler matrix.** PgBouncer transaction-mode is supported
+   via `pg_trickle.connection_pooler_mode = 'transaction'`. Pgcat / Odyssey
+   are untested.
+10. **Multi-database soak test.** The G17-MDB workflow exists; it should
+    be promoted from `stability-tests.yml` to the main `ci.yml` for v1.0
+    GA.
+11. **Release artefact signing.** GHCR images are not yet
+    cosign-signed.
+12. **Marketplace / extension catalog.** PG Extension Network listing
+    not yet pursued.
+
+---
+
+## 10. Recommended New Features
+
+The following ten ideas are ranked roughly by user value × effort. Each
+maps to a v0.28+ release window.
+
+### 10.1 Reactive subscription API
+
+**Idea:** A `pgtrickle.subscribe(stream_table, channel)` SQL function
+that emits `NOTIFY` payloads on every commit affecting a stream table.
+Clients use ordinary `LISTEN`. v0.27.0's
+[`src/api/publication.rs`](../src/api/publication.rs) already builds the
+plumbing for downstream publication; the reactive API is the next step.
+
+**Cost:** ~1 sprint. **Value:** unlocks browser-side reactive UIs without
+needing Apollo, Hasura, or Postgraphile.
+
+**Risk:** Need to coalesce notifies to avoid storms.
+
+### 10.2 Temporal IVM (time-travel materialisation)
+
+**Idea:** Allow a stream-table query to reference `AS OF TIMESTAMP $1`
+(or LSN). Materialise rolling history. Useful for slowly-changing
+dimensions and audit reporting.
+
+**Cost:** ~3 sprints. Requires extending the frontier model to a
+two-dimensional (frontier, ts).
+
+**Value:** First-class SCD-Type-2 semantics out of the box.
+
+### 10.3 Adaptive batching
+
+**Idea:** The scheduler currently runs each ready stream table
+independently. An adaptive batcher would notice that two STs share
+a source table and a refresh window and run them together, reusing
+the change-buffer scan.
+
+**Cost:** ~2 sprints in `scheduler.rs`.
+
+**Value:** 10-30% throughput win for multi-tenant deployments with
+shared sources.
+
+### 10.4 Plan-aware delta routing
+
+**Idea:** Inspect `EXPLAIN ANALYZE` output for the delta MERGE and
+choose between `merge_strategy=merge` and `merge_strategy=delete_insert`
+adaptively per refresh. Today the strategy is per-stream-table.
+
+**Cost:** ~1 sprint. Heuristics already exist in
+[`src/refresh/codegen.rs`](../src/refresh/codegen.rs).
+
+**Value:** Removes the “tune `merge_strategy` by hand” chore.
+
+### 10.5 GraphQL / PostGraphile integration
+
+**Idea:** A Postgraphile plugin that exposes stream tables as
+subscription-capable types. v0.27's publication primitive is the wire
+format.
+
+**Cost:** ~2 sprints, mostly in JavaScript.
+
+**Value:** “real-time GraphQL backed by PostgreSQL with no extra
+infrastructure” is a unique selling point.
+
+### 10.6 Kafka outbox pattern
+
+**Idea:** A built-in outbox stream table type that writes deltas to a
+Kafka topic instead of (or in addition to) materialising. The v0.28
+roadmap entry covers this.
+
+**Cost:** ~3 sprints (Kafka client, retry semantics, partition strategy).
+
+**Value:** Closes the “how do I get pg_trickle results into my event
+bus?” question.
+
+### 10.7 Columnar materialisation backend
+
+**Idea:** Allow a stream table to materialise into Citus columnar
+storage or pg_mooncake. Massively reduces storage cost for analytic
+workloads.
+
+**Cost:** ~3 sprints, mostly catalog plumbing.
+
+**Value:** Bridges OLTP and OLAP in one extension.
+
+### 10.8 Zero-downtime view evolution
+
+**Idea:** Today, `ALTER QUERY` triggers a full refresh. A “shadow ST”
+mode would build the new query side-by-side, switch atomically, and
+keep the old version readable for the duration.
+
+**Cost:** ~2 sprints.
+
+**Value:** Removes the operational fear of `ALTER QUERY` on large
+tables.
+
+### 10.9 LLM-assisted advisor
+
+**Idea:** A `pgtrickle.advise()` function that takes a query and
+returns recommendations: refresh mode, schedule, source-table indexes,
+flagged anti-patterns. Backed by a small open model (e.g. Phi-3) called
+via PL/Python.
+
+**Cost:** ~2 sprints (mostly prompt engineering).
+
+**Value:** Onboarding accelerator for new users.
+
+### 10.10 Edge / embedded WASM (PGlite)
+
+**Idea:** Compile the DVM core to WebAssembly and run inside PGlite.
+Aligns with the v1.4 roadmap entry. v0.27.0's clean module split
+(`refresh/`, `dvm/`, `cdc/`) is finally a tractable starting point.
+
+**Cost:** ~4 sprints (the WASM toolchain interaction with pgrx is the
+hard part).
+
+**Value:** Reactive client-side databases with full IVM — no JavaScript
+ORM needed.
+
+---
+
+## 11. Prioritised Action Plan
+
+The table below lists 30 actionable items. **Items marked P0 must land
+before v0.30.0.** The order within a priority band is the order I would
+ship them.
+
+| # | Item | Section | Priority | Target |
+|---|---|---|---|---|
+| 1 | Eliminate EC-01 cross-cycle phantoms (route every cycle through PH-D1 cleanup or fix Part 2 row-id derivation) | §3.1 | P0 | v0.28.0 |
+| 2 | Wrap snapshot/restore in subxact + take exclusive lock on storage during restore | §3.2 | P0 | v0.28.0 |
+| 3 | Replace `classify_spi_error_retryable` text matching with SQLSTATE-based classifier | §3.4 | P0 | v0.28.0 |
+| 4 | Bound `IVM_DELTA_CACHE` via `pg_trickle.template_cache_max_entries` | §3.3 | P0 | v0.28.0 |
+| 5 | Document v0.27.0 GUCs (`schedule_recommendation_min_samples`, `schedule_alert_cooldown_seconds`, `metrics_request_timeout_ms`) | §8, App C | P0 | v0.28.0 |
+| 6 | Document v0.15.0–v0.27.0 upgrade notes in [docs/UPGRADING.md](../docs/UPGRADING.md) | §8 | P0 | v0.28.0 |
+| 7 | Add E2E test for snapshot atomicity under crash | §7 | P0 | v0.28.0 |
+| 8 | Bound L2 template-cache catalog table via age-based purge | §3.5 | P0 | v0.28.0 |
+| 9 | Surface `snapshot_stream_table` catalog INSERT failure as WARNING | §3.8 | P0 | v0.28.0 |
+| 10 | Replace `restore_from_snapshot`'s `SELECT * EXCEPT` with explicit column list | §3.7 | P0 | v0.28.0 |
+| 11 | Implement real shared-shmem L0 dshash template cache | §4.1 | P1 | v0.29.0 |
+| 12 | Bound parser memory via `pg_trickle.max_parse_nodes` GUC + `XactCallback` | §4.4 | P1 | v0.29.0 |
+| 13 | Replace `refresh::*` blanket re-exports with explicit `pub use` lists | §4.2 | P1 | v0.29.0 |
+| 14 | Add IVM lock-mode counter to metrics | §4.3 | P1 | v0.29.0 |
+| 15 | Switch IVM transition-table access to ENR (drop temp tables) | §4.6 | P1 | v0.29.0 |
+| 16 | Eliminate `wal_decoder.rs:307` `.expect()` via `c"test_decoding"` | §3.10 | P1 | v0.29.0 |
+| 17 | Generalise `node_tree_contains_sublink` to recurse into CASE/COALESCE/FuncCall | §3.6 | P1 | v0.29.0 |
+| 18 | Add benchmarks: SNAP, PLAN, CLUS, IVM apply, WAL decoder | §5 | P1 | v0.29.0 |
+| 19 | Document new error variants (HINT/DETAIL) in [docs/ERRORS.md](../docs/ERRORS.md) | §8 | P1 | v0.29.0 |
+| 20 | Update SQL_REFERENCE.md to fully cover SNAP/PLAN/CLUS/METR functions | §8 | P1 | v0.29.0 |
+| 21 | Add fuzz targets: WAL decoder, MERGE template, snapshot builder, DAG SCC | §7 | P1 | v0.29.0 |
+| 22 | Add E2E tests: predictive planner sparse history, multi-DB worker fairness | §7 | P1 | v0.29.0 |
+| 23 | Document `change_buffer_durability` in [docs/PRE_DEPLOYMENT.md](../docs/PRE_DEPLOYMENT.md) | §8 | P1 | v0.29.0 |
+| 24 | Surface CNPG 1.29 compatibility in [cnpg/](../cnpg/) and CI | §9 | P1 | v0.29.0 |
+| 25 | Add TUI parity for SNAP/PLAN/CLUS/METR functions | §9 | P2 | v0.30.0 |
+| 26 | Ship first-party Grafana dashboard JSON in `monitoring/grafana/` | §9 | P2 | v0.30.0 |
+| 27 | Add OpenTelemetry tracing spans for refresh/CDC/snapshot | §9 | P2 | v1.0 |
+| 28 | Adaptive batching of refreshes that share a source table | §10.3 | P2 | v0.30.0 |
+| 29 | Plan-aware delta routing (auto-pick `merge_strategy`) | §10.4 | P2 | v0.30.0 |
+| 30 | Cosign-sign GHCR release images | §9 | P2 | v1.0 |
+
+---
+
+## 12. Risk Register
+
+| ID | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| R-01 | EC-01 phantom drift causes silent data corruption in production | Medium | Critical | Action items #1, #7 |
+| R-02 | Snapshot crash leaves orphan tables, fills disk | Medium | High | Action items #2, #7 |
+| R-03 | Localised PG build silently retries non-retryable SPI errors | High (if deployed in fr/de/ja) | Medium | Action item #3 |
+| R-04 | Long-lived backend memory growth via IVM cache | Medium | Medium | Action item #4 |
+| R-05 | L2 template-cache catalog table grows unbounded | Low | Medium | Action item #8 |
+| R-06 | Operator does not know snapshot was un-tracked | Medium | Low | Action item #9 |
+| R-07 | Restore fails on non-mainstream PG 18 build | Low | Medium | Action item #10 |
+| R-08 | New v0.27.0 GUCs are misconfigured because undocumented | Medium | Medium | Action items #5, #19, #20 |
+| R-09 | dbt-pgtrickle blocks dbt 1.11 adoption | Medium | Low | Track upstream dbt 1.11 release |
+| R-10 | EC-01 fix re-introduces another regression in TPC-H Q15 | Medium | Medium | Property test + soak test (item #1) |
+| R-11 | pgrx 0.18 → 0.19 rev (when 0.19 ships) breaks pg_trickle | Medium | Medium | Pin strict, plan dedicated upgrade window |
+| R-12 | Per-DB worker quota starves a noisy-neighbour database | Medium | Medium | `cluster_worker_summary` Grafana alert |
+
+---
+
+## Appendix A — Unsafe Block Inventory
+
+282 `unsafe { … }` blocks total across [`src/`](../src/). A heuristic
+audit (preceding line contains `// SAFETY:`) finds **40** unsafe blocks
+**without an immediately preceding SAFETY comment**. The vast majority
+of these are inside the `cast_node!` and `pg_deref!` macros in
+[`src/dvm/parser/mod.rs:80-160`](../src/dvm/parser/mod.rs), which carry
+the SAFETY comment **inside** the macro body — these are sound. The
+remaining sites worth a closer audit are:
+
+- [`src/dvm/parser/mod.rs:60-90`](../src/dvm/parser/mod.rs) — `cast_node!`,
+  `is_node_type!`, `pg_deref!` macros. SAFETY comments are inside the
+  macros, but the call sites do not repeat them. The G13-PRF refactor
+  that introduced the macros explicitly accepts this trade-off.
+- [`src/dvm/parser/sublinks.rs`](../src/dvm/parser/sublinks.rs) —
+  numerous unsafe-block call sites with sub-comments referring back
+  to “Parse-tree pointer from PostgreSQL's raw_parser; valid within
+  current memory context.” Sound.
+- [`src/wal_decoder.rs:300-390`](../src/wal_decoder.rs) — All blocks
+  carry SAFETY justifications referencing the PG replication-slot API
+  contract. Sound.
+- [`src/scheduler.rs:250-308`](../src/scheduler.rs) (`SubTransaction`
+  RAII) — Every block carries a SAFETY comment. Sound.
+- [`src/api/helpers.rs:560-1010`](../src/api/helpers.rs) (parse-tree
+  walker) — All blocks carry SAFETY comments. Sound.
+
+**No** unsafe block was found that lacks justification entirely.
+
+The `#![cfg_attr(not(test), deny(clippy::unwrap_used))]` lint at
+[`src/lib.rs:23`](../src/lib.rs) keeps `unwrap()` out of production
+code. The 31 `unreachable!()` calls in
+[`src/api/mod.rs`](../src/api/mod.rs) are all unreachable-after-`report()`
+and are sound.
+
+---
+
+## Appendix B — Undocumented SQL Functions
+
+93 `#[pg_extern]` functions in production source (per file):
+
+| File | Count |
+|---|---|
+| [`src/api/diagnostics.rs`](../src/api/diagnostics.rs) | 30 |
+| [`src/monitor.rs`](../src/monitor.rs) | 19 |
+| [`src/api/mod.rs`](../src/api/mod.rs) | 9 |
+| [`src/diagnostics.rs`](../src/diagnostics.rs) | 5 |
+| [`src/api/self_monitoring.rs`](../src/api/self_monitoring.rs) | 5 |
+| [`src/api/helpers.rs`](../src/api/helpers.rs) | 5 |
+| [`src/api/snapshot.rs`](../src/api/snapshot.rs) | 4 |
+| [`src/api/publication.rs`](../src/api/publication.rs) | 3 |
+| [`src/lib.rs`](../src/lib.rs) | 2 |
+| [`src/ivm.rs`](../src/ivm.rs) | 2 |
+| [`src/hooks.rs`](../src/hooks.rs) | 2 |
+| [`src/hash.rs`](../src/hash.rs) | 2 |
+| [`src/api/planner.rs`](../src/api/planner.rs) | 2 |
+| [`src/error.rs`](../src/error.rs) | 1 |
+| [`src/api/metrics_ext.rs`](../src/api/metrics_ext.rs) | 1 |
+| [`src/api/cluster.rs`](../src/api/cluster.rs) | 1 |
+
+The functions confirmed shipped by [the v0.27.0 migration script](../sql/pg_trickle--0.26.0--0.27.0.sql)
+are all under `pgtrickle.*`:
+
+- `snapshot_stream_table(p_name text, p_target text DEFAULT NULL) → text`
+- `restore_from_snapshot(p_name text, p_source text) → void`
+- `list_snapshots(p_name text) → TABLE(snapshot_table text, created_at timestamptz, row_count bigint, frontier jsonb, size_bytes bigint)`
+- `drop_snapshot(p_snapshot_table text) → void`
+- `recommend_schedule(p_name text) → jsonb`
+- `schedule_recommendations() → TABLE(name text, current_interval_seconds float8, recommended_interval_seconds float8, delta_pct float8, confidence float8, reasoning text)`
+- `cluster_worker_summary() → TABLE(db_oid bigint, db_name text, active_workers int, scheduler_pid int, scheduler_running bool, total_active_workers int)`
+- `metrics_summary() → TABLE(db_name text, total_stream_tables bigint, active_stream_tables bigint, suspended_stream_tables bigint, total_refreshes bigint, successful_refreshes bigint, failed_refreshes bigint, total_rows_processed bigint, active_workers int)`
+
+A spot check of [`docs/SQL_REFERENCE.md`](../docs/SQL_REFERENCE.md) shows
+`fuse_status`, `trigger_inventory`, and `parallel_job_status` are
+documented; the new SNAP/PLAN/CLUS/METR functions need verification that
+they all have full sections. This is action item #20.
+
+---
+
+## Appendix C — Undocumented GUCs
+
+The new v0.27.0 GUCs registered in [`src/config.rs`](../src/config.rs)
+that **do not appear** in the [docs/CONFIGURATION.md](../docs/CONFIGURATION.md)
+TOC:
+
+- `pg_trickle.schedule_recommendation_min_samples` (default 20) — gates
+  PLAN-1 confidence
+- `pg_trickle.schedule_alert_cooldown_seconds` (default 300) — throttles
+  PLAN-3 alerts
+- `pg_trickle.metrics_request_timeout_ms` (default 5000) — bounds
+  metrics endpoint scrape
+- `pg_trickle.change_buffer_durability` (`unlogged|logged|sync`,
+  default `unlogged`) — referenced but not in TOC
+- `pg_trickle.frontier_holdback_lsn_bytes` (gauge) — internal, but
+  noted in [`src/shmem.rs`](../src/shmem.rs)
+- `pg_trickle.template_cache_max_entries` — referenced by L1, not by L2
+- `pg_trickle.worker_pool_size` — referenced indirectly via
+  `max_dynamic_refresh_workers`
+- `pg_trickle.unlogged_buffers` (default `false`) — documented in
+  upgrade notes for v0.14, but not in CONFIGURATION.md
+- `pg_trickle.agg_diff_cardinality_threshold` (default 1000) — in TOC
+  but no individual section verified
+- `pg_trickle.cost_model_safety_margin` — in TOC but no individual
+  section verified
+
+These need full sections in [docs/CONFIGURATION.md](../docs/CONFIGURATION.md)
+following the existing template (Property/Default/Range/Context table +
+Tuning Guidance + example).
+
+---
+
+*End of assessment.*


### PR DESCRIPTION
## Summary

Comprehensive third-generation technical audit of the pg_trickle v0.27.0
codebase, followed by a full roadmap refresh that translates every finding
into actionable milestone items. This PR adds:

1. **`plans/PLAN_OVERALL_ASSESSMENT_3.md`** — 1,048-line deep-dive covering
   10 critical bugs (4 × P0), 10 architecture gaps, 7 missing benchmarks,
   22 test coverage gaps, 16 documentation gaps, 12 operational/ecosystem
   items, 10 new feature ideas, a 30-item prioritised action plan, a
   12-risk register, and three appendices (282 `unsafe` blocks, 93
   `#[pg_extern]` functions, undocumented GUCs).

2. **`ROADMAP.md`** — four new milestones (v0.30.0, v1.7.0, v1.8.0,
   v1.9.0) plus gap-filling across all existing milestones and the
   Post-1.0 Addendum to achieve complete coverage of every §11 action
   item and every §3–§10 finding.

## Changes

### `plans/PLAN_OVERALL_ASSESSMENT_3.md` (new, 1,048 lines)

- §3 — 10 critical bugs: EC-01 phantom rows (P0), snapshot/restore
  non-atomicity (P0), `IVM_DELTA_CACHE` unbounded growth (P0),
  text-based SPI error classifier (P0), L2 cache unbounded, SubLink
  detection in CASE/COALESCE, `SELECT * EXCEPT` regression, snapshot
  catalog WARNING, SCC Tarjan `unwrap()`, `wal_decoder.rs` `expect()`
- §4 — 10 architecture gaps: L0 dshash cache signal-not-store, blanket
  `pub use`, undocumented IVM lock mode, parser memory unbounded,
  catalog hot-path in `metrics_summary()`, IVM temp-table `XactCallback`,
  no multi-DB singleton, no back-pressure, dead imports in
  `orchestrator.rs`, IVM cache not cleared on subxact abort
- §5 — 7 missing benchmark areas
- §7 — 22 test coverage gaps
- §8 — 16 documentation gaps
- §9 — 12 operational/ecosystem items
- §10 — 10 new feature ideas
- §11 — 30-item prioritised action plan targeting v0.28.0–v1.0
- §12 — 12-risk register
- Appendix A — 282 `unsafe` block inventory
- Appendix B — 93 `#[pg_extern]` function inventory
- Appendix C — undocumented GUC list

### `ROADMAP.md` (4 commits, +1,755 lines net)

**New milestones:**

| Milestone | Goal |
|-----------|------|
| v0.30.0 | Correctness, stability, documentation, and test blitz — closes all §3/§4 P0/P1 findings |
| v1.7.0 | Adaptive batching, plan-aware routing, IVM lock counter, ENR tables |
| v1.8.0 | Reactive subscription API + zero-downtime view evolution |
| v1.9.0 | Temporal IVM + columnar storage integration |

**v0.30.0 item count (49 items across 6 categories):**

- CORR-1/2/3 — phantom rows fix, SubLink CASE downgrade NOTICE, `SELECT * EXCEPT`
- STAB-1–6 — snapshot atomicity, IVM cache bound, L2 eviction, snapshot WARNING, WAL decoder `expect()`, IVM `XactCallback`
- PERF-1–4 — L0 dshash cache, parser memory bound, 7 missing benchmarks, catalog hot-path snapshot
- SCAL-1–3 — SQLSTATE classifier, explicit `pub use`, dead import cleanup
- UX-1–18 — GUC docs, UPGRADING.md, ERRORS.md, SQL_REFERENCE, TUI parity, Grafana dashboard, `pg_trickle_dump` docs, snapshot PITR walkthrough, PRE_DEPLOYMENT GUCs, BACKUP_AND_RESTORE atomicity warning, FAQ, RELEASE checklist, PLAYGROUND snapshot demo, CNPG 1.29, dbt 1.11, noisy-neighbour example, `recommend_schedule` cookbook recipe, dbt-pgtrickle version matrix
- TEST-1–19 — atomicity crash, version mismatch, sparse planner, worker fairness, IVM cache soak, `lc_messages` classifier, 4 fuzz targets, EC-01 reproducer, concurrent snapshot, `pg_dump` round-trip, G17-MDB soak promotion, WAL decoder failure injection, CDC ordering invariants, `restore_from_snapshot` rollback, 2 property tests

**v1.0.0 additions:**
- OTL-1 — OpenTelemetry refresh/CDC/snapshot spans (moved from Post-1.0)
- SIGN-1 — cosign-sign GHCR release images (moved from Post-1.0)
- MDB-1 — G17-MDB multi-database soak promoted to `ci.yml`
- Upgrade path reference updated: v0.30.0 → v1.0.0

**Post-1.0 Addendum:** POST-OTL and POST-SIGN removed (now actionable in
v1.0.0). POST-HELM, POST-LLM, POST-GQL, POST-MDSB, POST-PGXN, POST-POOL
remain as long-horizon vision items.

## Assessment Coverage

All items from `PLAN_OVERALL_ASSESSMENT_3.md` are now tracked in `ROADMAP.md`:

| Assessment section | Coverage |
|---|---|
| §3 — 10 critical bugs | ✅ All in v0.30.0 CORR/STAB items |
| §4 — 10 architecture gaps | ✅ All in v0.30.0 PERF/SCAL or v1.7.0 |
| §5 — 7 missing benchmarks | ✅ v0.30.0 PERF-3 |
| §7 — 22 test coverage gaps | ✅ v0.30.0 TEST-1 through TEST-19 |
| §8 — 16 documentation gaps | ✅ v0.30.0 UX-1 through UX-18 |
| §9 — 12 operational/ecosystem items | ✅ v0.30.0 UX-14/15, v1.0.0 OTL-1/SIGN-1/MDB-1, Post-1.0 POST-HELM/GQL/MDSB/PGXN/POOL |
| §10 — 10 new feature ideas | ✅ v1.7.0–v1.9.0 + Post-1.0 POST-LLM/GQL |
| §11 — 30 action items | ✅ All 30 mapped to milestone items |

## Testing

No source code changes — documentation and roadmap only.

- `just fmt` — not applicable (no Rust changes)
- `just lint` — not applicable (no Rust changes)

## Notes

- The assessment's §11 action plan targets some P0 items at "v0.28.0"
  but ROADMAP.md places them in v0.30.0. This is intentional: v0.28.0 is
  already fully committed to the inbox/outbox relay feature; v0.29.0 is
  the relay CLI release. v0.30.0 is the first release with bandwidth for
  the correctness/stability blitz.
- §11 items #14/#15 (IVM lock counter, ENR transition tables) are placed
  in v1.7.0 rather than §11's v0.29.0 target, since v0.29.0 is occupied
  by the relay CLI.
- §11 items #28/#29 (adaptive batching, plan-aware routing) are placed in
  v1.7.0 rather than §11's v0.30.0 target; v0.30.0 is already 49 items.
