### PR TITLE
docs(v0.34.0): update README, citus guide, configuration, and upgrade notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ We also do not think the use of AI should lower the standard for trust. If anyth
 - **Tiered scheduling** — Hot / Warm / Cold / Frozen tiers control effective refresh rates in large deployments; Frozen tables are skipped until manually thawed.
 - **Multi-database** — a single launcher worker auto-discovers every database with the extension installed and spawns a scheduler for each.
 
+### Citus distributed tables (v0.32.0+)
+
+- **Distributed sources** — stream tables can be defined over Citus distributed source tables; the scheduler polls per-worker WAL slots via `dblink` and merges changes on the coordinator.
+- **Distributed output** — pass `output_distribution_column` to `create_stream_table()` to co-locate the result table with the source shards.
+- **Automated scheduler** — since v0.34.0 the scheduler drives the full per-worker slot lifecycle automatically (no manual wiring required): `ensure_worker_slot`, `poll_worker_slot_changes`, and `pgt_st_locks` lease management.
+- **Shard rebalance auto-recovery** — topology changes are detected by comparing `pg_dist_node` against `pgt_worker_slots`; stale slots are pruned and new ones inserted without operator intervention.
+- **Worker failure isolation** — per-worker poll failures are logged and skipped; after `pg_trickle.citus_worker_retry_ticks` (default 5) consecutive failures a WARNING is raised while healthy workers continue uninterrupted.
+
 ### Production & operations
 
 - **PgBouncer / connection-pool compatible** — works behind PgBouncer in transaction-pool mode (Supabase, Railway, Neon, etc.); row-level locking replaces session locks; per-table `pooler_compatibility_mode` available.
