### PR TITLE
ci: fix upgrade-e2e timeout and add pgrx-home cache restore-keys

### DIFF
--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -85,6 +85,10 @@ runs:
       with:
         path: ~/.pgrx
         key: pgrx-home-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS || 'unknown' }}-pg${{ inputs.pg-version }}-${{ inputs.pg-install-mode }}-pgrx0.18.0
+        # Fallback to any runner image version (survives ubuntu-latest image updates)
+        restore-keys: |
+          pgrx-home-${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS || 'unknown' }}-pg${{ inputs.pg-version }}-${{ inputs.pg-install-mode }}-
+          pgrx-home-${{ runner.os }}-${{ runner.arch }}-pg${{ inputs.pg-version }}-${{ inputs.pg-install-mode }}-
 
     # ── PostgreSQL headers (Linux) ────────────────────────────────────────
     - name: Install PostgreSQL ${{ inputs.pg-version }} (Linux)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,7 +351,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: [e2e-tests, upgrade-e2e-prepare]
-    timeout-minutes: 35
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.upgrade-e2e-prepare.outputs.matrix) }}


### PR DESCRIPTION
## Summary

Upgrade E2E matrix jobs for `0.10.0 → 0.11.0` and `0.11.0 → 0.12.0` were
consistently timing out at 35 minutes. The root cause was a cache miss on
the `~/.pgrx` home directory (caused by a runner image update changing
`env.ImageOS`), which forced every affected job to cold-compile `cargo-pgrx`
(~25 min) and re-run `pgrx init` (~10 min), exhausting the entire budget
before any build or test step could execute.

## Changes

- **`ci.yml`** — raise `upgrade-e2e-tests` `timeout-minutes` from 35 → 60 so
  even a full cold-start (setup + build + test) can complete within the limit.
- **`setup-pgrx/action.yml`** — add `restore-keys` to the `cache-pgrx-home`
  step so a runner image update falls back to a cache entry from the prior
  image version rather than always triggering a cold `pgrx init`. This mirrors
  the existing fallback strategy already used for the `cargo-pgrx` binary cache.

## Testing

- No code changes; CI workflow and composite action only.
- Verified against [run #1817](https://github.com/grove/pg-trickle/actions/runs/24782435603)
  where the failures occurred.

## Notes

The `pgrx-home` restore-keys are intentionally conservative — they only fall
back within the same OS/arch/install-mode combination, so a Linux `system`
install never accidentally restores a `download`-mode cache.
