### PR TITLE
docs(plans): add v7 overall project assessment for v0.34.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,8 +80,9 @@
 | [v0.32.0](roadmap/v0.32.0.md) | Citus: stable object naming and per-source frontier foundation | ✅ Released | Medium | [Full details](roadmap/v0.32.0.md-full.md) |
 | [v0.33.0](roadmap/v0.33.0.md) | Citus: world-class distributed source CDC and stream table support | ✅ Released | Large | [Full details](roadmap/v0.33.0.md-full.md) |
 | [v0.34.0](roadmap/v0.34.0.md) | Citus: automated distributed CDC scheduler wiring and shard rebalance auto-recovery | ✅ Released | Medium | [Full details](roadmap/v0.34.0.md-full.md) |
-| [v0.35.0](roadmap/v0.35.0.md) | Live push notifications and safe live schema changes | Planned | Medium | [Full details](roadmap/v0.35.0.md-full.md) |
-| [v0.36.0](roadmap/v0.36.0.md) | Time-travel queries and analytic storage | Planned | Medium | [Full details](roadmap/v0.36.0.md-full.md) |
+| [v0.35.0](roadmap/v0.35.0.md) | EC-01 correctness closeout, Citus chaos hardening, reactive subscriptions, zero-downtime schema changes | Planned | Large | [Full details](roadmap/v0.35.0.md-full.md) |
+| [v0.36.0](roadmap/v0.36.0.md) | Structural hardening, L0 cache, WAL backpressure, temporal IVM, columnar storage | Planned | Large | [Full details](roadmap/v0.36.0.md-full.md) |
+| [v0.37.0](roadmap/v0.37.0.md) | Scheduler modularisation, pgVectorMV, OpenTelemetry trace propagation | Planned | Medium | [Full details](roadmap/v0.37.0.md-full.md) |
 
 ### Beyond v1.0
 
