### PR TITLE
docs(roadmap): pull Citus CDC forward to v0.33.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,9 +78,9 @@
 | [v0.30.0](roadmap/v0.30.0.md) | Quality gate before 1.0 — correctness, stability, and docs | ✅ Released | Medium | [Full details](roadmap/v0.30.0.md-full.md) |
 | [v0.31.0](roadmap/v0.31.0.md) | Smarter scheduling and faster hot paths | ✅ Released | Medium | [Full details](roadmap/v0.31.0.md-full.md) |
 | [v0.32.0](roadmap/v0.32.0.md) | Citus: stable object naming and per-source frontier foundation | Planned | Medium | [Full details](roadmap/v0.32.0.md-full.md) |
-| [v0.33.0](roadmap/v0.33.0.md) | Live push notifications and safe live schema changes | Planned | Medium | [Full details](roadmap/v0.33.0.md-full.md) |
-| [v0.34.0](roadmap/v0.34.0.md) | Time-travel queries and analytic storage | Planned | Medium | [Full details](roadmap/v0.34.0.md-full.md) |
-| [v0.35.0](roadmap/v0.35.0.md) | Citus: world-class distributed source CDC and stream table support | Planned | Large | [Full details](roadmap/v0.35.0.md-full.md) |
+| [v0.33.0](roadmap/v0.33.0.md) | Citus: world-class distributed source CDC and stream table support | Planned | Large | [Full details](roadmap/v0.33.0.md-full.md) |
+| [v0.34.0](roadmap/v0.34.0.md) | Live push notifications and safe live schema changes | Planned | Medium | [Full details](roadmap/v0.34.0.md-full.md) |
+| [v0.35.0](roadmap/v0.35.0.md) | Time-travel queries and analytic storage | Planned | Medium | [Full details](roadmap/v0.35.0.md-full.md) |
 
 ### Beyond v1.0
 
@@ -119,9 +119,9 @@ v0.31    ─── Scheduler intelligence and performance hot paths
     │
 v0.32    ─── Citus: stable naming foundation (additive, safe for all users)
     │
-v0.33–34 ─── Push notifications, zero-downtime schema changes, time-travel
+v0.33    ─── Citus: distributed CDC and stream table support
     │
