### PR TITLE
fix(upgrade): add missing self-monitoring functions to 0.24.0→0.25.0 script

### DIFF
--- a/sql/pg_trickle--0.24.0--0.25.0.sql
+++ b/sql/pg_trickle--0.24.0--0.25.0.sql
@@ -39,6 +39,32 @@ RETURNS TABLE (
     LANGUAGE c STRICT
 AS 'MODULE_PATHNAME', 'worker_allocation_status_fn_wrapper';
 
+-- MON-1: Register self-monitoring functions.
+-- setup_self_monitoring() — installs the self-monitoring background worker.
+CREATE OR REPLACE FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
+
+-- teardown_self_monitoring() — uninstalls the self-monitoring background worker.
+CREATE OR REPLACE FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
+
+-- self_monitoring_status() — returns per-stream monitoring status.
+CREATE OR REPLACE FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
+    "st_name"        TEXT,
+    "exists"         bool,
+    "status"         TEXT,
+    "refresh_mode"   TEXT,
+    "last_refresh_at" TEXT,
+    "total_refreshes" bigint
+)
+    STRICT
+    LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
+
 -- Record the schema version for the upgrade chain.
 INSERT INTO pgtrickle.pgt_schema_version (version, description)
 VALUES ('0.25.0', 'Scheduler Scalability & Pooler Performance')


### PR DESCRIPTION
## Summary

The `0.24.0 → 0.25.0` upgrade script was missing three self-monitoring functions
that were introduced in v0.25.0. Without them, `ALTER EXTENSION pg_trickle UPDATE
TO '0.25.0'` silently skipped the functions, leaving an upgraded installation with
a different schema than a fresh install.

## Changes

- Added the three missing `CREATE OR REPLACE FUNCTION` statements to
  `sql/pg_trickle--0.24.0--0.25.0.sql`:
  - `pgtrickle.setup_self_monitoring()`
  - `pgtrickle.teardown_self_monitoring()`
  - `pgtrickle.self_monitoring_status()`

## Root Cause

The self-monitoring API functions (`#[pg_extern]` in Rust) were added in v0.25.0
(pgrx auto-includes them in the full install SQL), but the hand-authored upgrade
script was not updated to include the corresponding `CREATE OR REPLACE FUNCTION`
statements. The `check-upgrade-all` checker compares the pgrx-generated full
install SQL for each version pair and reports any objects present in the new
version but absent from the upgrade script.

## Testing

- `just check-version-sync` — passes
- `just check-upgrade-all` — all 31 upgrade steps pass (was 1 failure before fix)
- `just test-upgrade-all` — 32/32 upgrade paths pass, 18/18 tests pass per path