@@ -122,7 +123,11 @@ v0.32    ─── Citus: stable naming foundation (additive, safe for all users
     │
 v0.33    ─── Citus: distributed CDC and stream table support
     │
-v0.34–35 ─── Push notifications, zero-downtime schema changes, time-travel
+v0.35    ─── EC-01 fix, Citus chaos rig, reactive subscriptions, shadow-ST, relay hardening
+    │
+v0.36    ─── L0 cache, WAL backpressure, api split, temporal IVM, columnar, RowIdSchema
+    │
+v0.37    ─── Scheduler split, pgVectorMV, OpenTelemetry, pg_partman compat
     │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries
 ```
@@ -137,5 +142,12 @@ delivers the full Citus integration immediately after — per-worker slot CDC,
 distributed ST placement, cross-node coordination, and the Citus test suite.
 Pulling v0.33.0 forward means users with Citus topologies (including
 billion-row all-distributed deployments) are unblocked two releases earlier.
-v0.34.0 and v0.35.0 add push notifications and time-travel/columnar storage;
-both are independent of the Citus work and ship in their own right.
+v0.35.0 is the single most important release before v1.0: it closes the EC-01
+phantom-row correctness bug (flagged in three consecutive overall assessments)
+and adds the Citus chaos test rig, on top of reactive subscriptions and
+zero-downtime schema changes. v0.36.0 builds on that foundation with
+performance hardening (L0 cache, WAL backpressure), structural refactoring
+(`src/api/mod.rs` split, `RowIdSchema` type), and temporal IVM / columnar
+storage. v0.37.0 completes the modularisation arc (scheduler and merge splits),
+adds pgVectorMV for AI/RAG workloads, and threads OpenTelemetry traces through
+the refresh pipeline.

--- a/plans/PLAN_OVERALL_ASSESSMENT_7.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT_7.md
@@ -1,0 +1,1340 @@
+# pg_trickle — Overall Project Assessment v7
+
+> **Status:** Draft (review-ready)
+> **Type:** Audit / project-wide gap analysis
+> **Last updated:** 2026-04-27
+> **Scope:** Codebase as of v0.34.0 (Citus distributed-source CDC scheduler
+> automation just shipped; CHANGELOG head documents v0.34.0; `Cargo.toml`
+> reads `version = "0.34.0"`).
+> **Target audience:** Maintainers, release managers, senior contributors
+> planning v0.35.0 → v1.0.0.
+> **Sibling documents:**
+> - [PLAN_OVERALL_ASSESSMENT.md](PLAN_OVERALL_ASSESSMENT.md) — v0.20.0 baseline
+> - [PLAN_OVERALL_ASSESSMENT_2.md](PLAN_OVERALL_ASSESSMENT_2.md) — v0.23.0 follow-up
+> - [PLAN_OVERALL_ASSESSMENT_3.md](PLAN_OVERALL_ASSESSMENT_3.md) — v0.27.0 follow-up
+> - [ROADMAP.md](../ROADMAP.md), [PLAN.md](PLAN.md), [AGENTS.md](../AGENTS.md)
+
+---
+
+## Executive Summary
+
+Between v0.27.0 (April 2026) and v0.34.0 the project absorbed **seven minor
+releases** of substantial new surface area: a transactional outbox + inbox
+([src/api/outbox.rs](../src/api/outbox.rs), [src/api/inbox.rs](../src/api/inbox.rs)),
+the `pgtrickle-relay` CLI, a pre-1.0 correctness gate (v0.30.0), scheduler
+intelligence work (v0.31.0), and the three-release Citus arc (v0.32–v0.34)
+that ships per-worker WAL slot CDC, distributed stream-table output, the
+`pgt_st_locks` distributed mutex, and a fully-automated scheduler
+([src/citus.rs](../src/citus.rs) is now 1,174 LOC of additive code that does
+not perturb single-node behaviour). Several of the critical findings from
+the v0.27.0 assessment have been **closed in production**: snapshot/restore
+is now wrapped in a sub-transaction RAII helper
+([src/api/snapshot.rs:27-87](../src/api/snapshot.rs)); a SQLSTATE-based
+locale-safe error classifier was added in v0.30.0
+([src/error.rs:312-380](../src/error.rs)); the L1 catalog snapshot cache
+landed in v0.31.0 ([src/scheduler.rs:59-118](../src/scheduler.rs)); and the
+DAG is now rebuilt copy-on-write outside the watermark lock
+([src/scheduler.rs:134-144](../src/scheduler.rs)). The architectural worry
+that dominated the v0.20 and v0.23 assessments — monolithic
+`refresh.rs`/`scheduler.rs` and a single mega-lock — is, structurally, gone.
+
+The **top-five risks remaining** at v0.34.0 are sharper but narrower:
+
+1. **EC-01 phantom-row residue is *still* in production.**
+   [src/dvm/operators/join.rs:657-668](../src/dvm/operators/join.rs) still
+   sets `is_deduplicated: false`; PH-D1 cross-cycle cleanup
+   ([src/refresh/phd1.rs](../src/refresh/phd1.rs)) is opt-in and not
+   invoked unconditionally. Repo memory
+   (`/memories/repo/join-delta-phantom-rows.md`) confirms test flakes
+   continue. Three assessments in a row have flagged this; it is the single
+   biggest risk to a credible v1.0.
+
+2. **Locale-text classifier still exists alongside SQLSTATE classifier.**
+   `classify_spi_error_retryable` ([src/error.rs:282-340](../src/error.rs))
+   is the legacy English-text path; the new SQLSTATE-aware
+   `classify_spi_sqlstate_retryable` ([src/error.rs:312-380](../src/error.rs))
+   is only reached when the new `SpiErrorCode` variant is constructed,
+   which (per static search) **no call site does yet**. The bug is one
+   layer down: the right code exists, but the wiring is incomplete.
+
+3. **Citus distributed coordination has effectively zero hardening tests.**
+   [src/citus.rs](../src/citus.rs) introduces `pgt_st_locks` (distributed
+   advisory mutex via `INSERT … ON CONFLICT DO NOTHING`),
+   `ensure_worker_slot`, `poll_worker_slot_changes`, and rebalance
+   auto-recovery — none of which has a chaos test for worker death,
+   coordinator failover, partial rebalance, lease-expiry under clock skew,
+   or split-brain. The CNPG smoke test does not run in a Citus topology.
+
+4. **Inbox/outbox lack unit-level coverage.** Both
+   [src/api/inbox.rs](../src/api/inbox.rs) and
+   [src/api/outbox.rs](../src/api/outbox.rs) have **no `#[cfg(test)]
+   mod tests` block**. Coverage is only via `tests/e2e_inbox_tests.rs` and
+   `tests/e2e_outbox_tests.rs`, which means dedup-key collisions, envelope
+   replay, NULL handling, and offset durability are untested at the unit
+   level. For an "at-least-once with dedup" guarantee this is too thin.
+
+5. **Operational ergonomics gap: 111 GUCs with no top-level catalogue.**
+   `src/config.rs` defines 111 `GucRegistry::define_*_guc` calls (`grep -c`
+   on [src/config.rs](../src/config.rs)). [docs/CONFIGURATION.md](../docs/CONFIGURATION.md)
+   does not enumerate all of them; new operators cannot tune without
+   reading source. Several GUCs (e.g. `pg_trickle.parallel_refresh_mode`,
+   `pg_trickle.matview_polling`, `pg_trickle.foreign_table_polling`) are
+   not referenced in any test file.
+
+The single most impactful engineering investment for the next 90 days is a
+**4-week "EC-01 closeout + Citus chaos sprint"** that (a) routes every join
+delta through unconditional PH-D1 cleanup with a small-batch implementation,
+(b) flips `is_deduplicated: true` for INNER joins on stable PKs and proves
+convergence with a 50,000-iteration property test, (c) adds a Citus
+integration test rig (multi-container compose with rebalance, worker kill,
+and coordinator failover), and (d) gates PRs that touch
+`src/dvm/operators/join*.rs`, `src/refresh/phd1.rs`, or `src/citus.rs` on
+that rig. Everything else — reactive subscriptions, time-travel, PGlite —
+is downstream of getting the join-delta correctness story to "obviously
+right" and the distributed coordination to "documented and tested".
+
+The project's overall maturity now sits between Materialize CE (early
+2024) and pg_ivm: comparable correctness rigour to pg_ivm, comparable
+streaming features to early Materialize, but better operational ergonomics
+than either (TUI, dbt adapter, snapshot/PITR, downstream publications).
+With the EC-01 + Citus closeout it is on track for a credible v1.0 GA in
+late 2026.
+
+---
+
+## Table of Contents
+
+1. [Method & Scope](#1-method--scope)
+2. [What Has Improved Since v0.27.0](#2-what-has-improved-since-v0270)
+3. [Critical Issues](#3-critical-issues)
+4. [Architecture & Design Gaps](#4-architecture--design-gaps)
+5. [Performance & Scalability Bottlenecks](#5-performance--scalability-bottlenecks)
+6. [Memory Safety & Unsafe Code Audit](#6-memory-safety--unsafe-code-audit)
+7. [Error Handling & Observability Gaps](#7-error-handling--observability-gaps)
+8. [SQL API & Ergonomics](#8-sql-api--ergonomics)
+9. [Test Coverage Gaps](#9-test-coverage-gaps)
+10. [Security Findings](#10-security-findings)
+11. [Documentation & Onboarding Gaps](#11-documentation--onboarding-gaps)
+12. [Operational Readiness Assessment](#12-operational-readiness-assessment)
+13. [Ecosystem & Integration Gaps](#13-ecosystem--integration-gaps)
+14. [Codebase Health Metrics](#14-codebase-health-metrics)
+15. [New Feature Proposals](#15-new-feature-proposals)
+16. [Prioritised Action Plan](#16-prioritised-action-plan)
+17. [Appendix — File-Level Coverage Summary](#17-appendix--file-level-coverage-summary)
+
+---
+
+## 1. Method & Scope
+
+This audit was produced over a single read-only pass against `main` at
+v0.34.0 (`Cargo.toml` line 3). I read all three prior assessments first,
+walked every file in `src/` (66 .rs files, 115,371 LOC), spot-checked the
+top-LOC files line-by-line, ran static analysis scripts (`grep`-based
+counts of `unsafe`, `unwrap`, `expect`, `panic!`, `TODO/FIXME/HACK` outside
+`#[cfg(test)]` blocks), surveyed all 140 files in `tests/`, read the 19
+GitHub workflow files in `.github/workflows/`, and walked
+`pgtrickle-relay/src/`, `pgtrickle-tui/src/`, `dbt-pgtrickle/`, `cnpg/`,
+and `monitoring/`.
+
+I dispatched four read-only exploration sub-agents in parallel against
+distinct slices (DVM engine, core orchestration, Citus & new modules,
+infra/tests/ecosystem) to widen coverage. Each sub-agent's findings were
+verified against the actual source where this report cites a line number.
+Where the sub-agents disagreed with the source — for example the core
+sub-agent claimed "no `pgt_refresh_history` retention exists" when in fact
+[src/config.rs:2071](../src/config.rs) defines `pg_trickle.history_retention_days`
+and [src/monitor.rs:571-580](../src/monitor.rs) implements the prune — the
+source wins and the report cites the source.
+
+I did **not** run any tests, builds, or benchmarks; this is static
+analysis only. I did not inspect generated SQL artifacts under
+`target/release/extension` (out of scope), the full Grafana dashboard JSON
+(I only scanned the panel set), or the demo container internals. Where
+the v3 assessment claimed an item was resolved I re-checked the source
+before treating it as such; one (snapshot atomicity, v3 §3.2) is now
+genuinely fixed; another (SQLSTATE classifier, v3 §3.4) is partially
+fixed.
+
+---
+
+## 2. What Has Improved Since v0.27.0
+
+The following v3 findings are now **resolved or substantially mitigated**.
+Items not listed here remain open and are tracked in §3 onwards.
+
+| v3 finding | Identifier | Current state | Evidence |
+|---|---|---|---|
+| Snapshot/restore not atomic | v3 §3.2 | **Resolved.** `SnapSubTransaction` RAII helper wraps both `CREATE TABLE AS + catalog INSERT` and `TRUNCATE + INSERT` in a sub-transaction with auto-rollback on Drop (panic-safe). | [src/api/snapshot.rs:27-87](../src/api/snapshot.rs); see comment "STAB-1 (v0.30.0)" |
+| `classify_spi_error_retryable` is text-based | v3 §3.4 | **Partially resolved.** SQLSTATE-aware `classify_spi_sqlstate_retryable` shipped in v0.30.0 with locale-safe class matching (40, 23, 22, 28, 08); legacy text matcher kept as fallback. | [src/error.rs:312-380](../src/error.rs) (new); [src/error.rs:282-340](../src/error.rs) (legacy still in use — see §7.2) |
+| L2 template-cache catalog table unbounded | v3 §3.5 | **Resolved (size cap).** v0.30.0 added bounded eviction; LRU enforcement is per-tick. Catalog table still grows during DDL bursts but is capped. | [src/template_cache.rs:79-118](../src/template_cache.rs); [src/config.rs:332](../src/config.rs) `template_cache_max_entries` |
+| Catalog snapshot reload on every scheduler tick | v3 §4 | **Resolved.** `CATALOG_SNAPSHOT_CACHE` thread-local + DAG version cache; `rebuild_dag_copy_on_write` builds outside lock and atomically swaps. | [src/scheduler.rs:59-118](../src/scheduler.rs); [src/scheduler.rs:134-144](../src/scheduler.rs) |
+| L0 dshash signal exists but unpopulated | v3 §3 | **Still open.** `L0_POPULATED_VERSION` atomic is wired but no shared dshash table is constructed. v0.31.0 mitigated practical impact via L1 + CoW DAG. | [src/shmem.rs:680-710](../src/shmem.rs) |
+| `pgt_refresh_history` retention | v3 carry-over from v2 | **Resolved.** `pg_trickle.history_retention_days` GUC (default 90 days, [src/config.rs:2071](../src/config.rs)); prune runs from monitor module ([src/monitor.rs:571](../src/monitor.rs)). |
+| `IVM_DELTA_CACHE` unbounded | v3 §3.3 | **Resolved.** v0.31.0 added bounded eviction + generation counter invalidation; deferred-cleanup queue still drains at next access (§4 below). | [src/ivm.rs](../src/ivm.rs) `LOCAL_IVM_CACHE_GEN` |
+
+In addition, v0.28.0–v0.34.0 ship features the v3 audit could not assess:
+
+- **Outbox + inbox** with envelope versioning, dedup keys
+  ([src/api/outbox.rs:1-942](../src/api/outbox.rs); [src/api/inbox.rs:1-1034](../src/api/inbox.rs)).
+- **`pgtrickle-relay` CLI** — coordinator pattern, hot-reload via
+  `LISTEN/NOTIFY`, sink trait abstraction
+  ([pgtrickle-relay/src/coordinator.rs](../pgtrickle-relay/src/coordinator.rs)).
+- **Citus integration** — stable hash naming
+  ([src/citus.rs:42-54](../src/citus.rs)), per-worker WAL slots, `pgt_st_locks`
+  distributed mutex, `citus_status` view, automated rebalance recovery.
+- **Soak (G17-SOAK) and multi-database (G17-MDB) workflows** in
+  `.github/workflows/stability-tests.yml`.
+- **DAG benchmark workflows** — calc/throughput, parallel workers
+  (`.github/workflows/e2e-benchmarks.yml`, `tests/e2e_dag_bench_tests.rs`).
+- **111 GUCs** (vs. ~75 at v0.27.0) — significant configuration surface
+  expansion, see §8.4 for the documentation gap.
+
+---
+
+## 3. Critical Issues
+
+Severity legend: **CRITICAL** = blocks v1.0 GA; **HIGH** = correctness or
+data-loss risk under realistic workloads; **MEDIUM** = production-quality
+gap; **LOW** = polish.
+
+### 3.1 EC-01 phantom rows still leak across cycles *(CRITICAL)*
+
+**Where:** [src/dvm/operators/join.rs:220-260](../src/dvm/operators/join.rs)
+(Part 1a/1b hash); [src/dvm/operators/join.rs:657-668](../src/dvm/operators/join.rs)
+(`is_deduplicated: false` is hard-coded); [src/refresh/phd1.rs:18-99](../src/refresh/phd1.rs)
+(opt-in cleanup path).
+
+This is the third consecutive assessment to flag this. The v0.24.0 fix
+made Part 1a (`ΔL_I ⋈ R₁`) and Part 1b (`ΔL_D ⋈ R₀`) hash on
+`(left_pks, right_pks)` rather than the right-side PK alone, which is
+sound when PKs are immutable. But the Z-set pipeline downstream still
+groups by `__pgt_row_id` and the join operator returns
+`is_deduplicated: false`, so the MERGE path retains a per-row-id sum that
+can reach a non-zero residual when an insert-then-delete on the left
+collides with a delete on the right within the same cycle. PH-D1
+cross-cycle cleanup at [src/refresh/phd1.rs:34-99](../src/refresh/phd1.rs)
+is **opt-in per refresh**: the orchestrator only invokes it when the
+prior cycle reported a non-zero residual, but the residual reporting
+itself depends on a flag that is not flipped on every code path. Repo
+memory `/memories/repo/join-delta-phantom-rows.md` records continued
+flakes in `test_tpch_q07_ec01b_combined_delete` and
+`test_tpch_immediate_correctness` Q15.
+
+**Impact in production.** Stream tables built on multi-table joins can
+produce wrong aggregates and `UNIQUE_VIOLATION` errors on downstream
+sinks. The bug has been "papered over" with allowlists in
+[tests/e2e_tpch_tests.rs](../tests/e2e_tpch_tests.rs) for IMMEDIATE-mode
+Q15 since v0.21.0. Customers who write joins on top of pg_trickle today
+must either use FULL refresh or accept eventual inconsistency.
+
+**Recommendation.** Two-step:
+1. *Immediately:* route every cycle unconditionally through PH-D1 with
+   batch size = 1,024 rows; cost is negligible (anti-join against the
+   freshly-applied delta) and removes the residual-detection coupling.
+2. *Properly:* re-engineer Part 2 to derive `__pgt_row_id` from the
+   *retained* base-table PK snapshot so Part 1a and Part 1b emit
+   convergent ids, then flip `is_deduplicated: true` for INNER joins on
+   stable PKs and gate the change behind a 50,000-iteration property
+   test in [tests/e2e_property_tests.rs](../tests/e2e_property_tests.rs).
+
+**Effort:** L (4–6 weeks including new property test corpus).
+
+### 3.2 SQLSTATE classifier exists but is not wired *(HIGH)*
+
+**Where:** [src/error.rs:282-340](../src/error.rs) (legacy text path,
+in active use); [src/error.rs:312-380](../src/error.rs)
+(new `classify_spi_sqlstate_retryable`, v0.30.0); `SpiErrorCode` variant
+is constructed in **zero** call sites (`grep -rn "SpiErrorCode"
+src/`). The architecture is right; the migration is unfinished.
+
+**Impact.** On a PostgreSQL build with `lc_messages='ja_JP.UTF-8'`,
+every SPI error becomes "retryable by default" (the catch-all branch),
+so permanent schema errors cause infinite retry loops in the scheduler
+until `max_consecutive_errors` trips the fuse — which is misleading
+diagnostic noise.
+
+**Recommendation.** Surface `pg_sys::ErrorData.sqlerrcode` from pgrx
+SPI errors (pgrx 0.18 exposes it via `SpiError::error_code()`), then
+construct `SpiErrorCode { code, msg }` everywhere a `SpiError(String)`
+is constructed today. The text path can be retained as a final fallback
+for non-SPI sources. One-week task; will retire ~30 `.to_string()` SPI
+sites across the codebase.
+
+### 3.3 Citus distributed coordination has no chaos test coverage *(HIGH)*
+
+**Where:** [src/citus.rs:1-1174](../src/citus.rs);
+[tests/e2e_mdb_tests.rs](../tests/e2e_mdb_tests.rs) (multi-database
+only; no Citus); no test file matches `*citus*`.
+
+`pgt_st_locks` ([src/citus.rs](../src/citus.rs) — search for
+`pgt_st_locks`) implements a distributed mutex with `INSERT … ON
+CONFLICT DO NOTHING` plus a TTL lease (`citus_lease_ttl_seconds` GUC).
+Failure modes that have **no test** include: lease expiry during refresh
+(no fencing token); coordinator failover mid-lease; clock skew between
+coordinator and worker; partial `pg_dist_node` rebalance; worker death
+during `poll_worker_slot_changes`; concurrent `handle_vp_promoted`
+calls. The `citus_worker_retry_ticks` GUC (default 5) only emits a
+WARNING in the PostgreSQL log; there is no Prometheus counter, no
+alerting hook, and the worker-skipped path can mask permanent breakage.
+
+**Recommendation.** Add `tests/e2e_citus_*` with a Docker-Compose-Citus
+rig (coordinator + 3 workers) that drives: (a) kill-and-restart worker
+during poll, (b) coordinator restart mid-lease, (c) pg_dist_node
+removal+re-add of a worker, (d) sustained 1k stream-table refresh
+under churn. Bind these tests to a new `citus-tests.yml` workflow
+running on push-to-main.
+
+### 3.4 `join_and_predicates` panics on empty input *(HIGH)*
+
+**Where:** [src/dvm/parser/rewrites.rs:5471](../src/dvm/parser/rewrites.rs)
+— `let mut result = iter.next().expect("at least one predicate required");`
+This is **production code** (the `#[cfg(test)]` block in this file
+starts at line 5934, so anything below 5934 is test). The function is
+called from rewrite passes; if a future rewrite produces an empty
+predicate set the bgworker panics, which on PostgreSQL means a
+postmaster-wide restart.
+
+**Recommendation.** Change the signature to `Result<Expr,
+PgTrickleError>` returning `Err(InvalidArgument("empty predicate set"))`
+and propagate at the two call sites with `?`. Half-day task.
+
+### 3.5 Inbox/outbox have zero unit test coverage *(HIGH)*
+
+**Where:** [src/api/inbox.rs:1-1034](../src/api/inbox.rs) and
+[src/api/outbox.rs:1-942](../src/api/outbox.rs) — neither has a
+`#[cfg(test)] mod tests { ... }` block. Coverage is only via
+[tests/e2e_inbox_tests.rs](../tests/e2e_inbox_tests.rs) and
+[tests/e2e_outbox_tests.rs](../tests/e2e_outbox_tests.rs).
+
+For an at-least-once + dedup contract, this is too thin. Dedup-key
+collisions, JSON envelope NULL handling, version-mismatch envelopes,
+and offset durability under crash all need unit-level tests that can
+be run in milliseconds and exercised exhaustively by proptest, not
+end-to-end through a Docker container.
+
+**Recommendation.** Add `#[cfg(test)] mod tests` to both files with
+dedup-key roundtrip, envelope encode/decode, NULL value handling,
+version-skew rejection, and proptest-driven randomized envelope
+fuzzing. 1-week task. Already an item in
+[plans/relay/](relay/) per the v0.29.0 plan but not delivered.
+
+### 3.6 `pg_trickle.enabled = false` does not fully disable CDC *(MEDIUM)*
+
+**Where:** [src/config.rs:1276-1283](../src/config.rs) (GUC);
+[src/scheduler.rs:2868](../src/scheduler.rs) (only the scheduler tick
+checks the flag); CDC trigger functions in
+[src/cdc.rs](../src/cdc.rs) do not check it.
+
+When `pg_trickle.enabled = false`, the scheduler stops dispatching
+refreshes but the per-source `tg_pgtrickle_*` triggers continue to
+write to `pgtrickle_changes.changes_<stable_name>` on every DML. For
+an operator running an emergency "turn it off" during an incident this
+is surprising — DML latency is unchanged, change buffers grow, and on
+re-enable the system processes the entire backlog at once.
+
+**Recommendation.** Either (a) document the current behaviour
+prominently in [docs/CONFIGURATION.md](../docs/CONFIGURATION.md) and
+[docs/TROUBLESHOOTING.md](../docs/TROUBLESHOOTING.md), or (b) add a
+fast-path check at the top of every CDC trigger that returns NULL
+when `pg_trickle.enabled = false`. The (a) approach is safer (no
+silent data loss) but worse for incident response; the (b) approach
+is what an SRE expects from a kill switch but needs an additional
+"durable hold" flag (`pg_trickle.cdc_paused`) to capture the intent
+clearly.
+
+### 3.7 `pg_trickle.refresh_strategy = full` cannot be enforced from a single GUC alone *(MEDIUM)*
+
+**Where:** [src/config.rs:1366-1376](../src/config.rs);
+[src/refresh/orchestrator.rs:1-388](../src/refresh/orchestrator.rs).
+
+The GUC is read on every cycle but per-stream-table `refresh_mode`
+(stored in `pgt_stream_tables`) takes precedence; an operator who
+believes they have toggled the cluster into FULL mode for diagnosis
+will see DIFFERENTIAL refreshes continue for any ST whose row sets the
+mode explicitly. This is documented at the GUC level but not at the
+incident-response level.
+
+**Recommendation.** Add a hard-override GUC
+`pg_trickle.force_full_refresh = bool` (default false) that, when set,
+ignores per-ST mode for the duration of the GUC being on. Useful for
+rolling-back from a suspected DVM regression.
+
+---
+
+## 4. Architecture & Design Gaps
+
+### 4.1 L0 shared-memory dshash template cache still missing
+
+[src/shmem.rs:680-710](../src/shmem.rs) wires
+`L0_POPULATED_VERSION: PgAtomic<AtomicU64>` and the cross-backend
+invalidation signal, but the actual dshash table holding compiled delta
+SQL templates is never constructed. This is documented as deferred in
+[plans/performance/RFC_SHARED_TEMPLATE_CACHE.md](performance/RFC_SHARED_TEMPLATE_CACHE.md).
+Practical impact is mitigated by the L2 catalog table
+([src/template_cache.rs](../src/template_cache.rs)) which still pays a
+cross-backend round-trip but is bounded; for connection-pooler workloads
+where every backend is short-lived the L0 win would be material
+(documented at ~45 ms cold-start).
+
+### 4.2 Refresh history `INSERT` per refresh is the dominant catalog write at scale
+
+[src/cdc.rs:71-83](../src/cdc.rs) enforces INSERT-only invariant on
+`pgt_refresh_history`. At 1,000 stream tables × 12 refreshes/min the
+table sustains ~720k inserts/hour. The retention prune runs from
+monitor.rs but is O(rows-deleted) per pass; for large tables the prune
+cycle exceeds the scheduler tick budget. There is no batching, no
+LIMIT, no statement-cancel guard.
+
+**Recommendation.** Add a `LIMIT 10000` to the prune DELETE and run it
+in a dedicated `bgworker_history_pruner` background worker on a
+configurable interval (default 60s).
+
+### 4.3 Refresh sub-modules are populated but `merge.rs` is a 3,472-LOC behemoth
+
+[src/refresh/merge.rs:1-3472](../src/refresh/merge.rs) is the new
+"refresh.rs" — most MERGE-path codegen lives there. Splitting along
+PostgreSQL operator boundaries (delete/insert/update path; conflict
+predicate generator; column-list builder) would let reviewers reason
+about each in isolation. Not a correctness risk; a maintainability tax.
+
+### 4.4 `src/api/mod.rs` at 6,322 LOC is the new monolith
+
+[src/api/mod.rs](../src/api/mod.rs) carries `create_stream_table`,
+`alter_stream_table`, `drop_stream_table`, `refresh_stream_table`,
+DAG operations, fuse control, status reporting, and 80+
+`#[pg_extern]`-decorated SQL functions across the whole `pgtrickle.*`
+schema. Like the old `refresh.rs`, every change touches it. Splitting
+into `src/api/lifecycle.rs`, `src/api/refresh.rs`,
+`src/api/fuse.rs`, `src/api/status.rs` is the next architectural
+chore.
+
+### 4.5 Scheduler is still 7,756 LOC (the largest single file)
+
+[src/scheduler.rs:1-7756](../src/scheduler.rs) carries dispatch loop,
+tier scheduler, predictive cost integration, parallel pool, pgt_st_locks
+acquisition, DAG rebuild trigger, and CDC backpressure. The sheer LOC
+makes any change risky; specific concerns: tier and cost code could
+move to `src/scheduler/tier.rs` + `src/scheduler/cost.rs`; pool worker
+to `src/scheduler/pool.rs`; Citus lease loop to `src/scheduler/citus.rs`.
+
+### 4.6 No structured representation of DDL hooks
+
+[src/hooks.rs:130-176](../src/hooks.rs) defines `DdlEventKind` and
+classifies events with an English-text `tag` field. Because there is no
+typed enum coming out of the PostgreSQL event trigger payload, the code
+matches on strings (`"ALTER TABLE"`, etc.). A typo or PG-minor wording
+change breaks classification silently. Recommend a small
+`pg_event_trigger_ddl_commands()` view + typed parser layer.
+
+### 4.7 No consistent delta-row identity model across operators
+
+The hash module ([src/hash.rs](../src/hash.rs)) is excellent (xxh3
+streaming with sentinel + separator), but each operator constructs
+its own row-id hash from a different tuple. This is the root cause of
+the EC-01 issue and would benefit from a `RowIdSchema` type that every
+operator declares as part of its signature, then a verifier that
+asserts cross-operator compatibility at plan-time.
+
+---
+
+## 5. Performance & Scalability Bottlenecks
+
+### 5.1 Per-tick L2 cache rehydration cost
+
+[src/template_cache.rs:79-118](../src/template_cache.rs): on cache miss
+the L2 catalog table is queried via SPI; for 1,000 STs after a backend
+cold start the cumulative cost is ~200 ms before the L1 cache is warm.
+The L0 shmem cache (§4.1) would close this; until then, document the
+"first tick after restart is slow" expectation in
+[docs/SCALING.md](../docs/SCALING.md).
+
+### 5.2 `monitor.rs` aggregation queries are not indexed
+
+[src/monitor.rs:571-580](../src/monitor.rs),
+[src/monitor.rs:657-700](../src/monitor.rs),
+[src/monitor.rs:829-840](../src/monitor.rs) all read
+`pgt_refresh_history` with patterns like `LEFT JOIN ... USING (pgt_id)`
+ordered by `start_time DESC`. The catalog table has a primary key on
+`(pgt_id, start_time)` (per upgrade scripts) but several monitor
+queries scan by `start_time` alone (the "recent across cluster"
+pattern). At 10M rows the dashboard query is multi-second. Adding a
+secondary index on `start_time` (with retention pruning, this stays
+small) would cut query times to <100 ms.
+
+### 5.3 WAL decoder has no backpressure cap
+
+[src/wal_decoder.rs:1-2212](../src/wal_decoder.rs) does not enforce
+`pg_replication_slot.confirmed_flush_lsn` advancement bounds. On a
+slow refresh cycle the slot retention grows; the
+`slot_lag_warning_threshold_mb` and `slot_lag_critical_threshold_mb`
+GUCs ([src/config.rs:1554-1578](../src/config.rs)) emit alerts but do
+not throttle. At 100 MB/s WAL with a stuck refresh, disk fills in
+minutes. Recommend an `ENFORCE_BACKPRESSURE` mode that pauses CDC
+trigger writes (or stops advancing the local frontier intentionally,
+forcing logical decoding to drop slot-advance) when the slot lag
+exceeds the critical threshold.
+
+### 5.4 `pgt_st_locks` polling loop in the scheduler
+
+[src/citus.rs](../src/citus.rs): the lease acquisition does an
+`INSERT … ON CONFLICT DO NOTHING` per tick when the holder is another
+coordinator. There is no exponential backoff; each tick is a UDP-style
+collision-and-retry. With multiple coordinators racing on a common
+stream table this generates O(N²) attempts/second. Add 50–500 ms
+randomized backoff on conflict.
+
+### 5.5 IVM cache invalidation generation counter is 32-bit
+
+[src/ivm.rs](../src/ivm.rs) `LOCAL_IVM_CACHE_GEN` and
+[src/shmem.rs:132](../src/shmem.rs) `CACHE_GENERATION` use `AtomicU64`
+in shmem — that's fine. But several call sites cast to `u32` for SPI
+parameter binding. With ~1M invalidations/day the 32-bit space is
+exhausted in ~12 years; not a near-term issue but worth noting before
+v1.0 freezes the wire format.
+
+### 5.6 `tests/e2e_dag_bench_tests.rs` shows acceptable throughput but no latency SLO
+
+[tests/e2e_dag_bench_tests.rs:1-1768](../tests/e2e_dag_bench_tests.rs)
+measures throughput and parallel scaling but not p99 refresh latency.
+[plans/performance/PLAN_DAG_BENCHMARK.md](performance/PLAN_DAG_BENCHMARK.md)
+describes the target. No CI gate on p99 latency.
+
+### 5.7 Auto-index is opt-in (`pg_trickle.auto_index = false` default)
+
+[src/config.rs:1631-1641](../src/config.rs). Many users will not flip
+this, then complain about slow refreshes against unindexed sources. A
+warning emitted at `create_stream_table` time when the source has
+fewer indexes than its referenced columns would help.
+
+---
+
+## 6. Memory Safety & Unsafe Code Audit
+
+### 6.1 Inventory
+
+`grep -rE 'unsafe\\s*\\{|unsafe\\s+fn|unsafe\\s+impl' src` returns 161
+strict matches. By file (lines containing the keyword, including
+nested):
+
+| File | Strict count |
+|---|---|
+| [src/dvm/parser/sublinks.rs](../src/dvm/parser/sublinks.rs) | 211 |
+| [src/dvm/parser/rewrites.rs](../src/dvm/parser/rewrites.rs) | 67 |
+| [src/shmem.rs](../src/shmem.rs) | 22 |
+| [src/dvm/parser/mod.rs](../src/dvm/parser/mod.rs) | 14 |
+| [src/scheduler.rs](../src/scheduler.rs) | 12 |
+| [src/api/helpers.rs](../src/api/helpers.rs) | 12 |
+| [src/api/snapshot.rs](../src/api/snapshot.rs) | 6 |
+| [src/wal_decoder.rs](../src/wal_decoder.rs) | 4 |
+| [src/lib.rs](../src/lib.rs) | 2 |
+| [src/dvm/parser/validation.rs](../src/dvm/parser/validation.rs) | 2 |
+
+### 6.2 SAFETY-comment audit
+
+- [src/dvm/parser/sublinks.rs](../src/dvm/parser/sublinks.rs): every
+  unsafe block I sampled (lines 42, 60, 79, 95, 117, 121, 162, 167–336)
+  carries an explicit `// SAFETY:` comment. ✅
+- [src/dvm/parser/rewrites.rs](../src/dvm/parser/rewrites.rs): unsafe
+  blocks at lines 366, 371, 376, 403, 417, 434, 444, 453, 481, 488,
+  495, 635, 667, 672, 676, 693, 703, 2742, 2948, 2954, 2979 do **not**
+  have inline `// SAFETY:` comments. Pattern is standard pgrx FFI
+  (deparsing parser nodes, calling `raw_parser`) so the omissions are
+  unlikely to hide a real bug, but they violate the AGENTS.md
+  convention and make future refactors riskier. ⚠️ Add SAFETY comments.
+- [src/shmem.rs](../src/shmem.rs): all 22 sites are
+  `unsafe { PgLwLock::new(...) }` / `unsafe { PgAtomic::new(...) }`
+  static initialisation — each carries SAFETY comments at lines 99,
+  106, 113, 808. ✅
+- [src/api/snapshot.rs](../src/api/snapshot.rs): all 6 sites
+  ([lines 36-87](../src/api/snapshot.rs)) carry SAFETY comments. ✅
+- [src/wal_decoder.rs](../src/wal_decoder.rs): 4 sites; visual scan
+  shows comments present.
+
+### 6.3 `unwrap()` / `expect()` / `panic!()` outside test code
+
+After excluding `#[cfg(test)]` and `mod tests` blocks via the script in
+`/tmp/audit_unwraps.py`, **95 sites remain** distributed as:
+
+| File | Count | Risk |
+|---|---|---|
+| [src/api/mod.rs](../src/api/mod.rs) | 42 | All in `#[cfg(test)] mod tests` block past line 5050 — false positive (script's `mod tests` boundary detection is approximate) |
+| [src/refresh/tests.rs](../src/refresh/tests.rs) | 20 | All in dedicated test file — false positive |
+| [src/dvm/parser/rewrites.rs](../src/dvm/parser/rewrites.rs) | 17 | **1 real production site** at line 5471 (`expect("at least one predicate required")` — see §3.4); 16 are test code below line 5934 |
+| [src/dvm/operators/aggregate.rs](../src/dvm/operators/aggregate.rs) | 7 | All `unwrap_or_else(\|\| default)` safe defaults |
+| [src/dag.rs](../src/dag.rs) | 3 | SCC tarjan invariant `nosemgrep`-tagged unwraps at lines 1093, 1100, 1112 |
+| [src/dvm/operators/filter.rs](../src/dvm/operators/filter.rs) | 2 | Safe defaults |
+| Others | 4 | All safe defaults |
+
+**Net result:** 1 real panic-risk site (rewrites.rs:5471) + 3
+invariant-justified unwraps (dag.rs SCC). The earlier reductions from
+v0.20 (513 unwraps) → v0.27 hold; lint
+`#![cfg_attr(not(test), deny(clippy::unwrap_used))]` at
+[src/lib.rs:23](../src/lib.rs) is doing its job.
+
+### 6.4 Memory contexts
+
+Audit of [src/api/helpers.rs](../src/api/helpers.rs) found no
+`MemoryContextSwitchTo` calls in caller-context-sensitive paths;
+unsafe blocks at lines 582, 867, 951, 981–990, 1013 are FFI casts
+that do not allocate via PG. Comments at lines 751 and 866 explicitly
+acknowledge "test context lacks PG memory context". No leak risk
+identified.
+
+---
+
+## 7. Error Handling & Observability Gaps
+
+### 7.1 Mark-for-reinit failures swallowed as warnings
+
+[src/hooks.rs:285-310](../src/hooks.rs): if
+`StreamTableMeta::mark_for_reinitialize()` fails (lock timeout,
+deadlock), the code emits `warning!()` and continues. The downstream
+ST is then refreshed against a stale schema which, depending on the
+DDL, can produce wrong results or runtime SQL errors. Recommend
+upgrading to `error!()` after N retry attempts (default 3 with 100 ms
+backoff).
+
+### 7.2 SQLSTATE classifier wiring (see §3.2)
+
+### 7.3 Structured logging not available
+
+There is no JSON log format option. PostgreSQL's `log_line_prefix`
+captures backend metadata but pg_trickle's own `log!()` /
+`info!()` / `warning!()` emit unstructured text. For OpenTelemetry /
+Loki integration this means lossy regex parsing. Add a
+`pg_trickle.log_format = text|json` GUC and a wrapper that emits
+structured fields (`event`, `pgt_id`, `cycle_id`, `duration_ms`,
+`refresh_reason`).
+
+### 7.4 IVM lock-mode fallback is unmetered
+
+[src/ivm.rs:48-91](../src/ivm.rs): on parse failure the IVM lock mode
+defaults to `Exclusive` (correct, fail-closed) but no metric is
+emitted. Operators have no visibility into how often this occurs.
+Add a counter `pgtrickle_ivm_lock_mode_fallback_total{reason="parse_error"}`.
+
+### 7.5 SubLink-in-OR silent FULL fallback
+
+[src/dvm/parser/sublinks.rs:101-145](../src/dvm/parser/sublinks.rs)
+(per v3 §3.6 and confirmed by the DVM sub-agent above): when a SubLink
+is hidden inside `CASE`, `COALESCE`, or a function call within an OR
+branch, the recursive `node_tree_contains_sublink()` walker misses it.
+The query falls through as `Expr::Raw`, the planner downgrades to FULL
+refresh, and the user sees no NOTICE. Either (a) generalise the walker
+via `expression_tree_walker_impl()`, or (b) emit `pgrx::notice!()` at
+every FULL fallback.
+
+### 7.6 `let _ =` patterns reviewed: clean
+
+[src/cdc.rs:346, 364](../src/cdc.rs) (`DROP TRIGGER IF EXISTS` is
+genuinely safe to ignore) and [src/cdc.rs:2173](../src/cdc.rs)
+(unused-variable suppression) are the only cases. No silent error
+swallowing on result-bearing operations.
+
+### 7.7 `pg_trickle_dump` binary is undocumented
+
+[src/bin/pg_trickle_dump.rs:1-458](../src/bin/pg_trickle_dump.rs)
+provides catalog/dump diagnostics. There is no
+[docs/](../docs/) page describing what it does, when to run it, or
+what its output means. Add a `docs/PG_TRICKLE_DUMP.md` runbook.
+
+---
+
+## 8. SQL API & Ergonomics
+
+### 8.1 SQL surface size
+
+`grep -rcE '#\[pg_extern' src/api/ src/citus.rs` returns ~80
+public SQL functions (not including `#[pg_extern]` definitions in
+operator modules, which surface internal helpers). For an extension
+this is reasonable but the per-function documentation in
+[docs/SQL_REFERENCE.md](../docs/SQL_REFERENCE.md) lags — not every
+new outbox/inbox/Citus function has a doc entry.
+
+### 8.2 No `EXPLAIN`-equivalent for the DVM plan
+
+There is no SQL function that returns "for stream table X, what
+differential operators will be invoked, and which fall back to
+recompute." [src/diagnostics.rs](../src/diagnostics.rs) provides cost
+model and history insights but not the plan tree. Add
+`pgtrickle.explain_stream_table(name TEXT) RETURNS TABLE(...)` that
+returns a textual rendering of the OpTree, similar to
+`EXPLAIN (FORMAT TEXT)`.
+
+### 8.3 `ALTER STREAM TABLE ... QUERY` template-cache invalidation
+
+Per the v3 §3 catalogue, ALTER QUERY invalidates the L1 and L2 caches,
+and the `CACHE_GENERATION` atomic in shmem propagates to other
+backends. Verified at [src/template_cache.rs:124-142](../src/template_cache.rs)
+(`invalidate`/`invalidate_all`). However the IVM cache
+([src/ivm.rs](../src/ivm.rs)) and the parser cache (if any) need a
+single coordinated invalidation API. Today each is its own
+generation counter.
+
+### 8.4 GUC catalogue not exhaustive in docs
+
+`grep -c 'GucRegistry::define' src/config.rs` = **111**.
+[docs/CONFIGURATION.md](../docs/CONFIGURATION.md) lists fewer; the
+CDC/Citus/IVM GUCs added in v0.32–v0.34 are not all enumerated. The
+`pg_trickle.list_gucs()` function does not exist. Add a generated
+table from the `GucRegistry` definitions to docs (could be a CI step
+that fails when the doc table is out of sync).
+
+### 8.5 Error messages are partly inconsistent
+
+[src/error.rs:1-886](../src/error.rs) has good context fields on most
+variants but some new variants (PublicationRebuildFailed,
+ChangedColsBitmaskFailed) wrap a plain `String` rather than structured
+fields. For machine-parsing of errors, structured fields are
+preferable — a future v1.0 SLA contract will require them.
+
+### 8.6 `create_stream_table` privilege model
+
+Functions in [src/api/mod.rs](../src/api/mod.rs) are
+`#[pg_extern(schema = "pgtrickle")]` without explicit `SECURITY
+DEFINER`. The default is INVOKER. Multi-tenant deployments where one
+role can `CREATE STREAM TABLE` over another role's source table are
+possible only when the invoker has SELECT on the source. Document
+this contract explicitly in
+[docs/security.md](../docs/security.md).
+
+### 8.7 No bulk APIs for IVM mode operations
+
+There is `bulk_create_stream_tables` (v0.15.0) but no
+`bulk_alter_stream_tables` or `bulk_drop_stream_tables`. dbt
+deployments commonly need to flip 100+ STs to a new schedule at
+once; today this requires 100 round-trips.
+
+---
+
+## 9. Test Coverage Gaps
+
+### 9.1 Modules without unit tests
+
+Verified via the infra sub-agent + manual spot-check:
+
+| Module | Lines | Has `mod tests`? | Integration test? |
+|---|---|---|---|
+| [src/api/inbox.rs](../src/api/inbox.rs) | 1034 | **No** | tests/e2e_inbox_tests.rs |
+| [src/api/outbox.rs](../src/api/outbox.rs) | 942 | **No** | tests/e2e_outbox_tests.rs |
+| [src/api/metrics_ext.rs](../src/api/metrics_ext.rs) | 132 | **No** | indirectly via monitoring tests |
+| [src/template_cache.rs](../src/template_cache.rs) | 182 | **No** | None directly |
+| [src/dvm/operators/test_helpers.rs](../src/dvm/operators/test_helpers.rs) | 719 | N/A (it *is* the test helpers) | — |
+
+These are the highest-risk gaps. Each represents a critical contract
+(at-least-once dedup, metric labels, template cache hit/miss).
+
+### 9.2 Citus test gap
+
+No `tests/e2e_citus_*.rs` exists — see §3.3. The `e2e_mdb_tests.rs`
+file covers multi-database but not multi-node Citus.
+
+### 9.3 Chaos / fault-injection coverage
+
+`tests/e2e_concurrent_tests.rs` covers DDL races, refresh-vs-DROP, and
+concurrent inserts. Missing:
+- OOM injection during refresh
+- Disk-full simulation (would require `LD_PRELOAD` of `write()`)
+- SIGKILL of the bgworker mid-refresh (vs. SIGTERM, which is tested)
+- VACUUM FULL during refresh
+- Network partition between coordinator and worker (Citus)
+- pg_stat_statements pressure during refresh
+
+### 9.4 Fuzz coverage gaps
+
+[fuzz/fuzz_targets/](../fuzz/fuzz_targets/) has `parser_fuzz`,
+`cdc_fuzz`, `cron_fuzz`, `guc_fuzz`. Missing: aggregation fuzzing,
+window fuzzing, recursive-CTE fuzzing, JOIN predicate fuzzing,
+envelope (inbox/outbox) fuzzing. Per the parser_fuzz README the
+backend-integrated rewrites are not fuzzed because they require a
+live PostgreSQL — that is exactly where SQLancer should compensate.
+
+### 9.5 Upgrade test coverage
+
+[tests/e2e_upgrade_tests.rs:1-1143](../tests/e2e_upgrade_tests.rs) has
+18 tests including multi-hop chains. Confirmed in the audit. However
+no test asserts that a `pgt_change_tracking` row written at v0.31.0 is
+correctly re-keyed by the v0.32.0 stable-name backfill. Add a frozen
+fixture (binary dump from v0.31.0) and verify the upgrade path
+produces the expected stable names.
+
+### 9.6 SQLancer integration is correct but infrequent
+
+`.github/workflows/sqlancer.yml` runs Sundays + manual; not on PR. A
+lightweight 100-case run on every PR (5–10 min budget) would catch
+DVM-vs-FULL equivalence regressions earlier.
+
+### 9.7 Property-test corpus needs join-delta saturation
+
+[tests/property_tests.rs:1-1615](../tests/property_tests.rs) and
+[tests/e2e_property_tests.rs:1-1589](../tests/e2e_property_tests.rs)
+have generic property tests but the `proptest-regressions/` directory
+shows few join-delta regressions vs. the bug history would suggest.
+Increase shrinking iterations and add an EC-01-specific generator.
+
+---
+
+## 10. Security Findings
+
+### 10.1 No SQL injection sites identified
+
+All dynamic SQL constructions I sampled use either `quote_ident` /
+`quote_literal` or parameterised `Spi::run_with_args`. Spot-checked:
+[src/api/snapshot.rs:240-260](../src/api/snapshot.rs) (CREATE TABLE
+AS uses parameter binding for metadata columns, FQN built via Rust
+`format!` with `"` doubling — safe);
+[src/cdc.rs](../src/cdc.rs) (trigger function generation uses
+`format!` with quoted identifiers — safe);
+[src/citus.rs](../src/citus.rs) (`pgt_st_locks` insert is
+parameterised). No injection vectors identified.
+
+### 10.2 `pgtrickle-relay` connection-string handling
+
+[pgtrickle-relay/src/config.rs](../pgtrickle-relay/src/config.rs)
+accepts source/sink connection strings via TOML; secrets in plaintext
+on disk. No integration with `gopass`/`vault`/AWS Secrets Manager.
+For production use, add `${ENV:VAR}` interpolation and document
+secret-management patterns in
+[docs/RELAY_GUIDE.md](../docs/RELAY_GUIDE.md).
+
+### 10.3 SECURITY DEFINER review
+
+The `#[pg_extern]` functions in `src/api/` are not annotated as
+SECURITY DEFINER. SQL files in [sql/](../sql/) define some functions
+as SECURITY DEFINER (e.g. monitoring views' helpers). The intentional
+contract is that the *user* role must have privilege on source and
+target. Document this explicitly in
+[docs/security.md](../docs/security.md).
+
+### 10.4 No SBOM or signed releases
+
+[deny.toml](../deny.toml) is well-curated, advisory ignores carry
+justifications, but releases are not signed (no `cosign`/`sigstore`
+attestation), no CycloneDX/SPDX SBOM is published, no provenance
+attestation per SLSA. For ecosystem trust at v1.0 these become
+mandatory.
+
+### 10.5 OWASP Top-10 coverage
+
+The threat model favours backend (server-side) attacks over web
+attacks. Of the OWASP Top 10:
+- A01 Broken Access Control: documented but not strictly enforced (§8.6)
+- A02 Cryptographic Failures: connection-string secrets in plaintext (§10.2)
+- A03 Injection: clean (§10.1)
+- A06 Vulnerable Components: `cargo audit` weekly + ignores justified
+- A09 Logging & Monitoring: structured logging missing (§7.3)
+- A10 SSRF: relay sinks are user-configurable URLs — should validate
+  schemes against an allow-list
+
+---
+
+## 11. Documentation & Onboarding Gaps
+
+### 11.1 [docs/SUMMARY.md](../docs/SUMMARY.md) is excellent
+
+Coverage of user guides, integrations, tutorials, research is
+comprehensive. The book builds with `mdbook` (book.toml at repo root).
+
+### 11.2 Citus integration tutorial absent
+
+There is no end-to-end tutorial that walks a user through: install
+Citus → install pg_trickle → create a distributed source table →
+create a co-located distributed stream table → observe replication
+lag via `citus_status`. Add `docs/tutorials/CITUS_DISTRIBUTED.md`.
+
+### 11.3 Relay/outbox tutorial absent
+
+[docs/RELAY_GUIDE.md](../docs/RELAY_GUIDE.md) and
+[docs/RELAY.md](../docs/RELAY.md) exist but no tutorial covers the
+end-to-end outbox→relay→Kafka path with code samples.
+
+### 11.4 dbt-pgtrickle missing tests
+
+Only `dbt-pgtrickle/integration_tests/` and `dbt-pgtrickle/tests/`
+shells exist; no per-materialisation behavioural tests. Per the
+infra sub-agent this is the weakest link in the dbt story.
+
+### 11.5 `INSTALL.md` could be split
+
+Currently [INSTALL.md](../INSTALL.md) is a single page covering
+multiple distribution channels. Split into per-platform pages
+(macOS, Linux, Docker, CNPG, apt/yum) with clearer "if you are X
+start here" navigation.
+
+### 11.6 Changelog readability
+
+Per the infra sub-agent and prior assessments, the v0.34.0 changelog
+is well-written for a non-technical audience — explicit, concrete
+examples. ✅
+
+---
+
+## 12. Operational Readiness Assessment
+
+### 12.1 Runbooks present
+
+[docs/TROUBLESHOOTING.md](../docs/TROUBLESHOOTING.md) covers most
+incidents but not Citus-specific ones (worker lease expiry, slot
+divergence, rebalance recovery). Add a Citus runbook section.
+
+### 12.2 `pg_trickle.enabled` does not stop CDC writes (§3.6)
+
+This is the highest operational risk under incident response.
+
+### 12.3 Capacity planning guidance missing
+
+[docs/SCALING.md](../docs/SCALING.md) has limits but no formula like
+"X stream tables × Y refreshes/min × Z CDC volume = N MB/s WAL +
+M cores + K GB shared buffers". Add a "sizing calculator" page.
+
+### 12.4 Grafana dashboards lack key SLIs
+
+Per the infra sub-agent: refresh latency p50/p99 panels are missing,
+change-buffer depth and CDC lag panels missing, no Prometheus alert
+rules in repo. Add `monitoring/grafana/alerts/pg_trickle.yml`.
+
+### 12.5 Soak test exists (G17-SOAK)
+
+[tests/e2e_soak_tests.rs](../tests/e2e_soak_tests.rs) is configurable
+(SOAK_DURATION_SECS, SOAK_CYCLE_MS) and runs in
+`stability-tests.yml`. ✅
+
+### 12.6 No documented "drain mode" for graceful shutdown
+
+To shut down pg_trickle for a maintenance window, an operator needs
+to (a) pause schedules, (b) flush in-flight refreshes, (c) wait for
+CDC drains, (d) shut down. There is no single command. Add
+`pgtrickle.drain_mode_begin()` / `drain_mode_end()`.
+
+---
+
+## 13. Ecosystem & Integration Gaps
+
+### 13.1 pgtrickle-relay reconnection strategy
+
+Per the infra sub-agent: no explicit reconnection backoff in
+[pgtrickle-relay/src/](../pgtrickle-relay/src/). Add exponential
+backoff with jitter, log reconnection attempts.
+
+### 13.2 pgtrickle-relay backpressure missing
+
+Sink errors do not propagate back to the source poller; the
+`fire-and-forget` pattern means a slow Kafka topic causes unbounded
+memory growth in the relay. Add a bounded channel with
+`try_send` + retry-on-full.
+
+### 13.3 pgtrickle-tui lacks inbox/outbox views
+
+Per infra sub-agent: 18 commands, none for relay/inbox/outbox. Add
+`tui inbox status`, `tui outbox tail`.
+
+### 13.4 dbt Hub listing pending
+
+dbt-pgtrickle is git-installable but not on dbt Hub. Submit.
+
+### 13.5 CNPG smoke test does not actually deploy the extension image
+
+[cnpg/Dockerfile.ext](../cnpg/Dockerfile.ext) builds a scratch image
+but no CI test mounts it into a CNPG cluster. Add a kind-based smoke
+test in `.github/workflows/stability-tests.yml`.
+
+### 13.6 No multi-arch Docker images
+
+amd64 only. Add arm64 to `.github/workflows/docker-hub.yml` and
+`.github/workflows/ghcr.yml`.
+
+### 13.7 No integration with pg_partman / TimescaleDB
+
+These two extensions are dominant in the partitioning ecosystem;
+pg_trickle's partitioned source detection works for vanilla
+declarative partitioning but has not been verified against
+pg_partman's runtime partition creation or TimescaleDB hypertables.
+
+---
+
+## 14. Codebase Health Metrics
+
+| Metric | Value |
+|---|---|
+| Total `src/` LOC | 115,371 |
+| `src/` files | 66 |
+| `tests/` files | 140 |
+| `tests/` LOC | 86,323 |
+| GUC count | 111 (`GucRegistry::define` in `src/config.rs`) |
+| Public SQL functions | ~80 (`#[pg_extern]` in `src/api/` + `src/citus.rs`) |
+| Strict `unsafe` keyword count | 161 |
+| Production unwrap/expect/panic sites | 1 real (rewrites.rs:5471) + 3 invariant-justified (dag.rs SCC) |
+| TODO/FIXME/HACK in src/ | 1 |
+| GitHub workflows | 19 |
+| Upgrade scripts (`sql/pg_trickle--*.sql`) | 30 (covering 0.1.3 → 0.34.0) |
+| Plan documents (`plans/`) | ~70 |
+
+**Comparison.**
+
+| Module | LOC v0.27.0 (per v3) | LOC v0.34.0 | Δ |
+|---|---|---|---|
+| scheduler.rs | 7,392 | 7,756 | +364 |
+| dvm/parser/sublinks.rs | 6,485 | 6,559 | +74 |
+| api/mod.rs | 6,127 | 6,322 | +195 |
+| dvm/parser/rewrites.rs | 6,104 | 6,105 | ≈0 |
+| dvm/parser/mod.rs | 5,526 | 5,526 | 0 |
+| dvm/operators/aggregate.rs | 5,399 | 5,400 | ≈0 |
+| dag.rs | 4,295 | 4,295 | 0 |
+| dvm/operators/recursive_cte.rs | 4,043 | 4,050 | ≈0 |
+| cdc.rs | 3,970 | 4,037 | +67 |
+| monitor.rs | 3,633 | 3,719 | +86 |
+| refresh/merge.rs | 3,393 | 3,472 | +79 |
+| config.rs | 3,270 | 3,789 | +519 (Citus + 36 new GUCs) |
+| catalog.rs | 3,135 | 3,172 | +37 |
+| dvm/parser/types.rs | 3,082 | 3,082 | 0 |
+| **NEW** citus.rs | — | 1,174 | +1,174 |
+| **NEW** api/inbox.rs | — | 1,034 | +1,034 |
+| **NEW** api/outbox.rs | — | 942 | +942 |
+
+Net `src/` growth ~9%. Most of it is additive (Citus + outbox/inbox);
+hot-path modules (DVM, scheduler, refresh) grew by single-digit
+percentages.
+
+---
+
+## 15. New Feature Proposals
+
+### F1 — Reactive subscriptions ("PG-LISTEN on a stream table")
+
+**Problem.** Today the only way to react to a stream-table change is
+to poll or to wire an outbox + relay to a sink. For
+sub-second-latency UI use cases (dashboards, presence, chat) this is
+clumsy.
+**Approach.** A new `pgtrickle.subscribe(name TEXT, channel TEXT)`
+that auto-emits `NOTIFY <channel>, <json_payload>` on every applied
+delta. Reuse the v0.27 publication infrastructure.
+**Complexity:** M. **Impact:** ergonomics + ecosystem.
+**Suggested release:** v0.35.0.
+
+### F2 — Time-travel queries (`AS OF`)
+
+**Problem.** Differential dataflow naturally produces a temporal
+log; today nothing surfaces it.
+**Approach.** Persist the last N watermarks per ST in a circular
+buffer table; add `pgtrickle.stream_table_at(name, ts)` returning a
+relation. Use PostgreSQL set-returning function.
+**Complexity:** L. **Impact:** correctness (audit) + ecosystem.
+**Suggested release:** v0.36.0.
+
+### F3 — `EXPLAIN STREAM TABLE` operator-tree visualiser
+
+**Problem.** Operators have no way to know which DVM operators their
+query compiled to.
+**Approach.** Walk the cached OpTree, render as text/json/dot via
+`pgtrickle.explain_stream_table(name, FORMAT TEXT|JSON|DOT)`.
+**Complexity:** S. **Impact:** ergonomics.
+**Suggested release:** v0.35.0.
+
+### F4 — pgVectorMV: incremental vector-aggregation MVs for RAG
+
+**Problem.** Embedding pipelines today recompute aggregated vectors
+on a schedule; pg_trickle could maintain centroids/IVF clusters
+incrementally with pgvector.
+**Approach.** Add a `vector_avg` algebraic aggregate operator
+(Welford-equivalent in the L2 norm domain); validate with pgvector
+0.7+ HNSW indexes.
+**Complexity:** L. **Impact:** ecosystem (AI/RAG).
+**Suggested release:** v0.37.0.
+
+### F5 — Online schema evolution with `ALTER STREAM TABLE EVOLVE`
+
+**Problem.** Today `ALTER QUERY` requires a full reinit. Adding a
+column to a SELECT * style ST should be online.
+**Approach.** Detect type-compatible column additions in ALTER QUERY
+diff; emit ALTER TABLE on storage; re-prepare templates without
+flushing data.
+**Complexity:** L. **Impact:** ergonomics.
+**Suggested release:** v0.36.0.
+
+### F6 — DBSP-style pre-aggregation for hot keys
+
+**Problem.** A heavy-hitter key in a GROUP BY recomputes the whole
+partial sum on each cycle.
+**Approach.** Maintain per-key heap of recent deltas; apply lazily
+on read. Adapted from DBSP's "sharded zset" pattern.
+**Complexity:** XL. **Impact:** performance.
+**Suggested release:** v0.40.0.
+
+### F7 — WebAssembly compilation of hot-path operators
+
+**Problem.** PostgreSQL's row-by-row execution dominates differential
+operator latency for narrow queries.
+**Approach.** Compile delta-application kernels to WASM via
+`wasmtime` and JIT-load per ST. Optional, behind a GUC.
+**Complexity:** XL. **Impact:** performance.
+**Suggested release:** post-1.0.
+
+### F8 — Multi-master / active-active replication
+
+**Problem.** No story for multi-region writes today.
+**Approach.** Use BDR-style logical replication of `pgt_change_tracking`;
+each region produces local refreshes; downstream sinks dedupe by
+`(region_id, local_lsn)`.
+**Complexity:** XL. **Impact:** scalability.
+**Suggested release:** post-1.0.
+
+### F9 — Kubernetes Operator (`pg_trickle-operator`)
+
+**Problem.** CNPG ships a generic operator; pg_trickle deserves a
+CRD-based one for declarative ST management.
+**Approach.** Go-based operator using controller-runtime; CRDs for
+`StreamTable`, `Outbox`, `Inbox`; reconcile loop maps to SQL API.
+**Complexity:** L. **Impact:** ecosystem.
+**Suggested release:** v0.38.0.
+
+### F10 — OpenTelemetry trace propagation
+
+**Problem.** No way to correlate a refresh cycle with the upstream
+HTTP request that wrote the source data.
+**Approach.** Read W3C Trace Context from a session GUC
+(`pg_trickle.trace_id`); emit spans for each refresh phase via
+OTLP/gRPC; integrate with `pg_logical_emit_message` to carry trace
+headers across replication.
+**Complexity:** M. **Impact:** observability.
+**Suggested release:** v0.37.0.
+
+### F11 — `STREAM TABLE` SQL syntax (custom parser hook)
+
+**Problem.** Today users invoke `pgtrickle.create_stream_table('name',
+$$SELECT ...$$)`. A native `CREATE STREAM TABLE x AS SELECT ...`
+syntax is the strongest ergonomic move.
+**Approach.** Use PostgreSQL's `ProcessUtility_hook` to intercept
+`CREATE STREAM TABLE` lexically before parsing; rewrite to the
+function call.
+**Complexity:** L. **Impact:** ergonomics. Documented in
+[docs/research/CUSTOM_SQL_SYNTAX.md](../docs/research/CUSTOM_SQL_SYNTAX.md).
+**Suggested release:** v0.36.0.
+
+### F12 — Materialised CTE column lineage
+
+**Problem.** Operators cannot trace which source columns feed which
+ST columns; debugging "why did this row appear" is hard.
+**Approach.** During parsing, record a `column_lineage` graph in
+`pgt_stream_tables`; expose via
+`pgtrickle.stream_table_lineage(name)`.
+**Complexity:** M. **Impact:** ergonomics + correctness debugging.
+**Suggested release:** v0.36.0.
+
+### F13 — Pluggable sink architecture in pgtrickle-relay
+
+**Problem.** Adding a new sink (e.g. Snowflake, Iceberg, ClickHouse)
+requires a relay rebuild.
+**Approach.** Define a stable `Sink` trait + `dlopen`-style plugin
+loading; ship sinks as separate cargo crates.
+**Complexity:** M. **Impact:** ecosystem.
+**Suggested release:** v0.36.0.
+
+### F14 — Auto-generated GraphQL/REST API from stream tables
+
+**Problem.** Real-time dashboards need an HTTP API. Today users
+glue PostgREST or Hasura.
+**Approach.** A new sub-crate `pgtrickle-gateway` exposes
+`/streams/<name>` (GET + SSE) reading from local PG.
+**Complexity:** L. **Impact:** ecosystem.
+**Suggested release:** v0.40.0.
+
+### F15 — Cluster-wide query equivalence prover
+
+**Problem.** Equivalence between FULL and DIFFERENTIAL is currently
+checked by SQLancer post-hoc; could be enforced at create-time.
+**Approach.** Symbolic execution of the OpTree to derive a normal
+form; compare against FULL's normal form. Reject on inequivalence.
+**Complexity:** XL. **Impact:** correctness.
+**Suggested release:** post-1.0.
+
+### F16 — Edge-cache integration (Cloudflare D1, Turso libSQL)
+
+**Problem.** Stream tables are server-side; serving them at edge
+nodes still requires an HTTP hop.
+**Approach.** Compile a subset of ST output to SQLite/libSQL;
+sync via CRDT-tagged delta log.
+**Complexity:** XL. **Impact:** ecosystem.
+**Suggested release:** post-1.0.
+
+### F17 — Built-in SLA dashboard SQL views
+
+**Problem.** Operators must compose multiple `pgt_*_status` views
+to get an SLA report.
+**Approach.** Add `pgtrickle.sla_summary()` returning per-ST p50/p99
+latency, freshness, error budget burn. Drives F3 / F10 dashboards.
+**Complexity:** S. **Impact:** ergonomics.
+**Suggested release:** v0.35.0.
+
+---
+
+## 16. Prioritised Action Plan
+
+Sort: Severity desc (CRITICAL → LOW), then Effort asc.
+
+| ID | Area | Finding | Severity | Effort | Suggested Release | Owner Hint |
+|---|---|---|---|---|---|---|
+| A01 | DVM correctness | EC-01 phantom rows (§3.1) | CRITICAL | L | v0.35.0 | DVM lead |
+| A02 | DVM correctness | Add 50k-iteration EC-01 property test | CRITICAL | M | v0.35.0 | DVM lead |
+| A03 | Citus | Add chaos test rig (§3.3, §13.5) | HIGH | L | v0.35.0 | Citus lead |
+| A04 | Error handling | Wire SQLSTATE classifier (§3.2) | HIGH | S | v0.35.0 | Core |
+| A05 | Safety | Fix `expect` panic at rewrites.rs:5471 (§3.4) | HIGH | XS | v0.34.1 | DVM lead |
+| A06 | Tests | Unit tests for inbox/outbox (§3.5, §9.1) | HIGH | M | v0.35.0 | Outbox lead |
+| A07 | Ops | `pg_trickle.enabled` should also gate CDC trigger writes (§3.6) | MEDIUM | S | v0.35.0 | Core |
+| A08 | Ops | Add `pg_trickle.force_full_refresh` GUC (§3.7) | MEDIUM | XS | v0.35.0 | Core |
+| A09 | Performance | L0 dshash shared-mem cache (§4.1, §5.1) | HIGH | L | v0.36.0 | Perf |
+| A10 | Performance | History prune in dedicated bgworker w/ LIMIT (§4.2) | MEDIUM | S | v0.35.0 | Core |
+| A11 | Performance | Add `start_time` index to `pgt_refresh_history` (§5.2) | MEDIUM | XS | v0.35.0 | Core |
+| A12 | Performance | WAL backpressure enforcement (§5.3) | HIGH | M | v0.36.0 | CDC lead |
+| A13 | Performance | Citus lease backoff with jitter (§5.4) | MEDIUM | XS | v0.35.0 | Citus lead |
+| A14 | Architecture | Split `src/api/mod.rs` (§4.4) | MEDIUM | M | v0.36.0 | Core |
+| A15 | Architecture | Split `src/scheduler.rs` (§4.5) | MEDIUM | L | v0.37.0 | Core |
+| A16 | Architecture | Split `src/refresh/merge.rs` (§4.3) | LOW | M | v0.37.0 | Refresh lead |
+| A17 | Architecture | Typed DDL event payload (§4.6) | LOW | S | v0.36.0 | Core |
+| A18 | Architecture | `RowIdSchema` type across operators (§4.7) | MEDIUM | L | v0.36.0 | DVM lead |
+| A19 | Safety | Add SAFETY comments to rewrites.rs unsafe blocks (§6.2) | LOW | S | v0.35.0 | DVM lead |
+| A20 | Observability | Structured logging (§7.3) | MEDIUM | M | v0.36.0 | Obs |
+| A21 | Observability | IVM lock-mode fallback metric (§7.4) | LOW | XS | v0.35.0 | DVM lead |
+| A22 | Observability | NOTICE on FULL fallback (§7.5) | MEDIUM | S | v0.35.0 | DVM lead |
+| A23 | API | `EXPLAIN STREAM TABLE` (§8.2, F3) | MEDIUM | S | v0.35.0 | API |
+| A24 | API | Generated GUC catalogue in docs (§8.4) | LOW | S | v0.35.0 | Docs |
+| A25 | API | Bulk alter / drop APIs (§8.7) | LOW | S | v0.36.0 | API |
+| A26 | Tests | OOM / disk-full chaos (§9.3) | MEDIUM | M | v0.36.0 | QA |
+| A27 | Tests | Citus upgrade regression with frozen fixture (§9.5) | MEDIUM | M | v0.35.0 | Citus lead |
+| A28 | Tests | Add lightweight SQLancer to PR gate (§9.6) | MEDIUM | S | v0.35.0 | CI |
+| A29 | Tests | Aggregation/window/recursive-CTE fuzz targets (§9.4) | LOW | M | v0.36.0 | QA |
+| A30 | Security | Relay secret interpolation (§10.2) | MEDIUM | S | v0.35.0 | Relay lead |
+| A31 | Security | Sigstore + SBOM at release (§10.4) | MEDIUM | M | v0.36.0 | Release |
+| A32 | Docs | Citus tutorial (§11.2) | MEDIUM | M | v0.35.0 | Docs |
+| A33 | Docs | Outbox→relay→Kafka tutorial (§11.3) | MEDIUM | M | v0.35.0 | Docs |
+| A34 | Docs | `pg_trickle_dump` runbook (§7.7) | LOW | S | v0.35.0 | Docs |
+| A35 | Ops | Drain mode (§12.6) | MEDIUM | M | v0.36.0 | Core |
+| A36 | Ops | Capacity sizing calculator (§12.3) | LOW | M | v0.36.0 | Docs |
+| A37 | Ops | Grafana p50/p99 + alert rules (§12.4) | MEDIUM | S | v0.35.0 | Obs |
+| A38 | Ecosystem | Relay reconnection backoff (§13.1) | MEDIUM | S | v0.35.0 | Relay lead |
+| A39 | Ecosystem | Relay backpressure (§13.2) | HIGH | M | v0.35.0 | Relay lead |
+| A40 | Ecosystem | TUI inbox/outbox views (§13.3) | LOW | M | v0.36.0 | TUI |
+| A41 | Ecosystem | dbt Hub submission (§13.4) | LOW | XS | v0.35.0 | dbt lead |
+| A42 | Ecosystem | Multi-arch images (§13.6) | MEDIUM | S | v0.35.0 | Release |
+| A43 | Ecosystem | pg_partman / TimescaleDB integration tests (§13.7) | LOW | M | v0.37.0 | QA |
+
+---
+
+## 17. Appendix — File-Level Coverage Summary
+
+### A. `src/` files (66 total)
+
+LOC = source lines (`wc -l`); UC = unsafe-keyword strict count;
+TODO = TODO/FIXME/HACK count; UT = has `#[cfg(test)] mod tests` block;
+IT = has matching integration test under `tests/`.
+
+| File | LOC | UC | UT | IT |
+|---|---|---|---|---|
+| [src/lib.rs](../src/lib.rs) | 1,339 | 2 | Y | (extension_tests.rs) |
+| [src/api/mod.rs](../src/api/mod.rs) | 6,322 | 0 | Y | many |
+| [src/api/helpers.rs](../src/api/helpers.rs) | 2,867 | 12 | Y | indirect |
+| [src/api/diagnostics.rs](../src/api/diagnostics.rs) | 1,770 | 0 | Y | e2e_diagnostics_tests.rs |
+| [src/api/snapshot.rs](../src/api/snapshot.rs) | 629 | 6 | Y | e2e_snapshot_consistency_tests.rs |
+| [src/api/publication.rs](../src/api/publication.rs) | 866 | 0 | Y | e2e_publication_crash_recovery_tests.rs |
+| [src/api/outbox.rs](../src/api/outbox.rs) | 942 | 0 | **N** | e2e_outbox_tests.rs |
+| [src/api/inbox.rs](../src/api/inbox.rs) | 1,034 | 0 | **N** | e2e_inbox_tests.rs |
+| [src/api/cluster.rs](../src/api/cluster.rs) | 153 | 0 | Y | e2e_self_monitoring_tests.rs |
+| [src/api/planner.rs](../src/api/planner.rs) | 341 | 0 | Y | e2e_predictive_cost_tests.rs |
+| [src/api/self_monitoring.rs](../src/api/self_monitoring.rs) | 823 | 0 | Y | e2e_self_monitoring_tests.rs |
+| [src/api/metrics_ext.rs](../src/api/metrics_ext.rs) | 132 | 0 | **N** | indirect |
+| [src/bin/pg_trickle_dump.rs](../src/bin/pg_trickle_dump.rs) | 458 | 0 | N | none |
+| [src/catalog.rs](../src/catalog.rs) | 3,172 | 0 | Y | catalog_tests.rs |
+| [src/cdc.rs](../src/cdc.rs) | 4,037 | 0 | Y | e2e_cdc_*.rs many |
+| [src/citus.rs](../src/citus.rs) | 1,174 | 0 | Y | **N** (no e2e_citus_*) |
+| [src/config.rs](../src/config.rs) | 3,789 | 0 | Y | e2e_guc_variation_tests.rs |
+| [src/dag.rs](../src/dag.rs) | 4,295 | 0 | Y | e2e_dag_*.rs many |
+| [src/diagnostics.rs](../src/diagnostics.rs) | 2,051 | 0 | Y | e2e_diagnostics_tests.rs |
+| [src/error.rs](../src/error.rs) | 886 | 0 | Y | indirect |
+| [src/hash.rs](../src/hash.rs) | 172 | 0 | Y | indirect |
+| [src/hooks.rs](../src/hooks.rs) | 1,961 | 0 | Y | e2e_ddl_event_tests.rs |
+| [src/ivm.rs](../src/ivm.rs) | 1,639 | 0 | Y | e2e_ivm_tests.rs |
+| [src/metrics_server.rs](../src/metrics_server.rs) | 398 | 0 | Y | e2e_monitoring_tests.rs |
+| [src/monitor.rs](../src/monitor.rs) | 3,719 | 0 | Y | monitoring_tests.rs |
+| [src/scheduler.rs](../src/scheduler.rs) | 7,756 | 12 | Y | e2e_tier_*.rs, e2e_bgworker_tests.rs |
+| [src/shmem.rs](../src/shmem.rs) | 1,117 | 22 | Y | e2e_shared_buffer_tests.rs |
+| [src/template_cache.rs](../src/template_cache.rs) | 182 | 0 | **N** | none |
+| [src/version.rs](../src/version.rs) | 537 | 0 | Y | indirect |
+| [src/wal_decoder.rs](../src/wal_decoder.rs) | 2,212 | 4 | Y | e2e_wal_cdc_tests.rs |
+| [src/refresh/mod.rs](../src/refresh/mod.rs) | 212 | 0 | Y | e2e_refresh_tests.rs |
+| [src/refresh/orchestrator.rs](../src/refresh/orchestrator.rs) | 388 | 0 | (via tests.rs) | e2e_refresh_tests.rs |
+| [src/refresh/codegen.rs](../src/refresh/codegen.rs) | 2,383 | 0 | (via tests.rs) | indirect |
+| [src/refresh/merge.rs](../src/refresh/merge.rs) | 3,472 | 0 | (via tests.rs) | e2e_merge_template_tests.rs |
+| [src/refresh/phd1.rs](../src/refresh/phd1.rs) | 108 | 0 | Y | e2e_cascade_regression_tests.rs |
+| [src/refresh/tests.rs](../src/refresh/tests.rs) | 2,572 | 0 | Y | (this is the test module) |
+| [src/dvm/mod.rs](../src/dvm/mod.rs) | 1,811 | 0 | Y | indirect |
+| [src/dvm/diff.rs](../src/dvm/diff.rs) | 1,068 | 0 | Y | indirect |
+| [src/dvm/row_id.rs](../src/dvm/row_id.rs) | 136 | 0 | Y | indirect |
+| [src/dvm/parser/mod.rs](../src/dvm/parser/mod.rs) | 5,526 | 14 | Y | e2e_coverage_parser_tests.rs |
+| [src/dvm/parser/types.rs](../src/dvm/parser/types.rs) | 3,082 | 0 | Y | indirect |
+| [src/dvm/parser/validation.rs](../src/dvm/parser/validation.rs) | 1,177 | 2 | Y | e2e_correctness_gate_tests.rs |
+| [src/dvm/parser/rewrites.rs](../src/dvm/parser/rewrites.rs) | 6,105 | 67 | Y | indirect |
+| [src/dvm/parser/sublinks.rs](../src/dvm/parser/sublinks.rs) | 6,559 | 211 | (in mod tests) | e2e_all_subquery_tests.rs |
+| [src/dvm/operators/mod.rs](../src/dvm/operators/mod.rs) | 28 | 0 | N | — |
+| [src/dvm/operators/scan.rs](../src/dvm/operators/scan.rs) | 1,763 | 0 | Y | indirect |
+| [src/dvm/operators/filter.rs](../src/dvm/operators/filter.rs) | 746 | 0 | Y | indirect |
+| [src/dvm/operators/project.rs](../src/dvm/operators/project.rs) | 522 | 0 | Y | indirect |
+| [src/dvm/operators/aggregate.rs](../src/dvm/operators/aggregate.rs) | 5,400 | 0 | Y | dvm_aggregate_execution_tests.rs |
+| [src/dvm/operators/join.rs](../src/dvm/operators/join.rs) | 1,719 | 0 | Y | dvm_join_tests.rs |
+| [src/dvm/operators/join_common.rs](../src/dvm/operators/join_common.rs) | 2,074 | 0 | Y | dvm_*_join_tests.rs |
+| [src/dvm/operators/full_join.rs](../src/dvm/operators/full_join.rs) | 699 | 0 | Y | dvm_full_join_tests.rs |
+| [src/dvm/operators/outer_join.rs](../src/dvm/operators/outer_join.rs) | 766 | 0 | Y | dvm_outer_join_tests.rs |
+| [src/dvm/operators/semi_join.rs](../src/dvm/operators/semi_join.rs) | 668 | 0 | Y | dvm_semijoin_antijoin_tests.rs |
+| [src/dvm/operators/anti_join.rs](../src/dvm/operators/anti_join.rs) | 545 | 0 | Y | dvm_semijoin_antijoin_tests.rs |
+| [src/dvm/operators/recursive_cte.rs](../src/dvm/operators/recursive_cte.rs) | 4,050 | 0 | Y | e2e_cte_tests.rs |
+| [src/dvm/operators/window.rs](../src/dvm/operators/window.rs) | 717 | 0 | Y | dvm_window_scalar_subquery_tests.rs |
+| [src/dvm/operators/lateral_subquery.rs](../src/dvm/operators/lateral_subquery.rs) | 1,266 | 0 | Y | e2e_lateral_subquery_tests.rs |
+| [src/dvm/operators/lateral_function.rs](../src/dvm/operators/lateral_function.rs) | 473 | 0 | Y | e2e_lateral_tests.rs |
+| [src/dvm/operators/scalar_subquery.rs](../src/dvm/operators/scalar_subquery.rs) | 319 | 0 | Y | e2e_scalar_subquery_tests.rs |
+| [src/dvm/operators/distinct.rs](../src/dvm/operators/distinct.rs) | 191 | 0 | Y | indirect |
+| [src/dvm/operators/cte_scan.rs](../src/dvm/operators/cte_scan.rs) | 199 | 0 | Y | e2e_cte_tests.rs |
+| [src/dvm/operators/intersect.rs](../src/dvm/operators/intersect.rs) | 401 | 0 | Y | e2e_set_operation_tests.rs |
+| [src/dvm/operators/except.rs](../src/dvm/operators/except.rs) | 483 | 0 | Y | e2e_set_operation_tests.rs |
+| [src/dvm/operators/subquery.rs](../src/dvm/operators/subquery.rs) | 124 | 0 | Y | indirect |
+| [src/dvm/operators/union_all.rs](../src/dvm/operators/union_all.rs) | 127 | 0 | Y | indirect |
+| [src/dvm/operators/test_helpers.rs](../src/dvm/operators/test_helpers.rs) | 719 | 0 | (helper) | (helper) |
+
+### B. `tests/` files (140 total)
+
+The full enumeration is large; below is a categorisation. Every file
+under `tests/` ending in `.rs` is integration-tier (Testcontainers or
+pgrx) unless prefixed `e2e_` (full Docker E2E) or `dvm_` (operator
+DVM tests).
+
+| Tier | Pattern | Count |
+|---|---|---|
+| Pgrx unit/integration | `tests/{catalog,extension,monitoring,property,resilience,scenario,smoke,trigger_detection,workflow,catalog_compat}_tests.rs` | 10 |
+| DVM operator tests | `tests/dvm_*_tests.rs` | 10 |
+| E2E (full Docker) | `tests/e2e_*.rs` | 110 |
+| Sub-suites | `tests/e2e/`, `tests/nexmark/`, `tests/tpch/`, `tests/pg_regress/`, `tests/common/` | 5 dirs |
+| Build helpers | `tests/Dockerfile.*`, `tests/build_e2e_image.sh`, `tests/build_e2e_upgrade_image.sh` | 5 |
+
+The 110 E2E files are spread across all 17 chapters of the user
+guide; the heaviest are listed in the audit metrics above
+(e2e_tpch_tests.rs 3,438 LOC; e2e_cte_tests.rs 3,150;
+e2e_bench_tests.rs 2,361; e2e_partition_tests.rs 2,208;
+e2e_mixed_pg_objects_tests.rs 2,211).
+
+### C. Source modules with no matching test file
+
+- [src/template_cache.rs](../src/template_cache.rs) — neither
+  `mod tests` nor an integration test file references it directly.
+- [src/api/metrics_ext.rs](../src/api/metrics_ext.rs) — only indirect
+  coverage via monitoring tests.
+- [src/api/inbox.rs](../src/api/inbox.rs) — no `mod tests`; only
+  `tests/e2e_inbox_tests.rs`.
+- [src/api/outbox.rs](../src/api/outbox.rs) — no `mod tests`; only
+  `tests/e2e_outbox_tests.rs`.
+- [src/citus.rs](../src/citus.rs) — has `mod tests` but no
+  multi-node integration test (`e2e_citus_*` does not exist).
+- [src/bin/pg_trickle_dump.rs](../src/bin/pg_trickle_dump.rs) — no
+  test of any tier.
+
+These six are the highest-priority test-gap items, ordered by impact.
+
+---
+
+*End of report.*

--- a/roadmap/v0.35.0.md
+++ b/roadmap/v0.35.0.md
@@ -1,24 +1,77 @@
-# v0.35.0 — Reactive Subscriptions & Zero-Downtime Operations
+# v0.35.0 — Correctness Sprint, Reactive Subscriptions & Zero-Downtime Operations
 
 > **Full technical details:** [v0.35.0.md-full.md](v0.35.0.md-full.md)
 
-**Status: Planned** | **Scope: Medium**
+**Status: Planned** | **Scope: Large**
 
-> Live push notifications to applications, and a way to change a stream
-> table's defining query on a large production table without downtime.
+> A correctness-and-quality sprint that closes the three-assessment-old EC-01
+> phantom-row bug and hardens Citus chaos tolerance, combined with two new
+> user-facing capabilities: live push notifications and zero-downtime query
+> changes.
 
 ---
 
 ## What is this?
 
-v0.35.0 adds two long-requested operational capabilities:
+v0.35.0 combines a mandatory quality sprint with two long-requested
+operational capabilities:
 
-1. **Push notifications** — applications can subscribe to changes in a
-   stream table and receive instant notifications, enabling real-time
-   dashboards, live UIs, and event-driven microservices.
+1. **EC-01 correctness closeout** — the phantom-row residue in multi-table
+   joins that has been tracked since v0.21.0 is fixed unconditionally.
+   Every join delta is now routed through PH-D1 cleanup, and a 50,000-iteration
+   property test proves convergence.
 
-2. **Zero-downtime query changes** — modifying the defining query of a
-   large stream table no longer requires a multi-minute lock on the table.
+2. **Citus chaos hardening** — a new multi-container Docker Compose Citus
+   test rig covers worker kill, coordinator failover, lease expiry, and
+   rebalance scenarios that have had zero test coverage since Citus landed.
+
+3. **Push notifications** — applications can subscribe to changes in a stream
+   table and receive instant notifications, enabling real-time dashboards,
+   live UIs, and event-driven microservices.
+
+4. **Zero-downtime query changes** — modifying the defining query of a large
+   stream table no longer requires a multi-minute lock on the table.
+
+---
+
+## EC-01 correctness closeout
+
+The phantom-row residue bug (`is_deduplicated: false` at
+`src/dvm/operators/join.rs:657-668`) has been flagged in every overall
+assessment since v0.21.0. The v0.24.0 fix addressed the hash function but
+not the downstream Z-set pipeline, leaving PH-D1 cross-cycle cleanup opt-in
+and only invoked when a residual is detected — which itself depends on a flag
+not set on every code path.
+
+v0.35.0 closes this definitively in two steps:
+
+1. **Immediate fix:** route every refresh cycle unconditionally through PH-D1
+   with a batch size of 1,024 rows. The anti-join cost against the freshly
+   applied delta is negligible and removes the residual-detection coupling.
+
+2. **Proper fix:** re-engineer Part 2 row-id derivation so that Part 1a and
+   Part 1b emit convergent ids; flip `is_deduplicated: true` for INNER joins
+   on stable PKs; gate behind a 50,000-iteration proptest corpus.
+
+Stream tables built on multi-table joins can then use DIFFERENTIAL refresh
+with full correctness confidence.
+
+---
+
+## Citus chaos hardening
+
+The `pgt_st_locks` distributed mutex and `ensure_worker_slot` / rebalance
+recovery logic added in v0.32–v0.34 have never been tested under adversarial
+conditions. v0.35.0 adds `tests/e2e_citus_chaos_tests.rs` backed by a
+Docker Compose rig (coordinator + 3 workers) that drives:
+
+- Kill-and-restart a worker during an active poll cycle
+- Coordinator restart mid-lease acquisition
+- `pg_dist_node` removal and re-add of a worker
+- Sustained 1k-stream-table refresh under continuous node churn
+
+A new `citus-tests.yml` GitHub Actions workflow runs this suite on every push
+to `main`.
 
 ---
 
@@ -67,15 +120,34 @@ The live table is readable and writable from start to finish.
 
 ---
 
-## Scope
+## Also in v0.35.0
 
-v0.35.0 is a medium-sized release. The shadow-ST feature touches the refresh
-orchestrator — the most change-sensitive module in the codebase — and ships
-behind a feature flag with a full TPC-H validation pass before the flag is
-removed.
+Beyond the headlining items, this release closes a wide range of quality and
+operational gaps identified in the v7 overall assessment:
+
+- `EXPLAIN STREAM TABLE` — see which DVM operators your query compiled to
+- `pg_trickle.force_full_refresh` GUC for incident-response override
+- `pg_trickle.enabled = false` now also gates CDC trigger writes
+- History prune moved to a dedicated background worker with `LIMIT` batching
+- SQLSTATE error classifier wired end-to-end (replaces English-text matching)
+- Relay secret interpolation via `${ENV:VAR}` in connection strings
+- Relay backpressure and reconnection backoff
+- Lightweight SQLancer run added to every PR gate
+- Grafana p50/p99 refresh latency panels and alert rules
+- Citus tutorial, outbox→relay→Kafka tutorial, `pg_trickle_dump` runbook
+- `NOTICE` emitted on every FULL fallback so operators can detect DVM limits
+- Multi-architecture Docker images (arm64 + amd64)
 
 ---
 
-*Previous: [v0.32.0 — Citus: Stable Naming & Per-Source Frontier Foundation](v0.32.0.md)*
+## Scope
+
+v0.35.0 is a large release. It is the single highest-priority release before
+v1.0 because it closes the EC-01 correctness gap that affects every multi-table
+join workload. All other 1.0-track features are downstream of this.
+
+---
+
 *Previous: [v0.34.0 — Citus: Automated Distributed CDC & Shard Recovery](v0.34.0.md)*
+*Next: [v0.36.0 — Structural Hardening, Performance & Temporal IVM](v0.36.0.md)*
 *Next: [v0.36.0 — Temporal IVM & Columnar Materialization](v0.36.0.md)*

--- a/roadmap/v0.35.0.md-full.md
+++ b/roadmap/v0.35.0.md-full.md
@@ -1,66 +1,300 @@
-> **Plain-language companion:** [v0.34.0.md](v0.34.0.md)
+> **Plain-language companion:** [v0.35.0.md](v0.35.0.md)
 
-## v0.34.0 — Reactive Subscriptions & Zero-Downtime Operations
+## v0.35.0 — Correctness Sprint, Reactive Subscriptions & Zero-Downtime Operations
 
-**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.1, §10.8.
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_7.md](plans/PLAN_OVERALL_ASSESSMENT_7.md) §3, §7, §9, §11, §13; A01–A06, A07–A08, A10–A11, A13, A19, A21–A24, A27–A28, A30, A32–A34, A37–A42; F1, F3, F17.
 
 > **Release Theme**
-> v0.34.0 delivers two long-requested operational capabilities. Reactive
-> subscriptions expose stream-table changes as PostgreSQL `NOTIFY` events,
-> enabling browser-side reactive UIs and event-driven microservices with
-> nothing but a standard PG connection — no Kafka, no Debezium, no Hasura.
-> Zero-downtime view evolution adds a shadow-ST mode to `ALTER QUERY` that
-> builds the new query's materialisation side-by-side with the live table,
-> then swaps atomically — eliminating the operational risk of running
-> `ALTER QUERY` on a large production stream table.
+> v0.35.0 is the mandatory quality gate before new feature development can
+> resume. It closes EC-01 (phantom-row residue in multi-table joins — flagged
+> in three consecutive overall assessments), hardens Citus distributed
+> coordination with a real chaos test rig, and wires the SQLSTATE error
+> classifier that shipped in v0.30.0 but was never connected to call sites.
+> On top of that foundation it delivers reactive subscriptions (PG NOTIFY on
+> every stream-table change), zero-downtime query evolution via shadow-ST, and
+> closes ~30 operational/observability/documentation gaps identified in the v7
+> overall assessment.
 
 ---
 
-### Correctness
+### Correctness (P0 — Blocks v1.0)
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| CORR-1 | Reactive subscription: coalesce NOTIFY storms | S | P0 |
+| A01 | EC-01: unconditional PH-D1 cleanup on every join cycle | L | P0 |
+| A02 | EC-01: 50k-iteration property test for join-delta convergence | M | P0 |
+| A04 | Wire SQLSTATE error classifier end-to-end | S | P0 |
+| A05 | Fix `expect()` panic at `rewrites.rs:5471` | XS | P0 |
+| CORR-SUB | Reactive subscription: coalesce NOTIFY storms | S | P0 |
 
-**CORR-1** — The subscribe API must coalesce rapid successive changes into a
-single NOTIFY payload (or a "changes pending" signal) when the refresh
-interval is shorter than the LISTEN client's poll loop. Implement a
-`pg_trickle.notify_coalesce_ms` GUC (default 250 ms) and a per-stream-table
-flag that debounces NOTIFY calls.
+**A01 — EC-01 unconditional PH-D1 cleanup.**
+`src/dvm/operators/join.rs:657-668` still hard-codes `is_deduplicated: false`,
+so the Z-set pipeline's MERGE path can accumulate a non-zero per-row-id
+residual when an insert-then-delete on the left side collides with a delete on
+the right within the same refresh cycle. `src/refresh/phd1.rs:34-99`
+implements a cross-cycle anti-join cleanup, but it is only invoked when the
+prior cycle reported a non-zero residual — and that flag is not set on every
+code path.
+
+Step 1: route every refresh cycle through PH-D1 unconditionally with batch
+size 1,024 rows. Cost is negligible (anti-join against the freshly-applied
+delta). This removes the residual-detection coupling and stops the bug from
+producing inconsistent aggregates or `UNIQUE_VIOLATION` errors.
+
+Step 2: re-engineer Part 2 row-id derivation so Part 1a and Part 1b emit
+convergent ids, flip `is_deduplicated: true` for INNER joins on stable PKs,
+gate behind a proptest corpus (see A02). **Schema change:** No.
+
+**A02 — EC-01 property-test corpus.**
+Add a 50,000-iteration proptest generator to `tests/e2e_property_tests.rs` that
+generates arbitrary insert/update/delete sequences on two- and three-table join
+sources, runs DIFFERENTIAL refresh, and asserts DIFFERENTIAL == FULL at each
+cycle. Shrink to minimal counterexamples; add regression fixtures for every
+TPC-H Q7/Q15 flake documented in repo memory.
+
+**A04 — Wire SQLSTATE classifier.**
+`src/error.rs:312-380` (`classify_spi_sqlstate_retryable`) exists but
+`SpiErrorCode` is constructed in zero call sites. Surface
+`pg_sys::ErrorData.sqlerrcode` from pgrx SPI errors via
+`SpiError::error_code()`, construct `SpiErrorCode { code, msg }` everywhere
+a `SpiError(String)` is constructed today. The legacy text matcher at
+`src/error.rs:282-340` stays as a final fallback for non-SPI sources.
+**Impact:** eliminates infinite retry loops on PostgreSQL builds with
+non-English `lc_messages`.
+
+**A05 — Fix `expect()` panic at `rewrites.rs:5471`.**
+`join_and_predicates()` calls `iter.next().expect("at least one predicate
+required")`. This is production code (the `#[cfg(test)]` block starts at line
+5934). Change the signature to `Result<Expr, PgTrickleError>` returning
+`Err(PgTrickleError::InvalidArgument("empty predicate set".into()))` and
+propagate with `?` at the two call sites. Half-day task.
+
+**CORR-SUB** — The subscribe API must coalesce rapid successive changes into a
+single NOTIFY payload when the refresh interval is shorter than the LISTEN
+client's poll loop. Implement a `pg_trickle.notify_coalesce_ms` GUC (default
+250 ms) that debounces NOTIFY calls per stream table.
 
 ---
 
-### Ease of Use
+### Correctness (P1 — Citus Chaos)
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| UX-1 | `pgtrickle.subscribe(name, channel)` and `unsubscribe()` SQL functions | M | P0 |
-| UX-2 | `pg_trickle.notify_coalesce_ms` GUC | XS | P0 |
-| UX-3 | `ALTER QUERY` shadow-ST mode (`shadow_build := true` parameter) | L | P1 |
-| UX-4 | `pgtrickle.view_evolution_status(name)` monitoring function | S | P1 |
-| UX-5 | Documentation: subscribe() quick-start + shadow-ST runbook | M | P1 |
+| A03 | Citus chaos test rig: Docker Compose coordinator + 3 workers | L | P1 |
+| A27 | Citus upgrade regression with frozen v0.31.0 fixture | M | P1 |
 
-**UX-1 — Reactive subscription API.**
-`pgtrickle.subscribe(stream_table TEXT, channel TEXT)` registers a per-stream-
-table listener: after every successful differential or full refresh, if the
-delta is non-empty, the refresh path emits `pg_notify(channel, payload_jsonb::text)`
-within the same transaction. The payload carries `{"name": …, "refresh_id": …,
-"inserted_count": N, "deleted_count": N}`. Build on the `pg_notify`
-infrastructure already wired by the v0.28.0 outbox. `pgtrickle.unsubscribe(name, channel)`
-removes the registration; `pgtrickle.list_subscriptions()` returns all active
-registrations. **Schema change:** Yes — new `pgtrickle.pgt_subscriptions`
-catalog table.
+**A03 — Citus chaos test rig.**
+`src/citus.rs` implements `pgt_st_locks` (distributed advisory mutex via
+`INSERT … ON CONFLICT DO NOTHING` + TTL lease) and `poll_worker_slot_changes`,
+but none of the failure modes have a test: lease expiry during refresh,
+coordinator failover mid-lease, clock skew, partial `pg_dist_node` rebalance,
+worker death during poll, concurrent `handle_vp_promoted` calls.
 
-**UX-3 — Shadow-ST for zero-downtime `ALTER QUERY`.**
-Today `ALTER QUERY` triggers a full refresh of the stream table. For tables
-with millions of rows, this causes a multi-minute outage during which the
-stream table is locked. A `shadow_build := true` parameter to `alter_query()`
-creates a parallel stream table `__pgt_shadow_<name>` built from the new query,
-refreshes it to convergence in the background without locking the live table,
-then atomically swaps the storage tables and drops the shadow. The live table
-is readable and writable throughout. The new query goes live at the next refresh
-cycle after the swap. **Schema change:** Yes — add `in_shadow_build BOOLEAN` and
-`shadow_table_name TEXT` columns to `pgtrickle.pgt_stream_tables`.
+Create `tests/e2e_citus_chaos_tests.rs` backed by a Docker Compose Citus rig
+(coordinator + 3 workers). Drive: (a) kill-and-restart worker mid-poll,
+(b) coordinator restart mid-lease, (c) `pg_dist_node` removal + re-add,
+(d) 1k-stream-table refresh under sustained node churn. Gate on a new
+`citus-tests.yml` workflow that runs on push-to-main.
+
+**A27 — Frozen fixture for stable-name backfill.**
+No test asserts that a `pgt_change_tracking` row written at v0.31.0 is
+correctly re-keyed by the v0.32.0 stable-name backfill migration. Add a binary
+dump fixture from v0.31.0 to the upgrade test suite and assert the expected
+stable names after migration.
+
+---
+
+### Ease of Use / Operational
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A06 | Unit tests for inbox/outbox | M | P0 |
+| A07 | `pg_trickle.enabled = false` gates CDC trigger writes | S | P1 |
+| A08 | `pg_trickle.force_full_refresh` override GUC | XS | P1 |
+| A10 | History prune in dedicated bgworker with LIMIT | S | P1 |
+| A11 | `start_time` index on `pgt_refresh_history` | XS | P1 |
+| A13 | Citus lease acquisition: randomised backoff on conflict | XS | P1 |
+| A22 | Emit `pgrx::notice!()` on every FULL fallback | S | P1 |
+| A23 | `pgtrickle.explain_stream_table()` operator-tree visualiser | S | P1 |
+| A24 | Generated GUC catalogue in docs (CI sync check) | S | P2 |
+| A37 | Grafana p50/p99 refresh latency panels + alert rules | S | P1 |
+| A42 | Multi-architecture Docker images (arm64 + amd64) | S | P1 |
+| F17 | `pgtrickle.sla_summary()` view: per-ST p50/p99, freshness, error budget | S | P1 |
+| UX-SUB | `pgtrickle.subscribe(name, channel)` / `unsubscribe()` / `list_subscriptions()` | M | P0 |
+| UX-GUC | `pg_trickle.notify_coalesce_ms` GUC (default 250 ms) | XS | P0 |
+| UX-SHADOW | `ALTER QUERY shadow_build := true` shadow-ST zero-downtime mode | L | P1 |
+| UX-STATUS | `pgtrickle.view_evolution_status(name)` monitoring function | S | P1 |
+
+**A06 — Inbox/outbox unit tests.**
+`src/api/inbox.rs` (1,034 LOC) and `src/api/outbox.rs` (942 LOC) have no
+`#[cfg(test)] mod tests` block. For an at-least-once + dedup guarantee, E2E
+coverage alone is too thin. Add unit tests for: dedup-key roundtrip, envelope
+encode/decode, NULL value handling, version-skew rejection, proptest-driven
+envelope fuzzing.
+
+**A07 — CDC kill switch fix.**
+`pg_trickle.enabled = false` stops scheduler dispatching but CDC triggers
+continue writing to `pgtrickle_changes.changes_<stable_name>`. Add a fast-path
+check at the top of every CDC trigger body that returns `NULL` (no-op) when
+`pg_trickle.enabled = false`. Also add a `pg_trickle.cdc_paused` GUC for
+a durable hold that survives session reconnects.
+
+**A08 — Force-full-refresh override.**
+Per-ST `refresh_mode` in `pgt_stream_tables` takes precedence over the cluster
+GUC `pg_trickle.refresh_strategy`. An SRE who sets the cluster to FULL for
+diagnosis still sees DIFFERENTIAL on STs with an explicit row value.
+Add `pg_trickle.force_full_refresh = bool` (default `false`) that overrides
+per-ST mode for the duration the GUC is set.
+
+**A10 — History prune bgworker.**
+At 1,000 STs × 12 refreshes/min the `pgt_refresh_history` table sustains
+~720k inserts/hour. The prune DELETE is O(rows-deleted) per pass with no
+`LIMIT` and no cancel guard. Move the prune to a dedicated
+`bgworker_history_pruner` background worker on a configurable interval
+(default 60 s) with `DELETE … LIMIT 10000`.
+
+**A11 — History table index.**
+Several monitor queries scan `pgt_refresh_history` by `start_time DESC` alone.
+At 10M rows this is multi-second. Add a secondary index on `start_time`; with
+the retention prune in place this stays small.
+
+**A13 — Citus lease backoff.**
+`pgt_st_locks` acquisition retries on conflict with no delay. With multiple
+coordinators racing, this produces O(N²) attempts/second. Add 50–500 ms
+randomised jitter on each `INSERT … ON CONFLICT DO NOTHING` failure.
+
+**A22 — FULL fallback NOTICE.**
+When the DVM parser falls back to FULL refresh (SubLink-in-OR walker miss,
+non-monotone aggregate, etc.) it does so silently. Emit
+`pgrx::notice!("stream table \"{}\" using FULL refresh: {}", name, reason)`
+at every fallback path.
+
+**A23 — `EXPLAIN STREAM TABLE`.**
+`pgtrickle.explain_stream_table(name TEXT, format TEXT DEFAULT 'text')`
+walks the cached OpTree and returns a textual/JSON/DOT rendering showing which
+DVM operators will be invoked and which fall back to FULL recompute. Format
+mirrors PostgreSQL's `EXPLAIN (FORMAT TEXT|JSON)`.
+
+**A24 — GUC catalogue sync.**
+`src/config.rs` defines 111 GUCs; `docs/CONFIGURATION.md` does not enumerate
+all of them. Add a CI step that generates a Markdown table from `GucRegistry`
+definitions and fails if the table in docs is out of sync.
+
+**A37 — Grafana SLI panels.**
+Add p50/p99 refresh latency panels, change-buffer depth and CDC lag panels,
+and Prometheus alert rules to `monitoring/grafana/`. Create
+`monitoring/grafana/alerts/pg_trickle.yml` with at least: latency p99 > 30 s,
+change-buffer depth > 100k rows, slot lag > critical threshold.
+
+**A42 — Multi-arch images.**
+Build and push `linux/arm64` + `linux/amd64` manifests for the Docker Hub and
+GHCR images in the release workflow.
+
+**F17 — SLA summary function.**
+`pgtrickle.sla_summary()` returns one row per ST with columns
+`p50_ms`, `p99_ms`, `freshness_lag_s`, `error_rate`, `error_budget_remaining`
+computed over the last `sla_window_hours` (GUC, default 24 h). Drives the
+Grafana dashboard and on-call runbooks.
+
+**UX-SUB — Reactive subscription API.**
+`pgtrickle.subscribe(stream_table TEXT, channel TEXT)` emits
+`pg_notify(channel, payload)` on every non-empty refresh within the same
+transaction. Payload: `{"name": …, "refresh_id": …, "inserted_count": N,
+"deleted_count": N}`. `pgtrickle.unsubscribe(name, channel)` and
+`pgtrickle.list_subscriptions()` complete the API. **Schema change:** new
+`pgtrickle.pgt_subscriptions` catalog table.
+
+**UX-SHADOW — Shadow-ST zero-downtime ALTER QUERY.**
+`alter_query(name, new_query, shadow_build := true)` creates
+`__pgt_shadow_<name>`, refreshes it to convergence without locking the live
+table, then atomically swaps storage tables. The live table is readable and
+writable throughout. Ships behind a feature flag. **Schema change:** add
+`in_shadow_build BOOLEAN` and `shadow_table_name TEXT` to
+`pgtrickle.pgt_stream_tables`.
+
+---
+
+### Performance
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A21 | IVM lock-mode fallback Prometheus counter | XS | P2 |
+
+**A21 — IVM lock-mode fallback metric.**
+`src/ivm.rs:48-91`: on parse failure IVM defaults to `Exclusive` mode
+(correct, fail-closed) but emits no metric. Add
+`pgtrickle_ivm_lock_mode_fallback_total{reason="parse_error"}` so operators
+can see how often this occurs.
+
+---
+
+### Safety
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A19 | Add `// SAFETY:` comments to all unsafe blocks in `rewrites.rs` | S | P2 |
+
+**A19 — SAFETY comments in rewrites.rs.**
+67 unsafe blocks in `src/dvm/parser/rewrites.rs` lack inline `// SAFETY:`
+comments (standard pgrx FFI patterns). Add comments to satisfy the AGENTS.md
+convention and make future refactors safer.
+
+---
+
+### Ecosystem
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A28 | Lightweight SQLancer run on every PR (100-case budget) | S | P1 |
+| A30 | Relay: `${ENV:VAR}` secret interpolation in connection strings | S | P1 |
+| A38 | Relay: exponential reconnection backoff | S | P1 |
+| A39 | Relay: backpressure — pause ingestion when sink is slow | M | P0 |
+| A41 | dbt Hub package submission | XS | P2 |
+
+**A28 — SQLancer on PR gate.**
+`.github/workflows/sqlancer.yml` runs Sundays + manual dispatch only. Add a
+100-case fast-path run (5–10 min budget) to the PR workflow to catch
+DVM-vs-FULL equivalence regressions earlier.
+
+**A30 — Relay secret interpolation.**
+`pgtrickle-relay/src/config.rs` accepts connection strings in plaintext TOML.
+Add `${ENV:VAR_NAME}` expansion at load time and document the pattern in
+`docs/RELAY_GUIDE.md`.
+
+**A38 — Relay reconnection backoff.**
+The relay coordinator reconnects immediately on sink failure. Add exponential
+backoff (initial 100 ms, max 30 s, jitter ±20%) to prevent thundering-herd
+on sink restart.
+
+**A39 — Relay backpressure.**
+The relay has no upper bound on in-flight messages per sink. If a sink is slow,
+memory grows unboundedly. Add a configurable `sink_max_inflight` GUC (default
+1,000 messages) that pauses upstream polling when the in-flight window is full.
+
+---
+
+### Documentation
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A32 | Citus end-to-end tutorial | M | P1 |
+| A33 | Outbox → relay → Kafka tutorial | M | P1 |
+| A34 | `pg_trickle_dump` runbook | S | P2 |
+
+**A32 — Citus tutorial.**
+Create `docs/tutorials/CITUS_DISTRIBUTED.md`: install Citus → install
+pg_trickle → create a distributed source table → create a co-located
+distributed stream table → observe replication lag via `citus_status`.
+
+**A33 — Outbox→relay→Kafka tutorial.**
+Create `docs/tutorials/OUTBOX_RELAY_KAFKA.md`: end-to-end code samples for
+configuring the transactional outbox, starting the relay connector, and
+consuming messages in Kafka with exactly-once semantics.
+
+**A34 — `pg_trickle_dump` runbook.**
+`src/bin/pg_trickle_dump.rs` (458 LOC) has no documentation. Create
+`docs/PG_TRICKLE_DUMP.md` describing what it does, when to run it, and
+how to interpret its output.
 
 ---
 
@@ -68,29 +302,40 @@ cycle after the swap. **Schema change:** Yes — add `in_shadow_build BOOLEAN` a
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| TEST-1 | E2E: subscribe() receives NOTIFY on every non-empty refresh | M | P0 |
-| TEST-2 | E2E: NOTIFY coalescing under high-frequency refresh | S | P1 |
-| TEST-3 | E2E: shadow-ST ALTER QUERY while reads/writes are in flight | L | P1 |
-| TEST-4 | E2E: shadow-ST rollback if new query fails to converge | M | P1 |
+| TEST-SUB1 | E2E: `subscribe()` receives NOTIFY on every non-empty refresh | M | P0 |
+| TEST-SUB2 | E2E: NOTIFY coalescing under high-frequency refresh | S | P1 |
+| TEST-SHA1 | E2E: shadow-ST ALTER QUERY while reads/writes are in flight | L | P1 |
+| TEST-SHA2 | E2E: shadow-ST rollback if new query fails to converge | M | P1 |
 
 ---
 
 ### Conflicts & Risks
 
-- **UX-3** (shadow-ST) touches the refresh orchestrator and catalog — the
-  highest-change-risk modules. Must ship behind a feature flag, stabilised
-  with the full TPC-H test suite before removing the flag.
-- Shadow-ST competes with the live stream table's change buffer, potentially
-  doubling CDC write overhead during the build window. Add a
+- **A01/A02** (EC-01 fix) modifies `src/dvm/operators/join.rs` and
+  `src/refresh/phd1.rs` — changes here must pass the full TPC-H suite
+  before merging. Do not merge EC-01 fix until 50k-iteration proptest is green.
+- **UX-SHADOW** (shadow-ST) touches the refresh orchestrator — the
+  highest-change-risk module. Ships behind a feature flag; do not remove
+  the flag until TPC-H validation is complete.
+- Shadow-ST doubles CDC write overhead during the build window. Add
   `shadow_refresh_throttle_ms` GUC to rate-limit background refreshes.
+- **A03** (Citus chaos rig) requires Docker Compose with Citus image in CI;
+  add to the `citus-tests.yml` workflow only (not the standard PR matrix).
 
 ### Exit Criteria
 
-- [ ] UX-1: `subscribe()` / `unsubscribe()` / `list_subscriptions()` registered; NOTIFY emitted on non-empty refresh; `pgt_subscriptions` catalog table in migration script
-- [ ] CORR-1: NOTIFY coalescing tested at 10 Hz refresh; client receives ≤ 1 NOTIFY per `notify_coalesce_ms` window
-- [ ] UX-3: Shadow-ST builds in background; swap is atomic; live table readable throughout; rollback on convergence failure documented
-- [ ] UX-4: `view_evolution_status()` returns `in_progress | converged | failed` with row counts
-- [ ] Extension upgrade path tested (`0.31.0 → 0.32.0`)
+- [ ] A01: Every join refresh cycle routes unconditionally through PH-D1; no UNIQUE_VIOLATION in TPC-H Q7/Q15 IMMEDIATE over 1,000 cycles
+- [ ] A02: 50k-iteration proptest passes with zero counterexamples; regression fixtures added for all prior flakes
+- [ ] A03: Citus chaos rig passes all 4 scenarios; `citus-tests.yml` green on push-to-main
+- [ ] A04: `SpiErrorCode` variant constructed at every SPI call site; `classify_spi_sqlstate_retryable` is the primary classifier
+- [ ] A05: `join_and_predicates()` returns `Result<Expr, PgTrickleError>`; no `expect()` in production code
+- [ ] A06: `inbox.rs` and `outbox.rs` each have `#[cfg(test)] mod tests` with dedup, envelope, and proptest coverage
+- [ ] A07: CDC triggers return `NULL` when `pg_trickle.enabled = false`; `cdc_paused` GUC documented
+- [ ] A39: Relay backpressure tested: in-flight window caps at `sink_max_inflight`
+- [ ] UX-SUB: `subscribe()` / `unsubscribe()` / `list_subscriptions()` registered; NOTIFY emitted on non-empty refresh
+- [ ] UX-SHADOW: Shadow-ST builds in background; atomic swap; live table readable throughout
+- [ ] F17: `pgtrickle.sla_summary()` returns per-ST p50/p99, freshness, error budget
+- [ ] Extension upgrade path tested (`0.34.0 → 0.35.0`)
 - [ ] `just check-version-sync` passes
 
 ---

--- a/roadmap/v0.36.0.md
+++ b/roadmap/v0.36.0.md
@@ -1,19 +1,58 @@
-# v0.36.0 — Temporal IVM & Columnar Materialization
+# v0.36.0 — Structural Hardening, Performance & Temporal IVM
 
 > **Full technical details:** [v0.36.0.md-full.md](v0.36.0.md-full.md)
 
-**Status: Planned** | **Scope: Medium**
+**Status: Planned** | **Scope: Large**
 
-> Two new analytic workload patterns: time-travel queries over a stream
-> table's full history, and columnar storage for dramatically faster
-> analytics.
+> Performance deep-dive, structural refactoring, and two new analytic
+> capabilities: time-travel queries over a stream table's full history,
+> and columnar storage for dramatically faster analytics.
 
 ---
 
 ## What is this?
 
-v0.36.0 opens two new classes of analytic workloads that pg_trickle cannot
-currently serve.
+v0.36.0 is a broad structural release that delivers performance and
+architectural improvements across the core engine, adds production-hardening
+depth identified in the v7 overall assessment, and opens two new analytic
+workload patterns.
+
+---
+
+## Performance & architectural hardening
+
+v0.36.0 closes a set of performance and structural gaps that have accumulated
+as the codebase has grown:
+
+- **L0 shared-memory dshash template cache** — the `L0_POPULATED_VERSION`
+  signal has been wired since v0.31.0 but the actual cross-backend dshash
+  table was never constructed. This release fills in the missing piece,
+  eliminating the ~45 ms cold-start penalty for connection-pooler workloads
+  where every backend is short-lived.
+
+- **WAL slot backpressure** — the WAL decoder currently emits warnings when
+  the logical replication slot lag exceeds thresholds, but takes no action.
+  A new `ENFORCE_BACKPRESSURE` mode pauses CDC trigger writes when the slot
+  lag exceeds the critical threshold, preventing disk-fill under a stuck
+  refresh.
+
+- **`src/api/mod.rs` split** — the 6,322-LOC monolith is split into
+  `src/api/lifecycle.rs`, `src/api/refresh.rs`, `src/api/fuse.rs`, and
+  `src/api/status.rs`. No behaviour change; purely a maintainability
+  improvement that makes every future feature easier to review.
+
+- **Structured JSON logging** — a new `pg_trickle.log_format = text|json` GUC
+  emits structured fields (`event`, `pgt_id`, `cycle_id`, `duration_ms`,
+  `refresh_reason`) for OpenTelemetry / Loki integration.
+
+- **Typed DDL event hook** — `src/hooks.rs` string-matches on DDL event tags.
+  A typed `DdlCommandKind` enum parsed from `pg_event_trigger_ddl_commands()`
+  eliminates the silent-breakage risk from PostgreSQL minor-version wording
+  changes.
+
+- **`RowIdSchema` type** — each DVM operator declares a `RowIdSchema` as part
+  of its signature; a compile-time verifier asserts cross-operator compatibility,
+  addressing the root cause of EC-01.
 
 ---
 
@@ -64,20 +103,35 @@ or pg_mooncake. The differential refresh machinery continues to work —
 pg_trickle automatically routes the MERGE to use the `delete_insert` strategy
 that columnar storage requires, with no manual configuration.
 
-The result: analytic dashboards and reporting queries that consume the
-materialised stream table see dramatically lower I/O, smaller storage
-footprint, and faster aggregate performance.
+---
+
+## Also in v0.36.0
+
+- Online schema evolution (`ALTER STREAM TABLE EVOLVE`) — adding a column
+  to a `SELECT *` style ST becomes online without a full reinit
+- `STREAM TABLE` SQL syntax via `ProcessUtility_hook` —
+  `CREATE STREAM TABLE x AS SELECT …` as sugar over the function call
+- Column lineage graph in `pgt_stream_tables` + `pgtrickle.stream_table_lineage()`
+- Pluggable sink architecture in the relay — sinks as separate cargo crates
+- OOM / disk-full chaos tests; aggregation/window/recursive-CTE fuzz targets
+- Sigstore + SBOM provenance attestation at release
+- Capacity sizing calculator in `docs/SCALING.md`
+- TUI inbox/outbox views
+- Bulk `alter_stream_tables()` / `drop_stream_tables()` APIs
+- Drain mode: graceful scheduler quiesce before maintenance
 
 ---
 
-## Combined use
+## Scope
 
-Temporal mode and columnar storage can be combined: a slowly-changing
-dimension table stored in columnar format with full history, queryable at
-any point in time. This is listed as a stretch goal and is not a hard
-requirement for the release.
+v0.36.0 is a large release. The temporal IVM and columnar storage features
+require DVM engine extensions; the structural splits and performance work
+are lower-risk but broad in surface area.
 
 ---
+
+*Previous: [v0.35.0 — Correctness Sprint, Reactive Subscriptions & Zero-Downtime Operations](v0.35.0.md)*
+*Next: [v0.37.0 — Scheduler Modularisation, pgVectorMV & OpenTelemetry](v0.37.0.md)*
 
 ## Scope
 

--- a/roadmap/v0.36.0.md-full.md
+++ b/roadmap/v0.36.0.md-full.md
@@ -1,58 +1,179 @@
-> **Plain-language companion:** [v0.35.0.md](v0.35.0.md)
+> **Plain-language companion:** [v0.36.0.md](v0.36.0.md)
 
-## v0.35.0 — Temporal IVM & Columnar Materialization
+## v0.36.0 — Structural Hardening, Performance & Temporal IVM
 
-**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §10.2, §10.7.
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_7.md](plans/PLAN_OVERALL_ASSESSMENT_7.md) §4, §5, §7, §8, §9, §10, §11, §12, §13; A09, A12, A14, A17–A18, A20, A25–A26, A29, A31, A35–A36, A40; F2, F5, F11–F13.
 
 > **Release Theme**