-v0.35    ─── Citus: distributed CDC and stream table support
+v0.34–35 ─── Push notifications, zero-downtime schema changes, time-travel
     │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries
 ```
@@ -130,10 +130,11 @@ v0.1.0 through v0.27.0 build the complete core engine and harden it for
 production use. v0.28.0 and v0.29.0 deliver the event-driven integration
 story. v0.30.0 is a mandatory correctness and polish gate before 1.0.
 v0.31.0 sharpens scheduler intelligence before new features are added.
-v0.32.0 is scheduled early — before v0.33.0 and v0.34.0 — so that every
-subscription object and temporal history table is created with the new
-stable naming scheme from day one, reducing migration scope later.
-v0.33.0 and v0.34.0 each add a distinct new capability (push notifications
-and time-travel/columnar storage) while the core IVM engine remains stable.
-v0.35.0 builds on v0.32.0's foundations to unlock distributed-source CDC,
-distributed ST placement, and the full Citus test suite.
+v0.32.0 is the first of two Citus releases, shipping stable object naming
+and detection helpers as an additive, non-breaking foundation. v0.33.0
+delivers the full Citus integration immediately after — per-worker slot CDC,
+distributed ST placement, cross-node coordination, and the Citus test suite.
+Pulling v0.33.0 forward means users with Citus topologies (including
+billion-row all-distributed deployments) are unblocked two releases earlier.
+v0.34.0 and v0.35.0 add push notifications and time-travel/columnar storage;
+both are independent of the Citus work and ship in their own right.

--- a/roadmap/v0.33.0.md
+++ b/roadmap/v0.33.0.md
@@ -1,80 +1,115 @@
-# v0.33.0 — Reactive Subscriptions & Zero-Downtime Operations
+# v0.33.0 — Citus: World-Class Distributed Source CDC
 
 > **Full technical details:** [v0.33.0.md-full.md](v0.33.0.md-full.md)
 
-**Status: Planned** | **Scope: Medium**
+**Status: Planned** | **Scope: Large**
 
-> Live push notifications to applications, and a way to change a stream
-> table's defining query on a large production table without downtime.
+> The culmination of pg_trickle's Citus integration. v0.33.0 delivers
+> end-to-end incremental view maintenance over Citus distributed tables —
+> per-worker change capture, distributed stream table storage, cross-node
+> coordination, and a full Citus-specific test suite.
 
 ---
 
 ## What is this?
 
-v0.33.0 adds two long-requested operational capabilities:
+With v0.32.0's naming and frontier foundations in place, v0.33.0 implements
+the full Citus integration. There are three distributed table problems that
+need solving:
 
-1. **Push notifications** — applications can subscribe to changes in a
-   stream table and receive instant notifications, enabling real-time
-   dashboards, live UIs, and event-driven microservices.
-
-2. **Zero-downtime query changes** — modifying the defining query of a
-   large stream table no longer requires a multi-minute lock on the table.
-
----
-
-## Reactive subscriptions
-
-`pgtrickle.subscribe('my_stream_table', 'my_notification_channel')` registers
-a listener. After every successful refresh that produces at least one change,
-pg_trickle sends a PostgreSQL `NOTIFY` message to the named channel with a
-payload like:
-
-```json
-{"name": "my_stream_table", "inserted_count": 12, "deleted_count": 3}
-```
-
-Any application holding a standard PostgreSQL connection and listening on
-that channel receives this signal immediately, without polling. This powers
-real-time dashboards, event-driven microservices, and reactive frontends —
-using nothing but a standard PostgreSQL driver, with no Kafka, no Debezium,
-no Hasura required.
-
-A configurable coalescence window prevents notification storms when a stream
-table refreshes at high frequency.
+1. **Change capture** — triggers don't propagate to Citus workers, so
+   pg_trickle can't use its normal trigger-based CDC for distributed tables.
+2. **Stream table storage** — a distributed stream table can't be updated
+   with a standard `MERGE` statement; Citus imposes restrictions on
+   cross-shard operations.
+3. **Coordination** — PostgreSQL advisory locks and `LISTEN/NOTIFY` are
+   node-local; a cluster needs a different mechanism for cross-node
+   mutual exclusion.
 
 ---
 
-## Shadow-ST: zero-downtime query evolution
+## Change capture on distributed tables
 
-Today, calling `alter_query()` on a large stream table triggers a full
-re-computation of the entire result set. For a stream table with millions of
-rows, this can lock the table for minutes — an unacceptable operation in
-production.
+For distributed tables (where data lives on Citus worker nodes), pg_trickle
+switches from trigger-based CDC to **WAL-based CDC over per-worker logical
+replication slots**. Each worker gets a publication and a replication slot
+for the source table. The pg_trickle scheduler on the coordinator polls
+each worker's slot, decodes the change stream, and writes the changes into
+the coordinator's local change buffer — exactly the same buffer used by
+trigger-based CDC.
 
-The new `shadow_build := true` parameter to `alter_query()` changes how
-this works:
+This reuses the WAL decoder already in `src/wal_decoder.rs`; the only new
+code is a connection path to call `pg_logical_slot_get_changes()` on a
+remote node. Reference tables and local tables continue to use the existing
+trigger path unchanged.
 
-1. A parallel "shadow" stream table is created from the new query, invisible
-   to users.
-2. The shadow table is refreshed to convergence in the background, with no
-   lock on the live table. The live table continues to serve reads and accept
-   writes normally throughout.
-3. When the shadow table has caught up, the storage is swapped atomically.
-4. The new query goes live at the next refresh cycle. The shadow table is
-   dropped.
+---
 
-The live table is readable and writable from start to finish.
+## Distributed stream table storage
+
+When a stream table materializes a view over distributed sources, it can
+store its result in three ways:
+
+- **Local** (default for small outputs) — a regular coordinator-side table,
+  same as today.
+- **Reference** — a Citus reference table, replicated to every worker.
+  Ideal for dimension tables read by many queries.
+- **Distributed** — a Citus distributed table, sharded by the stream
+  table's row identity. Required for outputs too large to fit on the
+  coordinator.
+
+For distributed stream tables, the standard `MERGE` statement is replaced
+by a `DELETE … WHERE row_id IN (…)` followed by an
+`INSERT … ON CONFLICT DO UPDATE` — the pattern Citus supports everywhere.
+The result is identical; only the internal SQL changes.
+
+---
+
+## Cross-node coordination
+
+Advisory locks that guard refresh scheduling are node-local. v0.33.0
+introduces a lightweight catalog-based lock table
+(`pgtrickle.pgt_st_locks`) that provides cross-node mutual exclusion
+without an external coordinator. The table uses `INSERT … ON CONFLICT DO
+NOTHING` for lock acquisition and timestamp-based lease expiry for
+failure recovery. Advisory locks remain the fast-path for the common
+single-node case.
+
+---
+
+## Observability
+
+A new `pgtrickle.citus_status` view surfaces the health of all
+distributed source connections: which workers are reachable, the
+replication lag per worker per source, slot positions, and any workers
+in a failed state. This integrates with the existing Prometheus metrics
+endpoint.
+
+---
+
+## Test suite
+
+v0.33.0 ships a dedicated Citus E2E test harness:
+`tests/e2e_citus_tests.rs` backed by a docker-compose environment
+(one coordinator + two workers) and `tests/Dockerfile.e2e-citus`. The
+test matrix covers 10 scenarios including local, reference, and
+distributed sources; mixed CDC backends; outbox integration; DDL
+propagation; and worker restarts.
+
+The non-Citus benchmark suite shows zero regression — all Citus code
+paths are guarded by the detection check introduced in v0.32.0 and
+compile out entirely when Citus is absent.
 
 ---
 
 ## Scope
 
-v0.33.0 is a medium-sized release. The shadow-ST feature touches the refresh
-orchestrator — the most change-sensitive module in the codebase — and ships
-behind a feature flag with a full TPC-H validation pass before the flag is
-removed.
+v0.33.0 is a large release. Phase 3 (per-worker slot CDC) is the deepest
+new code; it reuses the WAL decoder infrastructure but adds remote
+connection management. Phase 6 (test suite) requires building and
+maintaining a multi-container Citus CI environment.
 
 ---
 
 *Previous: [v0.32.0 — Citus: Stable Naming & Per-Source Frontier Foundation](v0.32.0.md)*
-*Next: [v0.34.0 — Temporal IVM & Columnar Materialization](v0.34.0.md)*
+*Next: [v0.34.0 — Reactive Subscriptions & Zero-Downtime Operations](v0.34.0.md)*

--- a/roadmap/v0.33.0.md-full.md
+++ b/roadmap/v0.33.0.md-full.md
@@ -1,97 +1,186 @@
 > **Plain-language companion:** [v0.33.0.md](v0.33.0.md)
 
-## v0.33.0 — Reactive Subscriptions & Zero-Downtime Operations
+## v0.33.0 — Citus: World-Class Distributed Source CDC
 
-**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.1, §10.8.
+**Status: Planned.** Derived from
+[plans/ecosystem/PLAN_CITUS.md](../plans/ecosystem/PLAN_CITUS.md)
+§6 Phases 3, 4, 5, and 6.
 
 > **Release Theme**
-> v0.33.0 delivers two long-requested operational capabilities. Reactive
-> subscriptions expose stream-table changes as PostgreSQL `NOTIFY` events,
-> enabling browser-side reactive UIs and event-driven microservices with
-> nothing but a standard PG connection — no Kafka, no Debezium, no Hasura.
-> Zero-downtime view evolution adds a shadow-ST mode to `ALTER QUERY` that
-> builds the new query's materialisation side-by-side with the live table,
-> then swaps atomically — eliminating the operational risk of running
-> `ALTER QUERY` on a large production stream table.
+> v0.33.0 delivers world-class incremental view maintenance over Citus
+> distributed tables. Building on v0.32.0's stable naming and frontier
+> foundations, this release adds: (P3) per-worker WAL slot polling for
+> distributed-table CDC; (P4) distributed ST storage with a Citus-safe
+> DELETE+UPSERT apply path; (P5) catalog-based cross-node coordination and
+> a `pgtrickle.citus_status` observability view; and (P6) a full Citus
+> E2E test suite (1 coordinator + 2 workers, 10-scenario matrix) with
+> dedicated benchmarks and documentation. The non-Citus code path has a
+> hard regression budget of 0% — every Citus code path short-circuits on
+> the `is_citus_loaded()` check introduced in v0.32.0.
 
 ---
 
-### Correctness
+### Phase 3 — Distributed CDC via Per-Worker Slots
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| CORR-1 | Reactive subscription: coalesce NOTIFY storms | S | P0 |
+| CDC-1 | Remote slot consumption via `dblink`-wrapped `pg_logical_slot_get_changes()` | L | P0 |
+| CDC-2 | `setup_cdc_for_source` for distributed sources: per-worker publication + slot creation | M | P0 |
+| CDC-3 | REPLICA IDENTITY FULL enforcement on each worker | S | P0 |
+| CDC-4 | Slot polling: scheduler iterates `pgt_remote_slots`, writes into coordinator change buffer | L | P0 |
+| CDC-5 | TRUNCATE + DDL propagation for distributed sources | M | P1 |
+| CDC-6 | New catalog: `pgtrickle.pgt_remote_slots (pgt_id, worker_id, worker_host, worker_port, slot_name, last_lsn)` | S | P0 |
+| CDC-7 | Libpq streaming fallback path (P3.1 option B) — implement if dblink bench fails threshold | L | P2 |
 
-**CORR-1** — The subscribe API must coalesce rapid successive changes into a
-single NOTIFY payload (or a "changes pending" signal) when the refresh
-interval is shorter than the LISTEN client's poll loop. Implement a
-`pg_trickle.notify_coalesce_ms` GUC (default 250 ms) and a per-stream-table
-flag that debounces NOTIFY calls.
+**CDC-1** — Today `src/wal_decoder.rs` calls
+`pg_logical_slot_get_changes()` via SPI on the local node. Add a sibling
+`poll_remote_slot(conn: &PgConnection, slot_name: &str, …)` that executes
+the same SQL via a `dblink` foreign connection to a worker. Connection
+parameters come from `pgt_remote_slots.worker_host/port`. Connection
+pooling reuses existing `libpq` handles per scheduler tick.
+
+**CDC-2** — When `is_citus_loaded()` and `placement(oid) == Distributed`:
+1. Issue `run_command_on_all_nodes("CREATE PUBLICATION pgtrickle_{stable_name} FOR TABLE {table} WITH (publish_via_partition_root = true)")`
+2. Issue `run_command_on_all_nodes("SELECT pg_create_logical_replication_slot('pgtrickle_{stable_name}', 'pgoutput')")`
+3. Insert one row per worker into `pgtrickle.pgt_remote_slots`.
+
+**CDC-4** — Scheduler tick: for each source with remote slots, call
+`poll_remote_slot()` for each worker row in `pgt_remote_slots`. Decoded
+rows written to coordinator's `changes_{stable_name}` buffer with two new
+columns: `origin_node SMALLINT`, `origin_lsn PG_LSN`. Compaction uses
+`(origin_node, origin_lsn)` as the watermark.
 
 ---
 
-### Ease of Use
+### Phase 4 — Distributed ST Storage & Apply Path
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| UX-1 | `pgtrickle.subscribe(name, channel)` and `unsubscribe()` SQL functions | M | P0 |
-| UX-2 | `pg_trickle.notify_coalesce_ms` GUC | XS | P0 |
-| UX-3 | `ALTER QUERY` shadow-ST mode (`shadow_build := true` parameter) | L | P1 |
-| UX-4 | `pgtrickle.view_evolution_status(name)` monitoring function | S | P1 |
-| UX-5 | Documentation: subscribe() quick-start + shadow-ST runbook | M | P1 |
+| APPLY-1 | `create_stream_table(…, placement => 'local' | 'reference' | 'distributed')` | M | P0 |
+| APPLY-2 | Auto-select placement from declared source placements + row-count heuristic | S | P1 |
+| APPLY-3 | DELETE + `INSERT … ON CONFLICT DO UPDATE` codegen template for distributed STs | M | P0 |
+| APPLY-4 | Delta materialisation to TEMP table for reference STs with non-pushable plans | S | P1 |
+| APPLY-5 | `__pgt_row_id` as distribution column when creating distributed ST | S | P0 |
+| APPLY-6 | `reltuples` fix: sum `pg_dist_shard` row counts for distributed tables in DAG planner | S | P1 |
+| APPLY-7 | GUC: `pg_trickle.citus_reference_st_max_rows` (default 1_000_000) | S | P1 |
 
-**UX-1 — Reactive subscription API.**
-`pgtrickle.subscribe(stream_table TEXT, channel TEXT)` registers a per-stream-
-table listener: after every successful differential or full refresh, if the
-delta is non-empty, the refresh path emits `pg_notify(channel, payload_jsonb::text)`
-within the same transaction. The payload carries `{"name": …, "refresh_id": …,
-"inserted_count": N, "deleted_count": N}`. Build on the `pg_notify`
-infrastructure already wired by the v0.28.0 outbox. `pgtrickle.unsubscribe(name, channel)`
-removes the registration; `pgtrickle.list_subscriptions()` returns all active
-registrations. **Schema change:** Yes — new `pgtrickle.pgt_subscriptions`
-catalog table.
+**APPLY-3** — Codegen in `src/refresh/codegen.rs` gets a second template
+selected by `st_placement = 'distributed'`:
+```sql
+WITH delta AS (...)
+DELETE FROM {st} st
+ USING delta d
+ WHERE d.__pgt_action = 'D'
+   AND st.__pgt_row_id = d.__pgt_row_id;
 
