### PR TITLE
docs(roadmap): renumber reordered Toward Stable versions sequentially

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -77,9 +77,9 @@
 | [v0.29.0](roadmap/v0.29.0.md) | Off-the-shelf connector to Kafka, NATS, SQS, and more | ✅ Released | Large | [Full details](roadmap/v0.29.0.md-full.md) |
 | [v0.30.0](roadmap/v0.30.0.md) | Quality gate before 1.0 — correctness, stability, and docs | Planned | Medium | [Full details](roadmap/v0.30.0.md-full.md) |
 | [v0.31.0](roadmap/v0.31.0.md) | Smarter scheduling and faster hot paths | Planned | Medium | [Full details](roadmap/v0.31.0.md-full.md) |
-| [v0.34.0](roadmap/v0.34.0.md) | Citus: stable object naming and per-source frontier foundation | Planned | Medium | [Full details](roadmap/v0.34.0.md-full.md) |
-| [v0.32.0](roadmap/v0.32.0.md) | Live push notifications and safe live schema changes | Planned | Medium | [Full details](roadmap/v0.32.0.md-full.md) |
-| [v0.33.0](roadmap/v0.33.0.md) | Time-travel queries and analytic storage | Planned | Medium | [Full details](roadmap/v0.33.0.md-full.md) |
+| [v0.32.0](roadmap/v0.32.0.md) | Citus: stable object naming and per-source frontier foundation | Planned | Medium | [Full details](roadmap/v0.32.0.md-full.md) |
+| [v0.33.0](roadmap/v0.33.0.md) | Live push notifications and safe live schema changes | Planned | Medium | [Full details](roadmap/v0.33.0.md-full.md) |
+| [v0.34.0](roadmap/v0.34.0.md) | Time-travel queries and analytic storage | Planned | Medium | [Full details](roadmap/v0.34.0.md-full.md) |
 | [v0.35.0](roadmap/v0.35.0.md) | Citus: world-class distributed source CDC and stream table support | Planned | Large | [Full details](roadmap/v0.35.0.md-full.md) |
 
 ### Beyond v1.0
@@ -117,9 +117,9 @@ v0.30    ─── Quality gate: correctness, stability, docs (required for 1.0)
     │
 v0.31    ─── Scheduler intelligence and performance hot paths
     │
-v0.34    ─── Citus: stable naming foundation (additive, safe for all users)
+v0.32    ─── Citus: stable naming foundation (additive, safe for all users)
     │
-v0.32–33 ─── Push notifications, zero-downtime schema changes, time-travel
+v0.33–34 ─── Push notifications, zero-downtime schema changes, time-travel
     │
 v0.35    ─── Citus: distributed CDC and stream table support
     │
@@ -130,10 +130,10 @@ v0.1.0 through v0.27.0 build the complete core engine and harden it for
 production use. v0.28.0 and v0.29.0 deliver the event-driven integration
 story. v0.30.0 is a mandatory correctness and polish gate before 1.0.
 v0.31.0 sharpens scheduler intelligence before new features are added.
-v0.34.0 is scheduled early — before v0.32.0 and v0.33.0 — so that every
+v0.32.0 is scheduled early — before v0.33.0 and v0.34.0 — so that every
 subscription object and temporal history table is created with the new
 stable naming scheme from day one, reducing migration scope later.