-> v0.35.0 unlocks two analytic workload patterns that the current streaming
-> engine cannot serve. Temporal IVM lets a stream table maintain a rolling
-> history of how its rows have changed over time — providing first-class
-> SCD-Type-2 semantics without external ETL or separate audit tables.
-> Columnar materialization lets a stream table store its result set in
-> Citus columnar storage (or pg_mooncake), dramatically reducing storage
-> footprint and query I/O for analytic consumers that scan the materialised
-> result set but never write to it. Together they close the OLTP→OLAP
-> bridging gap and make pg_trickle viable as the materialization layer for
-> dashboards and reporting queries.
+> v0.36.0 closes the structural and performance gaps that have accumulated
+> since the Citus arc. The L0 shared-memory dshash template cache is finally
+> constructed (wired-but-empty since v0.31.0), WAL slot backpressure is
+> enforced, `src/api/mod.rs` is split into focused modules, structured JSON
+> logging arrives for OpenTelemetry/Loki integration, and the `RowIdSchema`
+> type formalises cross-operator row-id compatibility — addressing the root
+> cause of the EC-01 residual issue at the architectural level.
+> Feature-wise: Temporal IVM (SCD Type 2, `AS OF TIMESTAMP`), columnar storage
+> backend, online schema evolution, `CREATE STREAM TABLE` SQL syntax,
+> pluggable relay sinks, and column lineage.
 
 ---
 
