### PR TITLE
roadmap(v0.35.0): add CITUS-BENCH and CITUS-XSHARD items for remaining Citus scalability gaps

### DIFF
--- a/roadmap/v0.35.0.md
+++ b/roadmap/v0.35.0.md
@@ -73,6 +73,23 @@ Docker Compose rig (coordinator + 3 workers) that drives:
 A new `citus-tests.yml` GitHub Actions workflow runs this suite on every push
 to `main`.
 
+Two additional Citus scalability gaps close alongside the chaos rig:
+
+- **`dblink` vs streaming libpq benchmark** (`CITUS-BENCH`) — the per-worker
+  slot polling path has never been benchmarked. A new `benches/bench_remote_slot_poll.rs`
+  compares `dblink`-wrapped `pg_logical_slot_get_changes()` against native libpq
+  streaming at 1, 4, and 9 workers. If streaming delivers ≥ 30% lower p99 latency
+  or ≥ 20% higher throughput the migration happens in the same PR; otherwise
+  the `dblink` path is formally closed as the right choice.
+
+- **Cross-shard join advisory** (`CITUS-XSHARD`) — when a distributed stream
+  table is keyed on `__pgt_row_id` (a surrogate) rather than the source table's
+  distribution column, any query joining the ST back to its source incurs a
+  cross-shard re-partition join. pg_trickle now detects this at `create_stream_table()`
+  time and emits a `NOTICE` suggesting the `output_distribution_column` parameter.
+  The co-location status is recorded in `pgt_stream_tables.citus_colocated_with`
+  and surfaced in the `citus_status` view.
+
 ---
 
 ## Reactive subscriptions

--- a/roadmap/v0.35.0.md-full.md
+++ b/roadmap/v0.35.0.md-full.md
@@ -114,6 +114,7 @@ stable names after migration.
 | A10 | History prune in dedicated bgworker with LIMIT | S | P1 |
 | A11 | `start_time` index on `pgt_refresh_history` | XS | P1 |
 | A13 | Citus lease acquisition: randomised backoff on conflict | XS | P1 |
+| CITUS-XSHARD | Citus: detect non-co-located ST↔source join plans and emit advisory | S | P1 |
 | A22 | Emit `pgrx::notice!()` on every FULL fallback | S | P1 |
 | A23 | `pgtrickle.explain_stream_table()` operator-tree visualiser | S | P1 |
 | A24 | Generated GUC catalogue in docs (CI sync check) | S | P2 |
@@ -162,6 +163,31 @@ the retention prune in place this stays small.
 `pgt_st_locks` acquisition retries on conflict with no delay. With multiple
 coordinators racing, this produces O(N²) attempts/second. Add 50–500 ms
 randomised jitter on each `INSERT … ON CONFLICT DO NOTHING` failure.