-**UX-3 — Shadow-ST for zero-downtime `ALTER QUERY`.**
-Today `ALTER QUERY` triggers a full refresh of the stream table. For tables
-with millions of rows, this causes a multi-minute outage during which the
-stream table is locked. A `shadow_build := true` parameter to `alter_query()`
-creates a parallel stream table `__pgt_shadow_<name>` built from the new query,
-refreshes it to convergence in the background without locking the live table,
-then atomically swaps the storage tables and drops the shadow. The live table
-is readable and writable throughout. The new query goes live at the next refresh
-cycle after the swap. **Schema change:** Yes — add `in_shadow_build BOOLEAN` and
-`shadow_table_name TEXT` columns to `pgtrickle.pgt_stream_tables`.
+WITH delta AS (...)
+INSERT INTO {st} (__pgt_row_id, ...)
+SELECT __pgt_row_id, ... FROM delta WHERE __pgt_action != 'D'
+ON CONFLICT (__pgt_row_id) DO UPDATE SET ...;
+```
+
+**APPLY-5** — At `create_distributed_table({st}, '__pgt_row_id')` time,
+validate that `__pgt_row_id` is not repurposed as a user column (rare;
+emit a hard error if so).
 
 ---
 
-### Test Coverage
+### Phase 5 — Coordination & Operability
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| TEST-1 | E2E: subscribe() receives NOTIFY on every non-empty refresh | M | P0 |
-| TEST-2 | E2E: NOTIFY coalescing under high-frequency refresh | S | P1 |
-| TEST-3 | E2E: shadow-ST ALTER QUERY while reads/writes are in flight | L | P1 |
-| TEST-4 | E2E: shadow-ST rollback if new query fails to converge | M | P1 |
+| COORD-1 | Catalog lock table: `pgtrickle.pgt_st_locks` | S | P0 |
+| COORD-2 | Replace advisory lock acquisition in scheduler with catalog-based locks for distributed STs | M | P0 |
+| COORD-3 | `pgtrickle.citus_status` view: worker reachability, slot lag, placement summary | M | P0 |
+| COORD-4 | Failure mode: pause refresh on unreachable worker; surface via monitor + Prometheus | M | P1 |
+| COORD-5 | Failure mode: WAL recycled past slot — fall back to FULL refresh, emit `WARNING` | S | P1 |
+| COORD-6 | Failure mode: slot missing on worker after node add — re-create on next tick | S | P1 |
+| COORD-7 | Pre-flight check: refuse to start if `pg_trickle` version mismatches across workers | S | P0 |
+| COORD-8 | Pre-flight check: enforce `wal_level = logical` on each worker at slot-create time | S | P0 |
+
+**COORD-1** — `pgtrickle.pgt_st_locks`:
+```sql
+CREATE TABLE pgtrickle.pgt_st_locks (
+  pgt_id     BIGINT PRIMARY KEY,
+  locked_by  INT    NOT NULL,   -- PID
+  locked_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  lease_until TIMESTAMPTZ NOT NULL
+);
+```
+`INSERT … ON CONFLICT DO NOTHING` acquires; `DELETE` releases; a
+background task reaps expired leases. Advisory locks remain the fast
+in-process path; catalog locks are used only when `is_citus_loaded()`.
+
+**COORD-3** — `pgtrickle.citus_status` columns:
+`pgt_id, source_table, worker_host, worker_port, slot_name, slot_lag_bytes, last_polled_at, status ('ok' | 'lagging' | 'unreachable' | 'slot_missing')`.
+
+---
+
+### Phase 6 — Validation, Benchmarks, Migration, Docs
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| TEST-1 | `tests/Dockerfile.e2e-citus`: Citus 13.x image with pg_trickle extension | M | P0 |
+| TEST-2 | docker-compose: 1 coordinator + 2 workers for Citus E2E tests | S | P0 |
+| TEST-3 | `tests/e2e_citus_tests.rs`: 10-scenario test matrix (see below) | L | P0 |
+| BENCH-1 | `benches/bench_remote_slot_poll`: dblink vs local SPI throughput | M | P1 |
+| BENCH-2 | `benches/bench_distributed_apply`: DELETE+UPSERT vs MERGE on 100M-row distributed ST | M | P1 |
+| MIG-1 | SQL migration: `pgt_remote_slots` catalog creation + new `origin_node`/`origin_lsn` buffer columns | S | P0 |
+| DOCS-1 | `docs/integrations/citus.md`: prerequisites, install guide, placement options, failure modes | M | P0 |
+| DOCS-2 | Update `docs/ARCHITECTURE.md` with multi-node Citus diagram | S | P1 |
+| DOCS-3 | Update `INSTALL.md` with "installing on a Citus cluster" section | S | P1 |
+
+**TEST-3 — 10-scenario matrix:**
+
+| # | Source(s) | ST placement | Exercises |
+|---|-----------|--------------|-----------|
+| 1 | Local table | local | Regression — trigger CDC unchanged |
+| 2 | Reference table | local | Coordinator trigger CDC |
+| 3 | Distributed table | reference | Per-worker slots, MERGE, replication of ST |
+| 4 | Distributed table | distributed | Per-worker slots, DELETE + UPSERT |
+| 5 | Mixed (ref + dist) | local | Mixed CDC backends, per-source frontier |
+| 6 | Distributed → outbox | distributed | Downstream publication + relay from distributed ST |
+| 7 | ALTER TABLE on dist source | distributed | DDL propagation, slot rebuild |
+| 8 | Worker restart | distributed | Slot survives, refresh resumes |
+| 9 | TRUNCATE on dist source | any | Full-refresh fallback |
+| 10 | Concurrent DML + refresh | distributed | Apply correctness under load |
+
+---
+
+### Performance Budget
+
+| Metric | Target |
+|--------|--------|
+| Non-Citus code path regression | 0% (hard gate) |
+| `create_stream_table()` overhead when Citus absent | ≤ 1 µs |
+| Refresh latency regression on single-node suite | ≤ 2% |
+| `bench_remote_slot_poll` (dblink) throughput | ≥ 50 k rows/s on loopback; if < 10 k rows/s trigger CDC-7 (libpq streaming) |
 
 ---
 
 ### Conflicts & Risks
 
-- **UX-3** (shadow-ST) touches the refresh orchestrator and catalog — the
-  highest-change-risk modules. Must ship behind a feature flag, stabilised
-  with the full TPC-H test suite before removing the flag.
-- Shadow-ST competes with the live stream table's change buffer, potentially
-  doubling CDC write overhead during the build window. Add a
-  `shadow_refresh_throttle_ms` GUC to rate-limit background refreshes.
-
-### Exit Criteria
-
-- [ ] UX-1: `subscribe()` / `unsubscribe()` / `list_subscriptions()` registered; NOTIFY emitted on non-empty refresh; `pgt_subscriptions` catalog table in migration script
-- [ ] CORR-1: NOTIFY coalescing tested at 10 Hz refresh; client receives ≤ 1 NOTIFY per `notify_coalesce_ms` window
-- [ ] UX-3: Shadow-ST builds in background; swap is atomic; live table readable throughout; rollback on convergence failure documented
-- [ ] UX-4: `view_evolution_status()` returns `in_progress | converged | failed` with row counts
-- [ ] Extension upgrade path tested (`0.31.0 → 0.32.0`)
-- [ ] `just check-version-sync` passes
+- **dblink latency** (CDC-1): bench result gates whether CDC-7 (libpq streaming) becomes P0. Add the bench early in the release to avoid a late scope change.
+- **Citus MERGE rejection** (APPLY-3): DELETE+UPSERT is the primary path; MERGE is only used for reference STs and is already known to work.
+- **Slot fills WAL on worker if coordinator stops** (COORD-4/5): document monitoring requirement; expose `slot_lag_bytes` in `citus_status`; auto-drop slot after configurable lease expiry (`pg_trickle.citus_slot_max_lag_bytes`, default 1 GB).
+- **Schema/role differences on workers** (COORD-8): `run_command_on_all_nodes("CREATE SCHEMA IF NOT EXISTS pgtrickle_changes")` + role grants at setup time.
+- **Shard rebalance invalidates slots**: out of scope for this release; emit a hard error in slot-poll path if `pg_dist_node` topology hash changes between polls.
 
 ---
 
+### Exit Criteria
+
+- [ ] CDC-1: `poll_remote_slot()` decodes INSERT/UPDATE/DELETE/TRUNCATE from a worker via dblink
+- [ ] CDC-2: `setup_cdc_for_source` on a distributed table creates publication + slot on every worker and populates `pgt_remote_slots`
+- [ ] CDC-4: Scheduler polls all workers for a distributed source and writes correct decoded rows into coordinator change buffer
+- [ ] APPLY-1/APPLY-3: `create_stream_table(…, placement => 'distributed')` works end-to-end; DELETE+UPSERT apply path produces identical results to single-node MERGE
+- [ ] COORD-3: `SELECT * FROM pgtrickle.citus_status` returns one row per (source, worker) with accurate lag
+- [ ] TEST-3: All 10 E2E scenarios pass against a live 1+2 Citus cluster
+- [ ] BENCH-1: `bench_remote_slot_poll` throughput ≥ 50 k rows/s (dblink loopback); report logged in `docs/BENCHMARK.md`
+- [ ] Non-Citus benchmark suite shows 0% regression
+- [ ] DOCS-1: `docs/integrations/citus.md` covers prerequisites, setup, placement options, monitoring, failure modes, and known limitations
+- [ ] Migration path `v0.32.0 → v0.33.0` tested with `just test-upgrade-all`
+- [ ] `just check-version-sync` passes
+- [ ] `just lint` passes (zero warnings)
+
+---

--- a/roadmap/v0.34.0.md
+++ b/roadmap/v0.34.0.md
@@ -1,92 +1,80 @@
-# v0.34.0 — Temporal IVM & Columnar Materialization
+# v0.34.0 — Reactive Subscriptions & Zero-Downtime Operations
 
 > **Full technical details:** [v0.34.0.md-full.md](v0.34.0.md-full.md)
 
 **Status: Planned** | **Scope: Medium**
 
-> Two new analytic workload patterns: time-travel queries over a stream
-> table's full history, and columnar storage for dramatically faster
-> analytics.
+> Live push notifications to applications, and a way to change a stream
+> table's defining query on a large production table without downtime.
 
 ---
 
 ## What is this?
 
-v0.34.0 opens two new classes of analytic workloads that pg_trickle cannot
-currently serve.
+v0.34.0 adds two long-requested operational capabilities:
+
+1. **Push notifications** — applications can subscribe to changes in a
+   stream table and receive instant notifications, enabling real-time
+   dashboards, live UIs, and event-driven microservices.
+
+2. **Zero-downtime query changes** — modifying the defining query of a
+   large stream table no longer requires a multi-minute lock on the table.
 
 ---
 
-## Temporal IVM — time-travel queries
+## Reactive subscriptions
 
-Normally, a stream table shows the *current* state of the world. Temporal
-mode changes this: the stream table maintains a full history of how every
-row has changed over time. Rows are never physically deleted; instead, each
-row carries a `valid_from` timestamp and an optional `valid_to` timestamp
-that records when a version was replaced.
+`pgtrickle.subscribe('my_stream_table', 'my_notification_channel')` registers
+a listener. After every successful refresh that produces at least one change,
+pg_trickle sends a PostgreSQL `NOTIFY` message to the named channel with a
+payload like:
 
-This enables queries like "what did this table look like at 3 PM on Tuesday?"
-without any external audit log infrastructure. The pattern is known as
-**SCD Type 2** (Slowly Changing Dimension Type 2) in data warehousing, and
-it is used for:
-
-- Customer history ("what address was on file when this order shipped?")
-- Regulatory audit trails ("what were the account balances at quarter-end?")
-- Slowly-changing dimension tables in analytics pipelines
-
-Creating a temporal stream table is a single parameter:
-
-```sql
-SELECT pgtrickle.create_stream_table(
-    'customer_history',
-    query := 'SELECT id, name, address FROM customers',
-    temporal := true
-);
+```json
+{"name": "my_stream_table", "inserted_count": 12, "deleted_count": 3}
 ```
 