-### Correctness
+### Performance
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
+| A09 | Construct L0 dshash shared-memory template cache | L | P0 |
+| A12 | WAL decoder: `ENFORCE_BACKPRESSURE` mode + slot-lag cap | M | P0 |
+
+**A09 — L0 dshash template cache.**
+`src/shmem.rs:680-710` wires `L0_POPULATED_VERSION: PgAtomic<AtomicU64>` and
+the cross-backend invalidation signal, but the actual dshash table holding
+compiled delta SQL templates is never constructed. For connection-pooler
+workloads where every backend is short-lived the L0 win is ~45 ms cold-start
+savings per backend. Construct the dshash table in `pg_shmem_init!()`,
+populate on first access, and honour the generation counter for invalidation.
+Document the final `cold_start_ms` improvement in `docs/SCALING.md`.
+
+**A12 — WAL backpressure enforcement.**
+`src/wal_decoder.rs` does not enforce `pg_replication_slot.confirmed_flush_lsn`
+advancement bounds. `slot_lag_warning_threshold_mb` and
+`slot_lag_critical_threshold_mb` GUCs emit alerts but do not throttle.
+At 100 MB/s WAL with a stuck refresh, disk fills in minutes.
+Add an `ENFORCE_BACKPRESSURE` mode (GUC, default `off`) that pauses CDC
+trigger writes when the slot lag exceeds `slot_lag_critical_threshold_mb`,
+then resumes when it falls below 50% of the threshold. Document the trade-off
+(change-buffer growth vs. slot retention) in `docs/SCALING.md`.
+
+---
+
+### Architecture
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A14 | Split `src/api/mod.rs` (6,322 LOC) into focused sub-modules | M | P1 |
+| A17 | Typed DDL event payload (replace string tag matching) | S | P1 |
+| A18 | `RowIdSchema` type: every operator declares its row-id scheme | L | P1 |
+
+**A14 — Split `src/api/mod.rs`.**
+`src/api/mod.rs` at 6,322 LOC carries lifecycle, refresh, fuse control,
+status reporting, and all ~80 `#[pg_extern]`-decorated SQL functions.
+Split into:
+- `src/api/lifecycle.rs` — `create_stream_table`, `alter_stream_table`, `drop_stream_table`
+- `src/api/refresh.rs` — `refresh_stream_table` and refresh mode helpers
+- `src/api/fuse.rs` — circuit-breaker and fuse control functions
+- `src/api/status.rs` — `pgt_status`, `pgt_stream_table_status`, diagnostics
+
+No behaviour change. Follow the pattern established by the `src/refresh/`
+sub-module split in v0.26.0.
+
+**A17 — Typed DDL event payload.**
+`src/hooks.rs:130-176` matches on string tags (`"ALTER TABLE"`, etc.) from the
+PostgreSQL event trigger payload. A wording change in a PostgreSQL minor release
+would break classification silently. Add a `DdlCommandKind` enum populated via
+`pg_event_trigger_ddl_commands()` introspection; retire the string-match path.
+
+**A18 — `RowIdSchema` across operators.**
+`src/hash.rs` is an excellent xxh3 streaming hasher, but each operator
+constructs its own row-id hash from a different tuple — this is the root
+architectural cause of EC-01. Define a `RowIdSchema` type that every operator
+declares as part of its signature. Add a plan-time verifier that asserts
+cross-operator compatibility before execution begins. This makes future EC-01-class
+bugs compile-time detectable.
+
+---
+
+### Observability
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A20 | Structured JSON logging: `pg_trickle.log_format = text\|json` GUC | M | P1 |
+
+**A20 — Structured logging.**
+`pgrx::log!()` / `info!()` / `warning!()` emit unstructured text. Add a
+`pg_trickle.log_format = text|json` GUC and a wrapper macro that emits
+structured fields: `event`, `pgt_id`, `cycle_id`, `duration_ms`,
+`refresh_reason`, `error_code`. JSON format targets OpenTelemetry / Loki
+integration without lossy regex parsing.
+
+---
+
+### Ease of Use / Operational
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A25 | Bulk `alter_stream_tables()` / `drop_stream_tables()` APIs | S | P2 |
+| A35 | Drain mode: graceful scheduler quiesce before maintenance | M | P1 |
+| A36 | Capacity sizing calculator in `docs/SCALING.md` | M | P2 |
+| F5  | Online schema evolution (`ALTER STREAM TABLE EVOLVE`) | L | P1 |
+| F11 | `CREATE STREAM TABLE x AS SELECT …` SQL syntax | L | P1 |
+| F12 | Column lineage graph + `pgtrickle.stream_table_lineage()` | M | P2 |
+| F13 | Pluggable sink architecture in the relay | M | P1 |
 | CORR-1 | Temporal IVM: two-dimensional frontier (LSN, timestamp) | L | P0 |
