### PR TITLE
fix(security): suppress semgrep SECURITY DEFINER alerts in 0.33.1 archive SQL

### DIFF
--- a/sql/archive/pg_trickle--0.33.1.sql
+++ b/sql/archive/pg_trickle--0.33.1.sql
@@ -532,7 +532,7 @@ COMMENT ON TABLE pgtrickle.relay_consumer_offsets IS
 CREATE OR REPLACE FUNCTION pgtrickle.relay_config_notify()
 RETURNS TRIGGER
 LANGUAGE plpgsql
-SECURITY DEFINER
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
 AS $$
 BEGIN
     PERFORM pg_notify(
@@ -568,7 +568,7 @@ CREATE OR REPLACE FUNCTION pgtrickle.set_relay_outbox(
     p_enabled         BOOLEAN DEFAULT true
 ) RETURNS void
 LANGUAGE plpgsql
-SECURITY DEFINER
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
 AS $$
 DECLARE
     v_sink_type TEXT;
@@ -607,7 +607,7 @@ CREATE OR REPLACE FUNCTION pgtrickle.set_relay_inbox(
     p_enabled          BOOLEAN DEFAULT true
 ) RETURNS void
 LANGUAGE plpgsql
-SECURITY DEFINER
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
 AS $$
 DECLARE
     v_source_type TEXT;
@@ -638,7 +638,8 @@ $$;
 
 -- RELAY-CAT (v0.29.0): enable_relay — enable a named pipeline.
 CREATE OR REPLACE FUNCTION pgtrickle.enable_relay(p_name TEXT) RETURNS void
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+AS $$
 DECLARE v_o INT; v_i INT;
 BEGIN
     UPDATE pgtrickle.relay_outbox_config SET enabled = true WHERE name = p_name;
@@ -653,7 +654,8 @@ $$;
 
 -- RELAY-CAT (v0.29.0): disable_relay — disable a named pipeline.
 CREATE OR REPLACE FUNCTION pgtrickle.disable_relay(p_name TEXT) RETURNS void
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+AS $$
 DECLARE v_o INT; v_i INT;
 BEGIN
     UPDATE pgtrickle.relay_outbox_config SET enabled = false WHERE name = p_name;
@@ -668,7 +670,8 @@ $$;
 
 -- RELAY-CAT (v0.29.0): delete_relay — delete a named pipeline.
 CREATE OR REPLACE FUNCTION pgtrickle.delete_relay(p_name TEXT) RETURNS void
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+AS $$
 DECLARE v_o INT; v_i INT;
 BEGIN
     DELETE FROM pgtrickle.relay_outbox_config WHERE name = p_name;
@@ -684,7 +687,8 @@ $$;
 -- RELAY-CAT (v0.29.0): get_relay_config — fetch config for a single pipeline.
 CREATE OR REPLACE FUNCTION pgtrickle.get_relay_config(p_name TEXT)
 RETURNS TABLE (name TEXT, direction TEXT, enabled BOOLEAN, config JSONB)
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+AS $$
 BEGIN
     RETURN QUERY
         SELECT r.name, 'forward'::TEXT, r.enabled, r.config
@@ -701,7 +705,8 @@ $$;
 -- RELAY-CAT (v0.29.0): list_relay_configs — list all pipelines.
 CREATE OR REPLACE FUNCTION pgtrickle.list_relay_configs()
 RETURNS TABLE (name TEXT, direction TEXT, enabled BOOLEAN, config JSONB)
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+AS $$
 BEGIN
     RETURN QUERY
         SELECT r.name, 'forward'::TEXT, r.enabled, r.config


### PR DESCRIPTION
## Summary

Adds `-- nosemgrep: sql.security-definer.present` suppressions to all 8
`SECURITY DEFINER` function declarations in `sql/archive/pg_trickle--0.33.1.sql`,
resolving the remaining open semgrep code-scanning alerts (#680–#687) from
the now-merged PR #654.

The suppressions match the identical pattern already used in
`sql/archive/pg_trickle--0.33.0.sql` (alerts #667–#674, resolved in PR #654).

## Changes

- `sql/archive/pg_trickle--0.33.1.sql`: Added `-- nosemgrep: sql.security-definer.present`
  to the 8 relay catalog helper functions that use `SECURITY DEFINER`:
  `relay_config_notify`, `set_relay_outbox`, `set_relay_inbox`, `enable_relay`,
  `disable_relay`, `delete_relay`, `get_relay_config`, `list_relay_configs`.

## Why These Are Safe

All eight functions operate exclusively on fully-qualified `pgtrickle`-schema
objects (e.g. `pgtrickle.relay_outbox_config`). Because every reference is
schema-qualified, the `search_path` privilege-escalation risk that semgrep
flags does not apply — an unprivileged user cannot shadow these objects by
pre-creating identically-named objects in a schema earlier on the path.

## Testing

- Semgrep suppression comments are identical to those already accepted and
  passing in `pg_trickle--0.33.0.sql`.
- No functional code changes; no test suite run required.

## Notes

This is a follow-up to PR #654 (v0.33.0 + v0.33.1 Citus release), which was
merged between the semgrep-fix commit being authored and being pushed.
