### PR TITLE
fix(release): bump META.json to v0.34.0 and add PGXN version-gate

### DIFF
--- a/.github/workflows/pgxn.yml
+++ b/.github/workflows/pgxn.yml
@@ -3,6 +3,7 @@ name: PGXN Publish
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
 
 jobs:
   pgxn:
@@ -19,6 +20,21 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.11'
+
+      - name: Validate META.json version matches tag
+        run: |
+          if [[ "${GITHUB_REF:-}" == refs/tags/v* ]]; then
+            TAG_VERSION="${GITHUB_REF_NAME#v}"
+            META_VERSION=$(jq -r '.version' META.json)
+            if [ "$META_VERSION" != "$TAG_VERSION" ]; then
+              echo "::error::META.json version ($META_VERSION) does not match git tag ($TAG_VERSION)."
+              echo "Run: jq --arg v '$TAG_VERSION' '.version=\$v | .provides[].version=\$v' META.json > META.json.tmp && mv META.json.tmp META.json"
+              exit 1
+            fi
+            echo "Version check passed: META.json=$META_VERSION matches tag=v$TAG_VERSION"
+          else
+            echo "Not a version tag push — skipping tag/META.json version check."
+          fi
 
       - name: Package and upload to PGXN
         run: just pgxn-publish