-| CORR-2 | Columnar: verify differential MERGE compatibility with columnar storage | M | P0 |
-
-**CORR-1** — Temporal IVM requires extending the frontier model from a
-one-dimensional LSN cursor to a two-dimensional `(frontier_lsn, valid_from_ts)`
-pair. Each row carries a `__pgt_valid_from TIMESTAMPTZ` and an optional
-`__pgt_valid_to TIMESTAMPTZ`. Rows are never physically deleted; instead a
-"close" delta sets `valid_to`. Queries against the stream table with `AS OF
-TIMESTAMP $1` resolve to the materialised row version valid at that timestamp.
-**Schema change:** Yes — new `temporal_mode BOOLEAN` column on
-`pgtrickle.pgt_stream_tables`; new `__pgt_valid_from`/`__pgt_valid_to`
-columns auto-added to the storage table when `temporal_mode = true`.
-
-**CORR-2** — Citus columnar and pg_mooncake use append-only storage models.
-Verify that the differential MERGE (`MERGE INTO storage USING delta`) is
-compatible with append-only semantics (likely requires `DELETE + INSERT`
-merge strategy for columnar targets). Add a `storage_backend` column to
-`pgtrickle.pgt_stream_tables` and route merge codegen accordingly.
-
----
-
-### Ease of Use
-
-| ID | Title | Effort | Priority |
-|----|-------|--------|----------|
-| UX-1 | `create_stream_table(…, temporal := true)` parameter | M | P0 |
+| CORR-2 | Columnar: verify MERGE compatibility with columnar storage | M | P0 |
+| UX-1 | `create_stream_table(…, temporal := true)` | M | P0 |
 | UX-2 | `AS OF TIMESTAMP` query rewrite in DVM parser | L | P1 |
