### PR TITLE
ci(dbt-getting-started): fix race condition in PostgreSQL readiness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -701,20 +701,22 @@ jobs:
             -p 15433:5432 \
             pg_trickle_e2e:latest
 
-          echo "Waiting for PostgreSQL to be ready..."
-          for i in $(seq 1 30); do
+          # pg_isready returns true before docker-entrypoint-initdb.d scripts
+          # finish, which causes a race condition: dbt tries to connect before
+          # postgres has finished initialising and published the host port.
+          # Poll pg_extension directly to ensure initdb.d has completed before
+          # running dbt (mirrors the approach used in the dbt-integration job).
+          echo "Waiting for pg_trickle extension to be ready..."
+          for i in $(seq 1 60); do
             if docker exec pgtrickle-getting-started \
-              pg_isready -U postgres -q 2>/dev/null; then
-              echo "PostgreSQL is ready (attempt $i)"
+              psql -U postgres -qtAc \
+                "SELECT 1 FROM pg_extension WHERE extname='pg_trickle'" \
+              2>/dev/null | grep -q 1; then
+              echo "pg_trickle extension is ready (attempt $i)"
               break
             fi
             sleep 1
           done
-
-      - name: Create pg_trickle extension
-        run: |
-          docker exec pgtrickle-getting-started \
-            psql -U postgres -c "CREATE EXTENSION IF NOT EXISTS pg_trickle;"
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary

The `dbt getting-started example` CI job was using `pg_isready` to wait for PostgreSQL, but `pg_isready` returns `true` before `docker-entrypoint-initdb.d` scripts finish running. This caused a race condition where dbt tried to connect before the host port was published and the extension was fully installed, producing:

```
Database Error: connection to server at "localhost" (::1), port 15433 failed: Connection refused
```

This was the sole failure in CI run [#1849](https://github.com/grove/pg-trickle/actions/runs/24852508020).

## Changes

- Replace the `pg_isready` loop + separate `CREATE EXTENSION` step with a single loop that polls `pg_extension` directly — the same approach used in the `dbt integration` job since PR #629.
- Timeout extended from 30 s to 60 s to match the `dbt integration` job.
- Remove the now-redundant `Create pg_trickle extension` step: the extension is already created by `/docker-entrypoint-initdb.d/00-create-pg-trickle.sql` in the E2E image, so we just need to wait until it's fully ready.

## Root Cause

The `dbt integration` job had this exact race fixed in PR #629 (`ci: fix dbt integration race condition between initdb.d and CREATE EXTENSION`). The `dbt getting-started example` job was added after that fix and didn't benefit from it.

## Testing

- Verified locally: container starts, readiness loop exits at attempt 1 (extension already installed by initdb.d).
- The existing `dbt integration` CI job (which uses the identical readiness pattern) passes consistently.
