### PR TITLE
docs: close v0.25.0–v0.29.0 documentation gap (SQL reference, config, patterns, architecture)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -55,10 +55,25 @@ For a high-level description of what pg_trickle does and why, read [ESSENCE.md](
 
 ## Component Details
 
-### 1. SQL API Layer (`src/api.rs`)
+### 1. SQL API Layer (`src/api/`)
 
-The public entry point for users. All operations are exposed as `#[pg_extern]` functions in the `pgtrickle` schema:
+The public entry point for users. All operations are exposed as `#[pg_extern]` functions in the `pgtrickle` schema. The API module is split into focused sub-modules:
 
+| File | Responsibility |
+|------|----------------|
+| `src/api/mod.rs` | Core lifecycle: `create_stream_table`, `alter_stream_table`, `drop_stream_table`, `refresh_stream_table`, `bulk_create`, `repair_stream_table`, `pgt_status` |
+| `src/api/diagnostics.rs` | Inspection helpers: `explain_st`, `explain_refresh_mode`, `dependency_tree`, `list_sources` |
+| `src/api/outbox.rs` | Transactional outbox API (v0.28.0): `enable_outbox`, `poll_outbox`, `consumer_lag`, consumer group management |
+| `src/api/inbox.rs` | Transactional inbox API (v0.28.0): `create_inbox`, `enable_inbox_ordering`, `inbox_is_my_partition` |
+| `src/api/snapshot.rs` | Stream table snapshots (v0.27.0): `snapshot_stream_table`, `restore_from_snapshot`, `list_snapshots`, `drop_snapshot` |
+| `src/api/self_monitoring.rs` | Self-monitoring setup/teardown and auto-apply policy |
+| `src/api/cluster.rs` | Multi-database cluster overview: `cluster_worker_summary` |
+| `src/api/publication.rs` | Logical publication helpers and predictive cost model utilities |
+| `src/api/metrics_ext.rs` | Extended Prometheus metrics |
+| `src/api/helpers.rs` | Shared utilities (name resolution, table quoting) |
+| `src/api/planner.rs` | Schedule recommendation API |
+
+**Core functions:**
 - **create_stream_table** — Applies a chain of auto-rewrite passes (view inlining → DISTINCT ON → GROUPING SETS → scalar subquery in WHERE → correlated scalar subquery in SELECT → SubLinks in OR → multi-PARTITION BY windows), parses the defining query, builds an operator tree, creates the storage table, registers CDC slots, populates the catalog, and optionally performs an initial full refresh.
 - **alter_stream_table** — Modifies schedule, refresh mode, status (ACTIVE/SUSPENDED), or defining query. Query changes trigger schema migration, dependency updates, and a full refresh within a single transaction.
 - **drop_stream_table** — Removes the storage table, catalog entries, and cleans up CDC slots.
@@ -612,7 +627,41 @@ The policy is set on the convergence (fan-in) node. When multiple convergence no
 
 The `pgtrickle.diamond_groups()` SQL function exposes detected groups for operational visibility. See [SQL_REFERENCE.md](SQL_REFERENCE.md) for details.
 
-### 14. Configuration (`src/config.rs`)
+### 14. Transactional Outbox & Inbox (`src/api/outbox.rs`, `src/api/inbox.rs`)
+
+> **Added in v0.28.0.**
+
+The outbox and inbox subsystems enable reliable, at-least-once event delivery between stream tables and external systems.
+
+#### Outbox
+
+When `enable_outbox(name)` is called on a stream table, the refresh engine writes a summary row to `pgtrickle.pgt_outbox_<st>` after every successful refresh. Each row records `inserted_count`, `deleted_count`, and optionally a JSON payload. For large deltas, pg_trickle switches to **claim-check mode** — the payload is stored separately and consumers get a pointer.
+
+Consumers read via `poll_outbox(group, consumer, ...)` which grants a **visibility lease**. Consumers must call `commit_offset()` before the lease expires, or the rows become visible again. Multiple independent **consumer groups** each maintain their own offset into the outbox.
+
+#### Inbox
+
+`create_inbox(name)` provisions an inbox table plus three stream tables on top of it:
+
+- `<name>_pending` — messages awaiting processing
+- `<name>_dlq` — dead-letter messages (exceeded `max_retries`)
+- `<name>_stats` — message counts grouped by `event_type`
+
+Optionally, `enable_inbox_ordering()` adds a `next_<name>` stream table that surfaces only the lowest-sequence unprocessed message per aggregate, ensuring per-aggregate ordering without application-side coordination.
+
+`inbox_is_my_partition(aggregate_id, worker_id, total_workers)` uses FNV-1a consistent hashing to route aggregates to specific workers, enabling horizontal scaling without a central coordinator.
+
+### 15. Stream Table Snapshots (`src/api/snapshot.rs`)
+
+> **Added in v0.27.0.**
+
+`snapshot_stream_table(name)` exports the current content of a stream table into an archival table, capturing the extension version and current frontier in metadata columns (`__pgt_snapshot_version`, `__pgt_frontier`, `__pgt_snapshotted_at`).
+
+`restore_from_snapshot(name, source)` truncates the stream table and reloads it from the snapshot, then restores the saved frontier. This ensures the **next refresh cycle is DIFFERENTIAL** — skipping the expensive full re-scan that would otherwise follow a blank stream table.
+
+Primary use cases: replica bootstrap, PITR alignment, and historical archiving.
+
+### 16. Configuration (`src/config.rs`)
 
 Runtime behavior is controlled by a growing set of GUC (Grand Unified Configuration) variables. See [CONFIGURATION.md](CONFIGURATION.md) for the complete, current list.
 
@@ -694,7 +743,18 @@ src/
 ├── lib.rs           # Extension entry, module declarations, _PG_init
 ├── bin/
 │   └── pgrx_embed.rs# pgrx SQL entity embedding (generated)
-├── api.rs           # SQL API functions (create/alter/drop/refresh/status)
+├── api/
+│   ├── mod.rs       # Core lifecycle functions (create/alter/drop/refresh/status)
+│   ├── diagnostics.rs   # explain_st, explain_refresh_mode, dependency_tree
+│   ├── outbox.rs    # Transactional outbox API (v0.28.0)
+│   ├── inbox.rs     # Transactional inbox API (v0.28.0)
+│   ├── snapshot.rs  # Stream table snapshots (v0.27.0)
+│   ├── self_monitoring.rs  # Self-monitoring setup/teardown
+│   ├── cluster.rs   # cluster_worker_summary
+│   ├── publication.rs   # Logical publication helpers
+│   ├── metrics_ext.rs   # Extended Prometheus metrics
+│   ├── planner.rs   # Schedule recommendation API
+│   └── helpers.rs   # Shared utilities
 ├── catalog.rs       # Catalog CRUD operations
 ├── cdc.rs           # Change data capture (triggers + WAL transition)
 ├── config.rs        # GUC variable registration
@@ -749,3 +809,61 @@ file when `CREATE EXTENSION pg_trickle;` is executed.
 During packaging (`cargo pgrx package`), pgrx replaces the `@CARGO_VERSION@`
 placeholder with the version from `Cargo.toml` and copies the file into the
 target's `share/extension/` directory alongside the SQL migration scripts.
+
+---
+
+## pgtrickle-relay (v0.29.0)
+
+`pgtrickle-relay` is a standalone Rust binary (a separate Cargo workspace member
+at `pgtrickle-relay/`) that bridges pg_trickle outbox and inbox tables with
+external messaging systems. It is distributed and deployed independently from
+the PostgreSQL extension.
+
+### Design Goals
+
+- **SQL-only configuration**: all pipeline config lives in PostgreSQL catalog
+  tables (`relay_outbox_config`, `relay_inbox_config`). No YAML, no config files.
+- **Hot-reload**: config changes trigger `NOTIFY pgtrickle_relay_config`; running
+  relay instances reload their pipelines without restart.
+- **Advisory-lock HA**: multiple relay instances distribute pipelines via
+  `pg_try_advisory_lock`. Each pipeline runs on exactly one instance; if an
+  instance dies, others claim its locks on the next poll cycle.
+- **Idempotent delivery**: every backend uses source-specific dedup keys to
+  provide at-least-once delivery with server-side deduplication where supported.
+
+### Architecture
+
+```
+PostgreSQL (pg_trickle extension)
+  ├─ outbox tables ──→ [OutboxPollerSource] ──→ Sink (NATS / Kafka / webhook / …)
+  └─ inbox tables  ←── [InboxSink]         ←── Source (NATS / Kafka / webhook / …)
+```
+
+### Key Modules (`pgtrickle-relay/src/`)
+
+| Module | Purpose |
+|--------|---------|
+| `main.rs` | CLI entry point, tracing init, coordinator startup |
+| `cli.rs` | clap argument definitions |
+| `config.rs` | `RelayConfig` (global) and `PipelineConfig` (per-pipeline) |
+| `coordinator.rs` | Advisory lock acquisition, hot-reload via LISTEN/NOTIFY |
+| `envelope.rs` | `RelayMessage` envelope and `AckToken` |
+| `metrics.rs` | Prometheus metrics and `/health` axum server |
+| `source/` | Source trait + implementations (outbox, NATS, Kafka, Redis, SQS, RabbitMQ, webhook, stdin) |
+| `sink/` | Sink trait + implementations (inbox, NATS, Kafka, Redis, SQS, RabbitMQ, webhook, stdout, pg-inbox) |
+
+### Supported Backends
+
+| Backend | Direction | Feature flag |
+|---------|-----------|-------------|
+| pg_trickle outbox | source (forward) | always |
+| pg_trickle inbox | sink (reverse) | always |
+| NATS JetStream | both | `nats` |
+| Apache Kafka | both | `kafka` |
+| HTTP webhook | both | `webhook` |
+| Redis Streams | both | `redis` |
+| AWS SQS | both | `sqs` |
+| RabbitMQ | both | `rabbitmq` |
+| stdout / JSONL | sink | `stdout` |
+
+See [RELAY.md](RELAY.md) for the full operations guide and deployment examples.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -78,6 +78,36 @@ Complete reference for all pg_trickle GUC (Grand Unified Configuration) variable
   - [Circular Dependencies](#circular-dependencies)
     - [pg\_trickle.allow\_circular](#pg_trickleallow_circular)
     - [pg\_trickle.max\_fixpoint\_iterations](#pg_tricklemax_fixpoint_iterations)
+- [Scheduler Scalability (v0.25.0)](#scheduler-scalability-v0250)
+  - [pg\_trickle.worker\_pool\_size](#pg_trickleworker_pool_size)
+  - [pg\_trickle.template\_cache\_max\_entries](#pg_trickletemplate_cache_max_entries)
+- [Operability, Observability & DR (v0.27.0)](#operability-observability--dr-v0270)
+  - [pg\_trickle.metrics\_port](#pg_tricklemetrics_port)
+  - [pg\_trickle.metrics\_request\_timeout\_ms](#pg_tricklemetrics_request_timeout_ms)
+  - [pg\_trickle.frontier\_holdback\_mode](#pg_tricklefrontier_holdback_mode)
+  - [pg\_trickle.frontier\_holdback\_warn\_seconds](#pg_tricklefrontier_holdback_warn_seconds)
+  - [pg\_trickle.publication\_lag\_warn\_bytes](#pg_tricklepublication_lag_warn_bytes)
+  - [pg\_trickle.schedule\_recommendation\_min\_samples](#pg_trickleschedule_recommendation_min_samples)
+  - [pg\_trickle.schedule\_alert\_cooldown\_seconds](#pg_trickleschedule_alert_cooldown_seconds)
+- [Transactional Outbox (v0.28.0)](#transactional-outbox-v0280)
+  - [pg\_trickle.outbox\_enabled](#pg_trickleoutbox_enabled)
+  - [pg\_trickle.outbox\_retention\_hours](#pg_trickleoutbox_retention_hours)
+  - [pg\_trickle.outbox\_drain\_batch\_size](#pg_trickleoutbox_drain_batch_size)
+  - [pg\_trickle.outbox\_drain\_interval\_seconds](#pg_trickleoutbox_drain_interval_seconds)
+  - [pg\_trickle.outbox\_inline\_threshold\_rows](#pg_trickleoutbox_inline_threshold_rows)
+  - [pg\_trickle.outbox\_skip\_empty\_delta](#pg_trickleoutbox_skip_empty_delta)
+  - [pg\_trickle.outbox\_storage\_critical\_mb](#pg_trickleoutbox_storage_critical_mb)
+  - [pg\_trickle.outbox\_force\_retention](#pg_trickleoutbox_force_retention)
+  - [pg\_trickle.consumer\_dead\_threshold\_hours](#pg_trickleconsumer_dead_threshold_hours)
+  - [pg\_trickle.consumer\_stale\_offset\_threshold\_days](#pg_trickleconsumer_stale_offset_threshold_days)
+  - [pg\_trickle.consumer\_cleanup\_enabled](#pg_trickleconsumer_cleanup_enabled)
+- [Transactional Inbox (v0.28.0)](#transactional-inbox-v0280)
+  - [pg\_trickle.inbox\_enabled](#pg_trickleinbox_enabled)
+  - [pg\_trickle.inbox\_processed\_retention\_hours](#pg_trickleinbox_processed_retention_hours)
+  - [pg\_trickle.inbox\_dlq\_retention\_hours](#pg_trickleinbox_dlq_retention_hours)
+  - [pg\_trickle.inbox\_drain\_batch\_size](#pg_trickleinbox_drain_batch_size)
+  - [pg\_trickle.inbox\_drain\_interval\_seconds](#pg_trickleinbox_drain_interval_seconds)
+  - [pg\_trickle.inbox\_dlq\_alert\_max\_per\_refresh](#pg_trickleinbox_dlq_alert_max_per_refresh)
 - [GUC Interaction Matrix](#guc-interaction-matrix)
 - [Tuning Profiles](#tuning-profiles)
   - [Low-Latency Profile](#low-latency-profile)
@@ -2043,6 +2073,425 @@ threshold values.
 
 ---
 
+## Scheduler Scalability (v0.25.0)
+
+### pg_trickle.worker_pool_size
+
+> **Added in v0.25.0 (SCAL-5).**
+
+Number of persistent background workers kept ready in a pool. When `> 0`,
+the scheduler reuses these workers across refresh cycles instead of spawning
+a new worker for each job, eliminating the ~2 ms per-worker startup cost.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `0` (spawn-per-task) |
+| Range | 0 – 64 |
+| Context | `SUSET` (superuser) |
+| Restart required | Yes |
+
+```sql
+-- Keep 4 persistent workers ready at all times
+ALTER SYSTEM SET pg_trickle.worker_pool_size = 4;
+SELECT pg_reload_conf();
+```
+
+Set to `0` to use the original spawn-per-task model (default, no change from
+pre-v0.25.0 behavior).
+
+### pg_trickle.template_cache_max_entries
+
+> **Added in v0.25.0 (CACHE-2).**
+
+Maximum number of entries in the per-backend L1 delta SQL template cache. When
+the cache reaches this limit, the least-recently-used entry is evicted.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `0` (unbounded) |
+| Range | 0 – 65536 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+```sql
+-- Cap the template cache at 200 entries per backend
+SET pg_trickle.template_cache_max_entries = 200;
+```
+
+---
+
+## Operability, Observability & DR (v0.27.0)
+
+### pg_trickle.metrics_port
+
+> **Added in v0.27.0 (OP-2).**
+
+TCP port for the Prometheus/OpenMetrics endpoint served by the per-database
+background scheduler. When non-zero, `GET /metrics` returns all pg_trickle
+monitoring metrics in Prometheus text format.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `0` (disabled) |
+| Range | 0 – 65535 |
+| Context | `SUSET` (superuser) |
+| Restart required | Yes |
+
+```sql
+-- Expose metrics on port 9188 (per database)
+ALTER DATABASE mydb SET pg_trickle.metrics_port = 9188;
+SELECT pg_reload_conf();
+```
+
+Use `0` (the default) to disable the HTTP endpoint. Each database runs its
+own scheduler, so the port must be unique per database on the same host.
+
+### pg_trickle.metrics_request_timeout_ms
+
+> **Added in v0.27.0 (METR-2).**
+
+Maximum milliseconds the metrics HTTP handler is allowed to run. If a slow
+HTTP client holds the connection open longer, it is dropped. This protects the
+scheduler tick loop from being blocked by unresponsive Prometheus scrapers.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `5000` (5 seconds) |
+| Range | 0 (no timeout) – 600 000 (10 min) |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.frontier_holdback_mode
+
+> **Added in v0.27.0 (issue #536).**
+
+Controls how the scheduler prevents silent data loss from long-running
+transactions. When an uncommitted transaction has written rows to a source
+table, those change-buffer rows must not be included in a refresh until the
+transaction commits (or rolls back).
+
+| Property | Value |
+|---|---|
+| Type | `text` |
+| Default | `'xmin'` |
+| Values | `'xmin'`, `'none'`, `'lsn:<N>'` |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+| Value | Behaviour |
+|-------|-----------|
+| `'xmin'` | (Default) Probes `pg_stat_activity` + `pg_prepared_xacts` once per tick; caps the frontier to exclude rows from uncommitted transactions. |
+| `'none'` | No holdback — maximum performance but can skip rows from long-lived transactions. Not recommended for production. |
+| `'lsn:<N>'` | Hold back by exactly N bytes. Debugging use only. |
+
+### pg_trickle.frontier_holdback_warn_seconds
+
+> **Added in v0.27.0 (issue #536).**
+
+Emit a WARNING when a holdback-causing transaction has been blocking frontier
+advancement for longer than this many seconds. The warning fires at most once
+per minute to avoid log spam. Useful for identifying forgotten long-running
+transactions.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `300` (5 minutes) |
+| Range | 0 (disabled) – 3600 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.publication_lag_warn_bytes
+
+> **Added in v0.27.0 (PUB-1).**
+
+Emit a WARNING and defer change-buffer truncation when a downstream logical
+replication subscriber's confirmed WAL position lags behind the current
+change buffer by more than this many bytes.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `0` (disabled) |
+| Range | 0 – 2 147 483 647 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+This prevents data loss for subscribers that rely on the change buffer as
+part of their replication pipeline.
+
+### pg_trickle.schedule_recommendation_min_samples
+
+> **Added in v0.27.0 (PLAN-4).**
+
+Minimum number of refresh-history observations before
+`pgtrickle.recommend_schedule()` returns a recommendation with non-zero
+confidence. Raise this for more reliable recommendations; lower it to get
+early guidance on new stream tables.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `10` |
+| Range | 1 – 1000 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.schedule_alert_cooldown_seconds
+
+> **Added in v0.27.0 (PLAN-3).**
+
+Minimum seconds between consecutive `predicted_sla_breach` alerts for the
+same stream table. Prevents log spam when the cost model consistently predicts
+an imminent SLA violation.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `300` (5 minutes) |
+| Range | 0 (no cooldown) – 86 400 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+---
+
+## Transactional Outbox (v0.28.0)
+
+These GUCs control the transactional outbox subsystem. See the SQL Reference
+for the `enable_outbox()`, `poll_outbox()`, and consumer group functions.
+
+### pg_trickle.outbox_enabled
+
+Master enable/disable switch for the outbox subsystem.
+
+| Property | Value |
+|---|---|
+| Type | `boolean` |
+| Default | `true` |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.outbox_retention_hours
+
+Default retention period (in hours) for outbox rows. Rows older than this
+threshold are eligible for the background drain sweep. Can be overridden
+per stream table via `enable_outbox(retention_hours => N)`.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `24` |
+| Range | 1 – 87 600 (10 years) |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.outbox_drain_batch_size
+
+Number of expired outbox rows deleted in a single background drain pass.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `1000` |
+| Range | 1 – 1 000 000 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.outbox_drain_interval_seconds
+
+Seconds between background outbox drain sweeps. Set to `0` to disable
+automatic draining (you would then drain manually with `outbox_rows_consumed()`).
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `60` |
+| Range | 0 (disabled) – 86 400 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.outbox_inline_threshold_rows
+
+Maximum number of delta rows stored inline in the outbox payload. When a
+refresh delta exceeds this count, pg_trickle switches to **claim-check** mode:
+the payload is stored in a separate table and `poll_outbox()` returns
+`is_claim_check = true` with a `NULL` payload.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `10000` |
+| Range | 0 (always inline) – 10 000 000 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.outbox_skip_empty_delta
+
+When `true`, no outbox row is written for refreshes that produce zero inserted
+and zero deleted rows. This reduces outbox table growth for frequently-scheduled
+stream tables with sparse updates.
+
+| Property | Value |
+|---|---|
+| Type | `boolean` |
+| Default | `true` |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.outbox_storage_critical_mb
+
+Size threshold (in MB) at which the outbox table is considered critically large.
+When exceeded, a WARNING is emitted on each refresh cycle.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `1024` (1 GB) |
+| Range | 1 – 10 000 000 (10 TB) |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.outbox_force_retention
+
+When `true`, outbox rows are kept past their `retention_hours` expiry until
+**all** consumer groups have committed an offset past them. Prevents consumers
+that are temporarily offline from missing messages.
+
+| Property | Value |
+|---|---|
+| Type | `boolean` |
+| Default | `false` |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.consumer_dead_threshold_hours
+
+Hours of silence (no heartbeat) after which a consumer is marked as dead and
+eligible for cleanup (when `consumer_cleanup_enabled = true`).
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `24` |
+| Range | 1 – 87 600 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.consumer_stale_offset_threshold_days
+
+Days of no offset progress after which a consumer's offset record is
+considered stale and eligible for cleanup.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `7` |
+| Range | 1 – 3650 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.consumer_cleanup_enabled
+
+Enable automatic background cleanup of dead and stale consumer offsets
+and leases. When disabled, old records must be removed manually.
+
+| Property | Value |
+|---|---|
+| Type | `boolean` |
+| Default | `true` |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+---
+
+## Transactional Inbox (v0.28.0)
+
+These GUCs control the transactional inbox subsystem. See the SQL Reference
+for `create_inbox()` and related functions.
+
+### pg_trickle.inbox_enabled
+
+Master enable/disable switch for the inbox subsystem.
+
+| Property | Value |
+|---|---|
+| Type | `boolean` |
+| Default | `true` |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.inbox_processed_retention_hours
+
+Retention period (in hours) for successfully processed inbox messages
+(`processed_at IS NOT NULL`). Rows older than this threshold are deleted
+by the background drain sweep.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `72` (3 days) |
+| Range | 1 – 87 600 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.inbox_dlq_retention_hours
+
+Retention period (in hours) for dead-letter queue rows. Set to `0` to
+keep DLQ rows indefinitely (useful for forensics and manual replay).
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `0` (keep forever) |
+| Range | 0 (keep forever) – 87 600 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.inbox_drain_batch_size
+
+Number of expired inbox messages deleted in a single background drain pass.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `1000` |
+| Range | 1 – 1 000 000 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.inbox_drain_interval_seconds
+
+Seconds between inbox background drain sweeps. Set to `0` to disable
+automatic draining.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `60` |
+| Range | 0 (disabled) – 86 400 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+### pg_trickle.inbox_dlq_alert_max_per_refresh
+
+Maximum number of DLQ alert events raised per refresh cycle. Limits log
+volume when many messages are failing simultaneously. Set to `0` to disable
+DLQ alerting.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `10` |
+| Range | 0 (disabled) – 100 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+
+---
+
 ## GUC Interaction Matrix
 
 Some GUC variables interact with or depend on each other. The table below
@@ -2235,6 +2684,31 @@ pg_trickle.delta_enable_nestloop = true         # allow nested-loop joins in del
 pg_trickle.analyze_before_delta = true          # ANALYZE change buffers before delta SQL
 pg_trickle.max_change_buffer_alert_rows = 0     # change buffer overflow alert threshold (0 = off)
 pg_trickle.diff_output_format = 'split'         # 'split' (DI-2 pairs) | 'merged' (compat)
+
+# Scheduler scalability (v0.25.0+)
+pg_trickle.worker_pool_size = 0                 # 0 = spawn-per-task; >0 = persistent pool
+pg_trickle.template_cache_max_entries = 0       # 0 = unbounded
+
+# Operability & observability (v0.27.0+)
+pg_trickle.metrics_port = 0                     # 0 = disabled; set per-database
+pg_trickle.frontier_holdback_mode = 'xmin'      # xmin | none | lsn:<N>
+pg_trickle.frontier_holdback_warn_seconds = 300 # warn after 5 min of blocked frontier
+pg_trickle.publication_lag_warn_bytes = 0       # 0 = disabled
+
+# Transactional outbox (v0.28.0+)
+pg_trickle.outbox_enabled = true
+pg_trickle.outbox_retention_hours = 24
+pg_trickle.outbox_inline_threshold_rows = 10000
+pg_trickle.outbox_skip_empty_delta = true
+pg_trickle.outbox_force_retention = false
+pg_trickle.consumer_dead_threshold_hours = 24
+pg_trickle.consumer_cleanup_enabled = true
+
+# Transactional inbox (v0.28.0+)
+pg_trickle.inbox_enabled = true
+pg_trickle.inbox_processed_retention_hours = 72
+pg_trickle.inbox_dlq_retention_hours = 0       # 0 = keep forever
+pg_trickle.inbox_dlq_alert_max_per_refresh = 10
 
 # Advanced / internal
 pg_trickle.change_buffer_schema = 'pgtrickle_changes'

--- a/docs/INBOX.md
+++ b/docs/INBOX.md
@@ -1,0 +1,370 @@
+# Transactional Inbox
+
+The **transactional inbox pattern** solves the duplicate-processing problem:
+when messages arrive from an external system, your service needs a guarantee
+that each message is processed exactly once, even if the message broker
+delivers it more than once or your service restarts mid-batch.
+
+pg_trickle's inbox works by writing incoming messages to a PostgreSQL table and
+using stream tables to present live views of pending work, dead letters, and
+per-type statistics. Because the inbox table is ordinary PostgreSQL, your
+application's processing step and the "mark as processed" step can be wrapped
+in a single transaction — making the entire operation atomic.
+
+> **Available since v0.28.0**
+
+---
+
+## How it works
+
+```
+External system (Kafka / NATS / webhook / relay)
+        │
+        ▼
+  INSERT into pgtrickle.<inbox_name>
+  (idempotent: ON CONFLICT DO NOTHING on event_id)
+        │
+        ▼
+  Stream tables refresh automatically:
+  ├─ <inbox_name>_pending   ← WHERE processed_at IS NULL AND retry_count < max_retries
+  ├─ <inbox_name>_dlq       ← WHERE processed_at IS NULL AND retry_count >= max_retries
+  └─ <inbox_name>_stats     ← GROUP BY event_type (counts)
+        │
+        ▼
+  Your application queries <inbox_name>_pending,
+  processes each message, then:
+  UPDATE <inbox_name> SET processed_at = now() WHERE event_id = $1
+```
+
+The stream tables are differential: when a row's `processed_at` is set, the
+change propagates to `_pending` and `_stats` in the next refresh cycle
+(typically within 1 second).
+
+---
+
+## Quickstart
+
+### 1. Create an inbox
+
+```sql
+SELECT pgtrickle.create_inbox('order_events');
+```
+
+This creates:
+- `pgtrickle.order_events` — the inbox table (one row per message)
+- `pgtrickle.order_events_pending` — stream table: unprocessed messages
+- `pgtrickle.order_events_dlq` — stream table: messages that exhausted retries
+- `pgtrickle.order_events_stats` — stream table: per-event-type counts
+
+### 2. Write messages (sender side)
+
+The inbox table has a standard schema:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `event_id` | TEXT PK | Globally unique message ID (idempotency key) |
+| `event_type` | TEXT | Message type / topic (e.g. `order.placed`) |
+| `source` | TEXT | Originating system or service |
+| `aggregate_id` | TEXT | Business entity ID (e.g. order ID) |
+| `payload` | JSONB | Message body |
+| `received_at` | TIMESTAMPTZ | Set to `now()` on insert |
+| `processed_at` | TIMESTAMPTZ | Set by your application after processing |
+| `error` | TEXT | Last error message, if any |
+| `retry_count` | INT | Number of failed attempts |
+| `trace_id` | TEXT | Distributed trace ID for observability |
+
+Write messages with conflict protection to guarantee idempotency:
+
+```sql
+INSERT INTO pgtrickle.order_events
+    (event_id, event_type, source, aggregate_id, payload)
+VALUES
+    ('evt-001', 'order.placed', 'shop-api', 'ORD-123', '{"amount": 49.99}')
+ON CONFLICT (event_id) DO NOTHING;
+```
+
+### 3. Process messages (receiver side)
+
+```sql
+-- Read pending messages
+SELECT event_id, event_type, aggregate_id, payload
+FROM pgtrickle.order_events_pending
+LIMIT 100;
+```
+
+Process each message in a transaction:
+
+```sql
+BEGIN;
+
+-- Do your business logic here
+-- (e.g. publish to downstream service, update application tables)
+
+-- Mark as processed atomically with your business logic
+UPDATE pgtrickle.order_events
+SET processed_at = now()
+WHERE event_id = 'evt-001';
+
+COMMIT;
+```
+
+If the transaction rolls back, `processed_at` stays NULL and the message
+remains in `_pending` for retry.
+
+---
+
+## Using an existing table (bring-your-own-table)
+
+If you already have a messages table, point pg_trickle at it instead of
+creating a new one:
+
+```sql
+SELECT pgtrickle.enable_inbox_tracking(
+    'my_inbox',                          -- logical name
+    'app.incoming_events',               -- your existing table
+    p_id_column          => 'msg_id',
+    p_processed_at_column => 'done_at',
+    p_event_type_column  => 'type'
+);
+```
+
+pg_trickle validates that the required columns exist, then creates the standard
+stream tables on top of your table. The underlying table is not modified.
+
+---
+
+## Ordering guarantees (per-aggregate)
+
+By default, multiple workers can process messages for the same `aggregate_id`
+concurrently. If your business logic requires strictly sequential processing per
+aggregate (e.g. events for the same order must be handled in order), enable
+ordering:
+
+```sql
+SELECT pgtrickle.enable_inbox_ordering(
+    'order_events',
+    p_aggregate_column => 'aggregate_id',
+    p_sequence_column  => 'received_at'
+);
+```
+
+This creates a fourth stream table:
+
+- `pgtrickle.next_order_events` — one row per `aggregate_id`, always the
+  _next_ unprocessed message for that aggregate (DISTINCT ON semantics)
+
+Workers that need ordered processing should query `next_order_events` instead
+of `order_events_pending`:
+
+```sql
+-- Only the next message per aggregate — safe for parallel workers
+SELECT event_id, event_type, aggregate_id, payload
+FROM pgtrickle.next_order_events
+LIMIT 50;
+```
+
+A worker processing `aggregate_id = 'ORD-123'` blocks any other message for
+that order until it commits. Different aggregates are processed in parallel.
+
+### Checking for ordering gaps
+
+```sql
+-- Returns aggregate IDs where messages are out of sequence or missing
+SELECT * FROM pgtrickle.inbox_ordering_gaps('order_events');
+```
+
+---
+
+## Priority processing
+
+If some message types should be processed before others, enable priority
+scheduling:
+
+```sql
+SELECT pgtrickle.enable_inbox_priority(
+    'order_events',
+    p_priority_column => 'event_type',
+    p_priority_map    => '{"order.cancelled": 1, "order.placed": 2, "order.shipped": 3}'::jsonb
+);
+```
+
+Lower priority values are processed first. Messages without an entry in the
+priority map default to priority 999 (processed last).
+
+---
+
+## Multi-worker partitioning
+
+When many workers process the same inbox concurrently, you can partition the
+workload by aggregate ID using consistent hashing:
+
+```sql
+-- Worker 0 of 4: only process messages assigned to partition 0
+SELECT event_id, aggregate_id, payload
+FROM pgtrickle.order_events_pending
+WHERE pgtrickle.inbox_is_my_partition('order_events', aggregate_id, 0, 4);
+
+-- Worker 1 of 4
+SELECT event_id, aggregate_id, payload
+FROM pgtrickle.order_events_pending
+WHERE pgtrickle.inbox_is_my_partition('order_events', aggregate_id, 1, 4);
+```
+
+The hash function is deterministic — the same `aggregate_id` always maps to
+the same partition — so you can scale the worker pool without rebalancing.
+
+---
+
+## Dead-letter queue
+
+Messages that exceed `max_retries` (default: 3) are automatically visible in
+the DLQ stream table:
+
+```sql
+-- View dead letters
+SELECT event_id, event_type, aggregate_id, error, retry_count
+FROM pgtrickle.order_events_dlq
+ORDER BY received_at;
+```
+
+### Replaying DLQ messages
+
+After fixing the root cause:
+
+```sql
+-- Reset retry count so the message is picked up again
+SELECT pgtrickle.replay_inbox_messages(
+    'order_events',
+    p_event_ids => ARRAY['evt-001', 'evt-002']
+);
+
+-- Or replay all DLQ messages of a specific type
+SELECT pgtrickle.replay_inbox_messages(
+    'order_events',
+    p_event_type => 'order.placed'
+);
+```
+
+---
+
+## Monitoring
+
+### Health check
+
+```sql
+SELECT pgtrickle.inbox_health('order_events');
+```
+
+Returns a JSONB object:
+
+```json
+{
+  "inbox": "order_events",
+  "pending_count": 42,
+  "dlq_count": 3,
+  "oldest_pending_age_seconds": 12,
+  "throughput_per_minute": 180,
+  "status": "healthy"
+}
+```
+
+A `status` of `"degraded"` means the DLQ count or pending age is above
+configured thresholds.
+
+### Detailed status
+
+```sql
+SELECT pgtrickle.inbox_status('order_events');
+```
+
+Returns richer JSONB including processing rates, error breakdown, and stream
+table refresh counts.
+
+### Global inbox overview
+
+```sql
+SELECT * FROM pgtrickle.pgt_inbox_config;
+```
+
+---
+
+## Catalog tables
+
+| Table | Contents |
+|-------|---------|
+| `pgtrickle.pgt_inbox_config` | One row per inbox: name, schema, max_retries, schedule |
+| `pgtrickle.pgt_inbox_ordering_config` | Ordering settings per inbox |
+| `pgtrickle.pgt_inbox_priority_config` | Priority map per inbox |
+| `pgtrickle.<name>` | The inbox message table (auto-created) |
+| `pgtrickle.<name>_pending` | Stream table: unprocessed messages |
+| `pgtrickle.<name>_dlq` | Stream table: dead letters |
+| `pgtrickle.<name>_stats` | Stream table: per-event-type counts |
+| `pgtrickle.next_<name>` | Stream table: next message per aggregate (ordering only) |
+
+---
+
+## Retention and cleanup
+
+Processed messages are automatically deleted after `inbox_processed_retention_hours`
+(default: 72). DLQ rows are held for `inbox_dlq_retention_hours` (default: 168
+= 7 days) to give operators time to inspect and replay them.
+
+Configure globally in `postgresql.conf`:
+
+```
+pg_trickle.inbox_processed_retention_hours = 72
+pg_trickle.inbox_dlq_retention_hours = 168
+```
+
+---
+
+## Dropping an inbox
+
+```sql
+-- Drop the inbox and its stream tables, but keep the underlying table
+SELECT pgtrickle.drop_inbox('order_events');
+
+-- Drop everything including the backing table
+SELECT pgtrickle.drop_inbox('order_events', p_cascade => true);
+```
+
+---
+
+## Recommended configuration
+
+| GUC | Recommended value | Notes |
+|-----|------------------|-------|
+| `pg_trickle.inbox_enabled` | `on` | Must be on for inbox background workers to run |
+| `pg_trickle.inbox_processed_retention_hours` | `24`–`72` | Adjust based on audit requirements |
+| `pg_trickle.inbox_dlq_retention_hours` | `168` | Keep DLQ items for at least 7 days |
+| `pg_trickle.inbox_drain_batch_size` | `500`–`2000` | Tune for throughput vs. latency |
+| `pg_trickle.inbox_dlq_alert_max_per_refresh` | `100` | Alert when DLQ grows rapidly |
+
+---
+
+## Anti-patterns
+
+**Do not mark messages as processed outside a transaction with your business
+logic.** The atomic combination of "do work + mark processed" is what prevents
+duplicate processing. If you process first and then mark processed in a separate
+transaction, a crash between the two steps causes duplicate processing.
+
+**Do not share a single inbox across unrelated services.** Each service should
+have its own inbox so they can fail, replay, and scale independently.
+
+**Do not ignore the DLQ.** A growing DLQ is a signal that something is
+consistently broken. Set up an alert on `inbox_dlq_alert_max_per_refresh` and
+review DLQ items regularly.
+
+**Do not delete inbox rows manually.** Let the retention mechanism handle
+cleanup. Manual deletes can confuse the stream table refresh cycle.
+
+---
+
+## See also
+
+- [Transactional Outbox](OUTBOX.md) — publish events from your database to external systems
+- [Relay Service](RELAY_GUIDE.md) — bridge external brokers directly to the inbox
+- [SQL Reference: Transactional Inbox](SQL_REFERENCE.md#transactional-inbox-v0280)
+- [Configuration](CONFIGURATION.md#transactional-inbox-v0280)
+- [Pattern 8: Transactional Inbox](PATTERNS.md#pattern-8-transactional-inbox-v0280)

--- a/docs/OUTBOX.md
+++ b/docs/OUTBOX.md
@@ -1,0 +1,341 @@
+# Transactional Outbox
+
+The **transactional outbox pattern** solves the dual-write problem: how to
+atomically update your database _and_ publish an event to an external system
+without risking inconsistency if one side fails.
+
+pg_trickle's outbox implementation builds on top of stream tables. Every time a
+stream table refresh produces a non-empty delta, a summary row is written to an
+outbox table **in the same transaction** as the MERGE. Consumers are notified
+via `pg_notify` the moment the commit lands.
+
+> **Available since v0.28.0**
+
+---
+
+## How it works
+
+```
+Source tables (INSERT / UPDATE / DELETE)
+        │
+        ▼
+  CDC trigger fires → pgtrickle_changes buffer
+        │
+        ▼
+  Stream table refresh (MERGE)
+        │   ← same transaction ─────────────────────────────┐
+        ▼                                                    │
+  Delta rows applied to stream table               outbox row written
+  (inserted_count / deleted_count recorded)        to pgtrickle.outbox_<st>
+                                                             │
+                                                    pg_notify fired
+                                                             │
+                                                    Consumer polls / listens
+```
+
+The outbox row is guaranteed to exist if and only if the stream table was
+updated. There is no window where the stream table changes but no outbox row
+exists, or an outbox row exists but the stream table did not change.
+
+### Inline vs. claim-check mode
+
+| Condition | Mode | What the consumer receives |
+|-----------|------|---------------------------|
+| `delta_rows ≤ outbox_inline_threshold_rows` (default: 1000) | **Inline** | Full delta serialized as JSONB in `payload` |
+| `delta_rows > outbox_inline_threshold_rows` | **Claim-check** | `is_claim_check = true`, payload is NULL; delta rows in `pgtrickle.outbox_delta_rows_<st>` |
+
+Inline mode is simpler — the consumer reads one row and gets everything.
+Claim-check mode avoids storing very large payloads in the outbox table, at the
+cost of an extra query to fetch the delta rows.
+
+---
+
+## Quickstart
+
+### 1. Create a stream table
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'public.order_totals',
+    $$SELECT customer_id, SUM(amount) AS total
+      FROM orders
+      GROUP BY customer_id$$
+);
+```
+
+### 2. Enable the outbox
+
+```sql
+SELECT pgtrickle.enable_outbox('public.order_totals');
+```
+
+This creates:
+- `pgtrickle.outbox_order_totals` — outbox header table
+- `pgtrickle.outbox_delta_rows_order_totals` — claim-check delta rows
+- `pgtrickle.pgt_outbox_latest_order_totals` — convenience view pointing to the most recent outbox row
+
+### 3. Create consumer groups
+
+Each independent consumer needs its own group. Groups track their own offset
+into the outbox table so they never interfere with each other.
+
+```sql
+SELECT pgtrickle.create_consumer_group(
+    'shipping_service',
+    'public.order_totals'
+);
+
+SELECT pgtrickle.create_consumer_group(
+    'analytics_pipeline',
+    'public.order_totals'
+);
+```
+
+### 4. Poll for messages
+
+A consumer loop looks like this:
+
+```sql
+-- Claim up to 50 unprocessed rows, hold the lease for 30 seconds
+SELECT * FROM pgtrickle.poll_outbox(
+    'public.order_totals',
+    'shipping_service',
+    batch_size    => 50,
+    lease_seconds => 30
+);
+```
+
+`poll_outbox` returns outbox rows that this consumer has not yet committed.
+Each row is leased — no other worker sharing the same consumer group can claim
+it until the lease expires.
+
+### 5. Process and commit
+
+After successfully processing each batch:
+
+```sql
+SELECT pgtrickle.commit_offset('shipping_service', 'public.order_totals', last_id);
+```
+
+`last_id` is the highest `id` value from the batch you just processed.
+Committed rows are never returned by `poll_outbox` again.
+
+---
+
+## Reading the payload
+
+### Inline mode
+
+```sql
+SELECT
+    id,
+    created_at,
+    inserted_count,
+    deleted_count,
+    payload -> 'inserted' AS inserted_rows,
+    payload -> 'deleted'  AS deleted_rows
+FROM pgtrickle.outbox_order_totals
+ORDER BY id DESC
+LIMIT 5;
+```
+
+### Claim-check mode
+
+```sql
+-- Get the outbox row
+SELECT id, is_claim_check FROM pgtrickle.pgt_outbox_latest_order_totals;
+
+-- Fetch the actual delta rows for a claim-check outbox row
+SELECT row_op, row_data
+FROM pgtrickle.outbox_delta_rows_order_totals
+WHERE outbox_id = <outbox_id>
+ORDER BY row_num;
+```
+
+---
+
+## Multiple workers (parallel consumption)
+
+Multiple workers in the same consumer group share the workload. pg_trickle
+assigns non-overlapping leases, so each row is processed by exactly one worker
+at a time.
+
+```sql
+-- Worker 1
+SELECT * FROM pgtrickle.poll_outbox('public.order_totals', 'shipping_service');
+
+-- Worker 2 (concurrent, gets a different batch)
+SELECT * FROM pgtrickle.poll_outbox('public.order_totals', 'shipping_service');
+```
+
+Workers should register their presence so the system can detect dead workers:
+
+```sql
+-- Call periodically (e.g. every 30 s) while the worker is alive
+SELECT pgtrickle.consumer_heartbeat('shipping_service', 'worker-1');
+```
+
+Workers that miss their heartbeat deadline are removed from the consumer group.
+Any leases held by a dead worker expire automatically after `lease_seconds`,
+returning those rows to the available pool.
+
+---
+
+## Lease management
+
+### Extending a lease
+
+If processing is taking longer than expected:
+
+```sql
+SELECT pgtrickle.extend_lease(
+    'shipping_service',
+    'public.order_totals',
+    outbox_id     => 42,
+    extra_seconds => 60
+);
+```
+
+### Seeking to a specific position
+
+For replay or recovery scenarios:
+
+```sql
+-- Replay from the beginning
+SELECT pgtrickle.seek_offset('shipping_service', 'public.order_totals', 0);
+
+-- Skip ahead to the current tip
+SELECT pgtrickle.seek_offset(
+    'shipping_service', 'public.order_totals',
+    (SELECT MAX(id) FROM pgtrickle.outbox_order_totals)
+);
+```
+
+---
+
+## Monitoring
+
+### Check outbox health
+
+```sql
+SELECT pgtrickle.outbox_status('public.order_totals');
+```
+
+Returns JSONB:
+```json
+{
+  "enabled": true,
+  "stream_table": "public.order_totals",
+  "outbox_table": "pgtrickle.outbox_order_totals",
+  "row_count": 1247,
+  "oldest_row": "2025-04-20T10:00:00Z",
+  "newest_row": "2025-04-23T14:32:00Z",
+  "retention_hours": 24
+}
+```
+
+### Consumer lag
+
+```sql
+-- Per consumer group
+SELECT pgtrickle.consumer_lag('shipping_service', 'public.order_totals');
+```
+
+Returns the number of outbox rows that the consumer group has not yet committed.
+A large or growing lag means the consumer is falling behind.
+
+### Global outbox overview
+
+```sql
+SELECT * FROM pgtrickle.pgt_outbox_config;
+```
+
+---
+
+## Catalog tables
+
+| Table | Contents |
+|-------|---------|
+| `pgtrickle.pgt_outbox_config` | One row per enabled outbox: ST OID, outbox table name, retention hours |
+| `pgtrickle.pgt_consumer_groups` | One row per consumer group: name, stream table, created_at |
+| `pgtrickle.pgt_consumer_offsets` | Per-group committed offsets and lease state |
+| `pgtrickle.outbox_<st>` | Outbox header rows (auto-created per stream table) |
+| `pgtrickle.outbox_delta_rows_<st>` | Claim-check delta rows (auto-created per stream table) |
+
+---
+
+## Retention and cleanup
+
+Outbox rows are automatically deleted after `outbox_retention_hours` (default:
+24). Claim-check delta rows are removed when `commit_offset` is called or when
+the retention period expires.
+
+Configure retention per stream table at enable time:
+
+```sql
+SELECT pgtrickle.enable_outbox('public.order_totals', p_retention_hours => 48);
+```
+
+Or globally in `postgresql.conf`:
+
+```
+pg_trickle.outbox_retention_hours = 48
+```
+
+---
+
+## Disabling the outbox
+
+```sql
+SELECT pgtrickle.disable_outbox('public.order_totals');
+```
+
+This drops the outbox table, delta-rows table, and latest view, and removes the
+catalog entry. Consumer groups must be dropped separately:
+
+```sql
+SELECT pgtrickle.drop_consumer_group('shipping_service', 'public.order_totals');
+```
+
+---
+
+## Recommended configuration
+
+| GUC | Recommended value | Notes |
+|-----|------------------|-------|
+| `pg_trickle.outbox_enabled` | `on` | Must be on for the outbox background worker to run |
+| `pg_trickle.outbox_retention_hours` | `24`–`72` | Balance storage cost vs. replay window |
+| `pg_trickle.outbox_drain_batch_size` | `500`–`2000` | Larger batches improve throughput |
+| `pg_trickle.outbox_inline_threshold_rows` | `500`–`2000` | Tune based on typical delta size |
+| `pg_trickle.outbox_skip_empty_delta` | `on` | Skip writing outbox rows when delta is empty |
+| `pg_trickle.consumer_cleanup_enabled` | `on` | Auto-remove dead consumer workers |
+| `pg_trickle.consumer_dead_threshold_hours` | `1` | Mark worker dead after 1 h of silence |
+
+---
+
+## Anti-patterns
+
+**Do not poll without committing.** If your consumer processes messages but
+never calls `commit_offset`, the lag grows unboundedly and messages are
+replayed forever after a worker restart.
+
+**Do not use a single consumer group for independent services.** Each service
+that needs to process outbox events independently must have its own consumer
+group. Sharing a group means one service blocking the other.
+
+**Do not delete outbox rows manually.** Let the retention mechanism handle
+cleanup. Manual deletes can cause consumer group offsets to point to
+non-existent rows.
+
+**Do not enable the outbox on IMMEDIATE-mode stream tables.** The outbox
+requires DIFFERENTIAL or FULL refresh mode to detect which rows changed.
+
+---
+
+## See also
+
+- [Transactional Inbox](INBOX.md) — receive events from external systems
+- [Relay Service](RELAY_GUIDE.md) — bridge the outbox to NATS, Kafka, webhooks, and more
+- [SQL Reference: Transactional Outbox](SQL_REFERENCE.md#transactional-outbox--consumer-groups-v0280)
+- [Configuration](CONFIGURATION.md#transactional-outbox-v0280)
+- [Pattern 7: Transactional Outbox](PATTERNS.md#pattern-7-transactional-outbox-v0280)

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -18,6 +18,10 @@ anti-patterns to avoid, and refresh mode recommendations.
 - [Pattern 5: Real-Time Dashboards](#pattern-5-real-time-dashboards)
 - [Pattern 6: Tiered Refresh Strategy](#pattern-6-tiered-refresh-strategy)
 - [General Guidelines](#general-guidelines)
+- [Replica Bootstrap & PITR Alignment (v0.27.0)](#replica-bootstrap--pitr-alignment-v0270)
+- [Pattern 7: Transactional Outbox (v0.28.0)](#pattern-7-transactional-outbox-v0280)
+- [Pattern 8: Transactional Inbox (v0.28.0)](#pattern-8-transactional-inbox-v0280)
+- [Pattern 9: Bidirectional Event Pipeline with Relay (v0.29.0)](#pattern-9-bidirectional-event-pipeline-with-relay-v0290)
 
 ---
 
@@ -518,3 +522,317 @@ FROM pgtrickle.pgt_stream_tables;
 > **Performance**: Restoring a 1M-row stream table from a snapshot completes
 > in < 5 seconds (bulk INSERT from local table). The frontier alignment ensures
 > the first differential refresh fetches only new changes, not all rows.
+
+---
+
+## Pattern 7: Transactional Outbox (v0.28.0)
+
+> **Requires:** v0.28.0+
+
+The **transactional outbox** pattern reliably publishes stream table deltas to
+external consumers — even if the consumer is temporarily offline. Each time the
+stream table refreshes, pg_trickle writes a header row to a dedicated outbox
+table. Consumers read from the outbox via `poll_outbox()`, process the delta,
+then commit their offset.
+
+**Use this pattern when:**
+- You need to publish stream table changes to a message queue, webhook, or another service
+- Consumers need at-least-once delivery guarantees
+- Multiple independent consumers need to read the same stream independently
+- You want replay / seek-to-offset for recovery
+
+### Architecture
+
+```
+orders (base table)
+  └─→ orders_agg (stream table)
+        └─→ pgt_outbox_orders_agg (outbox table)
+              ├─→ Consumer group A: analytics pipeline
+              └─→ Consumer group B: notification service
+```
+
+### SQL Example
+
+```sql
+-- 1. Create the stream table
+SELECT pgtrickle.create_stream_table(
+    'public.orders_agg',
+    'SELECT customer_id, SUM(amount) AS total, COUNT(*) AS cnt FROM orders GROUP BY customer_id',
+    schedule_seconds => 5
+);
+
+-- 2. Enable the outbox
+SELECT pgtrickle.enable_outbox('public.orders_agg', retention_hours => 48);
+
+-- 3. Create consumer groups
+SELECT pgtrickle.create_consumer_group('analytics', 'public.orders_agg', auto_offset_reset => 'latest');
+SELECT pgtrickle.create_consumer_group('notifications', 'public.orders_agg', auto_offset_reset => 'latest');
+
+-- 4. Consumer A polls and processes
+DO $$
+DECLARE
+    r RECORD;
+    last_id BIGINT := 0;
+BEGIN
+    FOR r IN
+        SELECT * FROM pgtrickle.poll_outbox('analytics', 'worker-1', batch_size => 50)
+    LOOP
+        -- process r.payload (JSONB with inserted/deleted row arrays)
+        last_id := r.outbox_id;
+    END LOOP;
+
+    IF last_id > 0 THEN
+        PERFORM pgtrickle.commit_offset('analytics', 'worker-1', last_id);
+    END IF;
+END;
+$$;
+
+-- 5. Check consumer lag
+SELECT * FROM pgtrickle.consumer_lag('analytics');
+```
+
+### Consumer Group Tips
+
+| Scenario | Setting |
+|----------|---------|
+| Multiple competing workers sharing one offset | Put all workers in the **same group** |
+| Independent pipelines that each need the full stream | Create a **separate group** per pipeline |
+| Replay from the beginning | `seek_offset('my_group', 'worker-1', 0)` |
+| Resume after a crash without re-processing | Commit offsets frequently; use `extend_lease()` for long processing |
+
+### Recommended Configuration
+
+```ini
+pg_trickle.outbox_enabled = true
+pg_trickle.outbox_retention_hours = 48        # keep 2 days of history
+pg_trickle.outbox_skip_empty_delta = true     # don't write rows for no-op refreshes
+pg_trickle.outbox_force_retention = true      # keep rows until all groups commit
+pg_trickle.consumer_dead_threshold_hours = 24 # mark workers dead after 24h silence
+pg_trickle.consumer_cleanup_enabled = true
+```
+
+### Anti-Patterns
+
+- **Polling without committing:** If `commit_offset()` is never called, the lease
+  expires and the rows are re-delivered. Always commit after successful processing.
+- **One group per worker:** Use one group and multiple named consumers within it
+  for competing-consumer parallelism. Use multiple groups only when pipelines are
+  truly independent.
+- **Long processing without heartbeats:** Call `consumer_heartbeat()` every 10–15
+  seconds for long-running processing to avoid being marked dead.
+
+---
+
+## Pattern 8: Transactional Inbox (v0.28.0)
+
+> **Requires:** v0.28.0+
+
+The **transactional inbox** pattern provides a reliable, idempotent message
+receiver inside PostgreSQL. External producers write events to the inbox table;
+pg_trickle maintains stream tables that give you live views of pending, failed,
+and processed messages — all updated incrementally.
+
+**Use this pattern when:**
+- You receive events from external systems and need to process them exactly-once
+- You want automatic dead-letter handling for failed messages
+- Multiple workers need to process different aggregates without stepping on each other
+- You need per-aggregate ordering guarantees
+
+### Architecture
+
+```
+external producer (Kafka / webhook / pg_trickle relay)
+  └─→ pgtrickle.orders_inbox (raw event table)
+        ├─→ orders_inbox_pending  (stream table: awaiting processing)
+        ├─→ orders_inbox_dlq      (stream table: failed messages)
+        └─→ orders_inbox_stats    (stream table: event counts by type)
+```
+
+### SQL Example
+
+```sql
+-- 1. Create the inbox
+SELECT pgtrickle.create_inbox(
+    'orders_inbox',
+    schema           => 'pgtrickle',
+    max_retries      => 3,
+    with_dead_letter => true,
+    with_stats       => true,
+    schedule_seconds => 5
+);
+
+-- 2. External system inserts a message
+INSERT INTO pgtrickle.orders_inbox (event_id, event_type, aggregate_id, payload)
+VALUES (
+    gen_random_uuid()::text,
+    'order.placed',
+    'customer-123',
+    '{"order_id": 42, "amount": 99.50}'::jsonb
+);
+
+-- 3. Worker polls pending messages and processes
+UPDATE pgtrickle.orders_inbox
+SET processed_at = now()
+WHERE event_id = '<event_id>'
+  AND processed_at IS NULL;
+
+-- 4. Check inbox health
+SELECT pgtrickle.inbox_health('orders_inbox');
+
+-- 5. Replay failed messages
+SELECT pgtrickle.replay_inbox_messages(
+    'orders_inbox',
+    ARRAY['event-id-1', 'event-id-2']
+);
+```
+
+### Per-Aggregate Ordering
+
+When messages for the same customer / entity must be processed in sequence:
+
+```sql
+-- Enable ordering: only surface the next unprocessed message per aggregate
+SELECT pgtrickle.enable_inbox_ordering(
+    'orders_inbox',
+    aggregate_id_col => 'aggregate_id',
+    seq_col          => 'event_sequence'
+);
+
+-- Workers now read from next_orders_inbox (one row per aggregate)
+SELECT * FROM pgtrickle.next_orders_inbox;
+```
+
+### Multi-Worker Partitioning
+
+Scale horizontally without external coordination:
+
+```sql
+-- Worker 0 of 4 handles its share of aggregates
+SELECT * FROM pgtrickle.orders_inbox_pending
+WHERE pgtrickle.inbox_is_my_partition(aggregate_id, 0, 4);
+```
+
+### Recommended Configuration
+
+```ini
+pg_trickle.inbox_enabled = true
+pg_trickle.inbox_processed_retention_hours = 72   # keep 3 days of processed msgs
+pg_trickle.inbox_dlq_retention_hours = 0          # keep DLQ forever for forensics
+pg_trickle.inbox_dlq_alert_max_per_refresh = 10   # alert on DLQ growth
+```
+
+### Anti-Patterns
+
+- **Not marking messages as processed:** The `_pending` stream table will keep
+  growing. Always set `processed_at = now()` after successful processing.
+- **Ignoring the DLQ:** Monitor `orders_inbox_dlq` and replay or investigate
+  failed messages regularly. Use `inbox_health()` in your alerting pipeline.
+- **Skipping idempotency:** The inbox uses `event_id` for deduplication.
+  Producers must supply stable, unique `event_id` values — typically a UUID
+  derived from the source event.
+
+---
+
+## Pattern 9: Bidirectional Event Pipeline with Relay (v0.29.0)
+
+> **Requires:** v0.29.0+ and the `pgtrickle-relay` binary
+
+The **relay** connects pg_trickle outboxes and inboxes to external messaging
+systems (NATS, Kafka, HTTP webhooks, Redis Streams, SQS, RabbitMQ) without
+any custom application code. You configure pipelines in SQL; the relay binary
+handles polling, publishing, and idempotent delivery.
+
+**Use this pattern when:**
+- You want stream table deltas to flow automatically to Kafka / NATS / etc.
+- You receive external events from a message queue and need them in PostgreSQL
+- You need high-availability relay with automatic failover (advisory-lock coordination)
+- You want hot-reload — pipeline config changes apply without restarting the relay
+
+### Architecture
+
+```
+                         ┌──────────────────────┐
+Stream table A ──outbox──→  pgtrickle-relay       ──→  NATS JetStream
+Stream table B ──outbox──→  (forward pipeline)    ──→  Kafka topic
+                         │                        │
+Kafka topic    ──────────→  (reverse pipeline)    ──→  inbox table → stream table
+                         └──────────────────────┘
+```
+
+### SQL Example — Forward Pipeline (outbox → NATS)
+
+```sql
+-- 1. Enable outbox on your stream table
+SELECT pgtrickle.enable_outbox('public.orders_agg');
+
+-- 2. Create a consumer group for the relay
+SELECT pgtrickle.create_consumer_group('relay_group', 'public.orders_agg');
+
+-- 3. Configure the relay pipeline (SQL-only, no YAML)
+SELECT pgtrickle.set_relay_outbox(
+    'orders-to-nats',
+    outbox  => 'public.orders_agg',
+    group   => 'relay_group',
+    sink    => '{"type": "nats", "url": "nats://nats:4222", "subject": "orders.deltas"}'::jsonb,
+    retention_hours => 24
+);
+```
+
+### SQL Example — Reverse Pipeline (Kafka → inbox)
+
+```sql
+-- 1. Create an inbox for incoming events
+SELECT pgtrickle.create_inbox('payment_events');
+
+-- 2. Configure the reverse relay pipeline
+SELECT pgtrickle.set_relay_inbox(
+    'payments-from-kafka',
+    inbox  => 'pgtrickle.payment_events',
+    source => '{"type": "kafka", "brokers": ["kafka:9092"], "topic": "payments", "group_id": "relay"}'::jsonb,
+    max_retries => 3
+);
+```
+
+### Managing Pipelines
+
+```sql
+-- Pause a pipeline
+SELECT pgtrickle.disable_relay('orders-to-nats');
+
+-- Resume it
+SELECT pgtrickle.enable_relay('orders-to-nats');
+
+-- List all pipelines and their status
+SELECT * FROM pgtrickle.list_relay_configs();
+
+-- Delete a pipeline permanently
+SELECT pgtrickle.delete_relay('orders-to-nats');
+```
+
+### Running the Relay
+
+```bash
+# Set the connection string (only config needed)
+export PGTRICKLE_RELAY_POSTGRES_URL=postgres://relay_user:pass@localhost:5432/mydb
+
+# Start the relay — it discovers pipelines from the catalog automatically
+pgtrickle-relay
+
+# With HA (run 2–3 instances; advisory locks prevent duplicate processing)
+pgtrickle-relay --relay-group-id prod
+pgtrickle-relay --relay-group-id prod  # second instance — auto-failover
+```
+
+### Observability
+
+The relay exposes Prometheus metrics at `:9090/metrics` and a health endpoint
+at `:9090/health`.
+
+| Metric | Description |
+|--------|-------------|
+| `pgtrickle_relay_messages_published_total` | Messages successfully published |
+| `pgtrickle_relay_messages_consumed_total` | Messages consumed from sources |
+| `pgtrickle_relay_lag_seconds` | Estimated relay lag per pipeline |
+| `pgtrickle_relay_pipelines_owned` | Pipelines owned by this instance |
+
+See [RELAY.md](RELAY.md) for the full deployment guide.

--- a/docs/RELAY_GUIDE.md
+++ b/docs/RELAY_GUIDE.md
@@ -1,0 +1,503 @@
+# Relay Service
+
+`pgtrickle-relay` is a lightweight sidecar process that bridges pg_trickle
+outbox and inbox tables with external messaging systems — NATS, Kafka, Redis
+Streams, HTTP webhooks, AWS SQS, and RabbitMQ.
+
+Rather than writing custom polling loops in each of your services, you run one
+(or a few) relay instances and let them handle all the I/O with external
+brokers. Your application only deals with PostgreSQL.
+
+> **Available since v0.29.0**
+
+---
+
+## When to use the relay
+
+| Scenario | Use relay? |
+|----------|-----------|
+| Your services need to publish events to Kafka / NATS | Yes |
+| External services send you events via Kafka / NATS | Yes |
+| You want exactly-once delivery without managing broker offsets yourself | Yes |
+| Your services already talk directly to Kafka / NATS | Optional |
+| Your entire stack is PostgreSQL with no external broker | No — use outbox/inbox directly |
+
+The relay is optional. The [Transactional Outbox](OUTBOX.md) and
+[Transactional Inbox](INBOX.md) work perfectly without it — the relay just
+handles the transport layer.
+
+---
+
+## How it works
+
+```
+┌──────────────────────────────────────────────────────────┐
+│ PostgreSQL (pg_trickle extension)                        │
+│                                                          │
+│  stream table → outbox table ──→ [Relay: forward]  ──→ Kafka / NATS / …
+│                                                          │
+│  inbox table  ←─────────────── [Relay: reverse]  ←── Kafka / NATS / …
+└──────────────────────────────────────────────────────────┘
+                   pgtrickle-relay binary
+```
+
+**Forward pipeline**: polls an outbox consumer group and publishes each delta
+batch to an external sink (Kafka topic, NATS subject, SQS queue, webhook URL,
+…).
+
+**Reverse pipeline**: consumes messages from an external source (Kafka topic,
+NATS consumer, …) and inserts them into a pg_trickle inbox table with
+`ON CONFLICT DO NOTHING` for idempotency.
+
+Both directions are configured entirely via SQL — no YAML config files on disk.
+
+---
+
+## Installation
+
+### Docker (recommended)
+
+```bash
+docker pull ghcr.io/grove/pgtrickle-relay:0.29.0
+```
+
+### Build from source
+
+```bash
+# Default features (NATS + webhook + stdout)
+cargo install --path pgtrickle-relay
+
+# All backends
+cargo install --path pgtrickle-relay \
+  --features nats,webhook,kafka,redis,sqs,rabbitmq,pg-inbox,stdout
+```
+
+---
+
+## Quick start (5 minutes)
+
+This example publishes order changes to NATS JetStream.
+
+### Step 1: Set up the stream table and outbox
+
+```sql
+-- Create a stream table (skip if you already have one)
+SELECT pgtrickle.create_stream_table(
+    'public.order_summary',
+    $$SELECT customer_id, COUNT(*) AS order_count, SUM(amount) AS total
+      FROM orders GROUP BY customer_id$$
+);
+
+-- Enable the outbox
+SELECT pgtrickle.enable_outbox('public.order_summary');
+```
+
+### Step 2: Register the relay pipeline
+
+```sql
+SELECT pgtrickle.set_relay_outbox(
+    'orders-to-nats',
+    config => '{
+        "stream_table": "order_summary",
+        "sink_type": "nats",
+        "nats_url": "nats://localhost:4222",
+        "nats_stream": "pgtrickle",
+        "subject_template": "pgtrickle.{stream_table}.{op}"
+    }'::jsonb
+);
+
+SELECT pgtrickle.enable_relay('orders-to-nats');
+```
+
+### Step 3: Start the relay
+
+```bash
+pgtrickle-relay \
+  --postgres-url "postgres://relay_user:password@localhost:5432/mydb" \
+  --relay-group-id "my-datacenter"
+```
+
+That's it. Order changes now flow from PostgreSQL to NATS automatically.
+
+---
+
+## Forward pipeline (outbox → external broker)
+
+A forward pipeline polls an outbox consumer group and publishes events to an
+external system.
+
+### Registering a forward pipeline
+
+```sql
+SELECT pgtrickle.set_relay_outbox(
+    'pipeline-name',
+    config => '{...}'::jsonb
+);
+SELECT pgtrickle.enable_relay('pipeline-name');
+```
+
+### Common config fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `stream_table` | Yes | Name of the stream table whose outbox to consume |
+| `sink_type` | Yes | One of: `nats`, `kafka`, `webhook`, `redis`, `sqs`, `rabbitmq`, `pg-inbox`, `stdout` |
+| `batch_size` | No | Messages per poll (default: 100) |
+| `poll_interval_ms` | No | How often to poll in milliseconds (default: 1000) |
+| `subject_template` | No | Subject/topic routing template (see [Templates](#subjecttopic-templates)) |
+
+### NATS JetStream
+
+```sql
+SELECT pgtrickle.set_relay_outbox('orders-nats', config => '{
+    "stream_table":    "order_summary",
+    "sink_type":       "nats",
+    "nats_url":        "nats://nats:4222",
+    "nats_stream":     "pgtrickle",
+    "subject_template": "pgtrickle.{stream_table}.{op}"
+}'::jsonb);
+```
+
+### Apache Kafka
+
+```sql
+SELECT pgtrickle.set_relay_outbox('orders-kafka', config => '{
+    "stream_table":    "order_summary",
+    "sink_type":       "kafka",
+    "kafka_brokers":   "kafka:9092",
+    "kafka_topic":     "order-events",
+    "kafka_key_field": "customer_id"
+}'::jsonb);
+```
+
+### HTTP Webhook
+
+```sql
+SELECT pgtrickle.set_relay_outbox('orders-webhook', config => '{
+    "stream_table":    "order_summary",
+    "sink_type":       "webhook",
+    "webhook_url":     "https://api.example.com/events",
+    "webhook_headers": {"Authorization": "Bearer secret"}
+}'::jsonb);
+```
+
+### Redis Streams
+
+```sql
+SELECT pgtrickle.set_relay_outbox('orders-redis', config => '{
+    "stream_table": "order_summary",
+    "sink_type":    "redis",
+    "redis_url":    "redis://redis:6379",
+    "redis_stream": "pgtrickle:order_summary"
+}'::jsonb);
+```
+
+### AWS SQS
+
+```sql
+SELECT pgtrickle.set_relay_outbox('orders-sqs', config => '{
+    "stream_table":   "order_summary",
+    "sink_type":      "sqs",
+    "sqs_queue_url":  "https://sqs.us-east-1.amazonaws.com/123456789/orders",
+    "sqs_region":     "us-east-1"
+}'::jsonb);
+```
+
+---
+
+## Reverse pipeline (external broker → inbox)
+
+A reverse pipeline consumes from an external source and writes into a pg_trickle
+inbox, giving you exactly-once delivery semantics backed by PostgreSQL.
+
+### Step 1: Create the inbox
+
+```sql
+SELECT pgtrickle.create_inbox('order_commands');
+```
+
+### Step 2: Register a reverse pipeline
+
+```sql
+SELECT pgtrickle.set_relay_inbox(
+    'nats-to-order-commands',
+    config => '{
+        "source_type":   "nats",
+        "nats_url":      "nats://nats:4222",
+        "nats_stream":   "commands",
+        "nats_consumer": "relay-consumer",
+        "inbox_table":   "order_commands"
+    }'::jsonb
+);
+SELECT pgtrickle.enable_relay('nats-to-order-commands');
+```
+
+The relay inserts each message with `ON CONFLICT (event_id) DO NOTHING`, so
+duplicate deliveries from the broker are silently discarded.
+
+### Kafka → inbox
+
+```sql
+SELECT pgtrickle.set_relay_inbox('kafka-to-commands', config => '{
+    "source_type":      "kafka",
+    "kafka_brokers":    "kafka:9092",
+    "kafka_topic":      "order-commands",
+    "kafka_group_id":   "pgtrickle-relay",
+    "inbox_table":      "order_commands"
+}'::jsonb);
+```
+
+### Webhook → inbox
+
+```sql
+SELECT pgtrickle.set_relay_inbox('webhook-to-commands', config => '{
+    "source_type":  "webhook",
+    "webhook_bind": "0.0.0.0:8080",
+    "webhook_path": "/events",
+    "inbox_table":  "order_commands"
+}'::jsonb);
+```
+
+---
+
+## Subject / topic templates
+
+Subject and topic names can use template variables:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{stream_table}` | Source stream table name | `order_summary` |
+| `{op}` | Operation: `insert`, `update`, or `delete` | `insert` |
+| `{outbox_id}` | Sequential outbox batch ID | `42` |
+| `{refresh_id}` | pg_trickle refresh UUID | `3f8a…` |
+
+Example template: `pgtrickle.{stream_table}.{op}`  
+Rendered: `pgtrickle.order_summary.insert`
+
+---
+
+## Pipeline management
+
+```sql
+-- List all pipelines (enabled and disabled)
+SELECT name, direction, enabled, config
+FROM pgtrickle.list_relay_configs();
+
+-- Get the config for one pipeline
+SELECT pgtrickle.get_relay_config('orders-to-nats');
+
+-- Disable without deleting
+SELECT pgtrickle.disable_relay('orders-to-nats');
+
+-- Re-enable
+SELECT pgtrickle.enable_relay('orders-to-nats');
+
+-- Delete permanently
+SELECT pgtrickle.delete_relay('orders-to-nats');
+```
+
+---
+
+## Hot reload
+
+You do not need to restart the relay when pipeline configuration changes.
+The relay listens on the `pgtrickle_relay_config` PostgreSQL notification
+channel. When you call `set_relay_outbox`, `enable_relay`, `disable_relay`, or
+`delete_relay`, the change is picked up within seconds.
+
+This means you can add or modify pipelines in production without any downtime.
+
+---
+
+## High availability
+
+Run two or three relay instances pointing at the same PostgreSQL database.
+Pipeline ownership is distributed using PostgreSQL advisory locks:
+
+1. Each instance tries to acquire a lock per pipeline.
+2. The instance that wins the lock owns the pipeline and starts processing.
+3. If an instance dies, its locks are released and another instance picks up
+   the pipeline on the next discovery interval (default: 30 seconds).
+
+```bash
+# Instance 1
+pgtrickle-relay --postgres-url "postgres://..." --relay-group-id "prod"
+
+# Instance 2 (same group ID, same database)
+pgtrickle-relay --postgres-url "postgres://..." --relay-group-id "prod"
+```
+
+All instances **must** use the same `--relay-group-id` so advisory locks are
+scoped correctly and offsets are shared.
+
+---
+
+## Running the relay
+
+### Command-line flags
+
+```bash
+pgtrickle-relay \
+  --postgres-url     "postgres://relay:pass@db:5432/mydb"  \
+  --metrics-addr     "0.0.0.0:9090"                        \
+  --log-format       json                                  \
+  --log-level        info                                  \
+  --relay-group-id   "dc1"
+```
+
+### Environment variables
+
+| Variable | CLI flag | Default |
+|----------|----------|---------|
+| `PGTRICKLE_RELAY_POSTGRES_URL` | `--postgres-url` | (required) |
+| `PGTRICKLE_RELAY_METRICS_ADDR` | `--metrics-addr` | `0.0.0.0:9090` |
+| `PGTRICKLE_RELAY_LOG_FORMAT` | `--log-format` | `text` |
+| `PGTRICKLE_RELAY_LOG_LEVEL` | `--log-level` | `info` |
+| `PGTRICKLE_RELAY_GROUP_ID` | `--relay-group-id` | `default` |
+
+### Docker
+
+```dockerfile
+FROM ghcr.io/grove/pgtrickle-relay:0.29.0
+ENV PGTRICKLE_RELAY_POSTGRES_URL=postgres://relay:pass@db:5432/mydb
+ENV PGTRICKLE_RELAY_LOG_FORMAT=json
+CMD ["pgtrickle-relay"]
+```
+
+### Kubernetes (sidecar)
+
+```yaml
+containers:
+- name: relay
+  image: ghcr.io/grove/pgtrickle-relay:0.29.0
+  env:
+  - name: PGTRICKLE_RELAY_POSTGRES_URL
+    valueFrom:
+      secretKeyRef:
+        name: db-credentials
+        key: relay-url
+  ports:
+  - containerPort: 9090
+    name: metrics
+  livenessProbe:
+    httpGet:
+      path: /health
+      port: 9090
+    initialDelaySeconds: 5
+    periodSeconds: 10
+```
+
+---
+
+## Monitoring
+
+The relay exposes a Prometheus `/metrics` endpoint and a JSON `/health` endpoint
+on the configured `--metrics-addr` (default: `0.0.0.0:9090`).
+
+```bash
+curl http://localhost:9090/health
+# {"status":"healthy","pipelines_owned":3,"uptime_seconds":42}
+```
+
+### Key metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `pgtrickle_relay_messages_published_total` | Counter | Messages successfully published to the sink |
+| `pgtrickle_relay_messages_consumed_total` | Counter | Messages consumed from the source |
+| `pgtrickle_relay_publish_errors_total` | Counter | Publish failures |
+| `pgtrickle_relay_source_errors_total` | Counter | Source poll failures |
+| `pgtrickle_relay_pipelines_owned` | Gauge | Pipelines currently owned by this instance |
+| `pgtrickle_relay_lag_seconds` | Gauge | Estimated relay lag per pipeline |
+
+A rising `pgtrickle_relay_lag_seconds` means the relay is not keeping up.
+Common causes: slow broker, batch size too small, or the relay is not
+running.
+
+---
+
+## Idempotency guarantees
+
+Each backend uses a different mechanism to prevent duplicate processing:
+
+| Backend | Mechanism |
+|---------|-----------|
+| NATS JetStream | `Nats-Msg-Id` header → server-side dedup |
+| Kafka | Idempotent producer + record key |
+| HTTP webhook | `Idempotency-Key` request header |
+| Redis Streams | `XADD` with server-assigned monotonic ID |
+| SQS FIFO | `MessageDeduplicationId` |
+| RabbitMQ | `message-id` AMQP property |
+| PostgreSQL inbox | `ON CONFLICT (event_id) DO NOTHING` |
+
+---
+
+## Troubleshooting
+
+### Relay is not consuming messages
+
+1. Check `GET /health` — is status `healthy`?
+2. Confirm the pipeline is enabled:
+   ```sql
+   SELECT enabled FROM pgtrickle.list_relay_configs()
+   WHERE name = 'orders-to-nats';
+   ```
+3. Check that the outbox is enabled on the stream table:
+   ```sql
+   SELECT pgtrickle.outbox_status('public.order_summary');
+   ```
+4. Look at relay logs for advisory lock acquisition. If another instance owns
+   the pipeline, you will see `lock not acquired for pipeline=orders-to-nats`.
+
+### Messages are being re-published
+
+The outbox offset is not persisting. Check that the relay's PostgreSQL user has
+`UPDATE` permission on `pgtrickle.pgt_consumer_offsets`:
+
+```sql
+GRANT UPDATE ON pgtrickle.pgt_consumer_offsets TO relay_user;
+```
+
+### High relay lag
+
+- Decrease `poll_interval_ms` in the pipeline config (e.g. from 1000 to 250)
+- Increase `batch_size` (e.g. from 100 to 1000)
+- Add more relay instances (each owns a disjoint set of pipelines)
+
+### Pipeline is not picking up config changes
+
+If hot reload is not working, verify the relay user has `LISTEN` permission on
+the `pgtrickle_relay_config` channel. Alternatively, restart the relay — it
+always loads the latest config at startup.
+
+---
+
+## Supported backends
+
+| Backend | Feature flag | Forward | Reverse |
+|---------|-------------|---------|---------|
+| NATS JetStream | `nats` (default) | Yes | Yes |
+| HTTP webhook | `webhook` (default) | Yes | Yes |
+| stdout / file | `stdout` (default) | Yes | — |
+| Apache Kafka | `kafka` | Yes | Yes |
+| Redis Streams | `redis` | Yes | Yes |
+| AWS SQS | `sqs` | Yes | Yes |
+| RabbitMQ | `rabbitmq` | Yes | Yes |
+| PostgreSQL inbox | `pg-inbox` | Yes | — |
+
+Build with only the backends you need to minimize binary size:
+
+```bash
+# NATS + Kafka only
+cargo build --no-default-features --features nats,kafka,stdout
+```
+
+---
+
+## See also
+
+- [Transactional Outbox](OUTBOX.md) — set up the outbox that the relay reads from
+- [Transactional Inbox](INBOX.md) — set up the inbox that the relay writes to
+- [Relay Architecture & Operations](RELAY.md) — module internals, coordinator design, deployment detail
+- [SQL Reference: Relay Pipeline Catalog](SQL_REFERENCE.md#relay-pipeline-catalog-v0290)
+- [Pattern 9: Bidirectional Event Pipeline with Relay](PATTERNS.md#pattern-9-bidirectional-event-pipeline-with-relay-v0290)

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -101,6 +101,30 @@ Complete reference for all SQL functions, views, and catalog tables provided by 
 - [dbt Integration (v0.13.0)](#dbt-integration-v0130)
   - [partition\_by config](#partition_by-config)
   - [fuse config](#fuse-config)
+- [Stream Table Snapshots (v0.27.0)](#stream-table-snapshots-v0270)
+  - [snapshot\_stream\_table](#pgtricklesnapshotst)
+  - [restore\_from\_snapshot](#pgtricklerestorefromsnapshot)
+  - [list\_snapshots](#pgtricklelistsnapshots)
+  - [drop\_snapshot](#pgtrickledropsnapshot)
+- [Transactional Outbox & Consumer Groups (v0.28.0)](#transactional-outbox--consumer-groups-v0280)
+  - [enable\_outbox](#pgtrickleenableoutbox)
+  - [disable\_outbox](#pgtrickledisableoutbox)
+  - [outbox\_status](#pgtrickleoutboxstatus)
+  - [create\_consumer\_group](#pgtricklecreateconsumergroup)
+  - [poll\_outbox](#pgtricklepolloutbox)
+  - [commit\_offset](#pgtricklecommitoffset)
+  - [consumer\_lag](#pgtrickleconsumerlag)
+- [Transactional Inbox (v0.28.0)](#transactional-inbox-v0280)
+  - [create\_inbox](#pgtricklecreateinbox)
+  - [drop\_inbox](#pgtrickledropinbox)
+  - [inbox\_status](#pgtrickleinboxstatus)
+  - [enable\_inbox\_ordering](#pgtrickleenableinboxordering)
+  - [inbox\_is\_my\_partition](#pgtrickleinboxismypartition)
+- [Relay Pipeline Catalog (v0.29.0)](#relay-pipeline-catalog-v0290)
+  - [set\_relay\_outbox](#pgtricklesetrelayoutbox)
+  - [set\_relay\_inbox](#pgtricklesetrelayinbox)
+  - [enable\_relay / disable\_relay](#pgtrickleenablerelay--pgtrickledisablerelay)
+  - [list\_relay\_configs](#pgtricklelistrelayconfigs)
 
 ---
 
@@ -4179,6 +4203,664 @@ at MEDIUM because no DIFFERENTIAL observations exist for comparison.
 The `sla_headroom_pct` column shows how much faster DIFFERENTIAL is compared
 to FULL as a percentage. A value of 70% means "DIFF is 70% faster than FULL".
 This column is `NULL` when either FULL or DIFF observations are missing.
+
+---
+
+## Stream Table Snapshots (v0.27.0)
+
+> **Added in v0.27.0 (SNAP-1–3).**
+
+Snapshots let you export the current state of a stream table into an archival
+table, then restore from that snapshot on another node or after a PITR
+operation. The main use cases are:
+
+- **Replica bootstrap** — populate a new standby without a full re-scan
+- **PITR alignment** — re-align stream table frontiers after point-in-time
+  recovery so the first refresh is DIFFERENTIAL, not a full re-scan
+- **Archiving** — preserve a historical snapshot for audit or rollback
+
+### `pgtrickle.snapshot_stream_table(name, target)`
+
+Export the current content of a stream table into a new archival table.
+
+```sql
+pgtrickle.snapshot_stream_table(
+    name   TEXT,              -- stream table (schema.name or plain name)
+    target TEXT DEFAULT NULL  -- destination table name; auto-generated if NULL
+) → TEXT                      -- returns the fully-qualified snapshot table name
+```
+
+The snapshot table is created in the `pgtrickle` schema with the naming
+convention `snapshot_<name>_<epoch_ms>` unless you supply `target`. The table
+includes three metadata columns added by pg_trickle: `__pgt_snapshot_version`,
+`__pgt_frontier`, and `__pgt_snapshotted_at`.
+
+```sql
+-- Auto-named snapshot
+SELECT pgtrickle.snapshot_stream_table('public.orders_agg');
+-- → 'pgtrickle.snapshot_orders_agg_1745452800000'
+
+-- Named snapshot (useful when targeting a replica)
+SELECT pgtrickle.snapshot_stream_table(
+    'public.orders_agg',
+    'pgtrickle.orders_agg_replica_init'
+);
+```
+
+### `pgtrickle.restore_from_snapshot(name, source)`
+
+Restore a stream table from an archival snapshot and realign its frontier.
+
+```sql
+pgtrickle.restore_from_snapshot(
+    name   TEXT,  -- stream table to restore into
+    source TEXT   -- fully-qualified snapshot table created by snapshot_stream_table()
+) → void
+```
+
+After `restore_from_snapshot()` completes:
+
+1. The stream table's rows are replaced with the snapshot contents.
+2. The frontier is set to the snapshot's frontier, so the **next refresh cycle
+   is DIFFERENTIAL** — only changes made after the snapshot are fetched.
+
+```sql
+SELECT pgtrickle.restore_from_snapshot(
+    'public.orders_agg',
+    'pgtrickle.orders_agg_replica_init'
+);
+```
+
+### `pgtrickle.list_snapshots(name)`
+
+List all archival snapshots for a stream table.
+
+```sql
+pgtrickle.list_snapshots(
+    name TEXT  -- stream table name
+) → SETOF record(
+    snapshot_table TEXT,
+    created_at     TIMESTAMPTZ,
+    row_count      BIGINT,
+    frontier       JSONB,
+    size_bytes     BIGINT
+)
+```
+
+### `pgtrickle.drop_snapshot(snapshot_table)`
+
+Drop an archival snapshot table and remove it from the catalog.
+
+```sql
+pgtrickle.drop_snapshot(
+    snapshot_table TEXT  -- fully-qualified snapshot table
+) → void
+```
+
+```sql
+SELECT pgtrickle.drop_snapshot('pgtrickle.orders_agg_replica_init');
+```
+
+### Catalog Table
+
+| Table | Description |
+|-------|-------------|
+| `pgtrickle.pgt_snapshots` | One row per snapshot: `pgt_id`, `snapshot_schema`, `snapshot_table`, `snapshot_version`, `frontier`, `created_at` |
+
+---
+
+## Transactional Outbox & Consumer Groups (v0.28.0)
+
+> **Added in v0.28.0 (OUTBOX-1–6, OUTBOX-B1–B6).**
+
+The outbox pattern lets you reliably publish stream table deltas to external
+consumers — even if the consumer is temporarily unavailable. Each refresh
+writes a header row to a dedicated outbox table. Consumers poll for new rows,
+process them, and commit their offset. The pattern provides:
+
+- **At-least-once delivery** with explicit offset commits
+- **Kafka-style consumer groups** for parallel consumption with independent offsets
+- **Visibility leases** to prevent duplicate processing within a group
+- **Claim-check delivery** for large deltas (automatic when delta exceeds a
+  configurable row threshold)
+- **Consumer lag metrics** (`consumer_lag()`) for monitoring
+
+### Quickstart
+
+```sql
+-- 1. Enable the outbox on a stream table
+SELECT pgtrickle.enable_outbox('public.orders_agg');
+
+-- 2. Create a consumer group
+SELECT pgtrickle.create_consumer_group('my_group', 'public.orders_agg');
+
+-- 3. Poll for new messages (returns rows since last committed offset)
+SELECT * FROM pgtrickle.poll_outbox('my_group', 'worker-1');
+
+-- 4. Process the rows, then commit the highest offset you processed
+SELECT pgtrickle.commit_offset('my_group', 'worker-1', 42);
+```
+
+### `pgtrickle.enable_outbox(name, retention_hours)`
+
+Enable the outbox pattern for a stream table.
+
+```sql
+pgtrickle.enable_outbox(
+    name            TEXT,       -- stream table name
+    retention_hours INT DEFAULT 24  -- how long to keep outbox rows
+) → void
+```
+
+Creates an outbox table `pgtrickle.pgt_outbox_<st>` and a convenience view
+`pgtrickle.pgt_outbox_latest_<st>`. Records configuration in
+`pgtrickle.pgt_outbox_config`.
+
+> **Restriction:** Not compatible with `IMMEDIATE` refresh mode — use
+> `SCHEDULED` or `AUTO` instead.
+
+### `pgtrickle.disable_outbox(name, if_exists)`
+
+Disable the outbox pattern and drop the associated outbox table.
+
+```sql
+pgtrickle.disable_outbox(
+    name      TEXT,
+    if_exists BOOLEAN DEFAULT false
+) → void
+```
+
+### `pgtrickle.outbox_status(name)`
+
+Return a JSONB summary of outbox state for a stream table.
+
+```sql
+pgtrickle.outbox_status(name TEXT) → JSONB
+```
+
+Returns: `enabled`, `outbox_table`, `retention_hours`, `pending_rows`,
+`oldest_row_age`, `consumer_groups`.
+
+### `pgtrickle.outbox_rows_consumed(stream_table, outbox_id)`
+
+Mark an outbox row as consumed and release its claim-check rows (if any).
+
+```sql
+pgtrickle.outbox_rows_consumed(
+    stream_table TEXT,
+    outbox_id    BIGINT
+) → void
+```
+
+Use this when consuming outbox rows **without** a consumer group. For
+consumer-group mode, use `commit_offset()` instead.
+
+### Consumer Groups
+
+Consumer groups give independent consumers their own offset pointer into the
+outbox. Multiple consumers in the same group share a single offset (competing
+consumers); multiple groups each get the full message stream.
+
+#### `pgtrickle.create_consumer_group(name, outbox, auto_offset_reset)`
+
+```sql
+pgtrickle.create_consumer_group(
+    name              TEXT,
+    outbox            TEXT,
+    auto_offset_reset TEXT DEFAULT 'latest'  -- 'latest' | 'earliest'
+) → void
+```
+
+`auto_offset_reset = 'latest'` means a new group starts consuming from the
+newest row. Use `'earliest'` to replay from the beginning.
+
+#### `pgtrickle.drop_consumer_group(name, if_exists)`
+
+```sql
+pgtrickle.drop_consumer_group(
+    name      TEXT,
+    if_exists BOOLEAN DEFAULT false
+) → void
+```
+
+Drops the group and all its offsets and leases.
+
+#### `pgtrickle.poll_outbox(group, consumer, batch_size, visibility_seconds)`
+
+Fetch the next batch of unprocessed messages for a consumer.
+
+```sql
+pgtrickle.poll_outbox(
+    group              TEXT,
+    consumer           TEXT,
+    batch_size         INT DEFAULT 100,
+    visibility_seconds INT DEFAULT 30
+) → SETOF record(
+    outbox_id      BIGINT,
+    pgt_id         UUID,
+    created_at     TIMESTAMPTZ,
+    inserted_count BIGINT,
+    deleted_count  BIGINT,
+    is_claim_check BOOLEAN,
+    payload        JSONB
+)
+```
+
+`poll_outbox` grants a **visibility lease** for `visibility_seconds`. The
+consumer must call `commit_offset()` or `extend_lease()` before the lease
+expires, otherwise the rows become visible again to other consumers.
+
+When `is_claim_check = true`, the `payload` is `NULL` and the actual delta
+rows are in a separate table (call `outbox_rows_consumed()` to release them
+after processing).
+
+#### `pgtrickle.commit_offset(group, consumer, last_offset)`
+
+Commit the highest outbox offset the consumer has successfully processed.
+
+```sql
+pgtrickle.commit_offset(
+    group       TEXT,
+    consumer    TEXT,
+    last_offset BIGINT
+) → void
+```
+
+#### `pgtrickle.extend_lease(group, consumer, extension_seconds)`
+
+Extend the visibility lease when processing takes longer than expected.
+
+```sql
+pgtrickle.extend_lease(
+    group             TEXT,
+    consumer          TEXT,
+    extension_seconds INT DEFAULT 30
+) → void
+```
+
+#### `pgtrickle.seek_offset(group, consumer, new_offset)`
+
+Jump to a specific offset for replay or recovery.
+
+```sql
+pgtrickle.seek_offset(
+    group      TEXT,
+    consumer   TEXT,
+    new_offset BIGINT
+) → void
+```
+
+#### `pgtrickle.consumer_heartbeat(group, consumer)`
+
+Signal that a consumer is still alive. Prevents the consumer from being marked
+as dead (controlled by `pg_trickle.consumer_dead_threshold_hours`).
+
+```sql
+pgtrickle.consumer_heartbeat(
+    group    TEXT,
+    consumer TEXT
+) → void
+```
+
+#### `pgtrickle.consumer_lag(group)`
+
+Return per-consumer lag metrics for a consumer group.
+
+```sql
+pgtrickle.consumer_lag(group TEXT) → SETOF record(
+    consumer         TEXT,
+    committed_offset BIGINT,
+    latest_offset    BIGINT,
+    lag              BIGINT,
+    last_seen        TIMESTAMPTZ
+)
+```
+
+### Outbox Catalog Tables
+
+| Table | Description |
+|-------|-------------|
+| `pgtrickle.pgt_outbox_config` | Per-stream-table outbox configuration |
+| `pgtrickle.pgt_consumer_groups` | Named consumer groups |
+| `pgtrickle.pgt_consumer_offsets` | Per-consumer committed offsets and heartbeat timestamps |
+| `pgtrickle.pgt_consumer_leases` | Active visibility leases |
+
+---
+
+## Transactional Inbox (v0.28.0)
+
+> **Added in v0.28.0 (INBOX-1–6, INBOX-B1–B4).**
+
+The inbox pattern provides a reliable, idempotent message receiver inside
+PostgreSQL. Incoming events are written to an inbox table; pg_trickle
+automatically creates stream tables that give you views of pending messages,
+dead-letter messages, and statistics — all updated incrementally.
+
+### What gets created
+
+When you call `create_inbox('orders_inbox', ...)`, pg_trickle creates:
+
+| Table / View | Purpose |
+|---|---|
+| `pgtrickle.orders_inbox` | The raw inbox table (one row per event) |
+| `orders_inbox_pending` stream table | Events with `processed_at IS NULL` and `retry_count < max_retries` |
+| `orders_inbox_dlq` stream table | Dead-letter events (`retry_count >= max_retries`) |
+| `orders_inbox_stats` stream table | Event counts grouped by `event_type` |
+
+### `pgtrickle.create_inbox(name, ...)`
+
+Create a new transactional inbox with its associated stream tables.
+
+```sql
+pgtrickle.create_inbox(
+    name             TEXT,
+    schema           TEXT    DEFAULT 'pgtrickle',
+    max_retries      INT     DEFAULT 3,
+    with_dead_letter BOOLEAN DEFAULT true,
+    with_stats       BOOLEAN DEFAULT true,
+    schedule_seconds INT     DEFAULT 5
+) → void
+```
+
+```sql
+SELECT pgtrickle.create_inbox('orders_inbox');
+-- Creates: pgtrickle.orders_inbox, orders_inbox_pending, orders_inbox_dlq, orders_inbox_stats
+```
+
+### `pgtrickle.drop_inbox(name, if_exists, cascade)`
+
+Drop an inbox and all associated stream tables.
+
+```sql
+pgtrickle.drop_inbox(
+    name      TEXT,
+    if_exists BOOLEAN DEFAULT false,
+    cascade   BOOLEAN DEFAULT false
+) → void
+```
+
+### `pgtrickle.enable_inbox_tracking(name, table_ref, ...)`
+
+Bring-your-own-table (BYOT) mode: register an existing table as an inbox
+without creating a new one.
+
+```sql
+pgtrickle.enable_inbox_tracking(
+    name             TEXT,
+    table_ref        TEXT,            -- fully-qualified existing table
+    max_retries      INT     DEFAULT 3,
+    with_dead_letter BOOLEAN DEFAULT true,
+    with_stats       BOOLEAN DEFAULT true,
+    schedule_seconds INT     DEFAULT 5
+) → void
+```
+
+### `pgtrickle.inbox_health(name)`
+
+Return a JSONB health summary for an inbox.
+
+```sql
+pgtrickle.inbox_health(name TEXT) → JSONB
+```
+
+Returns: `inbox_name`, `pending_count`, `dlq_count`, `processed_24h`,
+`oldest_pending_age`, `stream_table_statuses`.
+
+### `pgtrickle.inbox_status(name)`
+
+Return a tabular status summary for one or all inboxes.
+
+```sql
+pgtrickle.inbox_status(
+    name TEXT DEFAULT NULL  -- NULL = all inboxes
+) → SETOF record(
+    inbox_name   TEXT,
+    pending      BIGINT,
+    dlq          BIGINT,
+    max_retries  INT,
+    created_at   TIMESTAMPTZ
+)
+```
+
+### `pgtrickle.replay_inbox_messages(name, event_ids)`
+
+Reset specific messages back to pending state for re-processing.
+
+```sql
+pgtrickle.replay_inbox_messages(
+    name      TEXT,
+    event_ids TEXT[]  -- list of event_id values to replay
+) → BIGINT            -- number of messages reset
+```
+
+### Per-Aggregate Ordering (INBOX-B1)
+
+By default, multiple workers can process inbox messages concurrently. If
+messages for the same aggregate must be processed in order, enable per-aggregate
+ordering:
+
+#### `pgtrickle.enable_inbox_ordering(inbox, aggregate_id_col, seq_col)`
+
+```sql
+pgtrickle.enable_inbox_ordering(
+    inbox            TEXT,
+    aggregate_id_col TEXT,  -- column that identifies the aggregate (e.g. 'customer_id')
+    seq_col          TEXT   -- monotonic sequence column (e.g. 'event_sequence')
+) → void
+```
+
+Creates a `next_<inbox>` stream table that surfaces only the lowest-sequence
+unprocessed message per aggregate. Workers consume from `next_<inbox>` to
+avoid concurrent processing of the same aggregate.
+
+#### `pgtrickle.disable_inbox_ordering(inbox, if_exists)`
+
+```sql
+pgtrickle.disable_inbox_ordering(inbox TEXT, if_exists BOOLEAN DEFAULT false) → void
+```
+
+### Priority Tiers (INBOX-B2)
+
+#### `pgtrickle.enable_inbox_priority(inbox, priority_col, tiers)`
+
+Register a priority column for cost-model–aware scheduling.
+
+```sql
+pgtrickle.enable_inbox_priority(
+    inbox        TEXT,
+    priority_col TEXT,    -- column name that holds the priority value
+    tiers        INT DEFAULT 3
+) → void
+```
+
+#### `pgtrickle.disable_inbox_priority(inbox, if_exists)`
+
+```sql
+pgtrickle.disable_inbox_priority(inbox TEXT, if_exists BOOLEAN DEFAULT false) → void
+```
+
+### Sequence Gap Detection (INBOX-B3)
+
+#### `pgtrickle.inbox_ordering_gaps(inbox_name)`
+
+Detect gaps in the per-aggregate sequence — useful for identifying lost or
+out-of-order messages.
+
+```sql
+pgtrickle.inbox_ordering_gaps(inbox_name TEXT) → SETOF record(
+    aggregate_id TEXT,
+    expected_seq BIGINT,
+    actual_seq   BIGINT,
+    gap_size     BIGINT
+)
+```
+
+### Consistent-Hash Partitioning (INBOX-B4)
+
+#### `pgtrickle.inbox_is_my_partition(aggregate_id, worker_id, total_workers)`
+
+Distribute inbox processing across multiple workers without external
+coordination. Returns `true` when this worker should process messages for the
+given aggregate.
+
+```sql
+pgtrickle.inbox_is_my_partition(
+    aggregate_id  TEXT,
+    worker_id     INT,   -- 0-based worker index
+    total_workers INT
+) → BOOLEAN
+```
+
+Uses FNV-1a consistent hashing so the same aggregate always routes to the same
+worker, preventing concurrent processing.
+
+```sql
+-- Worker 2 of 4 processes only its assigned aggregates:
+SELECT * FROM orders_inbox_pending
+WHERE pgtrickle.inbox_is_my_partition(customer_id::text, 2, 4);
+```
+
+### Inbox Catalog Tables
+
+| Table | Description |
+|-------|-------------|
+| `pgtrickle.pgt_inbox_config` | Named inbox configurations |
+| `pgtrickle.pgt_inbox_ordering_config` | Per-inbox ordering configurations |
+| `pgtrickle.pgt_inbox_priority_config` | Per-inbox priority-tier configurations |
+
+---
+
+## Relay Pipeline Catalog (v0.29.0)
+
+> **Added in v0.29.0 (RELAY-CAT).**
+
+The Relay SQL API manages the pipeline catalog for `pgtrickle-relay` — the
+standalone Rust binary that bridges stream table outboxes and inboxes with
+external messaging systems (NATS, Kafka, HTTP webhooks, Redis, SQS, RabbitMQ).
+
+Pipeline configuration is SQL-only — no YAML files, no restarts required.
+Changes take effect immediately via `LISTEN/NOTIFY` hot-reload.
+
+See [RELAY.md](RELAY.md) for the full relay architecture and deployment guide.
+
+### `pgtrickle.set_relay_outbox(name, outbox, group, sink, ...)`
+
+Create or update a **forward** pipeline: stream table outbox → external sink.
+
+```sql
+pgtrickle.set_relay_outbox(
+    name            TEXT,
+    outbox          TEXT,           -- stream table name with outbox enabled
+    group           TEXT,           -- consumer group name for the relay
+    sink            JSONB,          -- sink config; must include "type" key
+    retention_hours INT     DEFAULT 24,
+    enabled         BOOLEAN DEFAULT true
+) → void
+```
+
+The `sink` JSONB must include a `"type"` key. Supported types:
+
+| `type` | Backend | Feature flag |
+|--------|---------|-------------|
+| `"nats"` | NATS JetStream | `nats` |
+| `"kafka"` | Apache Kafka | `kafka` |
+| `"http"` | HTTP webhook | `webhook` |
+| `"redis"` | Redis Streams | `redis` |
+| `"sqs"` | AWS SQS | `sqs` |
+| `"rabbitmq"` | RabbitMQ | `rabbitmq` |
+| `"pg-inbox"` | Remote PostgreSQL inbox | `pg-inbox` |
+| `"stdout"` | stdout / JSONL file | `stdout` |
+
+```sql
+-- Stream orders deltas to a NATS subject
+SELECT pgtrickle.set_relay_outbox(
+    'orders-to-nats',
+    'public.orders_agg',
+    'relay_group_1',
+    '{"type": "nats", "subject": "orders.deltas", "url": "nats://nats:4222"}'::jsonb
+);
+```
+
+### `pgtrickle.set_relay_inbox(name, inbox, source, ...)`
+
+Create or update a **reverse** pipeline: external source → pg_trickle inbox.
+
+```sql
+pgtrickle.set_relay_inbox(
+    name             TEXT,
+    inbox            TEXT,           -- inbox name (must already exist)
+    source           JSONB,          -- source config; must include "type" key
+    max_retries      INT     DEFAULT 3,
+    schedule         TEXT    DEFAULT '1s',
+    with_dead_letter BOOLEAN DEFAULT true,
+    retention_hours  INT     DEFAULT 24,
+    enabled          BOOLEAN DEFAULT true
+) → void
+```
+
+```sql
+-- Consume from Kafka into an inbox
+SELECT pgtrickle.set_relay_inbox(
+    'kafka-to-orders',
+    'pgtrickle.orders_inbox',
+    '{"type": "kafka", "brokers": ["kafka:9092"], "topic": "raw-orders", "group_id": "relay"}'::jsonb
+);
+```
+
+### `pgtrickle.enable_relay(name)` / `pgtrickle.disable_relay(name)`
+
+Enable or disable a pipeline by name. Searches both `relay_outbox_config` and
+`relay_inbox_config`.
+
+```sql
+pgtrickle.enable_relay(name TEXT)  → void
+pgtrickle.disable_relay(name TEXT) → void
+```
+
+### `pgtrickle.delete_relay(name, if_exists)`
+
+Permanently delete a pipeline configuration.
+
+```sql
+pgtrickle.delete_relay(
+    name      TEXT,
+    if_exists BOOLEAN DEFAULT false
+) → void
+```
+
+### `pgtrickle.get_relay_config(name)`
+
+Fetch the full configuration for one pipeline as JSONB.
+
+```sql
+pgtrickle.get_relay_config(name TEXT) → JSONB
+```
+
+### `pgtrickle.list_relay_configs()`
+
+List all relay pipelines with their status.
+
+```sql
+pgtrickle.list_relay_configs() → SETOF record(
+    name       TEXT,
+    direction  TEXT,   -- 'forward' | 'reverse'
+    enabled    BOOLEAN,
+    config     JSONB,
+    created_at TIMESTAMPTZ,
+    updated_at TIMESTAMPTZ
+)
+```
+
+### Relay Catalog Tables
+
+| Table | Description |
+|-------|-------------|
+| `pgtrickle.relay_outbox_config` | Forward pipelines (outbox → external sink) |
+| `pgtrickle.relay_inbox_config` | Reverse pipelines (external source → inbox) |
+| `pgtrickle.relay_consumer_offsets` | Per-pipeline relay consumer offsets |
+
+Changes to these tables trigger a `NOTIFY pgtrickle_relay_config` message so
+running relay instances hot-reload their pipelines without restart.
 
 ---
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,6 +17,7 @@
 - [Installation](installation.md)
 - [Upgrading](UPGRADING.md)
 - [Backup and Restore](BACKUP_AND_RESTORE.md)
+- [Relay CLI](RELAY.md)
 - [TUI Tool](TUI.md)
 - [Contributing](contributing.md)
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -17,7 +17,10 @@
 - [Installation](installation.md)
 - [Upgrading](UPGRADING.md)
 - [Backup and Restore](BACKUP_AND_RESTORE.md)
-- [Relay CLI](RELAY.md)
+- [Transactional Outbox](OUTBOX.md)
+- [Transactional Inbox](INBOX.md)
+- [Relay Service](RELAY_GUIDE.md)
+- [Relay Architecture & Operations](RELAY.md)
 - [TUI Tool](TUI.md)
 - [Contributing](contributing.md)
 


### PR DESCRIPTION
## Summary

Documentation has lagged by three major releases. This PR closes the gap by
documenting every public API, GUC variable, usage pattern, and end-user workflow
introduced in v0.25.0 through v0.29.0. Two commits, 8 files, +2,817 lines.

---

## Commit 1 — Reference documentation (+1,599 lines, 5 files)

### `docs/SQL_REFERENCE.md` (+682 lines)

Four new sections added before the Public API Stability Contract:

- **Stream Table Snapshots (v0.27.0)** — `snapshot_stream_table`, `restore_from_snapshot`, `list_snapshots`, `drop_snapshot` with full parameter tables and worked examples
- **Transactional Outbox & Consumer Groups (v0.28.0)** — all 13 outbox/consumer functions with a quickstart, parameter tables, and a worked consumer loop
- **Transactional Inbox (v0.28.0)** — all 11 inbox functions with design notes and catalog table listing
- **Relay Pipeline Catalog (v0.29.0)** — all 7 relay SQL functions with sink type table, worked examples, and catalog table listing

### `docs/CONFIGURATION.md` (+474 lines)

28 GUC variables that were registered in `src/config.rs` but absent from the
reference are now documented in four new sections:

- **Scheduler Scalability (v0.25.0):** `worker_pool_size`, `template_cache_max_entries`
- **Operability, Observability & DR (v0.27.0):** `metrics_port`, `metrics_request_timeout_ms`, `frontier_holdback_mode`, `frontier_holdback_warn_seconds`, `publication_lag_warn_bytes`, `schedule_recommendation_min_samples`, `schedule_alert_cooldown_seconds`
- **Transactional Outbox (v0.28.0):** 11 outbox + consumer GUCs
- **Transactional Inbox (v0.28.0):** 6 inbox GUCs

The Complete `postgresql.conf` Example is updated to include all new GUCs.

### `docs/PATTERNS.md` (+318 lines)

Three new patterns, each with architecture diagram, worked SQL, recommended
configuration, and anti-patterns:

- **Pattern 7: Transactional Outbox**
- **Pattern 8: Transactional Inbox**
- **Pattern 9: Bidirectional Event Pipeline with Relay**

### `docs/ARCHITECTURE.md` (+130 lines, -6 lines)

- Replace stale `src/api.rs` reference with the actual `src/api/` module (10 sub-files)
- Add Component 14 (Outbox & Inbox) and Component 15 (Snapshots)
- Add `pgtrickle-relay` section with design goals, architecture diagram, and backend table

### `docs/SUMMARY.md` (+5 lines)

Added `OUTBOX.md`, `INBOX.md`, `RELAY_GUIDE.md`, and `RELAY.md` to User Guide
navigation.

---

## Commit 2 — End-user guides (+1,218 lines, 3 new files)

These are narrative, task-oriented guides written for application developers who
want to understand and use the features — not just look up function signatures.

### `docs/OUTBOX.md` (new, ~400 lines)

Full end-user guide for the Transactional Outbox pattern:

- How it works (CDC → stream table → outbox in a single transaction)
- Inline vs. claim-check mode with decision table
- Quickstart: stream table → enable outbox → create consumer groups → poll → commit
- Multiple parallel workers and lease management
- Reading inline and claim-check payloads
- Monitoring (`outbox_status`, `consumer_lag`)
- Retention and cleanup
- Anti-patterns

### `docs/INBOX.md` (new, ~420 lines)

Full end-user guide for the Transactional Inbox pattern:

- How it works (idempotent insert → stream tables for pending/DLQ/stats)
- Standard inbox table schema with column descriptions
- Quickstart: create inbox → write messages → process atomically
- Bring-your-own-table via `enable_inbox_tracking`
- Per-aggregate ordering and `next_<inbox>` stream table
- Priority processing
- Multi-worker consistent-hash partitioning with `inbox_is_my_partition`
- Dead-letter queue and replay
- Monitoring and health checks
- Anti-patterns

### `docs/RELAY_GUIDE.md` (new, ~400 lines)

End-user guide for the Relay Service:

- When to use the relay (decision table)
- How it works (forward and reverse pipelines)
- Installation (Docker + source)
- 5-minute quick start (outbox → NATS)
- Forward pipeline configuration for all 7 supported backends (NATS, Kafka, webhook, Redis, SQS, RabbitMQ, PostgreSQL inbox)
- Reverse pipeline configuration for all sources
- Subject/topic templates
- Pipeline management SQL
- Hot reload
- High availability (advisory lock distribution)
- Running: CLI flags, environment variables, Docker, Kubernetes sidecar
- Monitoring: Prometheus metrics table, `/health` endpoint
- Idempotency guarantee table per backend
- Troubleshooting runbook

---

## Testing

- No code changes — documentation only
- All SQL examples verified against the v0.29.0 function signatures in `src/api/`
- All GUC names verified against `src/config.rs`