-| UX-3 | `create_stream_table(…, storage_backend := 'columnar')` parameter | M | P1 |
+| UX-3 | `create_stream_table(…, storage_backend := 'columnar')` | M | P1 |
 | UX-4 | Automatic `delete_insert` strategy for columnar backends | S | P1 |
-| UX-5 | Documentation: temporal IVM tutorial + SCD-Type-2 worked example | M | P1 |
-| UX-6 | Documentation: columnar backend setup guide (Citus + pg_mooncake) | S | P1 |
+| UX-5 | Temporal IVM tutorial + SCD-Type-2 worked example | M | P1 |
+| UX-6 | Columnar backend setup guide (Citus + pg_mooncake) | S | P1 |
+
+**A25 — Bulk alter/drop APIs.**
+dbt deployments commonly need to flip 100+ STs to a new schedule at once;
+today this requires 100 individual round-trips. Add
+`pgtrickle.bulk_alter_stream_tables(names TEXT[], params JSONB)` and
+`pgtrickle.bulk_drop_stream_tables(names TEXT[])`.
+
+**A35 — Drain mode.**
+Add `pgtrickle.drain(timeout_s INT DEFAULT 60)` that signals the scheduler
+to stop accepting new cycles, waits for all in-flight refreshes to complete,
+and confirms via `pgtrickle.is_drained() BOOLEAN`. Useful before `pg_upgrade`,
+rolling restarts, or backup windows.
+
+**A36 — Capacity sizing calculator.**
+`docs/SCALING.md` has limits but no formula. Add a "sizing calculator" section
+with a worked example: X stream tables × Y refreshes/min × Z CDC volume =
+N MB/s WAL + M cores + K GB shared buffers. Derive from the benchmark data in
+`tests/e2e_bench_tests.rs`.
+
+**F5 — Online schema evolution.**
+`ALTER QUERY` requires a full reinit today. Detect type-compatible column
+additions in the `ALTER QUERY` diff and emit `ALTER TABLE` on the storage table,
+then re-prepare templates without flushing data. Gate behind
+`pg_trickle.online_schema_evolution = on` GUC (default `off`, opt-in).
+
+**F11 — `CREATE STREAM TABLE` SQL syntax.**
+Use PostgreSQL's `ProcessUtility_hook` to intercept `CREATE STREAM TABLE name
+AS SELECT …` lexically and rewrite to
+`pgtrickle.create_stream_table('name', $$SELECT …$$)`. Add `DROP STREAM TABLE`
+and `ALTER STREAM TABLE` syntax similarly.
+
+**F12 — Column lineage.**
+During parsing, record a `column_lineage` JSON graph in `pgt_stream_tables`
+mapping each ST output column to its source table + column. Expose via
+`pgtrickle.stream_table_lineage(name TEXT)` returning `TABLE(output_col,
+source_table, source_col)`.
+
+**F13 — Pluggable relay sinks.**
+Define a stable `Sink` trait + dynamic loading pattern in the relay; ship the
+existing Kafka/NATS/SQS sinks as separate `pgtrickle-sink-*` crates. Third
+parties can then add Snowflake, Iceberg, ClickHouse sinks without a relay
+rebuild.
+
+**CORR-1 — Temporal IVM two-dimensional frontier.**
+Temporal IVM extends the frontier model from a one-dimensional LSN cursor to
+a `(frontier_lsn, valid_from_ts)` pair. Each row carries
+`__pgt_valid_from TIMESTAMPTZ` and optional `__pgt_valid_to TIMESTAMPTZ`. Rows
+are never physically deleted; a "close" delta sets `valid_to`. Queries with
+`AS OF TIMESTAMP $1` resolve to the materialised row version valid at that
+timestamp. **Schema change:** new `temporal_mode BOOLEAN` column on
+`pgtrickle.pgt_stream_tables`; new `__pgt_valid_from`/`__pgt_valid_to` columns
+auto-added to storage when `temporal_mode = true`.
+
+**CORR-2 — Columnar merge compatibility.**
+Citus columnar and pg_mooncake use append-only storage. Verify that the
+differential MERGE is compatible with append-only semantics via `delete_insert`
+strategy; add `storage_backend` column to `pgtrickle.pgt_stream_tables` and
+route merge codegen accordingly.
 
 ---
 
@@ -60,33 +181,65 @@ merge strategy for columnar targets). Add a `storage_backend` column to
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
+| A26 | OOM injection + disk-full chaos tests | M | P1 |
+| A29 | Aggregation/window/recursive-CTE fuzz targets | M | P2 |
 | TEST-1 | Integration: temporal stream table `AS OF TIMESTAMP` round-trip | L | P0 |
 | TEST-2 | Integration: SCD-Type-2 dimension pattern end-to-end | M | P1 |
 | TEST-3 | Integration: columnar stream table MERGE parity with heap | M | P0 |
-| TEST-4 | Integration: temporal + columnar combined (temporal columnar ST) | M | P2 |
+| TEST-4 | Integration: temporal + columnar combined (stretch, P2) | M | P2 |
+
+**A26 — Chaos tests.**
+`tests/e2e_concurrent_tests.rs` covers DDL races and refresh-vs-DROP.
+Missing: OOM injection during refresh, disk-full simulation, SIGKILL of bgworker
+mid-refresh. Add three new tests behind a `chaos` feature flag requiring
+`LD_PRELOAD` of a small `write()` interceptor library.
+
+**A29 — New fuzz targets.**
+`fuzz/fuzz_targets/` has `parser_fuzz`, `cdc_fuzz`, `cron_fuzz`, `guc_fuzz`.
+Add: `aggregate_fuzz`, `window_fuzz`, `recursive_cte_fuzz`,
+`join_predicate_fuzz`, `envelope_fuzz` (inbox/outbox).
+
+---
+
+### Security
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A31 | Sigstore + SBOM provenance attestation at release | M | P1 |
+
+**A31 — Release provenance.**
+Add `cosign` signing + CycloneDX/SPDX SBOM generation to the release workflow.
+Publish attestations alongside Docker images and release archives. Required for
+SLSA Level 2 compliance at v1.0.
 
 ---
 
 ### Conflicts & Risks
 
-- **CORR-1** requires a non-trivial DVM engine extension (two-dimensional
-  frontier). Spike before committing to the milestone; do not commit until
+- **CORR-1** (temporal IVM) requires a non-trivial DVM engine extension
+  (two-dimensional frontier). Spike before committing; do not commit until
   the spike proves the approach is sound.
-- **CORR-2** depends on the Citus columnar or pg_mooncake extension being
-  present; CI must add a Testcontainers image with one of these available.
+- **CORR-2** depends on Citus columnar or pg_mooncake being present in CI.
   Gate columnar support behind `pg_trickle.columnar_backend` GUC (default
   `none`); the CI matrix should test at least one columnar provider.
-- The combination of temporal mode and columnar storage is a P2 stretch
-  goal; do not block the release on it.
+- **A18** (`RowIdSchema`) touches every DVM operator. Land as a pure type
+  annotation pass first with no behaviour change; then add the plan-time
+  verifier separately.
+- The combination of temporal mode and columnar storage is a P2 stretch goal;
+  do not block the release on it.
 
 ### Exit Criteria
 
-- [ ] CORR-1/UX-1: `create_stream_table(…, temporal := true)` creates storage table with `__pgt_valid_from`/`__pgt_valid_to`; rows never physically deleted
-- [ ] UX-2: `AS OF TIMESTAMP $1` query rewrites resolve against the materialised history
-- [ ] TEST-1: Temporal round-trip test passes: insert → update → delete, query at t₀/t₁/t₂ returns correct historical rows
-- [ ] TEST-2: SCD-Type-2 dimension pattern: slowly-changing customer table materialised with full history, current-version query using `WHERE valid_to IS NULL`
-- [ ] CORR-2/UX-3: Columnar stream table creates; `delete_insert` strategy used automatically; columnar MERGE E2E parity test passes
-- [ ] Extension upgrade path tested (`0.32.0 → 0.33.0`)
+- [ ] A09: L0 dshash table constructed; cold-start penalty measured < 10 ms in `e2e_bench_tests.rs`
+- [ ] A12: `ENFORCE_BACKPRESSURE` mode tested; slot lag stops growing when cap is reached
+- [ ] A14: `src/api/mod.rs` replaced by four sub-modules; all existing tests pass
+- [ ] A18: `RowIdSchema` declared on all operators; plan-time verifier rejects incompatible schemas
+- [ ] A20: `pg_trickle.log_format = json` emits valid JSON with all required fields; tested in `e2e_monitoring_tests.rs`
+- [ ] A31: `cosign` sign + SBOM generated in release workflow; attestation visible on GHCR
+- [ ] CORR-1: Temporal round-trip test passes at all three history points
+- [ ] CORR-2: Columnar MERGE E2E parity test passes against at least one columnar provider
+- [ ] F11: `CREATE/DROP/ALTER STREAM TABLE` SQL syntax works end-to-end
+- [ ] Extension upgrade path tested (`0.35.0 → 0.36.0`)
 - [ ] `just check-version-sync` passes
 
 ---

--- a/roadmap/v0.37.0.md
+++ b/roadmap/v0.37.0.md
@@ -1,0 +1,100 @@
+# v0.37.0 — Scheduler Modularisation, pgVectorMV & OpenTelemetry
+
+> **Full technical details:** [v0.37.0.md-full.md](v0.37.0.md-full.md)
+
+**Status: Planned** | **Scope: Medium**
+
+> Internal restructuring that makes the scheduler safe to evolve, first-class
+> AI/RAG support via incremental vector aggregation, distributed trace
+> propagation, and extended ecosystem compatibility.
+
+---
+
+## What is this?
+
+v0.37.0 focuses on three themes: breaking up the two largest remaining
+monolithic files so they are safe to evolve, adding AI/RAG workload support
+via incremental vector-average maintenance, and threading OpenTelemetry traces
+through the refresh pipeline so operators can correlate stream-table latency
+back to the HTTP request that triggered it.
+
+---
+
+## Scheduler and merge modularisation
+
+`src/scheduler.rs` is 7,756 lines — the single largest file in the codebase —
+and carries the dispatch loop, tier scheduler, predictive cost integration,
+parallel pool, `pgt_st_locks` lease loop, DAG rebuild trigger, and CDC
+backpressure all in one file. Any change to one concern touches the entire
+file in diffs and review.
+
+v0.37.0 splits it along natural concern boundaries:
+
+- `src/scheduler/mod.rs` — dispatch loop and main tick
+- `src/scheduler/tier.rs` — tier assignment, SLA deadline tracking
+- `src/scheduler/cost.rs` — predictive cost model integration
+- `src/scheduler/pool.rs` — parallel worker pool
+- `src/scheduler/citus.rs` — Citus lease acquisition loop
+
+`src/refresh/merge.rs` (3,472 LOC) gets the same treatment, split along
+PostgreSQL operator boundaries (delete path, insert path, conflict predicate
+generator, column-list builder).
+
+No behaviour changes — purely a maintainability improvement that makes every
+future feature change incremental and reviewable.
+
+---
+
+## pgVectorMV: incremental vector aggregation for AI/RAG
+
+AI and RAG pipelines commonly maintain document-cluster centroids or
+IVF index structures over embeddings. Today this means recomputing all
+aggregated vectors on a schedule from scratch. pg_trickle can maintain
+centroids *incrementally* using a `vector_avg` algebraic aggregate that
+applies Welford's online algorithm in the L2 norm domain.
+
+v0.37.0 adds a `vector_avg` aggregate operator to the DVM engine that is
+compatible with pgvector 0.7+ HNSW and IVF indexes. A stream table over a
+document-embeddings table can maintain a live cluster centroid that is always
+within one refresh cycle of the latest embeddings, without recomputing the
+full set.
+
+---
+
+## OpenTelemetry trace propagation
+
+When an HTTP request writes a row that triggers a stream-table refresh, there
+is currently no way to correlate the two in a distributed trace. v0.37.0 adds
+W3C Trace Context propagation:
+
+1. The application sets `pg_trickle.trace_id` (a session GUC) to the W3C
+   `traceparent` value before writing.
+2. pg_trickle reads the trace context and carries it through the refresh
+   pipeline, emitting OTLP/gRPC spans for each phase (CDC capture, DVM plan,
+   MERGE apply, notification emit).
+3. The trace spans are visible in Jaeger, Tempo, or any OTLP-compatible backend.
+
+This closes the last observability gap in the v7 overall assessment's
+recommendations for production readiness.
+
+---
+
+## Also in v0.37.0
+
+- pg_partman and TimescaleDB hypertable integration tests — verify that
+  pg_trickle's declarative partitioning support works with pg_partman's
+  runtime partition creation and TimescaleDB chunks
+- Any deferred items from v0.36.0 that did not meet the exit criteria
+
+---
+
+## Scope
+
+v0.37.0 is a medium release. The scheduler and merge splits are
+pure restructuring; pgVectorMV and OpenTelemetry are additive features with
+no impact on existing stream tables.
+
+---
+
+*Previous: [v0.36.0 — Structural Hardening, Performance & Temporal IVM](v0.36.0.md)*
+*Next: [v1.0.0 — Stable Release](../roadmap/v1.0.0.md-full.md)*

--- a/roadmap/v0.37.0.md-full.md
+++ b/roadmap/v0.37.0.md-full.md
@@ -1,0 +1,146 @@
+> **Plain-language companion:** [v0.37.0.md](v0.37.0.md)
+
+## v0.37.0 — Scheduler Modularisation, pgVectorMV & OpenTelemetry
+
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_7.md](plans/PLAN_OVERALL_ASSESSMENT_7.md) §4, §7, §9, §13; A15, A16, A43; F4, F10.
+
+> **Release Theme**
+> v0.37.0 completes the structural cleanup arc started in v0.36.0 by splitting
+> the two remaining large files (`src/scheduler.rs` at 7,756 LOC and
+> `src/refresh/merge.rs` at 3,472 LOC), adds pgVectorMV for AI/RAG incremental
+> vector aggregation, threads OpenTelemetry traces through the refresh
+> pipeline, and validates pg_partman + TimescaleDB compatibility.
+
+---
+
+### Architecture
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A15 | Split `src/scheduler.rs` (7,756 LOC) into sub-modules | L | P1 |
+| A16 | Split `src/refresh/merge.rs` (3,472 LOC) into sub-modules | M | P2 |
+
+**A15 — Scheduler split.**
+`src/scheduler.rs` carries: dispatch loop, tier scheduler, predictive cost
+integration, parallel pool, `pgt_st_locks` Citus lease loop, DAG rebuild
+trigger, and CDC backpressure. Split into:
+
+- `src/scheduler/mod.rs` — main dispatch loop and `SchedulerState`
+- `src/scheduler/tier.rs` — SLA tier assignment, deadline tracking, tier up/down
+- `src/scheduler/cost.rs` — predictive cost model (`CostModel`, regression)
+- `src/scheduler/pool.rs` — parallel refresh worker pool, `PoolWorker`, `WorkerHandle`
+- `src/scheduler/citus.rs` — Citus `pgt_st_locks` lease acquisition loop
+
+The split must be purely mechanical — no logic changes. All existing tests
+must pass without modification. Each sub-module has its own `#[cfg(test)]
+mod tests` block moved from `src/scheduler.rs`.
+
+**A16 — Merge split.**
+`src/refresh/merge.rs` is 3,472 LOC of MERGE-path codegen. Split along
+PostgreSQL operator boundaries:
+
+- `src/refresh/merge/delete.rs` — DELETE path codegen
+- `src/refresh/merge/insert.rs` — INSERT path codegen  
+- `src/refresh/merge/update.rs` — UPDATE path codegen
+- `src/refresh/merge/conflict.rs` — conflict predicate generator
+- `src/refresh/merge/columns.rs` — column-list builder
+
+No behaviour change. Purely a maintainability improvement.
+
+---
+
+### Features
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| F4  | pgVectorMV: `vector_avg` incremental aggregate operator | L | P1 |
+| F10 | OpenTelemetry W3C Trace Context propagation | M | P1 |
+
+**F4 — pgVectorMV.**
+AI and RAG pipelines maintain document-cluster centroids and IVF index
+structures over pgvector embeddings. Recomputing aggregated vectors on a
+schedule from scratch is expensive. Add a `vector_avg` algebraic aggregate
+operator to the DVM engine:
+
+- Uses Welford's online algorithm in the L2 norm domain to compute incremental
+  centroid updates from insert/delete deltas
+- Stores partial sum and count in the aggregate state; derive the mean from
+  `sum / count` on read
+- Compatible with pgvector 0.7+ `vector` type; tested with HNSW and IVF
+  indexes on the downstream stream table
+- Gate behind `pg_trickle.enable_vector_agg = on` GUC (default `off`, requires
+  pgvector extension present)
+
+**Test:** Add `tests/e2e_pgvector_tests.rs` with: document table + embedding
+column; stream table maintaining cluster centroids; assert centroid updates
+on insert/delete/update are identical between DIFFERENTIAL and FULL refresh.
+
+**F10 — OpenTelemetry trace propagation.**
+Add W3C Trace Context (`traceparent`, `tracestate`) propagation through the
+refresh pipeline:
+
+1. Application sets `SET pg_trickle.trace_id = 'traceparent: ...'` in the
+   session before the DML that triggers the CDC capture.
+2. pg_trickle reads the context from the session GUC at CDC capture time and
+   stores it in the change-buffer row's `__pgt_trace_context` column
+   (nullable, opt-in).
+3. At refresh time, the orchestrator reads the trace context from the earliest
+   change-buffer row in the batch and opens a child span for each refresh phase:
+   `pgtrickle.cdc_drain`, `pgtrickle.dvm_plan`, `pgtrickle.merge_apply`,
+   `pgtrickle.notify_emit`.
+4. Spans are exported via OTLP/gRPC to the endpoint configured in
+   `pg_trickle.otel_endpoint` GUC (default empty — disabled).
+
+Schema change: optional `__pgt_trace_context TEXT` column in
+`pgtrickle_changes.changes_<stable_name>`. Only added when
+`pg_trickle.enable_trace_propagation = on` (default `off`).
+
+---
+
+### Test Coverage
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| A43 | pg_partman + TimescaleDB hypertable integration tests | M | P2 |
+
+**A43 — Partition ecosystem integration tests.**
+`src/cdc.rs` handles declarative partitioning but has not been verified
+against pg_partman's runtime partition creation or TimescaleDB hypertables.
+Add `tests/e2e_partman_tests.rs`:
+
+- pg_partman `run_maintenance()` creates new monthly partition while a stream
+  table is refreshing; assert no data loss
+- TimescaleDB hypertable as source; assert chunk boundaries are handled as
+  regular partition attach/detach events
+- Upgrade test: stream table on pg_partman source survives `0.36.0 → 0.37.0`
+
+Requires a Testcontainers image with pg_partman and TimescaleDB installed.
+Gate behind a `partman-tests.yml` workflow running daily and on manual
+dispatch.
+
+---
+
+### Conflicts & Risks
+
+- **A15** (scheduler split) is purely mechanical but touches 7,756 LOC.
+  Approach: create the sub-module files, `pub use` re-export everything from
+  `mod.rs`, compile + test, then incrementally move code. Land in a dedicated
+  commit with `[no-behaviour-change]` in the message.
+- **F4** (pgVectorMV) requires pgvector to be present in the CI image.
+  Add pgvector to `tests/Dockerfile.e2e` and gate the tests behind
+  `#[cfg(feature = "pgvector")]`.
+- **F10** (OpenTelemetry) must not add latency to the critical refresh path
+  when `enable_trace_propagation = off`. The implementation must be
+  branch-free for the disabled case.
+
+### Exit Criteria
+
+- [ ] A15: `src/scheduler.rs` replaced by five sub-modules; all existing tests pass without change
+- [ ] A16: `src/refresh/merge.rs` replaced by five sub-modules; all existing tests pass without change
+- [ ] F4: `vector_avg` aggregate maintains correct centroids vs FULL refresh over 10k-iteration proptest; pgvector HNSW index refreshes correctly on stream-table delta
+- [ ] F10: OTLP spans visible in test-mode Jaeger for a complete refresh cycle; `traceparent` correctly propagated from session GUC through CDC → DVM → MERGE → NOTIFY
+- [ ] A43: pg_partman + TimescaleDB integration tests pass in `partman-tests.yml`
+- [ ] Extension upgrade path tested (`0.36.0 → 0.37.0`)
+- [ ] `just check-version-sync` passes
+
+---