+
+**CITUS-XSHARD — Cross-shard join plan advisory.**
+When a `distributed` stream table's `__pgt_row_id` distribution column does
+not match the source table's Citus distribution column, any query that JOINs
+the ST back to its source produces a re-partition or broadcast join
+(PLAN_CITUS.md §P4.4). This is documented but there is no runtime signal;
+users discover it only by examining `EXPLAIN` output after the fact.
+
+At `create_stream_table()` time, when `st_placement = 'distributed'`:
+1. Compare the ST's inferred distribution column (from `output_distribution_column`
+   or the auto-selected `__pgt_row_id`) against the distribution column of each
+   distributed source in the query, using `pg_dist_partition.partkey`.
+2. If no source column matches, emit:
+   `NOTICE: stream table "<name>" is distributed on __pgt_row_id which does not
+   co-locate with source "<src>". Queries that JOIN this stream table to its
+   source will use cross-shard joins (re-partition or broadcast). Consider
+   passing output_distribution_column => '<source_dist_col>' to avoid this.`
+3. Record the co-location status in a new nullable column
+   `pgtrickle.pgt_stream_tables.citus_colocated_with TEXT` (NULL = local/reference,
+   `'<source_stable_name>'` = co-located, `'none'` = non-co-located). Expose it
+   in `pgtrickle.citus_status`.
+
+No schema migration is needed beyond the nullable column add (existing rows
+default to NULL). The advisory is also re-emitted by `alter_stream_table()`
+if the distribution is changed.
 
 **A22 — FULL fallback NOTICE.**
 When the DVM parser falls back to FULL refresh (SubLink-in-OR walker miss,
@@ -219,12 +245,33 @@ writable throughout. Ships behind a feature flag. **Schema change:** add
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
 | A21 | IVM lock-mode fallback Prometheus counter | XS | P2 |
+| CITUS-BENCH | Citus: benchmark `dblink` vs streaming libpq for per-worker slot polling | M | P1 |
 
 **A21 — IVM lock-mode fallback metric.**
 `src/ivm.rs:48-91`: on parse failure IVM defaults to `Exclusive` mode
 (correct, fail-closed) but emits no metric. Add
 `pgtrickle_ivm_lock_mode_fallback_total{reason="parse_error"}` so operators
 can see how often this occurs.
+
+**CITUS-BENCH — `dblink` vs streaming libpq poll benchmark.**
+`src/scheduler.rs` (via `src/citus.rs:poll_worker_slot_changes`) currently
+polls per-worker WAL slots through a `dblink`-wrapped
+`pg_logical_slot_get_changes()` call (PLAN_CITUS.md §3.1 option A). This has
+never been benchmarked. Streaming libpq (`START_REPLICATION`) would give
+push-based wakeups with sub-tick delivery latency at the cost of a
+persistent connection per worker.
+
+Add `benches/bench_remote_slot_poll.rs` that measures:
+- `dblink` + `pg_logical_slot_get_changes()` throughput (rows/s, p50/p99 latency)
+  at 1, 4, 9 workers with 100k CDC events per source
+- Native libpq streaming poll throughput under the same conditions
+
+If the streaming path delivers ≥ 30% lower p99 latency **or** ≥ 20% higher
+throughput at 9 workers, migrate `poll_worker_slot_changes` to the libpq path
+in the same PR. Record the decision (and the numbers) in
+`docs/BENCHMARK.md` under a new "Citus Distributed CDC" section.
+If `dblink` is within tolerance, close OQ#1 in PLAN_CITUS.md and document
+the rationale so it is not re-opened.
 
 ---
 
@@ -327,6 +374,8 @@ how to interpret its output.
 - [ ] A01: Every join refresh cycle routes unconditionally through PH-D1; no UNIQUE_VIOLATION in TPC-H Q7/Q15 IMMEDIATE over 1,000 cycles
 - [ ] A02: 50k-iteration proptest passes with zero counterexamples; regression fixtures added for all prior flakes
 - [ ] A03: Citus chaos rig passes all 4 scenarios; `citus-tests.yml` green on push-to-main
+- [ ] CITUS-BENCH: bench results committed to `docs/BENCHMARK.md`; libpq migration decision recorded in PLAN_CITUS.md OQ#1
+- [ ] CITUS-XSHARD: non-co-located ST emits `NOTICE` at create time; `citus_colocated_with` column added to `pgt_stream_tables` and visible in `citus_status`
 - [ ] A04: `SpiErrorCode` variant constructed at every SPI call site; `classify_spi_sqlstate_retryable` is the primary classifier
 - [ ] A05: `join_and_predicates()` returns `Result<Expr, PgTrickleError>`; no `expect()` in production code
 - [ ] A06: `inbox.rs` and `outbox.rs` each have `#[cfg(test)] mod tests` with dedup, envelope, and proptest coverage


### PR DESCRIPTION
## Summary

Adds two new items to the v0.35.0 roadmap that address the remaining Citus
scalability gaps identified in [PLAN_CITUS.md](plans/ecosystem/PLAN_CITUS.md)
but not yet tracked in the release plan: the unresolved open question on
`dblink` vs streaming libpq latency (OQ#1), and the silent cross-shard join
trap when a distributed stream table does not co-locate with its source.

## Changes

- **`CITUS-BENCH` (M, P1)** — benchmark `dblink`-wrapped
  `pg_logical_slot_get_changes()` vs native libpq `START_REPLICATION`
  streaming at 1, 4, and 9 workers. If streaming delivers ≥ 30% lower p99
  latency or ≥ 20% higher throughput the `poll_worker_slot_changes` path
  migrates in the same PR; otherwise PLAN_CITUS.md OQ#1 is formally closed.
  Results land in `docs/BENCHMARK.md` under a new "Citus Distributed CDC"
  section.

- **`CITUS-XSHARD` (S, P1)** — at `create_stream_table()` time, detect when
  a `distributed` stream table's distribution column does not co-locate with
  its source table's Citus distribution key. Emit a `NOTICE` recommending
  `output_distribution_column`. Record the co-location status in a new
  nullable column `pgt_stream_tables.citus_colocated_with` and surface it in
  the `citus_status` view.

Both items added to the performance/ease-of-use tables in
`roadmap/v0.35.0.md-full.md` with full implementation prose and exit
criteria, and summarised in the plain-language `roadmap/v0.35.0.md`.

## Testing

Documentation-only change; no code modified.

- `just check-version-sync` — unaffected (no SQL or Rust changes)

## Notes

The three Citus items already present in v0.35.0 (A03 chaos rig, A13 lease
jitter, A27 upgrade fixture) are unchanged.

The cross-shard join advisory (`CITUS-XSHARD`) is a small, isolated addition
to `src/api/mod.rs` at `create_stream_table()` time and a nullable column
in the SQL schema — it can be implemented in a single PR with no migration
complexity beyond an `ADD COLUMN … DEFAULT NULL`.