--- a/META.json
+++ b/META.json
@@ -1,12 +1,12 @@
 {
   "name": "pg_trickle",
-  "abstract": "pg_trickle turns PostgreSQL 18 into a real-time data platform. Define stream tables on top of any base table and let the extension maintain materialized views incrementally \u2014 keeping only the delta in flight rather than recomputing the full result set. Built on a trigger-based CDC pipeline and a differential dataflow engine written in Rust, pg_trickle delivers sub-millisecond propagation latency with no external dependencies, no message broker, and no ETL pipeline. Your views stay fresh, your queries stay fast, and your data never leaves the database.",
+  "abstract": "pg_trickle turns PostgreSQL 18 into a real-time data platform. Define stream tables on top of any base table and let the extension maintain materialized views incrementally — keeping only the delta in flight rather than recomputing the full result set. Built on a trigger-based CDC pipeline and a differential dataflow engine written in Rust, pg_trickle delivers sub-millisecond propagation latency with no external dependencies, no message broker, and no ETL pipeline. Your views stay fresh, your queries stay fast, and your data never leaves the database.",
   "version": "0.34.0",
   "maintainer": "pg_trickle contributors",
   "license": "apache_2_0",
   "provides": {
     "pg_trickle": {
-      "abstract": "Streaming tables with differential (incremental) view maintenance for PostgreSQL 18. Captures row-level changes via after-row triggers, propagates only the delta through a dependency DAG, and applies differential updates to downstream materialized views \u2014 all inside a single transaction, with zero external dependencies.",
+      "abstract": "Streaming tables with differential (incremental) view maintenance for PostgreSQL 18. Captures row-level changes via after-row triggers, propagates only the delta through a dependency DAG, and applies differential updates to downstream materialized views — all inside a single transaction, with zero external dependencies.",
       "file": "pg_trickle.control",
       "docfile": "doc/pg_trickle.md",
       "version": "0.34.0"

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
   "name": "pg_trickle",
   "abstract": "pg_trickle turns PostgreSQL 18 into a real-time data platform. Define stream tables on top of any base table and let the extension maintain materialized views incrementally \u2014 keeping only the delta in flight rather than recomputing the full result set. Built on a trigger-based CDC pipeline and a differential dataflow engine written in Rust, pg_trickle delivers sub-millisecond propagation latency with no external dependencies, no message broker, and no ETL pipeline. Your views stay fresh, your queries stay fast, and your data never leaves the database.",
-  "version": "0.31.0",
+  "version": "0.34.0",
   "maintainer": "pg_trickle contributors",
   "license": "apache_2_0",
   "provides": {
@@ -9,7 +9,7 @@
       "abstract": "Streaming tables with differential (incremental) view maintenance for PostgreSQL 18. Captures row-level changes via after-row triggers, propagates only the delta through a dependency DAG, and applies differential updates to downstream materialized views \u2014 all inside a single transaction, with zero external dependencies.",
       "file": "pg_trickle.control",
       "docfile": "doc/pg_trickle.md",
-      "version": "0.31.0"
+      "version": "0.34.0"
     }
   },
   "prereqs": {

--- a/justfile
+++ b/justfile
@@ -529,6 +529,36 @@ package:
 
 # ── Release ───────────────────────────────────────────────────────────────
 
+# Bump the version in Cargo.toml and META.json atomically, then print next steps.
+# Usage: just bump-version 0.35.0
+[group: "release"]
+bump-version VERSION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    NEW="{{ VERSION }}"
+    # Validate semver shape
+    if ! echo "$NEW" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+        echo "Error: version must be x.y.z (got '$NEW')"
+        exit 1
+    fi
+    OLD=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+    echo "Bumping $OLD → $NEW"
+    # Cargo.toml — only the first [package] version line (awk for macOS/Linux compat)
+    awk -v new_ver="$NEW" 'done!="yes" && /^version = "/ {sub(/"[0-9]+\.[0-9]+\.[0-9]+"/, "\"" new_ver "\""); done="yes"} 1' Cargo.toml > Cargo.toml.tmp && mv Cargo.toml.tmp Cargo.toml
+    # META.json — both version fields
+    jq --arg v "$NEW" '.version = $v | .provides["pg_trickle"].version = $v' META.json > META.json.tmp && mv META.json.tmp META.json
+    echo ""
+    echo "Done. Files updated:"
+    echo "  Cargo.toml  $(grep '^version' Cargo.toml | head -1)"
+    echo "  META.json   $(jq -r '.version' META.json)"
+    echo ""
+    echo "Next steps:"
+    echo "  1. cargo check --features pg18   # Cargo.lock refresh"
+    echo "  2. just check-meta-version       # sanity check"
+    echo "  3. git add Cargo.toml Cargo.lock META.json"
+    echo "  4. git commit -m \"chore: bump version to $NEW\""
+    echo "  5. git tag v$NEW && git push origin v$NEW"
+
 # Verify META.json version matches Cargo.toml (run before tagging a release)
 [group: "release"]
 check-meta-version:

--- a/justfile
+++ b/justfile
@@ -529,6 +529,28 @@ package:
 
 # ── Release ───────────────────────────────────────────────────────────────
 
+# Verify META.json version matches Cargo.toml (run before tagging a release)
+[group: "release"]
+check-meta-version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    CARGO_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+    META_VERSION=$(jq -r '.version' META.json)
+    META_PROVIDES=$(jq -r '.provides["pg_trickle"].version' META.json)
+    FAILED=0
+    if [ "$META_VERSION" != "$CARGO_VERSION" ]; then
+        echo "Error: META.json .version ($META_VERSION) != Cargo.toml ($CARGO_VERSION)"
+        FAILED=1
+    fi
+    if [ "$META_PROVIDES" != "$CARGO_VERSION" ]; then
+        echo "Error: META.json .provides.pg_trickle.version ($META_PROVIDES) != Cargo.toml ($CARGO_VERSION)"
+        FAILED=1
+    fi
+    if [ "$FAILED" -eq 0 ]; then
+        echo "META.json version check passed: $META_VERSION"
+    fi
+    exit $FAILED
+
 # Package the extension into a zip archive and upload it to PGXN
 [group: "release"]
 pgxn-publish:


### PR DESCRIPTION
## Summary

`META.json` was stuck at `0.31.0` while the codebase advanced to `0.34.0`.
Every PGXN publish run for v0.32.0–v0.34.0 silently no-op'd: the workflow
read the old version from `META.json`, tried to upload it, received HTTP 409
("already exists"), and exited 0 — appearing as a green "success" in CI while
publishing nothing new.

This PR fixes the immediate version mismatch and adds two safeguards to ensure
it can never go unnoticed again.

## Changes

- **`META.json`** — bump `.version` and `.provides.pg_trickle.version` from
  `0.31.0` → `0.34.0`
- **`.github/workflows/pgxn.yml`** — add a `Validate META.json version matches
  tag` step that compares `GITHUB_REF_NAME` (the pushed tag) against
  `META.json .version` and **fails loudly** if they diverge; add
  `workflow_dispatch` trigger so the workflow can be re-run without pushing a
  new tag (useful for recovery situations like this one)
- **`justfile`** — add `check-meta-version` recipe (group: release) that
  validates both `META.json .version` and `.provides.pg_trickle.version` match
  `Cargo.toml`; run locally before tagging a release

## How to avoid this in future

1. **CI gate**: the new `Validate META.json version matches tag` step in
   `pgxn.yml` will now fail the PGXN workflow with a clear error message if
   the version is not bumped, so no silent no-ops are possible.
2. **Local pre-tag check**: `just check-meta-version` can be added to any
   release checklist / runbook to catch the mismatch before pushing the tag.

## Testing

- `just check-meta-version` — passes (`META.json version check passed: 0.34.0`)
- `just fmt && just lint` — passes (no code changes)
- Manual inspection of `META.json` confirms both version fields are `0.34.0`

## Notes

After merge, trigger the PGXN workflow manually via `workflow_dispatch` to
publish v0.34.0 (since the tag was already pushed and the tag-triggered run
already no-op'd):

```bash
gh workflow run pgxn.yml --ref main
```