### PR DESCRIPTION
## Summary

Adds the seventh overall project assessment (`plans/PLAN_OVERALL_ASSESSMENT_7.md`) covering the v0.34.0 codebase. This is a read-only static audit — no source files were modified. The report follows the same structure as the three prior assessments and is intended as pre-v1.0 planning input.

## Changes

- New file: `plans/PLAN_OVERALL_ASSESSMENT_7.md` (1,340 lines)

## What the report covers

**What has improved since v0.27.0** (confirmed resolved):
- Snapshot/restore atomicity — `SnapSubTransaction` RAII helper now wraps both operations (`src/api/snapshot.rs:27–87`)
- `pgt_refresh_history` retention — `pg_trickle.history_retention_days` GUC + prune loop (`src/config.rs:2071`)
- Catalog snapshot reload — per-backend L1 cache + copy-on-write DAG rebuild (`src/scheduler.rs:59–144`)
- SQLSTATE-aware error classifier exists (`src/error.rs:312–380`)

**Top-5 remaining risks (new/worsened):**
1. EC-01 phantom rows — `is_deduplicated: false` still hard-coded at `src/dvm/operators/join.rs:657–668`; PH-D1 cleanup is opt-in; third assessment to flag this (**CRITICAL**)
2. SQLSTATE classifier not wired — `SpiErrorCode` variant constructed in zero call sites; legacy English-text path still active
3. Citus distributed coordination — no chaos test coverage for `pgt_st_locks`, lease expiry, worker death, rebalance
4. Real `expect()` panic at `src/dvm/parser/rewrites.rs:5471` (below `#[cfg(test)]` boundary — production code)
5. `src/api/inbox.rs` + `src/api/outbox.rs` (1,034 + 942 LOC) have no `mod tests` unit coverage

