### PR TITLE
ci: fix dbt integration race condition between initdb.d and CREATE EXTENSION

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -602,21 +602,22 @@ jobs:
             -p 5432:5432 \
             pg_trickle_e2e:latest
 
-          # Wait for PostgreSQL to accept connections
-          echo "Waiting for PostgreSQL to be ready..."
-          for i in $(seq 1 30); do
+          # Wait until the pg_trickle extension is fully installed.
+          # pg_isready returns true before docker-entrypoint-initdb.d scripts
+          # finish, which can cause a race condition if we try to CREATE
+          # EXTENSION concurrently with the initdb.d script.  Polling
+          # pg_extension directly ensures initdb.d has completed.
+          echo "Waiting for pg_trickle extension to be ready..."
+          for i in $(seq 1 60); do
             if docker exec pgtrickle-dbt-test \
-              pg_isready -U postgres -q 2>/dev/null; then
-              echo "PostgreSQL is ready (attempt $i)"
+              psql -U postgres -qtAc \
+                "SELECT 1 FROM pg_extension WHERE extname='pg_trickle'" \
+              2>/dev/null | grep -q 1; then
+              echo "pg_trickle extension is ready (attempt $i)"
               break
             fi
             sleep 1
           done
-
-      - name: Create pg_trickle extension
-        run: |
-          docker exec pgtrickle-dbt-test \
-            psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS pg_trickle;"
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary

The `dbt integration` CI job was failing with:

```
ERROR:  duplicate key value violates unique constraint "pg_extension_name_index"
DETAIL:  Key (extname)=(pg_trickle) already exists.
```

Root cause: `pg_isready` returns true as soon as PostgreSQL can accept TCP
connections — before `docker-entrypoint-initdb.d` scripts finish executing.
The `dbt integration` job then ran `CREATE EXTENSION IF NOT EXISTS pg_trickle`
concurrently with the still-running `00-create-pg-trickle.sql` initdb script,
and both tried to `INSERT` into `pg_extension` simultaneously, triggering the
unique constraint violation.

## Changes

- **`ci.yml`** — Replace the `pg_isready` poll in "Start PostgreSQL with
  pg_trickle" with a loop that queries `pg_extension` directly, confirming
  the initdb.d script has fully completed before proceeding.
- Remove the now-redundant "Create pg_trickle extension" step: the
  `Dockerfile.e2e` already creates the extension via `initdb.d`, so the
  explicit `CREATE EXTENSION` call is unnecessary and the source of the race.

## Testing

- Reproducer: [CI run #1820](https://github.com/grove/pg-trickle/actions/runs/24788260781/job/72538437841) — `dbt integration` failed with the duplicate key error.
- Fix is targeted at the wait loop only; no source or Docker changes.