-Queries against the stream table with `AS OF TIMESTAMP $1` automatically
-resolve against the historical row versions.
+Any application holding a standard PostgreSQL connection and listening on
+that channel receives this signal immediately, without polling. This powers
+real-time dashboards, event-driven microservices, and reactive frontends —
+using nothing but a standard PostgreSQL driver, with no Kafka, no Debezium,
+no Hasura required.
+
+A configurable coalescence window prevents notification storms when a stream
+table refreshes at high frequency.
 
 ---
 
-## Columnar materialization
+## Shadow-ST: zero-downtime query evolution
 
-Stream tables currently store their results in standard PostgreSQL heap
-storage — optimised for row-by-row reads and writes. Analytic queries that
-scan millions of rows to compute aggregates are better served by *columnar*
-storage, where all values for a single column are stored together on disk.
-This dramatically reduces I/O for aggregate queries (summing a column, for
-example, only reads that column, not the entire row).
+Today, calling `alter_query()` on a large stream table triggers a full
+re-computation of the entire result set. For a stream table with millions of
+rows, this can lock the table for minutes — an unacceptable operation in
+production.
 
-The `storage_backend := 'columnar'` parameter to `create_stream_table()`
-tells pg_trickle to store the materialised result in Citus columnar storage
-or pg_mooncake. The differential refresh machinery continues to work —
-pg_trickle automatically routes the MERGE to use the `delete_insert` strategy
-that columnar storage requires, with no manual configuration.
+The new `shadow_build := true` parameter to `alter_query()` changes how
+this works:
 
-The result: analytic dashboards and reporting queries that consume the
-materialised stream table see dramatically lower I/O, smaller storage
-footprint, and faster aggregate performance.
+1. A parallel "shadow" stream table is created from the new query, invisible
+   to users.
+2. The shadow table is refreshed to convergence in the background, with no
+   lock on the live table. The live table continues to serve reads and accept
+   writes normally throughout.
+3. When the shadow table has caught up, the storage is swapped atomically.
+4. The new query goes live at the next refresh cycle. The shadow table is
+   dropped.
 
----
-
-## Combined use
-
-Temporal mode and columnar storage can be combined: a slowly-changing
-dimension table stored in columnar format with full history, queryable at
-any point in time. This is listed as a stretch goal and is not a hard
-requirement for the release.
+The live table is readable and writable from start to finish.
 
 ---
 
 ## Scope
 
-v0.34.0 is a medium-sized release. The temporal IVM work requires extending
-the core frontier model — the internal mechanism that tracks which changes
-have been processed — from a single LSN cursor to a two-dimensional
-`(LSN, timestamp)` pair. A design spike in v0.33.0 is a prerequisite before
-committing this feature to the milestone.
+v0.34.0 is a medium-sized release. The shadow-ST feature touches the refresh
+orchestrator — the most change-sensitive module in the codebase — and ships
+behind a feature flag with a full TPC-H validation pass before the flag is
+removed.
 
 ---
 
-*Previous: [v0.33.0 — Reactive Subscriptions & Zero-Downtime Operations](v0.33.0.md)*
+*Previous: [v0.32.0 — Citus: Stable Naming & Per-Source Frontier Foundation](v0.32.0.md)*
+*Next: [v0.35.0 — Temporal IVM & Columnar Materialization](v0.35.0.md)*

--- a/roadmap/v0.34.0.md-full.md
+++ b/roadmap/v0.34.0.md-full.md
@@ -1,20 +1,18 @@
 > **Plain-language companion:** [v0.34.0.md](v0.34.0.md)
 
-## v0.34.0 — Temporal IVM & Columnar Materialization
+## v0.34.0 — Reactive Subscriptions & Zero-Downtime Operations
 
-**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.2, §10.7.
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.1, §10.8.
 
 > **Release Theme**
-> v0.34.0 unlocks two analytic workload patterns that the current streaming
-> engine cannot serve. Temporal IVM lets a stream table maintain a rolling
-> history of how its rows have changed over time — providing first-class
-> SCD-Type-2 semantics without external ETL or separate audit tables.
-> Columnar materialization lets a stream table store its result set in
-> Citus columnar storage (or pg_mooncake), dramatically reducing storage
-> footprint and query I/O for analytic consumers that scan the materialised
-> result set but never write to it. Together they close the OLTP→OLAP
-> bridging gap and make pg_trickle viable as the materialization layer for
-> dashboards and reporting queries.
+> v0.34.0 delivers two long-requested operational capabilities. Reactive
+> subscriptions expose stream-table changes as PostgreSQL `NOTIFY` events,
+> enabling browser-side reactive UIs and event-driven microservices with
+> nothing but a standard PG connection — no Kafka, no Debezium, no Hasura.
+> Zero-downtime view evolution adds a shadow-ST mode to `ALTER QUERY` that
+> builds the new query's materialisation side-by-side with the live table,
+> then swaps atomically — eliminating the operational risk of running
+> `ALTER QUERY` on a large production stream table.
 
 ---
 