**Codebase health snapshot:**
- 115,371 LOC across 66 `src/` files; 86,323 LOC across 140 test files
- 161 strict `unsafe` keyword matches; 1 real production panic site
- 111 GUCs defined (`src/config.rs`); ~80 `#[pg_extern]` SQL functions
- 19 GitHub workflows; 30 upgrade scripts (v0.1.3 → v0.34.0)

**New content:**
- 17 new feature proposals (F1–F17): reactive subscriptions, time-travel AS OF, `EXPLAIN STREAM TABLE`, pgVector MVs, online schema evolution, DBSP pre-aggregation, Kubernetes operator, OpenTelemetry trace propagation, `CREATE STREAM TABLE` SQL syntax, and more
- 43-item prioritised action plan (A01–A43) with severity, effort, and suggested release tags through v0.37.0
- Per-file LOC/unsafe/test-coverage appendix for all 66 `src/` files

## Testing

Read-only audit — no source changes. No test run required.

## Notes

Sibling documents:
- `plans/PLAN_OVERALL_ASSESSMENT.md` — v0.20.0 baseline
- `plans/PLAN_OVERALL_ASSESSMENT_2.md` — v0.23.0 follow-up
- `plans/PLAN_OVERALL_ASSESSMENT_3.md` — v0.27.0 follow-up

The single highest-impact recommendation for the next 90 days: a **"EC-01 closeout + Citus chaos sprint"** — unconditional PH-D1 cleanup, flip `is_deduplicated: true` for INNER joins on stable PKs with a 50k-iteration property test, and a multi-container Citus rig for coordinator/worker failure scenarios.
