### PR TITLE
ci: add pgtrickle-relay workspace stub to all Dockerfiles

### DIFF
--- a/Dockerfile.ghcr
+++ b/Dockerfile.ghcr
@@ -68,9 +68,10 @@ FROM build-env AS build-deps
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
+COPY pgtrickle-relay/Cargo.toml pgtrickle-relay/Cargo.toml
 
 # Minimal stubs so cargo can resolve the dependency graph.
-RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
+RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src pgtrickle-relay/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
     echo '' > src/dvm/mod.rs && \
@@ -79,7 +80,8 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
     echo 'fn main() {}' > benches/scheduler_bench.rs && \
-    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs && \
+    echo 'fn main() {}' > pgtrickle-relay/src/main.rs
 
 # Pre-fetch dependencies. Docker caches this layer independently.
 # If only src/ changes on the next build, this layer is reused.

--- a/Dockerfile.hub
+++ b/Dockerfile.hub
@@ -64,9 +64,10 @@ FROM build-env AS build-deps
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
+COPY pgtrickle-relay/Cargo.toml pgtrickle-relay/Cargo.toml
 
 # Minimal stubs so cargo can resolve the dependency graph.
-RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
+RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src pgtrickle-relay/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
     echo '' > src/dvm/mod.rs && \
@@ -75,7 +76,8 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
     echo 'fn main() {}' > benches/scheduler_bench.rs && \
-    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs && \
+    echo 'fn main() {}' > pgtrickle-relay/src/main.rs
 
 # Pre-fetch dependencies. Docker caches this layer independently.
 # If only src/ changes on the next build, this layer is reused.

--- a/cnpg/Dockerfile.ext-build
+++ b/cnpg/Dockerfile.ext-build
@@ -44,8 +44,9 @@ RUN cargo pgrx init --pg18 /usr/bin/pg_config
 WORKDIR /build
 COPY Cargo.toml ./
 COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
+COPY pgtrickle-relay/Cargo.toml pgtrickle-relay/Cargo.toml
 
-RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
+RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src pgtrickle-relay/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
     echo '' > src/dvm/mod.rs && \
@@ -55,6 +56,7 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
     echo 'fn main() {}' > benches/scheduler_bench.rs && \
     echo 'fn main() {}' > pgtrickle-tui/src/main.rs && \
+    echo 'fn main() {}' > pgtrickle-relay/src/main.rs && \
     cargo generate-lockfile && \
     cargo fetch
 

--- a/tests/Dockerfile.e2e
+++ b/tests/Dockerfile.e2e
@@ -34,9 +34,10 @@ FROM ${BUILDER_IMAGE} AS builder
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY pgtrickle-tui/Cargo.toml pgtrickle-tui/Cargo.toml
+COPY pgtrickle-relay/Cargo.toml pgtrickle-relay/Cargo.toml
 
 # Create minimal stubs so cargo can resolve the workspace without real source.
-RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
+RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src pgtrickle-relay/src && \
     echo '#![allow(warnings)] fn main() {}' > src/bin/pgrx_embed.rs && \
     echo '#![allow(warnings)]' > src/lib.rs && \
     echo '' > src/dvm/mod.rs && \
@@ -45,7 +46,8 @@ RUN mkdir -p src/bin src/dvm/operators benches pgtrickle-tui/src && \
     echo 'fn main() {}' > benches/refresh_bench.rs && \
     echo 'fn main() {}' > benches/diff_operators.rs && \
     echo 'fn main() {}' > benches/scheduler_bench.rs && \
-    echo 'fn main() {}' > pgtrickle-tui/src/main.rs
+    echo 'fn main() {}' > pgtrickle-tui/src/main.rs && \
+    echo 'fn main() {}' > pgtrickle-relay/src/main.rs
 
 # Pre-fetch all crates.  Cache mount keeps the registry between builds so
 # this becomes a no-op when Cargo.lock hasn't changed.


### PR DESCRIPTION
## Root Cause

`pgtrickle-relay` was added to the Cargo workspace in v0.29.0 (PR #634) but the four Dockerfiles that use stub-based dependency caching were not updated to include it. This caused all Docker-based CI jobs to fail with:

```
error: failed to load manifest for workspace member `pgtrickle-relay`
```

## Failed Jobs
- E2E tests (`tests/build_e2e_image.sh`)
- dbt integration (uses same image)
- DAG bench calc/throughput (uses same image)
- DAG bench parallel workers (uses same image)
- CNPG smoke test (`cnpg/Dockerfile.ext-build`)

## Fix

Add `COPY pgtrickle-relay/Cargo.toml` + stub source creation to all affected Dockerfiles:
- `tests/Dockerfile.e2e`
- `cnpg/Dockerfile.ext-build`
- `Dockerfile.ghcr`
- `Dockerfile.hub`

## Verified

- `./tests/build_e2e_image.sh` succeeds locally
- `just test-e2e`: **1302/1302 tests passed** (2 flaky on retry, 107 skipped)