@@ -22,24 +20,13 @@
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| CORR-1 | Temporal IVM: two-dimensional frontier (LSN, timestamp) | L | P0 |
-| CORR-2 | Columnar: verify differential MERGE compatibility with columnar storage | M | P0 |
+| CORR-1 | Reactive subscription: coalesce NOTIFY storms | S | P0 |
 
-**CORR-1** — Temporal IVM requires extending the frontier model from a
-one-dimensional LSN cursor to a two-dimensional `(frontier_lsn, valid_from_ts)`
-pair. Each row carries a `__pgt_valid_from TIMESTAMPTZ` and an optional
-`__pgt_valid_to TIMESTAMPTZ`. Rows are never physically deleted; instead a
-"close" delta sets `valid_to`. Queries against the stream table with `AS OF
-TIMESTAMP $1` resolve to the materialised row version valid at that timestamp.
-**Schema change:** Yes — new `temporal_mode BOOLEAN` column on
-`pgtrickle.pgt_stream_tables`; new `__pgt_valid_from`/`__pgt_valid_to`
-columns auto-added to the storage table when `temporal_mode = true`.
-
-**CORR-2** — Citus columnar and pg_mooncake use append-only storage models.
-Verify that the differential MERGE (`MERGE INTO storage USING delta`) is
-compatible with append-only semantics (likely requires `DELETE + INSERT`
-merge strategy for columnar targets). Add a `storage_backend` column to
-`pgtrickle.pgt_stream_tables` and route merge codegen accordingly.
+**CORR-1** — The subscribe API must coalesce rapid successive changes into a
+single NOTIFY payload (or a "changes pending" signal) when the refresh
+interval is shorter than the LISTEN client's poll loop. Implement a
+`pg_trickle.notify_coalesce_ms` GUC (default 250 ms) and a per-stream-table
+flag that debounces NOTIFY calls.
 
 ---
 
@@ -47,12 +34,33 @@ merge strategy for columnar targets). Add a `storage_backend` column to
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| UX-1 | `create_stream_table(…, temporal := true)` parameter | M | P0 |
-| UX-2 | `AS OF TIMESTAMP` query rewrite in DVM parser | L | P1 |
-| UX-3 | `create_stream_table(…, storage_backend := 'columnar')` parameter | M | P1 |
-| UX-4 | Automatic `delete_insert` strategy for columnar backends | S | P1 |
-| UX-5 | Documentation: temporal IVM tutorial + SCD-Type-2 worked example | M | P1 |
-| UX-6 | Documentation: columnar backend setup guide (Citus + pg_mooncake) | S | P1 |
+| UX-1 | `pgtrickle.subscribe(name, channel)` and `unsubscribe()` SQL functions | M | P0 |
+| UX-2 | `pg_trickle.notify_coalesce_ms` GUC | XS | P0 |
+| UX-3 | `ALTER QUERY` shadow-ST mode (`shadow_build := true` parameter) | L | P1 |
+| UX-4 | `pgtrickle.view_evolution_status(name)` monitoring function | S | P1 |
+| UX-5 | Documentation: subscribe() quick-start + shadow-ST runbook | M | P1 |
+
+**UX-1 — Reactive subscription API.**
+`pgtrickle.subscribe(stream_table TEXT, channel TEXT)` registers a per-stream-
+table listener: after every successful differential or full refresh, if the
+delta is non-empty, the refresh path emits `pg_notify(channel, payload_jsonb::text)`
+within the same transaction. The payload carries `{"name": …, "refresh_id": …,
+"inserted_count": N, "deleted_count": N}`. Build on the `pg_notify`
+infrastructure already wired by the v0.28.0 outbox. `pgtrickle.unsubscribe(name, channel)`
+removes the registration; `pgtrickle.list_subscriptions()` returns all active
+registrations. **Schema change:** Yes — new `pgtrickle.pgt_subscriptions`
+catalog table.
+
+**UX-3 — Shadow-ST for zero-downtime `ALTER QUERY`.**
+Today `ALTER QUERY` triggers a full refresh of the stream table. For tables
+with millions of rows, this causes a multi-minute outage during which the
+stream table is locked. A `shadow_build := true` parameter to `alter_query()`
+creates a parallel stream table `__pgt_shadow_<name>` built from the new query,
+refreshes it to convergence in the background without locking the live table,
+then atomically swaps the storage tables and drops the shadow. The live table
+is readable and writable throughout. The new query goes live at the next refresh
+cycle after the swap. **Schema change:** Yes — add `in_shadow_build BOOLEAN` and
+`shadow_table_name TEXT` columns to `pgtrickle.pgt_stream_tables`.
 
 ---
 
@@ -60,33 +68,29 @@ merge strategy for columnar targets). Add a `storage_backend` column to
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| TEST-1 | Integration: temporal stream table `AS OF TIMESTAMP` round-trip | L | P0 |
-| TEST-2 | Integration: SCD-Type-2 dimension pattern end-to-end | M | P1 |
-| TEST-3 | Integration: columnar stream table MERGE parity with heap | M | P0 |
-| TEST-4 | Integration: temporal + columnar combined (temporal columnar ST) | M | P2 |
+| TEST-1 | E2E: subscribe() receives NOTIFY on every non-empty refresh | M | P0 |
+| TEST-2 | E2E: NOTIFY coalescing under high-frequency refresh | S | P1 |
+| TEST-3 | E2E: shadow-ST ALTER QUERY while reads/writes are in flight | L | P1 |
+| TEST-4 | E2E: shadow-ST rollback if new query fails to converge | M | P1 |
 
 ---
 
 ### Conflicts & Risks
 
-- **CORR-1** requires a non-trivial DVM engine extension (two-dimensional
-  frontier). Spike in v0.33.0 first; do not commit to the milestone until
-  the spike proves the approach is sound.
-- **CORR-2** depends on the Citus columnar or pg_mooncake extension being
-  present; CI must add a Testcontainers image with one of these available.
-  Gate columnar support behind `pg_trickle.columnar_backend` GUC (default
-  `none`); the CI matrix should test at least one columnar provider.
-- The combination of temporal mode and columnar storage is a P2 stretch
-  goal; do not block the release on it.
+- **UX-3** (shadow-ST) touches the refresh orchestrator and catalog — the
+  highest-change-risk modules. Must ship behind a feature flag, stabilised
+  with the full TPC-H test suite before removing the flag.
+- Shadow-ST competes with the live stream table's change buffer, potentially
+  doubling CDC write overhead during the build window. Add a
+  `shadow_refresh_throttle_ms` GUC to rate-limit background refreshes.
 
 ### Exit Criteria
 
-- [ ] CORR-1/UX-1: `create_stream_table(…, temporal := true)` creates storage table with `__pgt_valid_from`/`__pgt_valid_to`; rows never physically deleted
-- [ ] UX-2: `AS OF TIMESTAMP $1` query rewrites resolve against the materialised history
-- [ ] TEST-1: Temporal round-trip test passes: insert → update → delete, query at t₀/t₁/t₂ returns correct historical rows
-- [ ] TEST-2: SCD-Type-2 dimension pattern: slowly-changing customer table materialised with full history, current-version query using `WHERE valid_to IS NULL`
-- [ ] CORR-2/UX-3: Columnar stream table creates; `delete_insert` strategy used automatically; columnar MERGE E2E parity test passes
-- [ ] Extension upgrade path tested (`0.32.0 → 0.33.0`)
+- [ ] UX-1: `subscribe()` / `unsubscribe()` / `list_subscriptions()` registered; NOTIFY emitted on non-empty refresh; `pgt_subscriptions` catalog table in migration script
+- [ ] CORR-1: NOTIFY coalescing tested at 10 Hz refresh; client receives ≤ 1 NOTIFY per `notify_coalesce_ms` window
+- [ ] UX-3: Shadow-ST builds in background; swap is atomic; live table readable throughout; rollback on convergence failure documented
+- [ ] UX-4: `view_evolution_status()` returns `in_progress | converged | failed` with row counts
+- [ ] Extension upgrade path tested (`0.31.0 → 0.32.0`)
 - [ ] `just check-version-sync` passes
 
 ---

--- a/roadmap/v0.35.0.md
+++ b/roadmap/v0.35.0.md
@@ -1,115 +1,92 @@
-# v0.35.0 — Citus: World-Class Distributed Source CDC
+# v0.35.0 — Temporal IVM & Columnar Materialization
 
 > **Full technical details:** [v0.35.0.md-full.md](v0.35.0.md-full.md)
 
-**Status: Planned** | **Scope: Large**
+**Status: Planned** | **Scope: Medium**
 
