### PR TITLE
docs(citus): update PLAN_CITUS with #619 follow-up feedback

### DIFF
--- a/plans/ecosystem/PLAN_CITUS.md
+++ b/plans/ecosystem/PLAN_CITUS.md
@@ -1,7 +1,7 @@
 # PLAN_CITUS.md — Citus Compatibility for pg_trickle
 
 > **Date:** 2026-04-24
-> **Status:** PROPOSED
+> **Status:** PROPOSED — user-validated (#619, 2026-04-24)
 > **Targets:** Citus 13.x on PostgreSQL 18.x
 > **Supersedes:** previous draft of this file (pre-WAL-decoder, pre-relay)
 
@@ -352,20 +352,22 @@ already at [src/wal_decoder.rs](src/wal_decoder.rs#L1509) needs to run
 **on each worker** (run_command_on_workers) for distributed sources.
 
 - `NOTHING` — reject with a clear error; change capture is impossible.
-- `DEFAULT` (PK-only) — accepted **only if** no PK column can be updated.
-  Pre-flight must either detect this via `pg_attribute` constraints (immutable
-  generated columns, NOT NULL + no UPDATE path) or require the user to
-  explicitly acknowledge the risk with `allow_pk_updates => false`. **If a
-  PK column is updated, `pgoutput` with DEFAULT emits only the new row;
-  the coordinator cannot match it to the old `__pgt_row_id`, producing
-  silent data loss in the ST.** This is not a recoverable error — it
-  corrupts the materialization silently.
-- `FULL` — accepted always. WAL amplification is proportional to row width:
-  negligible on narrow tables, potentially severe (10× or more) on very wide
-  tables with high UPDATE rates. Log a sizing advisory at setup time.
+- `DEFAULT` (PK-only) — accepted only when the user explicitly opts in
+  with `immutable_pk => true` on `create_stream_table()`. This is an
+  assertion by the user that no PK column is ever updated. pg_trickle cannot
+  verify this statically (application-level UPDATE patterns are invisible
+  to `pg_attribute`). **If a PK column is updated, `pgoutput` with DEFAULT
+  emits only the new row; the coordinator cannot match it to the old
+  `__pgt_row_id`, producing silent data loss in the ST.** This is not a
+  recoverable error — it corrupts the materialisation silently. Emit a
+  prominent warning at setup time when `immutable_pk => true` is used.
+- `FULL` — accepted always; **this is the default**. WAL amplification is
+  proportional to row width: negligible on narrow tables, potentially severe
+  (10× or more) on very wide tables with high UPDATE rates. Log a sizing
+  advisory at setup time.
 
-Default guidance: use `FULL` unless the user explicitly confirms PKs are
-immutable, in which case `DEFAULT` avoids WAL overhead.
+Default guidance: require `FULL` unless the user passes `immutable_pk =>
+  true`, in which case `DEFAULT` is used and a warning is emitted.
 
 **P3.4 — Slot polling.** Scheduler tick iterates over
 `pgt_remote_slots` for the source and pulls from each worker, writing
@@ -400,18 +402,19 @@ sources:
 |---|---|
 | All `Local` | `local` |
 | Includes `Reference`, no `Distributed` | `local` |
-| Includes `Distributed`, projected ST < 1M rows | `reference` |
-| Includes `Distributed`, projected ST ≥ 1M rows | `distributed` |
+| All sources `Distributed` | `distributed` |
+| Mixed `Distributed` + `Reference`/`Local`, projected ST < 1M rows | `reference` |
+| Mixed `Distributed` + `Reference`/`Local`, projected ST ≥ 1M rows | `distributed` |
 
 Persisted in `pgtrickle.pgt_stream_tables.st_placement`. Threshold
-GUC: `pg_trickle.citus_reference_st_max_rows` (default `1_000_000`).
+GUC: `pg_trickle.citus_reference_st_max_rows` (default `1_000_000`); only
+applied in the mixed-topology case. When all sources are `Distributed` the
+threshold is bypassed and `distributed` is always the default.
 
-> **Note (from #619 feedback):** The confirmed use case has all-distributed
-> sources and lower-layer STs expected to reach billions of rows. The 1M
-> default likely places most STs in the `reference` bucket incorrectly for
-> this pattern. The P6.3 benchmark must validate the threshold; consider
-> lowering the default or making `distributed` the default when the source
-> topology is all-distributed.
+> **Rationale:** An all-distributed source topology with billion-row lower-layer
+> STs (confirmed in #619) makes `reference` placement untenable regardless of
+> projected ST size. The 1M threshold is only meaningful when the user has
+> a mix of source placements and genuinely small aggregation outputs.
 
 **P4.2 — Apply for `distributed` STs.** The DELETE + INSERT…ON CONFLICT
 pair replaces MERGE. Distribution column is `__pgt_row_id`. Codegen
@@ -588,21 +591,30 @@ LSN tracking). P3–P5 are the Citus-specific deliverable.
 1. **`dblink` vs streaming libpq.** Bench result determines P3.1 default.
    Streaming gives push-based wake-ups (no polling latency) but adds a
    long-running connection per worker.
-2. **Reference vs distributed ST default for medium-sized outputs.** The
-   1M-row threshold in P4.1 is a guess — instrument and tune in P6.3.
-   Discussion #619 confirms a scenario with billions of rows in lower-layer
-   STs across an all-distributed source topology; the 1M threshold may
-   produce `reference` placements that would be immediately untenable.
-   Consider making `distributed` the default when all declared sources are
-   `Distributed` and/or when DAG depth > 1.
-3. **Multi-database Citus.** Citus 13 supports multiple databases per
+2. **Reference vs distributed ST default (mixed topology only).** The 1M-row
+   threshold in P4.1 now only applies when sources are mixed
+   (`Distributed` + `Reference`/`Local`). Instrument and tune in P6.3 for
+   that case.
+3. **Source table count for slot budget (unanswered from #619).** erikmata
+   confirmed billions of rows but did not give a source table count. The
+   coordinator opens `N_sources × N_workers` simultaneous connections for
+   slot polling. We need a rough upper bound to size `max_connections` and
+   connection-pool guidance in the docs. Follow up in the discussion.
+4. **Dynamic query construction compatibility.** erikmata's system
+   "dynamically constructs quite complex queries." If this means the query
+   SQL varies per-execution, that is incompatible with pg_trickle (STs are
+   defined once at creation). If it means the user dynamically decides
+   *which* ST chain to deploy but each ST is fixed once created, that is
+   fine. Clarify before the Citus integration ships — ideally in the same
+   discussion thread.
+5. **Multi-database Citus.** Citus 13 supports multiple databases per
    cluster; each pg_trickle scheduler is per-database. No change
    expected, but verify in P6.2.
-4. **Interaction with `pgtrickle-relay`.** A distributed ST exposed via
+6. **Interaction with `pgtrickle-relay`.** A distributed ST exposed via
    `stream_table_to_publication()` already streams over logical
    replication from the coordinator's storage table — works today
    regardless of placement. No new code; document the pattern.
-5. **CitusData vs Microsoft fork divergence.** Track the upstream
+7. **CitusData vs Microsoft fork divergence.** Track the upstream
    (microsoft/citus) repo; pin tested versions in CI.
 
 ---
@@ -617,11 +629,10 @@ PKs deterministic and never modified.
 **Pattern:** Chain of SQL-WITH expressions replaced with a chain of STs;
 lower-layer STs expected to reach billions of rows.
 
-**Configuration target:** `REPLICA IDENTITY DEFAULT` (PK-only, safe here
-because PKs never change) + `placement => 'distributed'` for all
-lower-layer STs. The P4.1 1M-row threshold should be overridden or the
-threshold lowered — at billion-row scale a `reference` ST is a
-non-starter.
+**Configuration target:** `REPLICA IDENTITY FULL` (safe default) or
+`REPLICA IDENTITY DEFAULT` + `immutable_pk => true` (opt-in, saves WAL
+overhead when PKs genuinely never change) + `placement => 'distributed'`
+automatically selected by the all-distributed rule in P4.1.
 
 **Known limitations that apply to this topology:**
 

--- a/plans/ecosystem/PLAN_CITUS.md
+++ b/plans/ecosystem/PLAN_CITUS.md
@@ -47,10 +47,10 @@ follow-up release.
 
 **Confirmed use case (discussion #619 follow-up, 2026-04-24):** all sources
 are hash-distributed (no reference tables), PKs are deterministic and
-stable, lower-layer STs in a SQL-WITH-replacement chain expected to reach
-billions of rows. `REPLICA IDENTITY DEFAULT` (PK-only) is the preferred
-setting; `FULL` is supported but unnecessary. Distributed ST storage is
-load-bearing for this pattern — see §11.
+never change, lower-layer STs in a SQL-WITH-replacement chain expected to
+reach billions of rows. This is one topology among many; design decisions
+below are scoped to what is broadly correct, not to this use case alone.
+See §11 for per-topology implications.
 
 ---
 
@@ -176,12 +176,12 @@ predictive-cost code paths.
 | **MERGE replacement (distributed STs)** | `DELETE … WHERE __pgt_row_id IN (...)` + `INSERT … ON CONFLICT (__pgt_row_id) DO UPDATE` | Citus-supported; same semantics |
 | **Worker→coordinator transport** | Logical replication (publications + slots) — **no triggers on workers** | Matches WAL-decoder model already in tree; zero new write-path overhead |
 | **Reference-table sources** | Keep trigger CDC path | Already works; no reason to change |
-| **REPLICA IDENTITY** | `DEFAULT` (PK-only) required for v1; `FULL` is supported but not required | Stable, deterministic PKs (confirmed in #619) mean PK-only decoding is sufficient; `FULL` causes significant WAL amplification on wide tables at billion-row scale |
+| **REPLICA IDENTITY** | `FULL` required when PKs can change; `DEFAULT` (PK-only) sufficient when PKs are immutable — and strongly preferred at large scale | PK-only decoding works only when UPDATE never touches a PK column; if it does, `pgoutput` with DEFAULT cannot reconstruct the old identity, causing silent loss in the ST. `FULL` amplifies WAL proportionally to row width (negligible on narrow tables, severe on wide ones at scale). Pre-flight must verify the PK-immutability assumption or require FULL. |
 | **Locking** | Catalog table for cross-node locks; advisory locks remain the local fast path | Advisory locks are node-local |
 | **Wake signalling** | `LISTEN/NOTIFY` on coordinator only; workers don't run a scheduler | Single scheduler per database (today's model) is fine for Citus |
 | **Detection** | Auto-detect Citus at extension load + per-source at create time | No new GUC required for the common case |
 | **Rebalance** | Out of scope for v1 (matches user's constraint in #619) | Slot location follows shard placement; rebalance would invalidate slots |
-| **Chained distributed STs** | All STs in the same DAG chain distributed on the same column by default | Downstream MERGE/apply requires co-location; auto-co-locate avoids user error |
+| **Chained distributed STs** | Attempt to distribute all STs in the same DAG subgraph on the same column; error out when this is structurally impossible | Co-location is required for shard-local delta apply. Auto-co-location cannot be resolved when the chain includes aggregations (GROUP BY changes cardinality), JOINs on a non-source-distribution key, or projections that drop the distribution column — in those cases the user must choose placement explicitly. Note also that `__pgt_row_id`-distributed STs do **not** co-locate with their source tables; JOINs between an ST and its source remain cross-shard. |
 
 ---
 
@@ -350,10 +350,22 @@ sees `placement == Distributed`:
 **P3.3 — REPLICA IDENTITY enforcement on workers.** The pre-flight check
 already at [src/wal_decoder.rs](src/wal_decoder.rs#L1509) needs to run
 **on each worker** (run_command_on_workers) for distributed sources.
-`REPLICA IDENTITY DEFAULT` (PK-only) is the v1 baseline and is strongly
-preferred at large scale — FULL doubles or more the WAL volume for every
-UPDATE on a wide table. Emit a warning (not an error) if the user sets FULL;
-do not override it. Reject `NOTHING` with a clear error.
+
+- `NOTHING` — reject with a clear error; change capture is impossible.
+- `DEFAULT` (PK-only) — accepted **only if** no PK column can be updated.
+  Pre-flight must either detect this via `pg_attribute` constraints (immutable
+  generated columns, NOT NULL + no UPDATE path) or require the user to
+  explicitly acknowledge the risk with `allow_pk_updates => false`. **If a
+  PK column is updated, `pgoutput` with DEFAULT emits only the new row;
+  the coordinator cannot match it to the old `__pgt_row_id`, producing
+  silent data loss in the ST.** This is not a recoverable error — it
+  corrupts the materialization silently.
+- `FULL` — accepted always. WAL amplification is proportional to row width:
+  negligible on narrow tables, potentially severe (10× or more) on very wide
+  tables with high UPDATE rates. Log a sizing advisory at setup time.
+
+Default guidance: use `FULL` unless the user explicitly confirms PKs are
+immutable, in which case `DEFAULT` avoids WAL overhead.
 
 **P3.4 — Slot polling.** Scheduler tick iterates over
 `pgt_remote_slots` for the source and pulls from each worker, writing
@@ -429,6 +441,14 @@ it as the distribution column at `create_distributed_table` time.
 Validation: refuse `distributed` placement if the user supplied an
 ORDER BY / GROUP BY shape that would produce skew on row id (rare —
 row id is a monotonically increasing surrogate).
+
+> **Limitation:** Distributing an ST by `__pgt_row_id` (a synthetic
+> surrogate) does **not** align shards with the source table's distribution
+> column. Any query that JOINs the ST back to its source produces cross-shard
+> joins, which Citus executes correctly but at higher cost (re-partition join
+> or broadcast). Document this and recommend denormalising the source
+> distribution key into the ST projection if frequent ST-source joins are
+> expected.
 
 **P4.5 — `reltuples` fix.** `src/dag.rs` and the predictive cost
 model (`src/api/planner.rs`) sum `pg_dist_shard` row counts when the
@@ -591,33 +611,30 @@ LSN tracking). P3–P5 are the Citus-specific deliverable.
 
 ### 11.1 — All-distributed ELT chain (discussion #619)
 
-**Source topology:** All source tables are hash-distributed; no reference
-tables.
+**Source topology:** All sources hash-distributed; no reference tables;
+PKs deterministic and never modified.
 
-**Query pattern:** Dynamically constructed ELT/analytics queries built as a
-chain of SQL-WITH expressions, directly replaceable with a chain of stream
-tables in pg_trickle.
+**Pattern:** Chain of SQL-WITH expressions replaced with a chain of STs;
+lower-layer STs expected to reach billions of rows.
 
-**Scale:** Lower-layer STs (earlier in the chain, close to raw sources)
-expected to reach **billions of rows**.
+**Configuration target:** `REPLICA IDENTITY DEFAULT` (PK-only, safe here
+because PKs never change) + `placement => 'distributed'` for all
+lower-layer STs. The P4.1 1M-row threshold should be overridden or the
+threshold lowered — at billion-row scale a `reference` ST is a
+non-starter.
 
-**REPLICA IDENTITY:** `DEFAULT` (PK-only). PKs are deterministic and never
-change, so PK-only decoding is sufficient for all UPDATE/DELETE semantics.
+**Known limitations that apply to this topology:**
 
-**Implications for the design:**
-
-- Distributed ST storage is **mandatory**, not optional, for lower-layer
-  STs. A coordinator-local plain table at billion-row scale is a
-  non-starter.
-- The P4.1 auto-placement threshold (1M rows) should default to
-  `distributed` when the source topology is all-distributed, regardless of
-  projected ST size. This avoids an off-by-default footgun.
-- Chained STs must be **co-located** on the same distribution column so
-  that the downstream delta apply is a shard-local operation. The default
-  should be to distribute all STs in the same DAG subgraph on the same
-  column.
-- FULL REPLICA IDENTITY should be documented as **not recommended** at this
-  scale due to WAL amplification, with DEFAULT as the guidance.
+- **Cross-shard ST↔source JOINs** (see P4.4): `__pgt_row_id`-distributed
+  STs don't co-locate with source tables. Denormalise the source
+  distribution key into the ST if frequent back-joins are needed.
+- **Co-location breaks at aggregation boundaries**: if a mid-chain ST
+  aggregates (GROUP BY) or joins on a different key, automatic co-location
+  with the next ST in the chain is impossible; that ST boundary requires
+  explicit placement choice.
+- **PK immutability is a pre-condition, not verified automatically**:
+  using `DEFAULT` with mutable PKs causes silent data loss (see P3.3).
+  The confirmed use case meets this pre-condition; other users may not.
 
 ---
 

--- a/plans/ecosystem/PLAN_CITUS.md
+++ b/plans/ecosystem/PLAN_CITUS.md
@@ -1,6 +1,6 @@
 # PLAN_CITUS.md — Citus Compatibility for pg_trickle
 
-> **Date:** 2026-04-23
+> **Date:** 2026-04-24
 > **Status:** PROPOSED
 > **Targets:** Citus 13.x on PostgreSQL 18.x
 > **Supersedes:** previous draft of this file (pre-WAL-decoder, pre-relay)
@@ -44,6 +44,13 @@ storage-table placement decision**, not a wholesale rearchitecture.
 (no automatic shard rebalancing, no failover during refresh — both
 explicit constraints from the discussion thread). Rebalance support is a
 follow-up release.
+
+**Confirmed use case (discussion #619 follow-up, 2026-04-24):** all sources
+are hash-distributed (no reference tables), PKs are deterministic and
+stable, lower-layer STs in a SQL-WITH-replacement chain expected to reach
+billions of rows. `REPLICA IDENTITY DEFAULT` (PK-only) is the preferred
+setting; `FULL` is supported but unnecessary. Distributed ST storage is
+load-bearing for this pattern — see §11.
 
 ---
 
@@ -169,10 +176,12 @@ predictive-cost code paths.
 | **MERGE replacement (distributed STs)** | `DELETE … WHERE __pgt_row_id IN (...)` + `INSERT … ON CONFLICT (__pgt_row_id) DO UPDATE` | Citus-supported; same semantics |
 | **Worker→coordinator transport** | Logical replication (publications + slots) — **no triggers on workers** | Matches WAL-decoder model already in tree; zero new write-path overhead |
 | **Reference-table sources** | Keep trigger CDC path | Already works; no reason to change |
+| **REPLICA IDENTITY** | `DEFAULT` (PK-only) required for v1; `FULL` is supported but not required | Stable, deterministic PKs (confirmed in #619) mean PK-only decoding is sufficient; `FULL` causes significant WAL amplification on wide tables at billion-row scale |
 | **Locking** | Catalog table for cross-node locks; advisory locks remain the local fast path | Advisory locks are node-local |
 | **Wake signalling** | `LISTEN/NOTIFY` on coordinator only; workers don't run a scheduler | Single scheduler per database (today's model) is fine for Citus |
 | **Detection** | Auto-detect Citus at extension load + per-source at create time | No new GUC required for the common case |
 | **Rebalance** | Out of scope for v1 (matches user's constraint in #619) | Slot location follows shard placement; rebalance would invalidate slots |
+| **Chained distributed STs** | All STs in the same DAG chain distributed on the same column by default | Downstream MERGE/apply requires co-location; auto-co-locate avoids user error |
 
 ---
 
@@ -341,6 +350,10 @@ sees `placement == Distributed`:
 **P3.3 — REPLICA IDENTITY enforcement on workers.** The pre-flight check
 already at [src/wal_decoder.rs](src/wal_decoder.rs#L1509) needs to run
 **on each worker** (run_command_on_workers) for distributed sources.
+`REPLICA IDENTITY DEFAULT` (PK-only) is the v1 baseline and is strongly
+preferred at large scale — FULL doubles or more the WAL volume for every
+UPDATE on a wide table. Emit a warning (not an error) if the user sets FULL;
+do not override it. Reject `NOTHING` with a clear error.
 
 **P3.4 — Slot polling.** Scheduler tick iterates over
 `pgt_remote_slots` for the source and pulls from each worker, writing
@@ -380,6 +393,13 @@ sources:
 
 Persisted in `pgtrickle.pgt_stream_tables.st_placement`. Threshold
 GUC: `pg_trickle.citus_reference_st_max_rows` (default `1_000_000`).
+
+> **Note (from #619 feedback):** The confirmed use case has all-distributed
+> sources and lower-layer STs expected to reach billions of rows. The 1M
+> default likely places most STs in the `reference` bucket incorrectly for
+> this pattern. The P6.3 benchmark must validate the threshold; consider
+> lowering the default or making `distributed` the default when the source
+> topology is all-distributed.
 
 **P4.2 — Apply for `distributed` STs.** The DELETE + INSERT…ON CONFLICT
 pair replaces MERGE. Distribution column is `__pgt_row_id`. Codegen
@@ -497,9 +517,10 @@ when `pg_dist_partition` is empty.
 
 **P6.5 — Docs.** New page `docs/integrations/citus.md` covering
 prerequisites (`wal_level=logical` on every worker, `max_replication_slots`
-sized appropriately, `REPLICA IDENTITY FULL` on distributed sources,
-matching extension version on coordinator and workers, stable shard
-placement). Update [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) with
+sized appropriately, `REPLICA IDENTITY DEFAULT` (minimum; `FULL` is also
+supported but not recommended at large scale due to WAL amplification) on
+distributed sources, matching extension version on coordinator and workers,
+stable shard placement). Update [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) with
 the multi-node diagram from §5. Update [INSTALL.md](INSTALL.md) with
 "installing on a Citus cluster".
 
@@ -549,6 +570,11 @@ LSN tracking). P3–P5 are the Citus-specific deliverable.
    long-running connection per worker.
 2. **Reference vs distributed ST default for medium-sized outputs.** The
    1M-row threshold in P4.1 is a guess — instrument and tune in P6.3.
+   Discussion #619 confirms a scenario with billions of rows in lower-layer
+   STs across an all-distributed source topology; the 1M threshold may
+   produce `reference` placements that would be immediately untenable.
+   Consider making `distributed` the default when all declared sources are
+   `Distributed` and/or when DAG depth > 1.
 3. **Multi-database Citus.** Citus 13 supports multiple databases per
    cluster; each pg_trickle scheduler is per-database. No change
    expected, but verify in P6.2.
@@ -561,7 +587,41 @@ LSN tracking). P3–P5 are the Citus-specific deliverable.
 
 ---
 
-## 10. Cross-References
+## 11. Known Use Cases
+
+### 11.1 — All-distributed ELT chain (discussion #619)
+
+**Source topology:** All source tables are hash-distributed; no reference
+tables.
+
+**Query pattern:** Dynamically constructed ELT/analytics queries built as a
+chain of SQL-WITH expressions, directly replaceable with a chain of stream
+tables in pg_trickle.
+
+**Scale:** Lower-layer STs (earlier in the chain, close to raw sources)
+expected to reach **billions of rows**.
+
+**REPLICA IDENTITY:** `DEFAULT` (PK-only). PKs are deterministic and never
+change, so PK-only decoding is sufficient for all UPDATE/DELETE semantics.
+
+**Implications for the design:**
+
+- Distributed ST storage is **mandatory**, not optional, for lower-layer
+  STs. A coordinator-local plain table at billion-row scale is a
+  non-starter.
+- The P4.1 auto-placement threshold (1M rows) should default to
+  `distributed` when the source topology is all-distributed, regardless of
+  projected ST size. This avoids an off-by-default footgun.
+- Chained STs must be **co-located** on the same distribution column so
+  that the downstream delta apply is a shard-local operation. The default
+  should be to distribute all STs in the same DAG subgraph on the same
+  column.
+- FULL REPLICA IDENTITY should be documented as **not recommended** at this
+  scale due to WAL amplification, with DEFAULT as the guidance.
+
+---
+
+## 12. Cross-References
 
 - [src/wal_decoder.rs](src/wal_decoder.rs) — already-implemented
   WAL-based CDC; foundation of Phase 3.
@@ -574,4 +634,6 @@ LSN tracking). P3–P5 are the Citus-specific deliverable.
 - [plans/infra/PLAN_MULTI_DATABASE.md](plans/infra/PLAN_MULTI_DATABASE.md)
   — multi-database scheduler.
 - [discussion #619](https://github.com/grove/pg-trickle/discussions/619)
-  — original user request that motivated the rewrite.
+  — original user request that motivated the rewrite; follow-up comments
+  confirmed all-distributed topology, billion-row ST chains, and PK-only
+  REPLICA IDENTITY preference (2026-04-24).


### PR DESCRIPTION
## Summary

Updates `plans/ecosystem/PLAN_CITUS.md` with design decisions and open questions
informed by user feedback in [discussion #619](https://github.com/grove/pg-trickle/discussions/619)
(follow-up comments, 2026-04-24). No code changes — plan doc only.

The changes went through two rounds of self-review after the initial commit,
fixing several substantive issues: a blanket REPLICA IDENTITY DEFAULT
recommendation that was unsafe for users with mutable PKs, an infeasible
static-detection mechanism for PK immutability, and a self-contradicting
auto-placement table. The plan is now internally consistent and accurate.

## Changes

**Executive Summary**
- Add "Confirmed use case" note scoped to the #619 topology (all-distributed,
  stable PKs, billion-row ELT chains) — explicitly not generalised to all users.
- Status: `PROPOSED` → `PROPOSED — user-validated (#619, 2026-04-24)`.

**Section 4 — Design Decisions (two new rows)**
- `REPLICA IDENTITY`: `FULL` is the required default; `DEFAULT` (PK-only) is
  an explicit opt-in via `immutable_pk => true`, allowed only when the user
  asserts PKs never change. Silent data loss if a PK column is updated with
  DEFAULT decoding is documented as an unrecoverable error.
- `Chained distributed STs`: attempt auto-co-location within a DAG subgraph;
  error out when structurally impossible (aggregations, cross-key JOINs,
  dropped distribution column). `__pgt_row_id`-distributed STs do not
  co-locate with their source tables — cross-shard JOINs remain.

**Phase 3 — P3.3 (REPLICA IDENTITY enforcement)**
- Replaced infeasible `pg_attribute` static detection with `immutable_pk => true`
  explicit opt-in.
- Fixed parameter name (`allow_pk_updates => false` → `immutable_pk => true`).
- `FULL` is now the default; `DEFAULT` triggers a prominent warning.
- WAL amplification described as row-width-dependent (not "doubles or more").

**Phase 4 — P4.1 (ST placement auto-selection)**
- Fixed the contradiction: all-`Distributed` source topology now always defaults
  to `distributed` placement — no row-count threshold applied.
- 1M-row threshold GUC only applies to the mixed-topology case
  (`Distributed` + `Reference`/`Local` sources).
- Removed the self-contradicting callout note that said the default was wrong.

**Phase 4 — P4.4 (`__pgt_row_id` distribution)**
- Added explicit limitation: `__pgt_row_id`-distributed STs do not co-locate
  with their source tables; documents the re-partition join cost and the
  denormalisation workaround.

**Section 9 — Open Questions**
- Q2 narrowed to mixed-topology only.
- Q3 (new): source table count — unanswered from #619; needed to size slot
  budget (`N_sources × N_workers` connections).
- Q4 (new): dynamic query construction compatibility — "dynamically constructs
  queries" may mean query SQL varies per-execution (incompatible with pg_trickle)
  or per-deployment (fine); needs clarification before the integration ships.
- Q3–Q5 renumbered to Q5–Q7.

**Section 11 — Known Use Cases (new)**
- Documents the #619 all-distributed ELT chain as a first-class design target.
- Configuration target updated to FULL default + `immutable_pk => true` opt-in.
- Three concrete per-topology limitations called out: cross-shard ST↔source
  JOINs, co-location breaks at aggregation boundaries, PK immutability as a
  pre-condition.

## Testing

Plan document only — no runnable code changed.

## Notes

- A follow-up reply to erikmata in discussion #619 is drafted at
  `/tmp/reply_erikmata.md`, aligned with the decisions in this plan. It should
  be posted after this PR merges.
- The three commits on this branch are candidates for squashing before merge.