-v0.32.0 and v0.33.0 each add a distinct new capability (push notifications
+v0.33.0 and v0.34.0 each add a distinct new capability (push notifications
 and time-travel/columnar storage) while the core IVM engine remains stable.
-v0.35.0 builds on v0.34.0's foundations to unlock distributed-source CDC,
+v0.35.0 builds on v0.32.0's foundations to unlock distributed-source CDC,
 distributed ST placement, and the full Citus test suite.

--- a/roadmap/v0.32.0.md
+++ b/roadmap/v0.32.0.md
@@ -1,80 +1,98 @@
-# v0.32.0 — Reactive Subscriptions & Zero-Downtime Operations
+# v0.32.0 — Citus: Stable Naming & Per-Source Frontier Foundation
 
 > **Full technical details:** [v0.32.0.md-full.md](v0.32.0.md-full.md)
 
 **Status: Planned** | **Scope: Medium**
 
-> Live push notifications to applications, and a way to change a stream
-> table's defining query on a large production table without downtime.
+> The first of two releases that bring world-class Citus support to
+> pg_trickle. v0.32.0 lays the additive foundation — stable object naming,
+> Citus detection helpers, and per-source frontier correctness — with zero
+> behaviour change on single-node deployments.
 
 ---
 
 ## What is this?
 
-v0.32.0 adds two long-requested operational capabilities:
+pg_trickle currently names every internal object (change buffers, trigger
+functions, index names, WAL slot names, frontier keys) after the PostgreSQL
+OID of the source table. An OID is a local, database-specific integer that
+is different on every node in a Citus cluster and changes after a
+`pg_dump` / restore cycle. This works fine for single-node PostgreSQL but
+is the root cause of every Citus incompatibility.
 
-1. **Push notifications** — applications can subscribe to changes in a
-   stream table and receive instant notifications, enabling real-time
-   dashboards, live UIs, and event-driven microservices.
-
-2. **Zero-downtime query changes** — modifying the defining query of a
-   large stream table no longer requires a multi-minute lock on the table.
+v0.32.0 replaces OID-keyed names with a **stable hash** derived from the
+schema-qualified table name — identical on every node, survives restores,
+and survives OID reassignment after a major upgrade. At the same time it
+ships a new `src/citus.rs` module with Citus detection helpers that allow
+the extension to make intelligent decisions about source placement in v0.35.0.
 
 ---
 
-## Reactive subscriptions
+## Stable naming
 
-`pgtrickle.subscribe('my_stream_table', 'my_notification_channel')` registers
-a listener. After every successful refresh that produces at least one change,
-pg_trickle sends a PostgreSQL `NOTIFY` message to the named channel with a
-payload like:
+Instead of `changes_12345`, `pg_trickle_cdc_fn_12345`, and
+`slot_pgtrickle_12345`, objects are now named using a short hex string
+derived from `stable_hash("myschema.my_table")`:
 
-```json
-{"name": "my_stream_table", "inserted_count": 12, "deleted_count": 3}
+```
+changes_a3f7b2c1
+pg_trickle_cdc_fn_a3f7b2c1
+slot_pgtrickle_a3f7b2c1
 ```
 
-Any application holding a standard PostgreSQL connection and listening on
-that channel receives this signal immediately, without polling. This powers
-real-time dashboards, event-driven microservices, and reactive frontends —
-using nothing but a standard PostgreSQL driver, with no Kafka, no Debezium,
-no Hasura required.
+This name is computed once at `create_stream_table()` time, stored in the
+catalog, and used for all subsequent object creation. Existing installations
+are upgraded automatically — the SQL migration script renames all existing
+objects in a single transaction with no downtime.
 
-A configurable coalescence window prevents notification storms when a stream
-table refreshes at high frequency.
+The change is invisible to end users: no SQL API changes, no configuration
+changes, no behaviour changes on a single-node deployment.
 
 ---
 
-## Shadow-ST: zero-downtime query evolution
+## Citus detection
 
-Today, calling `alter_query()` on a large stream table triggers a full
-re-computation of the entire result set. For a stream table with millions of
-rows, this can lock the table for minutes — an unacceptable operation in
-production.
+A new internal module learns to ask "is Citus loaded on this database?" and
+"how is this table distributed?". The answers — local, reference, or
+distributed — are stored alongside the stable name in the catalog and drive
+the CDC and apply strategies in v0.35.0.
 
-The new `shadow_build := true` parameter to `alter_query()` changes how
-this works:
+---
 
-1. A parallel "shadow" stream table is created from the new query, invisible
-   to users.
-2. The shadow table is refreshed to convergence in the background, with no
-   lock on the live table. The live table continues to serve reads and accept
-   writes normally throughout.
-3. When the shadow table has caught up, the storage is swapped atomically.
-4. The new query goes live at the next refresh cycle. The shadow table is
-   dropped.
+## Per-source frontier correctness
 
-The live table is readable and writable from start to finish.
+pg_trickle tracks a *frontier* for each source table — the point up to which
+changes have been consumed and applied. Today the frontier is keyed by the
+table OID, creating an implicit assumption that all sources share a single
+WAL namespace. v0.32.0 rekeys the frontier by stable name and audits all
+code paths that compare or merge frontier values across sources, removing
+the assumption of a single node's WAL.
+
+This fixes a latent correctness issue for any multi-source stream table
+where the two sources have wildly different write rates, and it is a
+prerequisite for tracking per-worker WAL positions in v0.35.0.
+
+---
+
+## Who benefits?
+
+- **All users** — stable naming survives `pg_dump` / restore, major
+  upgrades, and OID reassignment. The frontier fix improves correctness for
+  multi-source stream tables.
+- **Citus users** — v0.32.0 is the prerequisite for v0.35.0. Without stable
+  naming, per-worker slots cannot be named consistently across the cluster.
 
 ---
 
 ## Scope
 
-v0.32.0 is a medium-sized release. The shadow-ST feature touches the refresh
-orchestrator — the most change-sensitive module in the codebase — and ships
-behind a feature flag with a full TPC-H validation pass before the flag is
-removed.
+v0.32.0 is a medium-sized release. The naming refactor touches many files
+(`src/cdc.rs`, `src/wal_decoder.rs`, `src/dvm/diff.rs`,
+`src/refresh/codegen.rs`) but is purely additive: old behaviour is
+preserved in full, and the SQL migration handles existing installations
+automatically.
 
 ---
 
 *Previous: [v0.31.0 — Performance & Scheduler Intelligence](v0.31.0.md)*
-*Next: [v0.33.0 — Temporal IVM & Columnar Materialization](v0.33.0.md)*
+*Next: [v0.33.0 — Reactive Subscriptions & Zero-Downtime Operations](v0.33.0.md)*

--- a/roadmap/v0.32.0.md-full.md
+++ b/roadmap/v0.32.0.md-full.md
@@ -1,18 +1,22 @@
 > **Plain-language companion:** [v0.32.0.md](v0.32.0.md)
 
-## v0.32.0 — Reactive Subscriptions & Zero-Downtime Operations
+## v0.32.0 — Citus: Stable Naming & Per-Source Frontier Foundation
 
-**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.1, §10.8.
+**Status: Planned.** Derived from
+[plans/ecosystem/PLAN_CITUS.md](../plans/ecosystem/PLAN_CITUS.md)
+§6 Phase 1 and Phase 2.
 
 > **Release Theme**
-> v0.32.0 delivers two long-requested operational capabilities. Reactive
-> subscriptions expose stream-table changes as PostgreSQL `NOTIFY` events,
-> enabling browser-side reactive UIs and event-driven microservices with
-> nothing but a standard PG connection — no Kafka, no Debezium, no Hasura.
-> Zero-downtime view evolution adds a shadow-ST mode to `ALTER QUERY` that
-> builds the new query's materialisation side-by-side with the live table,
-> then swaps atomically — eliminating the operational risk of running
-> `ALTER QUERY` on a large production stream table.
+> v0.32.0 is the first of two releases delivering world-class Citus support.
+> It ships two additive, non-breaking layers: (1) a `src/citus.rs` module
+> with Citus detection and placement helpers; and (2) a stable-hash naming
+> scheme that replaces OID-keyed internal objects (`changes_{oid}`,
+> `pg_trickle_cdc_fn_{oid}`, slot names, frontier keys) with names derived
+> from `stable_hash(database_oid || '/' || schema || '.' || table)`. Both
+> layers produce immediate quality benefits for all users — stable names
+> survive `pg_dump`/restore and major-version upgrades — and they are
+> mandatory prerequisites for v0.35.0's per-worker slot CDC. There is zero
+> behaviour change on a single-node deployment.
 
 ---
 
@@ -20,47 +24,77 @@
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| CORR-1 | Reactive subscription: coalesce NOTIFY storms | S | P0 |
+| CITUS-1 | `src/citus.rs`: detection helpers and placement query | M | P0 |
+| CITUS-2 | `SourceIdentifier` struct carrying `(oid, stable_name)` | S | P0 |
+| CITUS-3 | Catalog migration: add `source_stable_name`, `source_placement`, `st_placement` columns | S | P0 |
+| CITUS-4 | Rename all OID-keyed objects to `stable_name` form | M | P0 |
+| CITUS-5 | Frontier rekey: `Frontier.sources` from OID string to `stable_name` | S | P1 |
+| CITUS-6 | Audit and remove cross-source global LSN comparisons | M | P1 |
+| CITUS-7 | Add `frontier_per_node JSONB` column for distributed sources | S | P1 |
+| CITUS-8 | SQL migration: rename existing `changes_{oid}` tables and trigger functions in a single transaction | M | P0 |
 
-**CORR-1** — The subscribe API must coalesce rapid successive changes into a
-single NOTIFY payload (or a "changes pending" signal) when the refresh
-interval is shorter than the LISTEN client's poll loop. Implement a
-`pg_trickle.notify_coalesce_ms` GUC (default 250 ms) and a per-stream-table
-flag that debounces NOTIFY calls.
+**CITUS-1** — New module `src/citus.rs`. Detection helpers:
+- `is_citus_loaded()` — `SELECT 1 FROM pg_extension WHERE extname='citus'`
+- `placement(oid)` → `Local | Reference | Distributed { dist_column }` via
+  `pg_dist_partition`
+- `worker_nodes()` → `Vec<NodeAddr>` from `pg_dist_node`
+- `shard_placements(table_oid)` — which workers host shards
+
+None of these panic if Citus is absent; all return sensible defaults
+(`Local`, empty vecs). Citus-specific code paths are always guarded by
+`is_citus_loaded()`.
+
+**CITUS-2** — `SourceIdentifier { oid: pg_sys::Oid, stable_name: String }`.
+`stable_name = lower_hex(FNV-1a-64(database_oid || "/" || schema || "." || table))[..16]`.
+Deterministic, short, URL-safe, identical on every Citus node. Serialised
+in `pgt_change_tracking.source_stable_name` and used for all object names.
+
+**CITUS-3** — Schema changes (nullable, backward-compatible):
+```sql
+ALTER TABLE pgtrickle.pgt_change_tracking
+  ADD COLUMN source_stable_name TEXT,
+  ADD COLUMN source_placement TEXT NOT NULL DEFAULT 'local';
+ALTER TABLE pgtrickle.pgt_dependencies
+  ADD COLUMN source_stable_name TEXT,
+  ADD COLUMN source_placement TEXT NOT NULL DEFAULT 'local';
+ALTER TABLE pgtrickle.pgt_stream_tables
+  ADD COLUMN st_placement TEXT NOT NULL DEFAULT 'local';
+```
+Old rows receive a synthetic stable name (hash of existing OID-based
+name) and continue to function unchanged.
+
+**CITUS-4** — Replace `changes_{oid}`, `pg_trickle_cdc_ins_{oid}`,
+`pg_trickle_cdc_fn_{oid}`, `idx_changes_{oid}_*`, WAL slot names
+(`pgtrickle_{oid}`), and the `__PGS_PREV_LSN_{oid}__` placeholder tokens
+in `src/dvm/diff.rs` with `{stable_name}` forms. Affected files:
+`src/cdc.rs`, `src/wal_decoder.rs`, `src/dvm/diff.rs`,
+`src/refresh/codegen.rs`, `src/dvm/operators/*`.
+
+**CITUS-5 / CITUS-6** — `Frontier.sources` is already a `HashMap`; rekey
+from OID string to `stable_name`. Audit `src/refresh/codegen.rs` and
+`src/scheduler.rs` for reads of `pg_current_wal_lsn()` used in cross-source
+comparisons; replace with per-source watermark logic from
+`src/wal_decoder.rs`.
+
+**CITUS-7** — Add `frontier_per_node JSONB` to `pgt_change_tracking` for
+distributed sources. When the source is `Local` this column is NULL; for
+`Distributed` sources it records `{ "worker_id": lsn, ... }` tuples.
+
+**CITUS-8** — `sql/pg_trickle--<prev>--<next>.sql` performs column adds
+then backfills `source_stable_name` from `pg_class + pg_namespace`,
+renames existing buffer tables and trigger functions to the stable-hash
+form, updates the WAL slot name in `pg_replication_slots` (via
+`pg_rename_logical_replication_slot` where available), and updates
+`pgt_change_tracking`. Provides a downgrade path in the same file.
 
 ---
 
-### Ease of Use
+### Stability
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| UX-1 | `pgtrickle.subscribe(name, channel)` and `unsubscribe()` SQL functions | M | P0 |
-| UX-2 | `pg_trickle.notify_coalesce_ms` GUC | XS | P0 |
-| UX-3 | `ALTER QUERY` shadow-ST mode (`shadow_build := true` parameter) | L | P1 |
-| UX-4 | `pgtrickle.view_evolution_status(name)` monitoring function | S | P1 |
-| UX-5 | Documentation: subscribe() quick-start + shadow-ST runbook | M | P1 |
-
-**UX-1 — Reactive subscription API.**
-`pgtrickle.subscribe(stream_table TEXT, channel TEXT)` registers a per-stream-
-table listener: after every successful differential or full refresh, if the
-delta is non-empty, the refresh path emits `pg_notify(channel, payload_jsonb::text)`
-within the same transaction. The payload carries `{"name": …, "refresh_id": …,
-"inserted_count": N, "deleted_count": N}`. Build on the `pg_notify`
-infrastructure already wired by the v0.28.0 outbox. `pgtrickle.unsubscribe(name, channel)`
-removes the registration; `pgtrickle.list_subscriptions()` returns all active
-registrations. **Schema change:** Yes — new `pgtrickle.pgt_subscriptions`
-catalog table.
-
-**UX-3 — Shadow-ST for zero-downtime `ALTER QUERY`.**
-Today `ALTER QUERY` triggers a full refresh of the stream table. For tables
-with millions of rows, this causes a multi-minute outage during which the
-stream table is locked. A `shadow_build := true` parameter to `alter_query()`
-creates a parallel stream table `__pgt_shadow_<name>` built from the new query,
-refreshes it to convergence in the background without locking the live table,
-then atomically swaps the storage tables and drops the shadow. The live table
-is readable and writable throughout. The new query goes live at the next refresh
-cycle after the swap. **Schema change:** Yes — add `in_shadow_build BOOLEAN` and
-`shadow_table_name TEXT` columns to `pgtrickle.pgt_stream_tables`.
+| STAB-1 | Keep OID-based lookup as fallback for rows without `source_stable_name` | S | P0 |
+| STAB-2 | Detect and surface a clear error if stable hash collides (astronomically unlikely; check at create time) | S | P1 |
 
 ---
 
@@ -68,30 +102,34 @@ cycle after the swap. **Schema change:** Yes — add `in_shadow_build BOOLEAN` a
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| TEST-1 | E2E: subscribe() receives NOTIFY on every non-empty refresh | M | P0 |
-| TEST-2 | E2E: NOTIFY coalescing under high-frequency refresh | S | P1 |
-| TEST-3 | E2E: shadow-ST ALTER QUERY while reads/writes are in flight | L | P1 |
-| TEST-4 | E2E: shadow-ST rollback if new query fails to converge | M | P1 |
+| TEST-1 | Unit tests for `stable_hash()` — known vectors, cross-platform determinism | S | P0 |
+| TEST-2 | Unit tests for `SourceIdentifier` round-trip serialisation | S | P0 |
+| TEST-3 | Integration: `pg_dump` / `pg_restore` cycle preserves stream table with stable-named objects | M | P0 |
+| TEST-4 | Integration: major-version upgrade simulation — OID changes, stable name unchanged | M | P1 |
+| TEST-5 | Integration: frontier rekey — multi-source ST with different write rates converges correctly | M | P0 |
+| TEST-6 | Integration: existing installation upgrade (v0.31.0 → v0.32.0) renames objects correctly | M | P0 |
 
 ---
 
-### Conflicts & Risks
+### Documentation
 
-- **UX-3** (shadow-ST) touches the refresh orchestrator and catalog — the
-  highest-change-risk modules. Must ship behind a feature flag, stabilised
-  with the full TPC-H test suite before removing the flag.
-- Shadow-ST competes with the live stream table's change buffer, potentially
-  doubling CDC write overhead during the build window. Add a
-  `shadow_refresh_throttle_ms` GUC to rate-limit background refreshes.
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| DOCS-1 | Changelog entry explaining stable naming motivation | S | P0 |
+| DOCS-2 | Upgrade guide: what changes, what to expect, rollback instructions | S | P0 |
+
+---
 
 ### Exit Criteria
 
-- [ ] UX-1: `subscribe()` / `unsubscribe()` / `list_subscriptions()` registered; NOTIFY emitted on non-empty refresh; `pgt_subscriptions` catalog table in migration script
-- [ ] CORR-1: NOTIFY coalescing tested at 10 Hz refresh; client receives ≤ 1 NOTIFY per `notify_coalesce_ms` window
-- [ ] UX-3: Shadow-ST builds in background; swap is atomic; live table readable throughout; rollback on convergence failure documented
-- [ ] UX-4: `view_evolution_status()` returns `in_progress | converged | failed` with row counts
-- [ ] Extension upgrade path tested (`0.31.0 → 0.32.0`)
+- [ ] CITUS-1: `is_citus_loaded()`, `placement()`, `worker_nodes()` compile and return sensible defaults when Citus is absent
+- [ ] CITUS-2: `stable_hash("public.orders")` produces identical output on two fresh PG instances with different OIDs
+- [ ] CITUS-4: no `{oid}` tokens remain in object names created by `setup_cdc_for_source()`
+- [ ] CITUS-8: migration script renames all existing objects; `just test-upgrade-all` passes
+- [ ] TEST-3: `pg_dump` / `pg_restore` round-trip test passes
+- [ ] TEST-6: v0.31.0 → v0.32.0 upgrade integration test passes
+- [ ] Zero performance regression on the single-node benchmark suite (Citus detection check adds ≤ 1 µs per `create_stream_table()` call when Citus is absent)
 - [ ] `just check-version-sync` passes
+- [ ] `just lint` passes (zero warnings)
 
 ---
-

--- a/roadmap/v0.33.0.md
+++ b/roadmap/v0.33.0.md
@@ -1,92 +1,80 @@
-# v0.33.0 — Temporal IVM & Columnar Materialization
+# v0.33.0 — Reactive Subscriptions & Zero-Downtime Operations
 
 > **Full technical details:** [v0.33.0.md-full.md](v0.33.0.md-full.md)
 
 **Status: Planned** | **Scope: Medium**
 
-> Two new analytic workload patterns: time-travel queries over a stream
-> table's full history, and columnar storage for dramatically faster
-> analytics.
+> Live push notifications to applications, and a way to change a stream
+> table's defining query on a large production table without downtime.
 
 ---
 
 ## What is this?
 
-v0.33.0 opens two new classes of analytic workloads that pg_trickle cannot
-currently serve.
+v0.33.0 adds two long-requested operational capabilities:
+
+1. **Push notifications** — applications can subscribe to changes in a
+   stream table and receive instant notifications, enabling real-time
+   dashboards, live UIs, and event-driven microservices.
+
+2. **Zero-downtime query changes** — modifying the defining query of a
+   large stream table no longer requires a multi-minute lock on the table.
 
 ---
 
-## Temporal IVM — time-travel queries
+## Reactive subscriptions
 
-Normally, a stream table shows the *current* state of the world. Temporal
-mode changes this: the stream table maintains a full history of how every
-row has changed over time. Rows are never physically deleted; instead, each
-row carries a `valid_from` timestamp and an optional `valid_to` timestamp
-that records when a version was replaced.
+`pgtrickle.subscribe('my_stream_table', 'my_notification_channel')` registers
+a listener. After every successful refresh that produces at least one change,
+pg_trickle sends a PostgreSQL `NOTIFY` message to the named channel with a
+payload like:
 
-This enables queries like "what did this table look like at 3 PM on Tuesday?"
-without any external audit log infrastructure. The pattern is known as
-**SCD Type 2** (Slowly Changing Dimension Type 2) in data warehousing, and
-it is used for:
-
-- Customer history ("what address was on file when this order shipped?")
-- Regulatory audit trails ("what were the account balances at quarter-end?")
-- Slowly-changing dimension tables in analytics pipelines
-
-Creating a temporal stream table is a single parameter:
-
-```sql
-SELECT pgtrickle.create_stream_table(
-    'customer_history',
-    query := 'SELECT id, name, address FROM customers',
-    temporal := true
-);
+```json
+{"name": "my_stream_table", "inserted_count": 12, "deleted_count": 3}
 ```
 
-Queries against the stream table with `AS OF TIMESTAMP $1` automatically
-resolve against the historical row versions.
+Any application holding a standard PostgreSQL connection and listening on
+that channel receives this signal immediately, without polling. This powers
+real-time dashboards, event-driven microservices, and reactive frontends —
+using nothing but a standard PostgreSQL driver, with no Kafka, no Debezium,
+no Hasura required.
+
+A configurable coalescence window prevents notification storms when a stream
+table refreshes at high frequency.
 
 ---
 
-## Columnar materialization
+## Shadow-ST: zero-downtime query evolution
 
-Stream tables currently store their results in standard PostgreSQL heap
-storage — optimised for row-by-row reads and writes. Analytic queries that
-scan millions of rows to compute aggregates are better served by *columnar*
-storage, where all values for a single column are stored together on disk.
-This dramatically reduces I/O for aggregate queries (summing a column, for
-example, only reads that column, not the entire row).
+Today, calling `alter_query()` on a large stream table triggers a full
+re-computation of the entire result set. For a stream table with millions of
+rows, this can lock the table for minutes — an unacceptable operation in
+production.
 
-The `storage_backend := 'columnar'` parameter to `create_stream_table()`
-tells pg_trickle to store the materialised result in Citus columnar storage
-or pg_mooncake. The differential refresh machinery continues to work —
-pg_trickle automatically routes the MERGE to use the `delete_insert` strategy
-that columnar storage requires, with no manual configuration.
+The new `shadow_build := true` parameter to `alter_query()` changes how
+this works:
 
-The result: analytic dashboards and reporting queries that consume the
-materialised stream table see dramatically lower I/O, smaller storage
-footprint, and faster aggregate performance.
+1. A parallel "shadow" stream table is created from the new query, invisible
+   to users.
+2. The shadow table is refreshed to convergence in the background, with no
+   lock on the live table. The live table continues to serve reads and accept
+   writes normally throughout.
+3. When the shadow table has caught up, the storage is swapped atomically.
+4. The new query goes live at the next refresh cycle. The shadow table is
+   dropped.
 
----
-
-## Combined use
-
-Temporal mode and columnar storage can be combined: a slowly-changing
-dimension table stored in columnar format with full history, queryable at
-any point in time. This is listed as a stretch goal and is not a hard
-requirement for the release.
+The live table is readable and writable from start to finish.
 
 ---
 
 ## Scope
 
-v0.33.0 is a medium-sized release. The temporal IVM work requires extending
-the core frontier model — the internal mechanism that tracks which changes
-have been processed — from a single LSN cursor to a two-dimensional
-`(LSN, timestamp)` pair. A design spike in v0.32.0 is a prerequisite before
-committing this feature to the milestone.
+v0.33.0 is a medium-sized release. The shadow-ST feature touches the refresh
+orchestrator — the most change-sensitive module in the codebase — and ships
+behind a feature flag with a full TPC-H validation pass before the flag is
+removed.
 
 ---
 
-*Previous: [v0.32.0 — Reactive Subscriptions & Zero-Downtime Operations](v0.32.0.md)*
+*Previous: [v0.32.0 — Citus: Stable Naming & Per-Source Frontier Foundation](v0.32.0.md)*
+*Next: [v0.34.0 — Temporal IVM & Columnar Materialization](v0.34.0.md)*

--- a/roadmap/v0.33.0.md-full.md
+++ b/roadmap/v0.33.0.md-full.md
@@ -1,20 +1,18 @@
 > **Plain-language companion:** [v0.33.0.md](v0.33.0.md)
 
-## v0.33.0 — Temporal IVM & Columnar Materialization
+## v0.33.0 — Reactive Subscriptions & Zero-Downtime Operations
 
-**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.2, §10.7.
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.1, §10.8.
 
 > **Release Theme**
-> v0.33.0 unlocks two analytic workload patterns that the current streaming
-> engine cannot serve. Temporal IVM lets a stream table maintain a rolling
-> history of how its rows have changed over time — providing first-class
-> SCD-Type-2 semantics without external ETL or separate audit tables.
-> Columnar materialization lets a stream table store its result set in
-> Citus columnar storage (or pg_mooncake), dramatically reducing storage
-> footprint and query I/O for analytic consumers that scan the materialised
-> result set but never write to it. Together they close the OLTP→OLAP
-> bridging gap and make pg_trickle viable as the materialization layer for
-> dashboards and reporting queries.
+> v0.33.0 delivers two long-requested operational capabilities. Reactive
+> subscriptions expose stream-table changes as PostgreSQL `NOTIFY` events,
+> enabling browser-side reactive UIs and event-driven microservices with
+> nothing but a standard PG connection — no Kafka, no Debezium, no Hasura.
+> Zero-downtime view evolution adds a shadow-ST mode to `ALTER QUERY` that
+> builds the new query's materialisation side-by-side with the live table,
+> then swaps atomically — eliminating the operational risk of running
+> `ALTER QUERY` on a large production stream table.
 
 ---
 
@@ -22,24 +20,13 @@
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| CORR-1 | Temporal IVM: two-dimensional frontier (LSN, timestamp) | L | P0 |
-| CORR-2 | Columnar: verify differential MERGE compatibility with columnar storage | M | P0 |
+| CORR-1 | Reactive subscription: coalesce NOTIFY storms | S | P0 |
 
-**CORR-1** — Temporal IVM requires extending the frontier model from a
-one-dimensional LSN cursor to a two-dimensional `(frontier_lsn, valid_from_ts)`
-pair. Each row carries a `__pgt_valid_from TIMESTAMPTZ` and an optional
-`__pgt_valid_to TIMESTAMPTZ`. Rows are never physically deleted; instead a
-"close" delta sets `valid_to`. Queries against the stream table with `AS OF
-TIMESTAMP $1` resolve to the materialised row version valid at that timestamp.
-**Schema change:** Yes — new `temporal_mode BOOLEAN` column on
-`pgtrickle.pgt_stream_tables`; new `__pgt_valid_from`/`__pgt_valid_to`
-columns auto-added to the storage table when `temporal_mode = true`.
-
-**CORR-2** — Citus columnar and pg_mooncake use append-only storage models.
-Verify that the differential MERGE (`MERGE INTO storage USING delta`) is
-compatible with append-only semantics (likely requires `DELETE + INSERT`
-merge strategy for columnar targets). Add a `storage_backend` column to
-`pgtrickle.pgt_stream_tables` and route merge codegen accordingly.
+**CORR-1** — The subscribe API must coalesce rapid successive changes into a
+single NOTIFY payload (or a "changes pending" signal) when the refresh
+interval is shorter than the LISTEN client's poll loop. Implement a
+`pg_trickle.notify_coalesce_ms` GUC (default 250 ms) and a per-stream-table
+flag that debounces NOTIFY calls.
 
 ---
 
@@ -47,12 +34,33 @@ merge strategy for columnar targets). Add a `storage_backend` column to
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| UX-1 | `create_stream_table(…, temporal := true)` parameter | M | P0 |
-| UX-2 | `AS OF TIMESTAMP` query rewrite in DVM parser | L | P1 |
-| UX-3 | `create_stream_table(…, storage_backend := 'columnar')` parameter | M | P1 |
-| UX-4 | Automatic `delete_insert` strategy for columnar backends | S | P1 |
-| UX-5 | Documentation: temporal IVM tutorial + SCD-Type-2 worked example | M | P1 |
-| UX-6 | Documentation: columnar backend setup guide (Citus + pg_mooncake) | S | P1 |
+| UX-1 | `pgtrickle.subscribe(name, channel)` and `unsubscribe()` SQL functions | M | P0 |
+| UX-2 | `pg_trickle.notify_coalesce_ms` GUC | XS | P0 |
+| UX-3 | `ALTER QUERY` shadow-ST mode (`shadow_build := true` parameter) | L | P1 |
+| UX-4 | `pgtrickle.view_evolution_status(name)` monitoring function | S | P1 |
+| UX-5 | Documentation: subscribe() quick-start + shadow-ST runbook | M | P1 |
+
+**UX-1 — Reactive subscription API.**
+`pgtrickle.subscribe(stream_table TEXT, channel TEXT)` registers a per-stream-
+table listener: after every successful differential or full refresh, if the
+delta is non-empty, the refresh path emits `pg_notify(channel, payload_jsonb::text)`
+within the same transaction. The payload carries `{"name": …, "refresh_id": …,
+"inserted_count": N, "deleted_count": N}`. Build on the `pg_notify`
+infrastructure already wired by the v0.28.0 outbox. `pgtrickle.unsubscribe(name, channel)`
+removes the registration; `pgtrickle.list_subscriptions()` returns all active
+registrations. **Schema change:** Yes — new `pgtrickle.pgt_subscriptions`
+catalog table.
+
+**UX-3 — Shadow-ST for zero-downtime `ALTER QUERY`.**
+Today `ALTER QUERY` triggers a full refresh of the stream table. For tables
+with millions of rows, this causes a multi-minute outage during which the
+stream table is locked. A `shadow_build := true` parameter to `alter_query()`
+creates a parallel stream table `__pgt_shadow_<name>` built from the new query,
+refreshes it to convergence in the background without locking the live table,
+then atomically swaps the storage tables and drops the shadow. The live table
+is readable and writable throughout. The new query goes live at the next refresh
+cycle after the swap. **Schema change:** Yes — add `in_shadow_build BOOLEAN` and
+`shadow_table_name TEXT` columns to `pgtrickle.pgt_stream_tables`.
 
 ---
 
@@ -60,33 +68,29 @@ merge strategy for columnar targets). Add a `storage_backend` column to
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| TEST-1 | Integration: temporal stream table `AS OF TIMESTAMP` round-trip | L | P0 |
-| TEST-2 | Integration: SCD-Type-2 dimension pattern end-to-end | M | P1 |
-| TEST-3 | Integration: columnar stream table MERGE parity with heap | M | P0 |
-| TEST-4 | Integration: temporal + columnar combined (temporal columnar ST) | M | P2 |
+| TEST-1 | E2E: subscribe() receives NOTIFY on every non-empty refresh | M | P0 |
+| TEST-2 | E2E: NOTIFY coalescing under high-frequency refresh | S | P1 |
+| TEST-3 | E2E: shadow-ST ALTER QUERY while reads/writes are in flight | L | P1 |
+| TEST-4 | E2E: shadow-ST rollback if new query fails to converge | M | P1 |
 
 ---
 
 ### Conflicts & Risks
 
-- **CORR-1** requires a non-trivial DVM engine extension (two-dimensional
-  frontier). Spike in v0.32.0 first; do not commit to the milestone until
-  the spike proves the approach is sound.
-- **CORR-2** depends on the Citus columnar or pg_mooncake extension being
-  present; CI must add a Testcontainers image with one of these available.
-  Gate columnar support behind `pg_trickle.columnar_backend` GUC (default
-  `none`); the CI matrix should test at least one columnar provider.
-- The combination of temporal mode and columnar storage is a P2 stretch
-  goal; do not block the release on it.
+- **UX-3** (shadow-ST) touches the refresh orchestrator and catalog — the
+  highest-change-risk modules. Must ship behind a feature flag, stabilised
+  with the full TPC-H test suite before removing the flag.
+- Shadow-ST competes with the live stream table's change buffer, potentially
+  doubling CDC write overhead during the build window. Add a
+  `shadow_refresh_throttle_ms` GUC to rate-limit background refreshes.
 
 ### Exit Criteria
 
-- [ ] CORR-1/UX-1: `create_stream_table(…, temporal := true)` creates storage table with `__pgt_valid_from`/`__pgt_valid_to`; rows never physically deleted
-- [ ] UX-2: `AS OF TIMESTAMP $1` query rewrites resolve against the materialised history
-- [ ] TEST-1: Temporal round-trip test passes: insert → update → delete, query at t₀/t₁/t₂ returns correct historical rows
-- [ ] TEST-2: SCD-Type-2 dimension pattern: slowly-changing customer table materialised with full history, current-version query using `WHERE valid_to IS NULL`
-- [ ] CORR-2/UX-3: Columnar stream table creates; `delete_insert` strategy used automatically; columnar MERGE E2E parity test passes
-- [ ] Extension upgrade path tested (`0.32.0 → 0.33.0`)
+- [ ] UX-1: `subscribe()` / `unsubscribe()` / `list_subscriptions()` registered; NOTIFY emitted on non-empty refresh; `pgt_subscriptions` catalog table in migration script
+- [ ] CORR-1: NOTIFY coalescing tested at 10 Hz refresh; client receives ≤ 1 NOTIFY per `notify_coalesce_ms` window
+- [ ] UX-3: Shadow-ST builds in background; swap is atomic; live table readable throughout; rollback on convergence failure documented
+- [ ] UX-4: `view_evolution_status()` returns `in_progress | converged | failed` with row counts
+- [ ] Extension upgrade path tested (`0.31.0 → 0.32.0`)
 - [ ] `just check-version-sync` passes
 
 ---

--- a/roadmap/v0.34.0.md
+++ b/roadmap/v0.34.0.md
@@ -1,98 +1,92 @@
-# v0.34.0 — Citus: Stable Naming & Per-Source Frontier Foundation
+# v0.34.0 — Temporal IVM & Columnar Materialization
 
 > **Full technical details:** [v0.34.0.md-full.md](v0.34.0.md-full.md)
 
 **Status: Planned** | **Scope: Medium**
 
-> The first of two releases that bring world-class Citus support to
-> pg_trickle. v0.34.0 lays the additive foundation — stable object naming,
-> Citus detection helpers, and per-source frontier correctness — with zero
-> behaviour change on single-node deployments.
+> Two new analytic workload patterns: time-travel queries over a stream
+> table's full history, and columnar storage for dramatically faster
+> analytics.
 
 ---
 
 ## What is this?
 
-pg_trickle currently names every internal object (change buffers, trigger
-functions, index names, WAL slot names, frontier keys) after the PostgreSQL
-OID of the source table. An OID is a local, database-specific integer that
-is different on every node in a Citus cluster and changes after a
-`pg_dump` / restore cycle. This works fine for single-node PostgreSQL but
-is the root cause of every Citus incompatibility.
-
-v0.34.0 replaces OID-keyed names with a **stable hash** derived from the
-schema-qualified table name — identical on every node, survives restores,
-and survives OID reassignment after a major upgrade. At the same time it
-ships a new `src/citus.rs` module with Citus detection helpers that allow
-the extension to make intelligent decisions about source placement in v0.35.0.
+v0.34.0 opens two new classes of analytic workloads that pg_trickle cannot
+currently serve.
 
 ---
 
-## Stable naming
+## Temporal IVM — time-travel queries
 
-Instead of `changes_12345`, `pg_trickle_cdc_fn_12345`, and
-`slot_pgtrickle_12345`, objects are now named using a short hex string
-derived from `stable_hash("myschema.my_table")`:
+Normally, a stream table shows the *current* state of the world. Temporal
+mode changes this: the stream table maintains a full history of how every
+row has changed over time. Rows are never physically deleted; instead, each
+row carries a `valid_from` timestamp and an optional `valid_to` timestamp
+that records when a version was replaced.
 
+This enables queries like "what did this table look like at 3 PM on Tuesday?"
+without any external audit log infrastructure. The pattern is known as
+**SCD Type 2** (Slowly Changing Dimension Type 2) in data warehousing, and
+it is used for:
+
+- Customer history ("what address was on file when this order shipped?")
+- Regulatory audit trails ("what were the account balances at quarter-end?")
+- Slowly-changing dimension tables in analytics pipelines
+
+Creating a temporal stream table is a single parameter:
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'customer_history',
+    query := 'SELECT id, name, address FROM customers',
+    temporal := true
+);
 ```
-changes_a3f7b2c1
-pg_trickle_cdc_fn_a3f7b2c1
-slot_pgtrickle_a3f7b2c1
-```
 
-This name is computed once at `create_stream_table()` time, stored in the
-catalog, and used for all subsequent object creation. Existing installations
-are upgraded automatically — the SQL migration script renames all existing
-objects in a single transaction with no downtime.
-
-The change is invisible to end users: no SQL API changes, no configuration
-changes, no behaviour changes on a single-node deployment.
+Queries against the stream table with `AS OF TIMESTAMP $1` automatically
+resolve against the historical row versions.
 
 ---
 
-## Citus detection
+## Columnar materialization
 
-A new internal module learns to ask "is Citus loaded on this database?" and
-"how is this table distributed?". The answers — local, reference, or
-distributed — are stored alongside the stable name in the catalog and drive
-the CDC and apply strategies in v0.35.0.
+Stream tables currently store their results in standard PostgreSQL heap
+storage — optimised for row-by-row reads and writes. Analytic queries that
+scan millions of rows to compute aggregates are better served by *columnar*
+storage, where all values for a single column are stored together on disk.
+This dramatically reduces I/O for aggregate queries (summing a column, for
+example, only reads that column, not the entire row).
 
----
+The `storage_backend := 'columnar'` parameter to `create_stream_table()`
+tells pg_trickle to store the materialised result in Citus columnar storage
+or pg_mooncake. The differential refresh machinery continues to work —
+pg_trickle automatically routes the MERGE to use the `delete_insert` strategy
+that columnar storage requires, with no manual configuration.
 
-## Per-source frontier correctness
-
-pg_trickle tracks a *frontier* for each source table — the point up to which
-changes have been consumed and applied. Today the frontier is keyed by the
-table OID, creating an implicit assumption that all sources share a single
-WAL namespace. v0.34.0 rekeys the frontier by stable name and audits all
-code paths that compare or merge frontier values across sources, removing
-the assumption of a single node's WAL.
-
-This fixes a latent correctness issue for any multi-source stream table
-where the two sources have wildly different write rates, and it is a
-prerequisite for tracking per-worker WAL positions in v0.35.0.
+The result: analytic dashboards and reporting queries that consume the
+materialised stream table see dramatically lower I/O, smaller storage
+footprint, and faster aggregate performance.
 
 ---
 
-## Who benefits?
+## Combined use
 
-- **All users** — stable naming survives `pg_dump` / restore, major
-  upgrades, and OID reassignment. The frontier fix improves correctness for
-  multi-source stream tables.
-- **Citus users** — v0.34.0 is the prerequisite for v0.35.0. Without stable
-  naming, per-worker slots cannot be named consistently across the cluster.
+Temporal mode and columnar storage can be combined: a slowly-changing
+dimension table stored in columnar format with full history, queryable at
+any point in time. This is listed as a stretch goal and is not a hard
+requirement for the release.
 
 ---
 
 ## Scope
 
-v0.34.0 is a medium-sized release. The naming refactor touches many files
-(`src/cdc.rs`, `src/wal_decoder.rs`, `src/dvm/diff.rs`,
-`src/refresh/codegen.rs`) but is purely additive: old behaviour is
-preserved in full, and the SQL migration handles existing installations
-automatically.
+v0.34.0 is a medium-sized release. The temporal IVM work requires extending
+the core frontier model — the internal mechanism that tracks which changes
+have been processed — from a single LSN cursor to a two-dimensional
+`(LSN, timestamp)` pair. A design spike in v0.33.0 is a prerequisite before
+committing this feature to the milestone.
 
 ---
 
-*Previous: [v0.33.0 — Temporal IVM & Columnar Materialization](v0.33.0.md)*
-*Next: [v0.35.0 — Citus: World-Class Distributed Source CDC](v0.35.0.md)*
+*Previous: [v0.33.0 — Reactive Subscriptions & Zero-Downtime Operations](v0.33.0.md)*

--- a/roadmap/v0.34.0.md-full.md
+++ b/roadmap/v0.34.0.md-full.md
@@ -1,22 +1,20 @@
 > **Plain-language companion:** [v0.34.0.md](v0.34.0.md)
 
-## v0.34.0 — Citus: Stable Naming & Per-Source Frontier Foundation
+## v0.34.0 — Temporal IVM & Columnar Materialization
 
-**Status: Planned.** Derived from
-[plans/ecosystem/PLAN_CITUS.md](../plans/ecosystem/PLAN_CITUS.md)
-§6 Phase 1 and Phase 2.
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.2, §10.7.
 
 > **Release Theme**
-> v0.34.0 is the first of two releases delivering world-class Citus support.
-> It ships two additive, non-breaking layers: (1) a `src/citus.rs` module
-> with Citus detection and placement helpers; and (2) a stable-hash naming
-> scheme that replaces OID-keyed internal objects (`changes_{oid}`,
-> `pg_trickle_cdc_fn_{oid}`, slot names, frontier keys) with names derived
-> from `stable_hash(database_oid || '/' || schema || '.' || table)`. Both
-> layers produce immediate quality benefits for all users — stable names
-> survive `pg_dump`/restore and major-version upgrades — and they are
-> mandatory prerequisites for v0.35.0's per-worker slot CDC. There is zero
-> behaviour change on a single-node deployment.
+> v0.34.0 unlocks two analytic workload patterns that the current streaming
+> engine cannot serve. Temporal IVM lets a stream table maintain a rolling
+> history of how its rows have changed over time — providing first-class
+> SCD-Type-2 semantics without external ETL or separate audit tables.
+> Columnar materialization lets a stream table store its result set in
+> Citus columnar storage (or pg_mooncake), dramatically reducing storage
+> footprint and query I/O for analytic consumers that scan the materialised
+> result set but never write to it. Together they close the OLTP→OLAP
+> bridging gap and make pg_trickle viable as the materialization layer for
+> dashboards and reporting queries.
 
 ---
 
@@ -24,77 +22,37 @@
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| CITUS-1 | `src/citus.rs`: detection helpers and placement query | M | P0 |
-| CITUS-2 | `SourceIdentifier` struct carrying `(oid, stable_name)` | S | P0 |
-| CITUS-3 | Catalog migration: add `source_stable_name`, `source_placement`, `st_placement` columns | S | P0 |
-| CITUS-4 | Rename all OID-keyed objects to `stable_name` form | M | P0 |
-| CITUS-5 | Frontier rekey: `Frontier.sources` from OID string to `stable_name` | S | P1 |
-| CITUS-6 | Audit and remove cross-source global LSN comparisons | M | P1 |
-| CITUS-7 | Add `frontier_per_node JSONB` column for distributed sources | S | P1 |
-| CITUS-8 | SQL migration: rename existing `changes_{oid}` tables and trigger functions in a single transaction | M | P0 |
+| CORR-1 | Temporal IVM: two-dimensional frontier (LSN, timestamp) | L | P0 |
+| CORR-2 | Columnar: verify differential MERGE compatibility with columnar storage | M | P0 |
 
-**CITUS-1** — New module `src/citus.rs`. Detection helpers:
-- `is_citus_loaded()` — `SELECT 1 FROM pg_extension WHERE extname='citus'`
-- `placement(oid)` → `Local | Reference | Distributed { dist_column }` via
-  `pg_dist_partition`
-- `worker_nodes()` → `Vec<NodeAddr>` from `pg_dist_node`
-- `shard_placements(table_oid)` — which workers host shards
+**CORR-1** — Temporal IVM requires extending the frontier model from a
+one-dimensional LSN cursor to a two-dimensional `(frontier_lsn, valid_from_ts)`
+pair. Each row carries a `__pgt_valid_from TIMESTAMPTZ` and an optional
+`__pgt_valid_to TIMESTAMPTZ`. Rows are never physically deleted; instead a
+"close" delta sets `valid_to`. Queries against the stream table with `AS OF
+TIMESTAMP $1` resolve to the materialised row version valid at that timestamp.
+**Schema change:** Yes — new `temporal_mode BOOLEAN` column on
+`pgtrickle.pgt_stream_tables`; new `__pgt_valid_from`/`__pgt_valid_to`
+columns auto-added to the storage table when `temporal_mode = true`.
 
-None of these panic if Citus is absent; all return sensible defaults
-(`Local`, empty vecs). Citus-specific code paths are always guarded by
-`is_citus_loaded()`.
-
-**CITUS-2** — `SourceIdentifier { oid: pg_sys::Oid, stable_name: String }`.
-`stable_name = lower_hex(FNV-1a-64(database_oid || "/" || schema || "." || table))[..16]`.
-Deterministic, short, URL-safe, identical on every Citus node. Serialised
-in `pgt_change_tracking.source_stable_name` and used for all object names.
-
-**CITUS-3** — Schema changes (nullable, backward-compatible):
-```sql
-ALTER TABLE pgtrickle.pgt_change_tracking
-  ADD COLUMN source_stable_name TEXT,
-  ADD COLUMN source_placement TEXT NOT NULL DEFAULT 'local';
-ALTER TABLE pgtrickle.pgt_dependencies
-  ADD COLUMN source_stable_name TEXT,
-  ADD COLUMN source_placement TEXT NOT NULL DEFAULT 'local';
-ALTER TABLE pgtrickle.pgt_stream_tables
-  ADD COLUMN st_placement TEXT NOT NULL DEFAULT 'local';
-```
-Old rows receive a synthetic stable name (hash of existing OID-based
-name) and continue to function unchanged.
-
-**CITUS-4** — Replace `changes_{oid}`, `pg_trickle_cdc_ins_{oid}`,
-`pg_trickle_cdc_fn_{oid}`, `idx_changes_{oid}_*`, WAL slot names
-(`pgtrickle_{oid}`), and the `__PGS_PREV_LSN_{oid}__` placeholder tokens
-in `src/dvm/diff.rs` with `{stable_name}` forms. Affected files:
-`src/cdc.rs`, `src/wal_decoder.rs`, `src/dvm/diff.rs`,
-`src/refresh/codegen.rs`, `src/dvm/operators/*`.
-
-**CITUS-5 / CITUS-6** — `Frontier.sources` is already a `HashMap`; rekey
-from OID string to `stable_name`. Audit `src/refresh/codegen.rs` and
-`src/scheduler.rs` for reads of `pg_current_wal_lsn()` used in cross-source
-comparisons; replace with per-source watermark logic from
-`src/wal_decoder.rs`.
-
-**CITUS-7** — Add `frontier_per_node JSONB` to `pgt_change_tracking` for
-distributed sources. When the source is `Local` this column is NULL; for
-`Distributed` sources it records `{ "worker_id": lsn, ... }` tuples.
-
-**CITUS-8** — `sql/pg_trickle--<prev>--<next>.sql` performs column adds
-then backfills `source_stable_name` from `pg_class + pg_namespace`,
-renames existing buffer tables and trigger functions to the stable-hash
-form, updates the WAL slot name in `pg_replication_slots` (via
-`pg_rename_logical_replication_slot` where available), and updates
-`pgt_change_tracking`. Provides a downgrade path in the same file.
+**CORR-2** — Citus columnar and pg_mooncake use append-only storage models.
+Verify that the differential MERGE (`MERGE INTO storage USING delta`) is
+compatible with append-only semantics (likely requires `DELETE + INSERT`
+merge strategy for columnar targets). Add a `storage_backend` column to
+`pgtrickle.pgt_stream_tables` and route merge codegen accordingly.
 
 ---
 
-### Stability
+### Ease of Use
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| STAB-1 | Keep OID-based lookup as fallback for rows without `source_stable_name` | S | P0 |
-| STAB-2 | Detect and surface a clear error if stable hash collides (astronomically unlikely; check at create time) | S | P1 |
+| UX-1 | `create_stream_table(…, temporal := true)` parameter | M | P0 |
+| UX-2 | `AS OF TIMESTAMP` query rewrite in DVM parser | L | P1 |
+| UX-3 | `create_stream_table(…, storage_backend := 'columnar')` parameter | M | P1 |
+| UX-4 | Automatic `delete_insert` strategy for columnar backends | S | P1 |
+| UX-5 | Documentation: temporal IVM tutorial + SCD-Type-2 worked example | M | P1 |
+| UX-6 | Documentation: columnar backend setup guide (Citus + pg_mooncake) | S | P1 |
 
 ---
 
@@ -102,34 +60,34 @@ form, updates the WAL slot name in `pg_replication_slots` (via
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| TEST-1 | Unit tests for `stable_hash()` — known vectors, cross-platform determinism | S | P0 |
-| TEST-2 | Unit tests for `SourceIdentifier` round-trip serialisation | S | P0 |
-| TEST-3 | Integration: `pg_dump` / `pg_restore` cycle preserves stream table with stable-named objects | M | P0 |
-| TEST-4 | Integration: major-version upgrade simulation — OID changes, stable name unchanged | M | P1 |
-| TEST-5 | Integration: frontier rekey — multi-source ST with different write rates converges correctly | M | P0 |
-| TEST-6 | Integration: existing installation upgrade (v0.33.0 → v0.34.0) renames objects correctly | M | P0 |
+| TEST-1 | Integration: temporal stream table `AS OF TIMESTAMP` round-trip | L | P0 |
+| TEST-2 | Integration: SCD-Type-2 dimension pattern end-to-end | M | P1 |
+| TEST-3 | Integration: columnar stream table MERGE parity with heap | M | P0 |
+| TEST-4 | Integration: temporal + columnar combined (temporal columnar ST) | M | P2 |
 
 ---
 
-### Documentation
+### Conflicts & Risks
 
-| ID | Title | Effort | Priority |
-|----|-------|--------|----------|
-| DOCS-1 | Changelog entry explaining stable naming motivation | S | P0 |
-| DOCS-2 | Upgrade guide: what changes, what to expect, rollback instructions | S | P0 |
-
----
+- **CORR-1** requires a non-trivial DVM engine extension (two-dimensional
+  frontier). Spike in v0.33.0 first; do not commit to the milestone until
+  the spike proves the approach is sound.
+- **CORR-2** depends on the Citus columnar or pg_mooncake extension being
+  present; CI must add a Testcontainers image with one of these available.
+  Gate columnar support behind `pg_trickle.columnar_backend` GUC (default
+  `none`); the CI matrix should test at least one columnar provider.
+- The combination of temporal mode and columnar storage is a P2 stretch
+  goal; do not block the release on it.
 
 ### Exit Criteria
 
-- [ ] CITUS-1: `is_citus_loaded()`, `placement()`, `worker_nodes()` compile and return sensible defaults when Citus is absent
-- [ ] CITUS-2: `stable_hash("public.orders")` produces identical output on two fresh PG instances with different OIDs
-- [ ] CITUS-4: no `{oid}` tokens remain in object names created by `setup_cdc_for_source()`
-- [ ] CITUS-8: migration script renames all existing objects; `just test-upgrade-all` passes
-- [ ] TEST-3: `pg_dump` / `pg_restore` round-trip test passes
-- [ ] TEST-6: v0.33.0 → v0.34.0 upgrade integration test passes
-- [ ] Zero performance regression on the single-node benchmark suite (Citus detection check adds ≤ 1 µs per `create_stream_table()` call when Citus is absent)
+- [ ] CORR-1/UX-1: `create_stream_table(…, temporal := true)` creates storage table with `__pgt_valid_from`/`__pgt_valid_to`; rows never physically deleted
+- [ ] UX-2: `AS OF TIMESTAMP $1` query rewrites resolve against the materialised history
+- [ ] TEST-1: Temporal round-trip test passes: insert → update → delete, query at t₀/t₁/t₂ returns correct historical rows
+- [ ] TEST-2: SCD-Type-2 dimension pattern: slowly-changing customer table materialised with full history, current-version query using `WHERE valid_to IS NULL`
+- [ ] CORR-2/UX-3: Columnar stream table creates; `delete_insert` strategy used automatically; columnar MERGE E2E parity test passes
+- [ ] Extension upgrade path tested (`0.32.0 → 0.33.0`)
 - [ ] `just check-version-sync` passes
-- [ ] `just lint` passes (zero warnings)
 
 ---
+

--- a/roadmap/v0.35.0.md
+++ b/roadmap/v0.35.0.md
@@ -13,7 +13,7 @@
 
 ## What is this?
 
-With v0.34.0's naming and frontier foundations in place, v0.35.0 implements
+With v0.32.0's naming and frontier foundations in place, v0.35.0 implements
 the full Citus integration. There are three distributed table problems that
 need solving:
 
@@ -97,7 +97,7 @@ distributed sources; mixed CDC backends; outbox integration; DDL
 propagation; and worker restarts.
 
 The non-Citus benchmark suite shows zero regression — all Citus code
-paths are guarded by the detection check introduced in v0.34.0 and
+paths are guarded by the detection check introduced in v0.32.0 and
 compile out entirely when Citus is absent.
 
 ---
@@ -111,5 +111,5 @@ maintaining a multi-container Citus CI environment.
 
 ---
 
-*Previous: [v0.34.0 — Citus: Stable Naming & Per-Source Frontier Foundation](v0.34.0.md)*
+*Previous: [v0.32.0 — Citus: Stable Naming & Per-Source Frontier Foundation](v0.32.0.md)*
 *Next: [v1.0.0 — Stable Release](v1.0.0.md-full.md)*

--- a/roadmap/v0.35.0.md-full.md
+++ b/roadmap/v0.35.0.md-full.md
@@ -8,7 +8,7 @@
 
 > **Release Theme**
 > v0.35.0 delivers world-class incremental view maintenance over Citus
-> distributed tables. Building on v0.34.0's stable naming and frontier
+> distributed tables. Building on v0.32.0's stable naming and frontier
 > foundations, this release adds: (P3) per-worker WAL slot polling for
 > distributed-table CDC; (P4) distributed ST storage with a Citus-safe
 > DELETE+UPSERT apply path; (P5) catalog-based cross-node coordination and
@@ -16,7 +16,7 @@
 > E2E test suite (1 coordinator + 2 workers, 10-scenario matrix) with
 > dedicated benchmarks and documentation. The non-Citus code path has a
 > hard regression budget of 0% — every Citus code path short-circuits on
-> the `is_citus_loaded()` check introduced in v0.34.0.
+> the `is_citus_loaded()` check introduced in v0.32.0.
 
 ---
 
@@ -179,7 +179,7 @@ in-process path; catalog locks are used only when `is_citus_loaded()`.
 - [ ] BENCH-1: `bench_remote_slot_poll` throughput ≥ 50 k rows/s (dblink loopback); report logged in `docs/BENCHMARK.md`
 - [ ] Non-Citus benchmark suite shows 0% regression
 - [ ] DOCS-1: `docs/integrations/citus.md` covers prerequisites, setup, placement options, monitoring, failure modes, and known limitations
-- [ ] Migration path `v0.34.0 → v0.35.0` tested with `just test-upgrade-all`
+- [ ] Migration path `v0.32.0 → v0.35.0` tested with `just test-upgrade-all`
 - [ ] `just check-version-sync` passes
 - [ ] `just lint` passes (zero warnings)
 


### PR DESCRIPTION
## Summary

Renumbers the reordered "Toward Stable" versions so they are sequential in
the new implementation order. This is a follow-up to PR #646, which moved
v0.34.0 (Citus stable naming) to execute before v0.32.0 and v0.33.0 but
kept the old numbers. This PR assigns the correct sequential numbers.

## Mapping

| Old number | Content | New number |
|-----------|---------|-----------|
| v0.34.0 | Citus: Stable Naming & Per-Source Frontier Foundation | **v0.32.0** |
| v0.32.0 | Reactive Subscriptions & Zero-Downtime Operations | **v0.33.0** |
| v0.33.0 | Temporal IVM & Columnar Materialization | **v0.34.0** |
| v0.35.0 | Citus: World-Class Distributed Source CDC | v0.35.0 (unchanged) |

## Changes

- **ROADMAP.md** — Toward Stable table uses the new sequential numbers;
  flow diagram updated from `v0.34 → v0.32-33` to `v0.32 → v0.33-34`;
  explanatory paragraph references updated
- **roadmap/v0.32.0.md** and **roadmap/v0.32.0.md-full.md** (renamed from
  v0.34.0) — all internal version references updated; prev/next navigation
  links updated
- **roadmap/v0.33.0.md** and **roadmap/v0.33.0.md-full.md** (renamed from
  v0.32.0) — all internal version references updated; prev/next links updated
- **roadmap/v0.34.0.md** and **roadmap/v0.34.0.md-full.md** (renamed from
  v0.33.0) — all internal version references updated; design-spike reference
  updated (was v0.32.0, now v0.33.0); prev link updated
- **roadmap/v0.35.0.md** and **roadmap/v0.35.0.md-full.md** — references to
  old v0.34.0 (Citus naming) updated to new v0.32.0; migration path updated;
  prev navigation link updated

## Testing

Documentation-only change — no code, SQL, or tests modified.