-> The culmination of pg_trickle's Citus integration. v0.35.0 delivers
-> end-to-end incremental view maintenance over Citus distributed tables —
-> per-worker change capture, distributed stream table storage, cross-node
-> coordination, and a full Citus-specific test suite.
+> Two new analytic workload patterns: time-travel queries over a stream
+> table's full history, and columnar storage for dramatically faster
+> analytics.
 
 ---
 
 ## What is this?
 
-With v0.32.0's naming and frontier foundations in place, v0.35.0 implements
-the full Citus integration. There are three distributed table problems that
-need solving:
-
-1. **Change capture** — triggers don't propagate to Citus workers, so
-   pg_trickle can't use its normal trigger-based CDC for distributed tables.
-2. **Stream table storage** — a distributed stream table can't be updated
-   with a standard `MERGE` statement; Citus imposes restrictions on
-   cross-shard operations.
-3. **Coordination** — PostgreSQL advisory locks and `LISTEN/NOTIFY` are
-   node-local; a cluster needs a different mechanism for cross-node
-   mutual exclusion.
+v0.35.0 opens two new classes of analytic workloads that pg_trickle cannot
+currently serve.
 
 ---
 
-## Change capture on distributed tables
+## Temporal IVM — time-travel queries
 
-For distributed tables (where data lives on Citus worker nodes), pg_trickle
-switches from trigger-based CDC to **WAL-based CDC over per-worker logical
-replication slots**. Each worker gets a publication and a replication slot
-for the source table. The pg_trickle scheduler on the coordinator polls
-each worker's slot, decodes the change stream, and writes the changes into
-the coordinator's local change buffer — exactly the same buffer used by
-trigger-based CDC.
+Normally, a stream table shows the *current* state of the world. Temporal
+mode changes this: the stream table maintains a full history of how every
+row has changed over time. Rows are never physically deleted; instead, each
+row carries a `valid_from` timestamp and an optional `valid_to` timestamp
+that records when a version was replaced.
 
-This reuses the WAL decoder already in `src/wal_decoder.rs`; the only new
-code is a connection path to call `pg_logical_slot_get_changes()` on a
-remote node. Reference tables and local tables continue to use the existing
-trigger path unchanged.
+This enables queries like "what did this table look like at 3 PM on Tuesday?"
+without any external audit log infrastructure. The pattern is known as
+**SCD Type 2** (Slowly Changing Dimension Type 2) in data warehousing, and
+it is used for:
 
----
+- Customer history ("what address was on file when this order shipped?")
+- Regulatory audit trails ("what were the account balances at quarter-end?")
+- Slowly-changing dimension tables in analytics pipelines
 
-## Distributed stream table storage
+Creating a temporal stream table is a single parameter:
 
-When a stream table materializes a view over distributed sources, it can
-store its result in three ways:
+```sql
+SELECT pgtrickle.create_stream_table(
+    'customer_history',
+    query := 'SELECT id, name, address FROM customers',
+    temporal := true
+);
+```
 
-- **Local** (default for small outputs) — a regular coordinator-side table,
-  same as today.
-- **Reference** — a Citus reference table, replicated to every worker.
-  Ideal for dimension tables read by many queries.
-- **Distributed** — a Citus distributed table, sharded by the stream
-  table's row identity. Required for outputs too large to fit on the
-  coordinator.
-
-For distributed stream tables, the standard `MERGE` statement is replaced
-by a `DELETE … WHERE row_id IN (…)` followed by an
-`INSERT … ON CONFLICT DO UPDATE` — the pattern Citus supports everywhere.
-The result is identical; only the internal SQL changes.
+Queries against the stream table with `AS OF TIMESTAMP $1` automatically
+resolve against the historical row versions.
 
 ---
 
-## Cross-node coordination
+## Columnar materialization
 
-Advisory locks that guard refresh scheduling are node-local. v0.35.0
-introduces a lightweight catalog-based lock table
-(`pgtrickle.pgt_st_locks`) that provides cross-node mutual exclusion
-without an external coordinator. The table uses `INSERT … ON CONFLICT DO
-NOTHING` for lock acquisition and timestamp-based lease expiry for
-failure recovery. Advisory locks remain the fast-path for the common
-single-node case.
+Stream tables currently store their results in standard PostgreSQL heap
+storage — optimised for row-by-row reads and writes. Analytic queries that
+scan millions of rows to compute aggregates are better served by *columnar*
+storage, where all values for a single column are stored together on disk.
+This dramatically reduces I/O for aggregate queries (summing a column, for
+example, only reads that column, not the entire row).
+
+The `storage_backend := 'columnar'` parameter to `create_stream_table()`
+tells pg_trickle to store the materialised result in Citus columnar storage
+or pg_mooncake. The differential refresh machinery continues to work —
+pg_trickle automatically routes the MERGE to use the `delete_insert` strategy
+that columnar storage requires, with no manual configuration.
+
+The result: analytic dashboards and reporting queries that consume the
+materialised stream table see dramatically lower I/O, smaller storage
+footprint, and faster aggregate performance.
 
 ---
 
-## Observability
+## Combined use
 
-A new `pgtrickle.citus_status` view surfaces the health of all
-distributed source connections: which workers are reachable, the
-replication lag per worker per source, slot positions, and any workers
-in a failed state. This integrates with the existing Prometheus metrics
-endpoint.
-
----
-
-## Test suite
-
-v0.35.0 ships a dedicated Citus E2E test harness:
-`tests/e2e_citus_tests.rs` backed by a docker-compose environment
-(one coordinator + two workers) and `tests/Dockerfile.e2e-citus`. The
-test matrix covers 10 scenarios including local, reference, and
-distributed sources; mixed CDC backends; outbox integration; DDL
-propagation; and worker restarts.
-
-The non-Citus benchmark suite shows zero regression — all Citus code
-paths are guarded by the detection check introduced in v0.32.0 and
-compile out entirely when Citus is absent.
+Temporal mode and columnar storage can be combined: a slowly-changing
+dimension table stored in columnar format with full history, queryable at
+any point in time. This is listed as a stretch goal and is not a hard
+requirement for the release.
 
 ---
 
 ## Scope
 
-v0.35.0 is a large release. Phase 3 (per-worker slot CDC) is the deepest
-new code; it reuses the WAL decoder infrastructure but adds remote
-connection management. Phase 6 (test suite) requires building and
-maintaining a multi-container Citus CI environment.
+v0.35.0 is a medium-sized release. The temporal IVM work requires extending
+the core frontier model — the internal mechanism that tracks which changes
+have been processed — from a single LSN cursor to a two-dimensional
+`(LSN, timestamp)` pair. A design spike before committing this feature to
+the milestone is recommended.
 
 ---
 
-*Previous: [v0.32.0 — Citus: Stable Naming & Per-Source Frontier Foundation](v0.32.0.md)*
-*Next: [v1.0.0 — Stable Release](v1.0.0.md-full.md)*
+*Previous: [v0.34.0 — Reactive Subscriptions & Zero-Downtime Operations](v0.34.0.md)*

--- a/roadmap/v0.35.0.md-full.md
+++ b/roadmap/v0.35.0.md-full.md
@@ -1,186 +1,93 @@
 > **Plain-language companion:** [v0.35.0.md](v0.35.0.md)
 
-## v0.35.0 — Citus: World-Class Distributed Source CDC
+## v0.35.0 — Temporal IVM & Columnar Materialization
 
-**Status: Planned.** Derived from
-[plans/ecosystem/PLAN_CITUS.md](../plans/ecosystem/PLAN_CITUS.md)
-§6 Phases 3, 4, 5, and 6.
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.2, §10.7.
 
 > **Release Theme**
-> v0.35.0 delivers world-class incremental view maintenance over Citus
-> distributed tables. Building on v0.32.0's stable naming and frontier
-> foundations, this release adds: (P3) per-worker WAL slot polling for
-> distributed-table CDC; (P4) distributed ST storage with a Citus-safe
-> DELETE+UPSERT apply path; (P5) catalog-based cross-node coordination and
-> a `pgtrickle.citus_status` observability view; and (P6) a full Citus
-> E2E test suite (1 coordinator + 2 workers, 10-scenario matrix) with
-> dedicated benchmarks and documentation. The non-Citus code path has a
-> hard regression budget of 0% — every Citus code path short-circuits on
-> the `is_citus_loaded()` check introduced in v0.32.0.
+> v0.35.0 unlocks two analytic workload patterns that the current streaming
+> engine cannot serve. Temporal IVM lets a stream table maintain a rolling
+> history of how its rows have changed over time — providing first-class
+> SCD-Type-2 semantics without external ETL or separate audit tables.
+> Columnar materialization lets a stream table store its result set in
+> Citus columnar storage (or pg_mooncake), dramatically reducing storage
+> footprint and query I/O for analytic consumers that scan the materialised
+> result set but never write to it. Together they close the OLTP→OLAP
+> bridging gap and make pg_trickle viable as the materialization layer for
+> dashboards and reporting queries.
 
 ---
 