@@ -355,7 +363,7 @@ CREATE EXTENSION pg_trickle;
 pg_trickle is distributed as a minimal OCI extension image for [CloudNativePG Image Volume Extensions](https://cloudnative-pg.io/docs/1.28/imagevolume_extensions/). The image is `scratch`-based (< 10 MB) and contains only the extension files — no PostgreSQL server, no OS.
 
 ```bash
-docker pull ghcr.io/grove/pg_trickle-ext:0.20.0
+docker pull ghcr.io/grove/pg_trickle-ext:0.34.0
 ```
 
 Deploy with the official CNPG PostgreSQL 18 operand image:
@@ -369,7 +377,7 @@ spec:
     extensions:
       - name: pg-trickle
         image:
-          reference: ghcr.io/grove/pg_trickle-ext:0.20.0
+          reference: ghcr.io/grove/pg_trickle-ext:0.34.0
 ```
 
 See [cnpg/cluster-example.yaml](cnpg/cluster-example.yaml) and [cnpg/database-example.yaml](cnpg/database-example.yaml) for complete examples. Requires Kubernetes 1.33+ and CNPG 1.28+.
@@ -479,7 +487,7 @@ The `dbt-pgtrickle` package provides a custom `stream_table` materialization for
 # packages.yml
 packages:
   - git: "https://github.com/grove/pg-trickle.git"
-    revision: v0.20.0
+    revision: v0.34.0
     subdirectory: "dbt-pgtrickle"
 ```
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -112,6 +112,9 @@ Complete reference for all pg_trickle GUC (Grand Unified Configuration) variable
   - [pg\_trickle.use\_sqlstate\_classification](#pg_trickleuse_sqlstate_classification)
   - [pg\_trickle.template\_cache\_max\_age\_hours](#pg_trickletemplate_cache_max_age_hours)
   - [pg\_trickle.max\_parse\_nodes](#pg_tricklemax_parse_nodes)
+- [Citus Distributed Tables (v0.32.0+)](#citus-distributed-tables-v0320)
+  - [pg\_trickle.citus\_st\_lock\_lease\_ms](#pg_tricklecitus_st_lock_lease_ms)
+  - [pg\_trickle.citus\_worker\_retry\_ticks](#pg_tricklecitus_worker_retry_ticks)
 - [GUC Interaction Matrix](#guc-interaction-matrix)
 - [Tuning Profiles](#tuning-profiles)
   - [Low-Latency Profile](#low-latency-profile)
@@ -2581,6 +2584,71 @@ recommended for production deployments.
 
 ---
 
+## Citus Distributed Tables (v0.32.0+)
+
+Configuration for Citus distributed-table CDC and stream table support.
+See [docs/integrations/citus.md](integrations/citus.md) for the full setup guide.
+
+---
+
+### pg_trickle.citus_st_lock_lease_ms
+
+Duration in milliseconds of the `pgtrickle.pgt_st_locks` lease used for
+cross-node refresh coordination in Citus clusters.
+
+The lease prevents two coordinator nodes from applying changes to the same
+distributed stream table simultaneously.  When pg_ripple is deployed alongside
+pg_trickle, set this value to be **≥ `pg_ripple.merge_fence_timeout_ms`** to
+prevent the lease from expiring mid-merge.
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `60000` (60 seconds) |
+| Range | 0 (disabled) – 600,000 ms (10 minutes) |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+| Added in | v0.33.0 (COORD-2) |
+
+```sql
+-- Align with a 30-second pg_ripple merge fence
+ALTER SYSTEM SET pg_trickle.citus_st_lock_lease_ms = 45000;
+SELECT pg_reload_conf();
+```
+
+---
+
+### pg_trickle.citus_worker_retry_ticks
+
+Number of consecutive per-worker poll failures before the scheduler emits a
+`WARNING` in the PostgreSQL log and flags the worker in `pgtrickle.citus_status`.
+The warning is for operator attention — healthy workers continue refreshing
+uninterrupted while a failed worker is skipped.
+
+Set to `0` to disable the alerting entirely (failures are still logged at
+`LOG` level per tick).
+
+| Property | Value |
+|---|---|
+| Type | `integer` |
+| Default | `5` |
+| Range | 0 (disabled) – 100 |
+| Context | `SUSET` (superuser) |
+| Restart required | No |
+| Added in | v0.34.0 (COORD-15) |
+
+```sql
+-- Alert after 3 consecutive failures instead of 5
+ALTER SYSTEM SET pg_trickle.citus_worker_retry_ticks = 3;
+SELECT pg_reload_conf();
+
+-- Disable alerting (failures logged at LOG level only)
+ALTER SYSTEM SET pg_trickle.citus_worker_retry_ticks = 0;
+SELECT pg_reload_conf();
+```
+
+---
+
 ## GUC Interaction Matrix
 
 Some GUC variables interact with or depend on each other. The table below
@@ -2798,6 +2866,10 @@ pg_trickle.inbox_enabled = true
 pg_trickle.inbox_processed_retention_hours = 72
 pg_trickle.inbox_dlq_retention_hours = 0       # 0 = keep forever
 pg_trickle.inbox_dlq_alert_max_per_refresh = 10
+
+# Citus distributed tables (v0.32.0+)
+pg_trickle.citus_st_lock_lease_ms = 60000      # lease duration for cross-node coordination
+pg_trickle.citus_worker_retry_ticks = 5        # failures before WARNING in citus_status
 
 # Advanced / internal
 pg_trickle.change_buffer_schema = 'pgtrickle_changes'

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -692,6 +692,107 @@ No breaking changes.
 
 ---
 
+### 0.30.0 → 0.31.0
+
+**No schema changes.** All improvements are confined to the Rust extension binary and scheduler logic.
+
+**New GUC variables:**
+
+| GUC | Default | Purpose |
+|-----|---------|---------|
+| `pg_trickle.cost_model_miss_penalty` | `2.0` | Weight applied to the estimated cost when the planner's row count estimate is inaccurate |
+| `pg_trickle.scheduler_hot_tier_interval_ms` | `500` | Effective polling interval (ms) for Hot-tier stream tables |
+
+**Behavioral changes:**
+
+- Scheduler now uses a predictive cost model to decide DIFFERENTIAL vs. FULL refresh per cycle; the model activates after `pg_trickle.prediction_min_samples` samples.
+- Event-driven wake now debounces duplicate NOTIFY payloads within a single tick to avoid redundant wakeups on bulk writes.
+
+No breaking changes.
+
+---
+
+### 0.31.0 → 0.32.0
+
+**No schema changes.** Citus stable naming infrastructure is added without altering the public catalog schema.
+
+**Behavioral changes:**
+
+- `pgtrickle.source_stable_name(rel_oid)` introduced as a deterministic, version-stable WAL slot name for Citus distributed sources.
+- Per-source `last_frontier` column added to `pgtrickle.pgt_stream_tables` via `ADD COLUMN IF NOT EXISTS` — existing rows receive `NULL`.
+
+No breaking changes.
+
+---
+
+### 0.32.0 → 0.33.0
+
+**Schema additions** — new catalog tables for Citus distributed CDC:
+
+| Object | Type | Purpose |
+|--------|------|---------|
+| `pgtrickle.pgt_worker_slots` | Table | Tracks per-worker WAL slot name and last-consumed frontier for each Citus worker / source combination |
+| `pgtrickle.pgt_st_locks` | Table | Lightweight distributed mutex for cross-coordinator refresh serialisation |
+| `pgtrickle.citus_status` | View | Per-(stream table, source, worker) CDC health view |
+
+**New SQL functions:**
+
+- `pgtrickle.ensure_worker_slot(st_name, worker_host, worker_port)` — creates the WAL slot on a Citus worker if it does not exist.
+- `pgtrickle.poll_worker_slot_changes(st_name, worker_host, worker_port)` — drains pending WAL changes from a worker slot into the coordinator change buffer.
+- `pgtrickle.handle_vp_promoted(payload TEXT)` — processes a `pg_ripple.vp_promoted` NOTIFY payload and signals the scheduler.
+- `pgtrickle.check_citus_version_compat()` — verifies that all worker nodes run the same pg_trickle version.
+- `pgtrickle.check_worker_wal_level()` — verifies that `wal_level = logical` on every worker.
+
+**New `create_stream_table()` parameter:**
+
+- `output_distribution_column TEXT` — when provided (and Citus is installed), converts the output storage table to a Citus distributed table on that column immediately after creation.
+
+**New GUC:**
+
+| GUC | Default | Purpose |
+|-----|---------|---------|
+| `pg_trickle.citus_st_lock_lease_ms` | `60000` | Duration (ms) of the `pgt_st_locks` lease for cross-node coordination |
+
+No application-level breaking changes.  Existing stream tables on non-Citus deployments are completely unaffected.
+
+---
+
+### 0.33.0 → 0.34.0
+
+**Schema additions** — the `pgtrickle.citus_status` view gains five new columns:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `last_polled_at` | `timestamptz` | Timestamp of the last successful per-worker poll |
+| `lease_holder` | `text` | Session holding the `pgt_st_locks` lease (NULL when unlocked) |
+| `lease_acquired_at` | `timestamptz` | When the current lease was acquired |
+| `lease_expires_at` | `timestamptz` | When the current lease expires |
+| `lease_health` | `text` | `'unlocked'` / `'locked'` / `'expired'` |
+
+**Behavioral changes:**
+
+- The scheduler now drives the full per-worker slot lifecycle automatically for stream tables with `source_placement = 'distributed'`: `ensure_worker_slot()` on first tick (and after topology changes), `poll_worker_slot_changes()` on every tick, and `pgt_st_locks` lease acquire/extend/release.  Manual wiring via `LISTEN "pg_ripple.vp_promoted" + handle_vp_promoted()` is no longer required (though harmless if left in place).
+- Shard rebalance auto-recovery: the scheduler detects `pg_dist_node` topology changes, prunes stale `pgt_worker_slots` rows, inserts new ones, and marks the stream table for a full refresh — no operator intervention required.
+- Worker failure isolation: per-worker `poll_worker_slot_changes()` failures are caught, logged, and skipped for that tick; healthy workers continue uninterrupted.
+
+**New GUC:**
+
+| GUC | Default | Purpose |
+|-----|---------|---------|
+| `pg_trickle.citus_worker_retry_ticks` | `5` | Consecutive per-worker poll failures before emitting a WARNING and flagging in `citus_status`. Set to `0` to disable. |
+
+**Migration note:**
+
+```sql
+ALTER EXTENSION pg_trickle UPDATE TO '0.34.0';
+```
+
+The migration script adds the five new columns to `citus_status` via `CREATE OR REPLACE VIEW`.  No data loss.
+
+No breaking changes.  Non-Citus deployments are completely unaffected.
+
+---
+
 ## Supported Upgrade Paths
 
 The following migration hops are available. PostgreSQL chains them
@@ -715,10 +816,30 @@ automatically when you run `ALTER EXTENSION pg_trickle UPDATE`.
 | 0.11.0 | 0.12.0 | `pg_trickle--0.11.0--0.12.0.sql` |
 | 0.12.0 | 0.13.0 | `pg_trickle--0.12.0--0.13.0.sql` |
 | 0.13.0 | 0.14.0 | `pg_trickle--0.13.0--0.14.0.sql` |
+| 0.14.0 | 0.15.0 | `pg_trickle--0.14.0--0.15.0.sql` |
+| 0.15.0 | 0.16.0 | `pg_trickle--0.15.0--0.16.0.sql` |
+| 0.16.0 | 0.17.0 | `pg_trickle--0.16.0--0.17.0.sql` |
+| 0.17.0 | 0.18.0 | `pg_trickle--0.17.0--0.18.0.sql` |
+| 0.18.0 | 0.19.0 | `pg_trickle--0.18.0--0.19.0.sql` |
+| 0.19.0 | 0.20.0 | `pg_trickle--0.19.0--0.20.0.sql` |
+| 0.20.0 | 0.21.0 | `pg_trickle--0.20.0--0.21.0.sql` |
+| 0.21.0 | 0.22.0 | `pg_trickle--0.21.0--0.22.0.sql` |
+| 0.22.0 | 0.23.0 | `pg_trickle--0.22.0--0.23.0.sql` |
+| 0.23.0 | 0.24.0 | `pg_trickle--0.23.0--0.24.0.sql` |
+| 0.24.0 | 0.25.0 | `pg_trickle--0.24.0--0.25.0.sql` |
+| 0.25.0 | 0.26.0 | `pg_trickle--0.25.0--0.26.0.sql` |
+| 0.26.0 | 0.27.0 | `pg_trickle--0.26.0--0.27.0.sql` |
+| 0.27.0 | 0.28.0 | `pg_trickle--0.27.0--0.28.0.sql` |
+| 0.28.0 | 0.29.0 | `pg_trickle--0.28.0--0.29.0.sql` |
+| 0.29.0 | 0.30.0 | `pg_trickle--0.29.0--0.30.0.sql` |
+| 0.30.0 | 0.31.0 | `pg_trickle--0.30.0--0.31.0.sql` |
+| 0.31.0 | 0.32.0 | `pg_trickle--0.31.0--0.32.0.sql` |
+| 0.32.0 | 0.33.0 | `pg_trickle--0.32.0--0.33.0.sql` |
+| 0.33.0 | 0.34.0 | `pg_trickle--0.33.0--0.34.0.sql` |
 
-That means any installation currently on 0.1.3 through 0.13.0 can upgrade to
-0.14.0 in one step after the new binaries are installed and PostgreSQL has been
-restarted.
+Any installation from 0.1.3 onward can be upgraded to 0.34.0 in a single
+`ALTER EXTENSION pg_trickle UPDATE` — PostgreSQL chains the hops automatically
+after the new binaries are installed and the server has been restarted.
 
 ---
 

--- a/docs/integrations/citus.md
+++ b/docs/integrations/citus.md
@@ -128,7 +128,9 @@ SELECT
     worker_name,
     worker_port,
     worker_slot,
-    worker_frontier
+    worker_frontier,
+    last_polled_at,     -- v0.34.0+
+    lease_health        -- v0.34.0+: 'unlocked' | 'locked' | 'expired'
 FROM pgtrickle.citus_status
 ORDER BY pgt_name, worker_name;
 ```
@@ -141,6 +143,18 @@ ORDER BY pgt_name, worker_name;
 | `worker_port` | Port of the Citus worker |
 | `worker_slot` | WAL slot name on the worker |
 | `worker_frontier` | Last consumed LSN on the worker |
+| `last_polled_at` | Timestamp of the last successful poll for each worker slot (v0.34.0+) |
+| `lease_holder` | Session that currently holds the `pgt_st_locks` lease, if any (v0.34.0+) |
+| `lease_acquired_at` | When the current lease was acquired (v0.34.0+) |
+| `lease_expires_at` | When the current lease expires (v0.34.0+) |
+| `lease_health` | `'unlocked'`, `'locked'`, or `'expired'` (v0.34.0+) |
+
+### Worker-failure alerting GUC (v0.34.0)
+
+| GUC | Default | Description |
+|-----|---------|-------------|
+| `pg_trickle.citus_worker_retry_ticks` | `5` | Consecutive per-worker poll failures before raising a WARNING in the PostgreSQL log. Set to `0` to disable. |
+| `pg_trickle.citus_st_lock_lease_ms` | `60000` | Duration (ms) of the `pgt_st_locks` distributed-refresh lease. Must be ≥ `pg_ripple.merge_fence_timeout_ms` when pg_ripple is in use. |
 
 ## Failure Modes
 
@@ -171,13 +185,16 @@ SELECT pg_drop_replication_slot('pgtrickle_<stable_name>');
 
 ### Shard rebalance
 
-Citus shard rebalancing changes which worker holds which shards. pg_trickle
-detects a topology change (by comparing `pg_dist_node` node sets) and raises
-an error rather than silently producing incorrect results.
+Citus shard rebalancing changes which worker holds which shards. Since v0.34.0,
+pg_trickle detects a topology change automatically (by comparing `pg_dist_node`
+active primaries against `pgt_worker_slots`) and recovers without operator
+intervention:
 
-**Recovery**: After a rebalance, drop and recreate the affected stream tables.
-Tracking automatic slot migration post-rebalance is planned for a future
-release.
+1. Stale slot entries for removed workers are dropped.
+2. New `pgt_worker_slots` rows are inserted for the incoming workers.
+3. The affected stream table is marked for a full refresh on the next tick.
+
+No manual `DROP + CREATE` of stream tables is required after a rebalance.
 
 ### Version mismatch across nodes
 
@@ -186,17 +203,6 @@ If pg_trickle versions differ between the coordinator and workers,
 same pg_trickle version on all nodes before creating distributed stream tables.
 
 ## Known Limitations
-
-- **Scheduler integration not yet automated** (v0.33.0): The infrastructure for
-  per-worker WAL slot polling is complete (`poll_worker_slot_changes`,
-  `ensure_worker_slot`, `handle_vp_promoted`, `pgt_st_locks` coordination),
-  but the scheduler's main loop does not yet automatically call it. Manual
-  polling via `LISTEN "pg_ripple.vp_promoted" + handle_vp_promoted()` or custom
-  application logic is required.  Full end-to-end automation is planned for a
-  future release.
-
-- **Shard rebalancing** (Citus `citus_rebalance_start`) invalidates per-worker
-  WAL slots. Manual recovery is required (see above).
 
 - **MERGE** is not supported for distributed stream tables. pg_trickle
   automatically uses the `DELETE + INSERT … ON CONFLICT DO UPDATE` path for
@@ -207,6 +213,10 @@ same pg_trickle version on all nodes before creating distributed stream tables.
 
 - Citus reference tables work as sources with trigger-based CDC only
   (per-worker WAL slots are not needed for reference tables).
+
+- **Worker failure alerting** — configure `pg_trickle.citus_worker_retry_ticks`
+  (default 5) to control how many consecutive poll failures trigger a WARNING.
+  Set to `0` to disable the alert entirely.
 
 ## pg_ripple Integration (v0.58.0+)
 
@@ -323,6 +333,6 @@ JOIN pgtrickle.citus_status      c
 - [SQL Reference — `create_stream_table`](../SQL_REFERENCE.md)
 - [Architecture — Citus distributed CDC](../ARCHITECTURE.md)
 - [Monitoring — `citus_status` view](../CONFIGURATION.md)
-- [CHANGELOG — v0.32.0](../../CHANGELOG.md) (stable naming and frontier
-  foundations)
+- [CHANGELOG — v0.32.0](../../CHANGELOG.md) (stable naming and frontier foundations)
 - [CHANGELOG — v0.33.0](../../CHANGELOG.md) (distributed CDC and stream tables)
+- [CHANGELOG — v0.34.0](../../CHANGELOG.md) (automated distributed CDC scheduler & shard rebalance auto-recovery)


### PR DESCRIPTION
## Summary

With v0.34.0 released, this PR brings the documentation fully up to date: version references, the Citus integration guide, the configuration reference, and the upgrade notes.

## Changes

### README.md
- Bump CNPG extension image tag from `0.20.0` → `0.34.0`
- Bump dbt package `revision` from `v0.20.0` → `v0.34.0`
- Add **Citus distributed tables** bullet block to the "Key Features → Scheduling & dependency management" section, covering distributed sources, distributed output, the automated scheduler (v0.34.0), shard rebalance auto-recovery, and worker failure isolation

### docs/integrations/citus.md
- Remove the outdated "Scheduler integration not yet automated (v0.33.0)" Known Limitation — the scheduler is now fully automated since v0.34.0
- Rewrite the "Shard rebalance" failure-mode section: recovery is now automatic (stale slots pruned, new ones inserted, full refresh triggered); manual drop + recreate is no longer required
- Add five new `citus_status` columns introduced in v0.34.0: `last_polled_at`, `lease_holder`, `lease_acquired_at`, `lease_expires_at`, `lease_health`
- Update the `citus_status` query example to include the new columns
- Add "Worker-failure alerting GUC" table documenting `citus_worker_retry_ticks` and `citus_st_lock_lease_ms`
- Add v0.34.0 changelog link to "See Also"

### docs/CONFIGURATION.md
- Add new **Citus Distributed Tables (v0.32.0+)** section to the Table of Contents
- Add full GUC reference entries for `pg_trickle.citus_st_lock_lease_ms` (default 60 000 ms, added v0.33.0) and `pg_trickle.citus_worker_retry_ticks` (default 5, added v0.34.0)
- Add both GUCs to the complete `postgresql.conf` example

### docs/UPGRADING.md
- Add `0.30.0 → 0.31.0` upgrade notes (scheduler performance GUCs, no schema changes)
- Add `0.31.0 → 0.32.0` upgrade notes (Citus stable naming, `last_frontier` column)
- Add `0.32.0 → 0.33.0` upgrade notes (new `pgt_worker_slots`, `pgt_st_locks` tables, `citus_status` view, new SQL functions, `output_distribution_column` parameter, new GUC)
- Add `0.33.0 → 0.34.0` upgrade notes (five new `citus_status` columns, automated scheduler behaviour, shard rebalance auto-recovery, `citus_worker_retry_ticks` GUC)
- Extend the Supported Upgrade Paths table from v0.13.0 → v0.34.0 (was truncated at 0.14.0)

## Testing

- No code changes — documentation only
- Verified all cross-links are consistent with existing file paths
- `just fmt` and `just lint` are not required for docs-only changes

## Notes

All changes are backwards-compatible doc improvements. No SQL or Rust code was modified.