-### Phase 3 — Distributed CDC via Per-Worker Slots
+### Correctness
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| CDC-1 | Remote slot consumption via `dblink`-wrapped `pg_logical_slot_get_changes()` | L | P0 |
-| CDC-2 | `setup_cdc_for_source` for distributed sources: per-worker publication + slot creation | M | P0 |
-| CDC-3 | REPLICA IDENTITY FULL enforcement on each worker | S | P0 |
-| CDC-4 | Slot polling: scheduler iterates `pgt_remote_slots`, writes into coordinator change buffer | L | P0 |
-| CDC-5 | TRUNCATE + DDL propagation for distributed sources | M | P1 |
-| CDC-6 | New catalog: `pgtrickle.pgt_remote_slots (pgt_id, worker_id, worker_host, worker_port, slot_name, last_lsn)` | S | P0 |
-| CDC-7 | Libpq streaming fallback path (P3.1 option B) — implement if dblink bench fails threshold | L | P2 |
+| CORR-1 | Temporal IVM: two-dimensional frontier (LSN, timestamp) | L | P0 |
+| CORR-2 | Columnar: verify differential MERGE compatibility with columnar storage | M | P0 |
 
-**CDC-1** — Today `src/wal_decoder.rs` calls
-`pg_logical_slot_get_changes()` via SPI on the local node. Add a sibling
-`poll_remote_slot(conn: &PgConnection, slot_name: &str, …)` that executes
-the same SQL via a `dblink` foreign connection to a worker. Connection
-parameters come from `pgt_remote_slots.worker_host/port`. Connection
-pooling reuses existing `libpq` handles per scheduler tick.
+**CORR-1** — Temporal IVM requires extending the frontier model from a
+one-dimensional LSN cursor to a two-dimensional `(frontier_lsn, valid_from_ts)`
+pair. Each row carries a `__pgt_valid_from TIMESTAMPTZ` and an optional
+`__pgt_valid_to TIMESTAMPTZ`. Rows are never physically deleted; instead a
+"close" delta sets `valid_to`. Queries against the stream table with `AS OF
+TIMESTAMP $1` resolve to the materialised row version valid at that timestamp.
+**Schema change:** Yes — new `temporal_mode BOOLEAN` column on
+`pgtrickle.pgt_stream_tables`; new `__pgt_valid_from`/`__pgt_valid_to`
+columns auto-added to the storage table when `temporal_mode = true`.
 
-**CDC-2** — When `is_citus_loaded()` and `placement(oid) == Distributed`:
-1. Issue `run_command_on_all_nodes("CREATE PUBLICATION pgtrickle_{stable_name} FOR TABLE {table} WITH (publish_via_partition_root = true)")`
-2. Issue `run_command_on_all_nodes("SELECT pg_create_logical_replication_slot('pgtrickle_{stable_name}', 'pgoutput')")`
-3. Insert one row per worker into `pgtrickle.pgt_remote_slots`.
-
-**CDC-4** — Scheduler tick: for each source with remote slots, call
-`poll_remote_slot()` for each worker row in `pgt_remote_slots`. Decoded
-rows written to coordinator's `changes_{stable_name}` buffer with two new
-columns: `origin_node SMALLINT`, `origin_lsn PG_LSN`. Compaction uses
-`(origin_node, origin_lsn)` as the watermark.
+**CORR-2** — Citus columnar and pg_mooncake use append-only storage models.
+Verify that the differential MERGE (`MERGE INTO storage USING delta`) is
+compatible with append-only semantics (likely requires `DELETE + INSERT`
+merge strategy for columnar targets). Add a `storage_backend` column to
+`pgtrickle.pgt_stream_tables` and route merge codegen accordingly.
 
 ---
 
-### Phase 4 — Distributed ST Storage & Apply Path
+### Ease of Use
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| APPLY-1 | `create_stream_table(…, placement => 'local' | 'reference' | 'distributed')` | M | P0 |
-| APPLY-2 | Auto-select placement from declared source placements + row-count heuristic | S | P1 |
-| APPLY-3 | DELETE + `INSERT … ON CONFLICT DO UPDATE` codegen template for distributed STs | M | P0 |
-| APPLY-4 | Delta materialisation to TEMP table for reference STs with non-pushable plans | S | P1 |
-| APPLY-5 | `__pgt_row_id` as distribution column when creating distributed ST | S | P0 |
-| APPLY-6 | `reltuples` fix: sum `pg_dist_shard` row counts for distributed tables in DAG planner | S | P1 |
-| APPLY-7 | GUC: `pg_trickle.citus_reference_st_max_rows` (default 1_000_000) | S | P1 |
-
-**APPLY-3** — Codegen in `src/refresh/codegen.rs` gets a second template
-selected by `st_placement = 'distributed'`:
-```sql
-WITH delta AS (...)
-DELETE FROM {st} st
- USING delta d
- WHERE d.__pgt_action = 'D'
-   AND st.__pgt_row_id = d.__pgt_row_id;
-
-WITH delta AS (...)
-INSERT INTO {st} (__pgt_row_id, ...)
-SELECT __pgt_row_id, ... FROM delta WHERE __pgt_action != 'D'
-ON CONFLICT (__pgt_row_id) DO UPDATE SET ...;
-```
-
-**APPLY-5** — At `create_distributed_table({st}, '__pgt_row_id')` time,
-validate that `__pgt_row_id` is not repurposed as a user column (rare;
-emit a hard error if so).
+| UX-1 | `create_stream_table(…, temporal := true)` parameter | M | P0 |
+| UX-2 | `AS OF TIMESTAMP` query rewrite in DVM parser | L | P1 |
+| UX-3 | `create_stream_table(…, storage_backend := 'columnar')` parameter | M | P1 |
+| UX-4 | Automatic `delete_insert` strategy for columnar backends | S | P1 |
+| UX-5 | Documentation: temporal IVM tutorial + SCD-Type-2 worked example | M | P1 |
+| UX-6 | Documentation: columnar backend setup guide (Citus + pg_mooncake) | S | P1 |
 
 ---
 
-### Phase 5 — Coordination & Operability
+### Test Coverage
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| COORD-1 | Catalog lock table: `pgtrickle.pgt_st_locks` | S | P0 |
-| COORD-2 | Replace advisory lock acquisition in scheduler with catalog-based locks for distributed STs | M | P0 |
-| COORD-3 | `pgtrickle.citus_status` view: worker reachability, slot lag, placement summary | M | P0 |
-| COORD-4 | Failure mode: pause refresh on unreachable worker; surface via monitor + Prometheus | M | P1 |
-| COORD-5 | Failure mode: WAL recycled past slot — fall back to FULL refresh, emit `WARNING` | S | P1 |
-| COORD-6 | Failure mode: slot missing on worker after node add — re-create on next tick | S | P1 |
-| COORD-7 | Pre-flight check: refuse to start if `pg_trickle` version mismatches across workers | S | P0 |
-| COORD-8 | Pre-flight check: enforce `wal_level = logical` on each worker at slot-create time | S | P0 |
-
-**COORD-1** — `pgtrickle.pgt_st_locks`:
-```sql
-CREATE TABLE pgtrickle.pgt_st_locks (
-  pgt_id     BIGINT PRIMARY KEY,
-  locked_by  INT    NOT NULL,   -- PID
-  locked_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-  lease_until TIMESTAMPTZ NOT NULL
-);
-```
-`INSERT … ON CONFLICT DO NOTHING` acquires; `DELETE` releases; a
-background task reaps expired leases. Advisory locks remain the fast
-in-process path; catalog locks are used only when `is_citus_loaded()`.
-
-**COORD-3** — `pgtrickle.citus_status` columns:
-`pgt_id, source_table, worker_host, worker_port, slot_name, slot_lag_bytes, last_polled_at, status ('ok' | 'lagging' | 'unreachable' | 'slot_missing')`.
-
----
-
-### Phase 6 — Validation, Benchmarks, Migration, Docs
-
-| ID | Title | Effort | Priority |
-|----|-------|--------|----------|
-| TEST-1 | `tests/Dockerfile.e2e-citus`: Citus 13.x image with pg_trickle extension | M | P0 |
-| TEST-2 | docker-compose: 1 coordinator + 2 workers for Citus E2E tests | S | P0 |
-| TEST-3 | `tests/e2e_citus_tests.rs`: 10-scenario test matrix (see below) | L | P0 |
-| BENCH-1 | `benches/bench_remote_slot_poll`: dblink vs local SPI throughput | M | P1 |
-| BENCH-2 | `benches/bench_distributed_apply`: DELETE+UPSERT vs MERGE on 100M-row distributed ST | M | P1 |
-| MIG-1 | SQL migration: `pgt_remote_slots` catalog creation + new `origin_node`/`origin_lsn` buffer columns | S | P0 |
-| DOCS-1 | `docs/integrations/citus.md`: prerequisites, install guide, placement options, failure modes | M | P0 |
-| DOCS-2 | Update `docs/ARCHITECTURE.md` with multi-node Citus diagram | S | P1 |
-| DOCS-3 | Update `INSTALL.md` with "installing on a Citus cluster" section | S | P1 |
-
-**TEST-3 — 10-scenario matrix:**
-
-| # | Source(s) | ST placement | Exercises |
-|---|-----------|--------------|-----------|
-| 1 | Local table | local | Regression — trigger CDC unchanged |
-| 2 | Reference table | local | Coordinator trigger CDC |
-| 3 | Distributed table | reference | Per-worker slots, MERGE, replication of ST |
-| 4 | Distributed table | distributed | Per-worker slots, DELETE + UPSERT |
-| 5 | Mixed (ref + dist) | local | Mixed CDC backends, per-source frontier |
-| 6 | Distributed → outbox | distributed | Downstream publication + relay from distributed ST |
-| 7 | ALTER TABLE on dist source | distributed | DDL propagation, slot rebuild |
-| 8 | Worker restart | distributed | Slot survives, refresh resumes |
-| 9 | TRUNCATE on dist source | any | Full-refresh fallback |
-| 10 | Concurrent DML + refresh | distributed | Apply correctness under load |
-
----
-
-### Performance Budget
-
-| Metric | Target |
-|--------|--------|
-| Non-Citus code path regression | 0% (hard gate) |
-| `create_stream_table()` overhead when Citus absent | ≤ 1 µs |
-| Refresh latency regression on single-node suite | ≤ 2% |
-| `bench_remote_slot_poll` (dblink) throughput | ≥ 50 k rows/s on loopback; if < 10 k rows/s trigger CDC-7 (libpq streaming) |
+| TEST-1 | Integration: temporal stream table `AS OF TIMESTAMP` round-trip | L | P0 |
+| TEST-2 | Integration: SCD-Type-2 dimension pattern end-to-end | M | P1 |
+| TEST-3 | Integration: columnar stream table MERGE parity with heap | M | P0 |
+| TEST-4 | Integration: temporal + columnar combined (temporal columnar ST) | M | P2 |
 
 ---
 
 ### Conflicts & Risks
 
-- **dblink latency** (CDC-1): bench result gates whether CDC-7 (libpq streaming) becomes P0. Add the bench early in the release to avoid a late scope change.
-- **Citus MERGE rejection** (APPLY-3): DELETE+UPSERT is the primary path; MERGE is only used for reference STs and is already known to work.
-- **Slot fills WAL on worker if coordinator stops** (COORD-4/5): document monitoring requirement; expose `slot_lag_bytes` in `citus_status`; auto-drop slot after configurable lease expiry (`pg_trickle.citus_slot_max_lag_bytes`, default 1 GB).
-- **Schema/role differences on workers** (COORD-8): `run_command_on_all_nodes("CREATE SCHEMA IF NOT EXISTS pgtrickle_changes")` + role grants at setup time.
-- **Shard rebalance invalidates slots**: out of scope for this release; emit a hard error in slot-poll path if `pg_dist_node` topology hash changes between polls.
-
----
+- **CORR-1** requires a non-trivial DVM engine extension (two-dimensional
+  frontier). Spike before committing to the milestone; do not commit until
+  the spike proves the approach is sound.
+- **CORR-2** depends on the Citus columnar or pg_mooncake extension being
+  present; CI must add a Testcontainers image with one of these available.
+  Gate columnar support behind `pg_trickle.columnar_backend` GUC (default
+  `none`); the CI matrix should test at least one columnar provider.
+- The combination of temporal mode and columnar storage is a P2 stretch
+  goal; do not block the release on it.
 
 ### Exit Criteria
 
-- [ ] CDC-1: `poll_remote_slot()` decodes INSERT/UPDATE/DELETE/TRUNCATE from a worker via dblink
-- [ ] CDC-2: `setup_cdc_for_source` on a distributed table creates publication + slot on every worker and populates `pgt_remote_slots`
-- [ ] CDC-4: Scheduler polls all workers for a distributed source and writes correct decoded rows into coordinator change buffer
-- [ ] APPLY-1/APPLY-3: `create_stream_table(…, placement => 'distributed')` works end-to-end; DELETE+UPSERT apply path produces identical results to single-node MERGE
-- [ ] COORD-3: `SELECT * FROM pgtrickle.citus_status` returns one row per (source, worker) with accurate lag
-- [ ] TEST-3: All 10 E2E scenarios pass against a live 1+2 Citus cluster
-- [ ] BENCH-1: `bench_remote_slot_poll` throughput ≥ 50 k rows/s (dblink loopback); report logged in `docs/BENCHMARK.md`
-- [ ] Non-Citus benchmark suite shows 0% regression
-- [ ] DOCS-1: `docs/integrations/citus.md` covers prerequisites, setup, placement options, monitoring, failure modes, and known limitations
-- [ ] Migration path `v0.32.0 → v0.35.0` tested with `just test-upgrade-all`
+- [ ] CORR-1/UX-1: `create_stream_table(…, temporal := true)` creates storage table with `__pgt_valid_from`/`__pgt_valid_to`; rows never physically deleted
+- [ ] UX-2: `AS OF TIMESTAMP $1` query rewrites resolve against the materialised history
+- [ ] TEST-1: Temporal round-trip test passes: insert → update → delete, query at t₀/t₁/t₂ returns correct historical rows
+- [ ] TEST-2: SCD-Type-2 dimension pattern: slowly-changing customer table materialised with full history, current-version query using `WHERE valid_to IS NULL`
+- [ ] CORR-2/UX-3: Columnar stream table creates; `delete_insert` strategy used automatically; columnar MERGE E2E parity test passes
+- [ ] Extension upgrade path tested (`0.32.0 → 0.33.0`)
 - [ ] `just check-version-sync` passes
-- [ ] `just lint` passes (zero warnings)
 
 ---
+


### PR DESCRIPTION
## Summary

Reshuffles the planned v0.33–v0.35 release sequence so the full Citus
integration ships immediately after its naming foundation, two releases
earlier than originally planned.

**Before:**
- v0.32.0 — Citus: stable naming + frontier (P1 + P2)
- v0.33.0 — Reactive subscriptions & zero-downtime ops
- v0.34.0 — Temporal IVM & columnar materialization
- v0.35.0 — Citus: distributed source CDC + distributed ST (P3–P6)

**After:**
- v0.32.0 — Citus: stable naming + frontier (P1 + P2) — unchanged
- v0.33.0 — Citus: distributed source CDC + distributed ST (P3–P6)
- v0.34.0 — Reactive subscriptions & zero-downtime ops
- v0.35.0 — Temporal IVM & columnar materialization

Motivated by discussion [#619](https://github.com/grove/pg-trickle/discussions/619):
users with all-distributed Citus topologies and billion-row stream table
chains are blocked until the full CDC integration lands. v0.33.0 and v0.34.0
are orthogonal to Citus and have no technical dependency on it — pulling
Citus CDC forward costs nothing and unblocks those deployments two releases
sooner.

## Changes

- `ROADMAP.md` — reorder the v0.33–v0.35 table entries; update the
  ASCII dependency diagram and the rationale paragraph.
- `roadmap/v0.33.0.md` + `v0.33.0.md-full.md` — now contains the Citus
  CDC content (was v0.35.0); all version numbers and cross-links updated;
  adds `*Next: v0.34.0*` footer link.
- `roadmap/v0.34.0.md` + `v0.34.0.md-full.md` — now contains reactive
  subscriptions content (was v0.33.0); version numbers and footer links
  updated.
- `roadmap/v0.35.0.md` + `v0.35.0.md-full.md` — now contains temporal
  IVM content (was v0.34.0); version numbers and footer links updated;
  removes stale "design spike in v0.33.0" prerequisite note (that
  reference pointed at push notifications after the reshuffle, which has
  no relation to temporal IVM) — replaced with a generic spike
  recommendation.

## Testing

Roadmap documentation only — no code changed.

## Notes

- This PR does not change any implementation plans, only the delivery
  order. The full Citus spec (`plans/ecosystem/PLAN_CITUS.md`) is
  unchanged.
- v0.34.0 (push notifications) and v0.35.0 (temporal IVM) retain their
  full scope; they ship in the same order relative to each other, just
  one slot later.
