### PR TITLE
docs: major documentation rework — discoverability, glossary, persona paths

### DIFF
--- a/ESSENCE.md
+++ b/ESSENCE.md
@@ -1,25 +1,201 @@
-# pg_trickle – Incremental View Maintenance for PostgreSQL, No External Infrastructure Required
+# What is pg_trickle?
 
-We've been building pg_trickle, an open-source PostgreSQL extension that brings automatic, incremental materialized view refreshes directly inside the database. No external processes, no sidecars — just `CREATE EXTENSION pg_trickle` and your views stay fresh.
+pg_trickle is a PostgreSQL 18 extension that adds **stream tables** —
+tables that are defined by a SQL query and stay up to date
+automatically as the underlying data changes. No external process,
+no streaming engine, no pipeline to operate. Just install the
+extension and write SQL.
 
-**The problem:** PostgreSQL's materialized views are powerful but frustrating. `REFRESH MATERIALIZED VIEW` re-runs the entire query from scratch, even if only one row changed in a million-row table. Your choices are: burn CPU on full recomputation, or accept stale data. Most teams end up building bespoke refresh pipelines just to keep summary tables current.
+If you have ever wished `CREATE MATERIALIZED VIEW` would just *keep
+itself fresh*, this is that.
 
-**What pg_trickle does differently:** You define a "stream table" with a SQL query and a schedule. The extension captures changes to your source tables and, on each refresh cycle, derives a *delta query* that processes only the changed rows and merges the result into the materialized table. One insert into a million-row source table? pg_trickle touches exactly one row's worth of computation.
+---
 
-**Demand-driven scheduling:** Stream tables can depend on base tables or on other stream tables, forming a dependency graph. With the default `CALCULATED` schedule mode, you only set an explicit refresh interval on the leaf-level stream tables your application actually queries — the ones that matter to your users. The system propagates that cadence upward through the DAG automatically: each upstream stream table inherits the tightest schedule among its downstream dependents. You declare freshness requirements where they matter — at the consumer — and the entire pipeline adjusts. No manual coordination of refresh ordering or timing across layers of dependent views.
+## The problem
 
-**Hybrid change capture:** pg_trickle bootstraps with lightweight row-level triggers — no configuration needed, works out of the box. Once the first refresh succeeds and `wal_level = logical` is available, the system automatically transitions to WAL-based logical replication for lower write-side overhead (~2–15 μs per row eliminated). The transition is seamless: trigger → transitioning (both run in parallel) → WAL-only. If anything goes wrong, it falls back to triggers.
+PostgreSQL's materialized views are powerful but frustrating.
+`REFRESH MATERIALIZED VIEW` re-runs the entire query from scratch,
+even if only one row changed in a million-row table. Your choices
+are:
 
-The approach is grounded in the DBSP differential dataflow framework (Budiu et al., 2022). Delta queries are derived automatically from your SQL's operator tree: joins produce the classic bilinear expansion, aggregates maintain auxiliary counters, and linear operators like filters just pass deltas through unchanged.
+- **Burn CPU on full recomputation**, on a schedule, and hope you
+  refresh often enough.
+- **Accept stale data**, and try to explain that to the dashboard
+  user.
+- **Build a bespoke refresh pipeline** — Debezium, Kafka Connect, a
+  streaming engine, a separate read database. Now you have *two*
+  systems to operate.
 
-**Broad SQL support:** JOINs (inner, left, right, full outer), GROUP BY with all common aggregates, DISTINCT, UNION/INTERSECT/EXCEPT, subqueries, EXISTS/IN, CTEs (including WITH RECURSIVE), window functions, LATERAL joins, and most common expressions.
+Most teams pick option 3 and end up maintaining infrastructure that
+is more complex than the application it supports.
 
-Other things we care about: crash-safe advisory locking, built-in monitoring views, NOTIFY-based alerting, and a dbt integration.
+---
 
-**Performance is a primary goal.** Maximum throughput, low latency, and minimal overhead drive every design decision. Differential refresh is the default mode; full refresh is a fallback of last resort. At a 1% change rate, benchmarks show 7–42× speedup over full refresh — and the bottleneck is PostgreSQL's own MERGE, not pg_trickle's pipeline.
+## What pg_trickle does instead
 
-Written in Rust using pgrx. Targets PostgreSQL 18. Apache 2.0 licensed. 1,200+ unit tests and 570+ E2E tests across eleven releases — approaching production readiness.
+You declare a stream table with a SQL query and a schedule:
 
-See [ROADMAP.md](ROADMAP.md) for the release milestone plan (v0.2.0 through v1.0.0 and beyond).
+```sql
+SELECT pgtrickle.create_stream_table(
+    name     => 'revenue_by_region',
+    query    => $$
+        SELECT c.region,
+               COUNT(*)                  AS order_count,
+               SUM(o.quantity * p.price) AS total_revenue
+        FROM orders   o
+        JOIN customers c ON c.id = o.customer_id
+        JOIN products  p ON p.id = o.product_id
+        GROUP BY c.region
+    $$,
+    schedule => '1s'
+);
 
-GitHub: https://github.com/grove/pg-trickle
+-- Read it like any table — always fresh.
+SELECT * FROM revenue_by_region ORDER BY total_revenue DESC;
+```
+
+Behind the scenes:
+
+1. pg_trickle parses your query into an *operator tree* (scans,
+   joins, aggregates).
+2. It captures every `INSERT`, `UPDATE`, and `DELETE` on the source
+   tables — by default with lightweight row-level triggers, with no
+   replication slots required.
+3. On each refresh cycle (every `1s`, in the example above) it
+   derives a *delta query* from the operator tree — the SQL that
+   computes only the change since the last refresh — and merges the
+   result into the stream table.
+
+When you insert one row into a million-row source table, pg_trickle
+processes one row's worth of computation. Not a million.
+
+---
+
+## Why people care
+
+A few things make this materially different from "just another IVM
+project":
+
+**No external infrastructure.** No Kafka, no Flink, no Debezium, no
+sidecar. The extension lives inside PostgreSQL and uses only its
+built-in mechanisms.
+
+**Stream tables can depend on stream tables.** A single write to a
+base table can ripple through a graph of derived tables, each
+refreshed in the right order, each doing only the work proportional
+to what actually changed.
+
+**Demand-driven scheduling.** With the default `CALCULATED` schedule
+mode, you only set a refresh interval on the *consumer-facing*
+stream tables — the ones your application actually reads. Upstream
+stream tables inherit the tightest cadence among their downstream
+dependents. You declare freshness where it matters; the system
+propagates it everywhere else.
+
+**Hybrid change capture.** It bootstraps with row-level triggers,
+which always work. If `wal_level = logical` is available, it
+transitions automatically to WAL-based capture for near-zero
+write-side overhead. The transition is seamless. If anything goes
+wrong, it falls back to triggers.
+
+**Broad SQL coverage.** Joins (inner, left, right, full outer,
+lateral), `GROUP BY` with 30+ aggregates, `DISTINCT`,
+`UNION`/`INTERSECT`/`EXCEPT`, subqueries (`EXISTS`, `IN`, scalar),
+CTEs including `WITH RECURSIVE`, window functions, and most of
+standard SQL. See [docs/SQL_REFERENCE.md](docs/SQL_REFERENCE.md) for
+the complete matrix.
+
+**Inside the same transaction, if you want it.** `IMMEDIATE` refresh
+mode maintains the stream table inside the same transaction as the
+source DML, giving read-your-writes consistency without any
+background worker.
+
+---
+
+## Where the design comes from
+
+The mathematical foundation is the
+[DBSP differential dataflow framework](https://arxiv.org/abs/2203.16684)
+(Budiu et al., 2022). Delta queries are derived automatically from
+your SQL's operator tree:
+
+- joins produce the classic bilinear expansion,
+- aggregates maintain auxiliary counters,
+- linear operators like filters and projections pass deltas
+  through unchanged.
+
+You do not need to know any of this to use the extension; the rules
+are baked in. If you are curious, the
+[DVM Operators](docs/DVM_OPERATORS.md) reference and the
+[DBSP Comparison](docs/research/DBSP_COMPARISON.md) explain how
+pg_trickle relates to the original.
+
+---
+
+## Performance, briefly
+
+Performance is a primary goal. Maximum throughput, low latency, and
+minimal overhead drive every design decision. Differential refresh
+is the default; full refresh is a fallback of last resort.
+
+A few headline numbers from the
+[TPC-H validation](README.md#tpc-h-validation-22-queries-sf001):
+
+- All 22 standard analytical queries pass in DIFFERENTIAL,
+  IMMEDIATE, and FULL modes, with identical results across modes.
+- 5–90× measured speedup over FULL across the suite at 1% change
+  rate.
+- The bottleneck is PostgreSQL's own `MERGE`, not pg_trickle's
+  pipeline.
+
+For workloads with high write volume,
+[hybrid CDC](docs/CDC_MODES.md) and column-level change tracking
+keep the write-side overhead low (sub-microsecond per row in WAL
+mode).
+
+---
+
+## What's it built on
+
+- **Language:** Rust, using [pgrx](https://github.com/pgcentralfoundation/pgrx) 0.18.
+- **Targets:** PostgreSQL 18.
+- **License:** Apache 2.0.
+- **Status:** active development, approaching 1.0. APIs may still
+  change between minor versions; see [ROADMAP.md](ROADMAP.md).
+- **Tests:** thousands of unit, integration, and end-to-end tests.
+  TPC-H 22/22 in all modes.
+
+---
+
+## Try it
+
+The fastest paths from zero to a working stream table:
+
+```bash
+# Option 1 — playground (sample data, dashboards, TUI ready)
+cd playground && docker compose up -d
+
+# Option 2 — minimal Docker image
+docker run --rm -e POSTGRES_PASSWORD=secret -p 5432:5432 \
+  ghcr.io/grove/pg_trickle:latest
+```
+
+Then read **[the 5-Minute Quickstart](docs/QUICKSTART_5MIN.md)**.
+
+---
+
+## Where to go next
+
+| Audience | Start here |
+|---|---|
+| **Curious / evaluator** | [Use Cases](docs/USE_CASES.md) · [Comparisons](docs/COMPARISONS.md) |
+| **Application developer** | [Quickstart (5 min)](docs/QUICKSTART_5MIN.md) → [Tutorial (in depth)](docs/GETTING_STARTED.md) → [Patterns](docs/PATTERNS.md) |
+| **DBA / SRE** | [Pre-Deployment Checklist](docs/PRE_DEPLOYMENT.md) → [Configuration](docs/CONFIGURATION.md) → [Troubleshooting](docs/TROUBLESHOOTING.md) |
+| **Data / analytics engineer** | [Use Cases](docs/USE_CASES.md) → [dbt integration](docs/integrations/dbt.md) → [Migrating from materialized views](docs/tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md) |
+
+Source: <https://github.com/grove/pg-trickle>
+
+> **Note on terminology.** A few terms are used throughout the
+> docs without further definition: *stream table*, *differential*,
+> *delta query*, *DAG*, *frontier*. The
+> [Glossary](docs/GLOSSARY.md) defines all of them.

--- a/README.md
+++ b/README.md
@@ -79,17 +79,18 @@ tables, pre-loaded data, and five stream tables demonstrating key pg_trickle pat
 aggregates, window functions, multi-table joins, time-series, and EXISTS subqueries. See
 [`playground/README.md`](playground/README.md) or the [Playground docs page](docs/PLAYGROUND.md).
 
-## History and Motivation
+## Choose your path
 
-This project started with a practical goal. We were inspired by existing data platforms built around pipelines that keep themselves incrementally up to date, and we wanted to bring that same style of self-maintaining data flow directly into PostgreSQL. In particular, we needed support for recursive CTEs, which were essential to the kinds of pipelines we had in mind. We could not find an open-source incremental view maintenance system that matched that requirement, so pg_trickle began as an attempt to close that gap.
+| Persona | Start here |
+|---|---|
+| **Curious / evaluator** | [What is pg_trickle?](ESSENCE.md) → [Use Cases](docs/USE_CASES.md) → [Comparisons](docs/COMPARISONS.md) → [Playground](playground/) |
+| **Application developer** | [5-Minute Quickstart](docs/QUICKSTART_5MIN.md) → [Getting Started tutorial](docs/GETTING_STARTED.md) → [Patterns](docs/PATTERNS.md) → [SQL Reference](docs/SQL_REFERENCE.md) |
+| **DBA / SRE** | [Pre-Deployment Checklist](docs/PRE_DEPLOYMENT.md) → [Configuration](docs/CONFIGURATION.md) → [Troubleshooting](docs/TROUBLESHOOTING.md) → [Capacity Planning](docs/CAPACITY_PLANNING.md) |
+| **Data / analytics engineer** | [Use Cases](docs/USE_CASES.md) → [dbt integration](docs/integrations/dbt.md) → [Migrating from materialized views](docs/tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md) |
+| **Confused by jargon** | [Glossary](docs/GLOSSARY.md) |
 
-It also became an experiment in what coding agents could realistically help build. We set out to develop pg_trickle without editing code by hand, while still holding it to the same bar we would expect from any other systems project: broad feature coverage, strong code quality, extensive tests, and thorough documentation. Skepticism toward AI-written software is reasonable; the right way to evaluate pg_trickle is by the codebase, the tests, and the docs.
-
-That constraint changed how we worked. Agents can produce a lot of surface area quickly, but database systems are unforgiving of vague assumptions and hidden edge cases. To make the project hold together, we had to be unusually explicit about architecture, operator semantics, failure handling, and test coverage. In practice, that pushed us toward more written design, more reviewable behavior, and more verification than a quick prototype would normally get.
-
-The result is a **spec-driven** development process, not vibe-coding. Every feature starts as a written plan — an architecture decision record, a gap analysis, or a phased implementation spec — before any code is generated. The [`plans/`](plans/) directory contains over 110 documents (~72,500 lines) covering operator semantics, CDC tradeoffs, performance strategies, ecosystem comparisons, and edge case catalogues. Agents work from these specs; the specs are reviewed and revised by humans. This is what makes it possible to maintain coherence across a large codebase without manually editing every line: the design is explicit, the invariants are written down, and the tests verify both.
-
-We also do not think the use of AI should lower the standard for trust. If anything, it raises it. The point of the experiment was not to ask people to trust the toolchain; it was to see whether disciplined use of coding agents could help produce a serious, inspectable PostgreSQL extension. Whether that worked is for readers and users to judge, but the intent is simple: make the code, the tests, the documentation, and the tradeoffs visible enough that the project can stand on its own merits.
+> **Curious about how pg_trickle came to be — and the role coding agents played in its development?**
+> See [Project History](docs/PROJECT_HISTORY.md).
 
 ## Key Features
 
@@ -502,20 +503,95 @@ reference, operations, and testing guide.
 
 ## Documentation
 
+The documentation is organised into reading paths so you can find what you
+need without scrolling. Start with **[ESSENCE.md](ESSENCE.md)** if you want
+the plain-language overview, or jump straight to a topic below.
+
+### Discover
+
 | Document | Description |
 |---|---|
-| [GETTING_STARTED.md](docs/GETTING_STARTED.md) | Hands-on tutorial building an org-chart with stream tables |
+| [What is pg_trickle?](ESSENCE.md) | Plain-language overview |
+| [Use Cases](docs/USE_CASES.md) | What people build with stream tables |
+| [Comparisons](docs/COMPARISONS.md) | vs. pg_ivm, Materialize, Flink, Debezium, … |
+| [Glossary](docs/GLOSSARY.md) | Decoder for every term used in the docs |
+
+### Get started
+
+| Document | Description |
+|---|---|
+| [5-Minute Quickstart](docs/QUICKSTART_5MIN.md) | Shortest possible introduction |
+| [Getting Started Tutorial](docs/GETTING_STARTED.md) | Hands-on tutorial building an org-chart with stream tables |
 | [INSTALL.md](INSTALL.md) | Detailed installation and configuration guide |
-| [docs/TUI.md](docs/TUI.md) | Terminal UI & CLI user guide — building, connecting, views, commands |
-| [docs/SQL_REFERENCE.md](docs/SQL_REFERENCE.md) | Complete SQL function reference |
-| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) | System architecture and data flow |
-| [docs/DVM_OPERATORS.md](docs/DVM_OPERATORS.md) | Supported operators and differentiation rules |
-| [docs/CONFIGURATION.md](docs/CONFIGURATION.md) | GUC variables and tuning guide |
-| [ROADMAP.md](ROADMAP.md) | Release milestones and future plans |
-| [What Happens on INSERT](docs/tutorials/WHAT_HAPPENS_ON_INSERT.md) | Full 7-phase lifecycle of a single INSERT through the pipeline |
-| [What Happens on UPDATE](docs/tutorials/WHAT_HAPPENS_ON_UPDATE.md) | D+I split, group key changes, net-effect for multiple UPDATEs |
-| [What Happens on DELETE](docs/tutorials/WHAT_HAPPENS_ON_DELETE.md) | Reference counting, group deletion, INSERT+DELETE cancellation |
-| [What Happens on TRUNCATE](docs/tutorials/WHAT_HAPPENS_ON_TRUNCATE.md) | Why TRUNCATE bypasses triggers and recovery strategies |
+
+### Build with stream tables
+
+| Document | Description |
+|---|---|
+| [Patterns](docs/PATTERNS.md) | Bronze/Silver/Gold, SCDs, dashboards, outbox/inbox |
+| [Performance Cookbook](docs/PERFORMANCE_COOKBOOK.md) | Tuning recipes |
+| [SQL Reference](docs/SQL_REFERENCE.md) | Every function, view, and option |
+| [Configuration](docs/CONFIGURATION.md) | All GUC variables |
+| [Predictive Cost Model](docs/COST_MODEL.md) | How AUTO mode chooses |
+
+### Operate
+
+| Document | Description |
+|---|---|
+| [Pre-Deployment Checklist](docs/PRE_DEPLOYMENT.md) | Before you go live |
+| [Scaling Guide](docs/SCALING.md) | Worker pool sizing, tiered scheduling |
+| [Capacity Planning](docs/CAPACITY_PLANNING.md) | Disk, memory, connections |
+| [Multi-Database Deployments](docs/MULTI_DATABASE.md) | One server, many databases |
+| [Backup and Restore](docs/BACKUP_AND_RESTORE.md) | pg_dump, pgBackRest, PITR |
+| [Snapshots](docs/SNAPSHOTS.md) | Point-in-time copies of stream tables |
+| [HA & Replication](docs/HA_AND_REPLICATION.md) | Failover, logical replicas, CNPG |
+| [Upgrading](docs/UPGRADING.md) | Version-to-version upgrade procedure |
+| [Security Guide](docs/SECURITY_GUIDE.md) | Roles, grants, RLS, auditing |
+| [Troubleshooting](docs/TROUBLESHOOTING.md) | Symptoms → diagnosis → fix |
+| [Error Reference](docs/ERRORS.md) | Every PgTrickleError variant with SQLSTATE |
+| [TUI Tool](docs/TUI.md) | Interactive terminal dashboard |
+| [CLI Reference](docs/CLI_REFERENCE.md) | Every `pgtrickle` subcommand |
+
+### Distributed & streaming
+
+| Document | Description |
+|---|---|
+| [Citus](docs/CITUS.md) | Distributed sources and outputs |
+| [CDC Modes](docs/CDC_MODES.md) | Trigger, WAL, hybrid |
+| [SLA-based Smart Scheduling](docs/SLA_SCHEDULING.md) | Set freshness goals, not intervals |
+| [Downstream Publications](docs/PUBLICATIONS.md) | Replicate stream tables to Debezium, Kafka, … |
+| [Transactional Outbox](docs/OUTBOX.md) | Reliable event emission |
+| [Transactional Inbox](docs/INBOX.md) | Idempotent event consumption |
+| [Relay Service](docs/RELAY_GUIDE.md) | Standalone bridge to NATS, Kafka, Redis, SQS, RabbitMQ, webhooks |
+
+### Tutorials & deep dives
+
+[What Happens on INSERT](docs/tutorials/WHAT_HAPPENS_ON_INSERT.md) ·
+[UPDATE](docs/tutorials/WHAT_HAPPENS_ON_UPDATE.md) ·
+[DELETE](docs/tutorials/WHAT_HAPPENS_ON_DELETE.md) ·
+[TRUNCATE](docs/tutorials/WHAT_HAPPENS_ON_TRUNCATE.md) ·
+[Tiered Scheduling](docs/tutorials/TIERED_SCHEDULING.md) ·
+[Fuse Circuit Breaker](docs/tutorials/FUSE_CIRCUIT_BREAKER.md) ·
+[Circular Dependencies](docs/tutorials/CIRCULAR_DEPENDENCIES.md) ·
+[Migrating from Materialized Views](docs/tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md) ·
+[Migrating from pg_ivm](docs/tutorials/MIGRATING_FROM_PG_IVM.md) ·
+[Row-Level Security](docs/tutorials/ROW_LEVEL_SECURITY.md) ·
+[Partitioned Tables](docs/tutorials/PARTITIONED_TABLES.md) ·
+[Foreign Table Sources](docs/tutorials/FOREIGN_TABLE_SOURCES.md) ·
+[Tuning Refresh Mode](docs/tutorials/tuning-refresh-mode.md) ·
+[Monitoring & Alerting](docs/tutorials/MONITORING_AND_ALERTING.md) ·
+[ETL & Bulk Load](docs/tutorials/ETL_BULK_LOAD.md)
+
+### Reference
+
+[FAQ](docs/FAQ.md) ·
+[What's New](docs/WHATS_NEW.md) ·
+[Changelog](CHANGELOG.md) ·
+[Roadmap](ROADMAP.md) ·
+[Project History](docs/PROJECT_HISTORY.md) ·
+[Architecture](docs/ARCHITECTURE.md) ·
+[DVM Operators](docs/DVM_OPERATORS.md) ·
+[Benchmarks](docs/BENCHMARK.md)
 
 ## Known Limitations
 

--- a/docs/BACKUP_AND_RESTORE.md
+++ b/docs/BACKUP_AND_RESTORE.md
@@ -1,83 +1,172 @@
 # Backup and Restore
 
-Like any standard PostgreSQL extension, `pg_trickle` supports logical backups via `pg_dump` and physical backups (via tools like pgBackRest or `pg_basebackup`).
+pg_trickle plays nicely with every standard PostgreSQL backup
+mechanism — `pg_dump`, `pg_basebackup`, pgBackRest, WAL archiving,
+PITR, and pre-built tools like CloudNativePG and Crunchy Operator.
+The catalog, change buffers, and stream-table contents are all
+ordinary PostgreSQL relations, so they get backed up like anything
+else.
 
-Because `pg_trickle` maintains automated states (like Change Data Capture buffers and DDL Event Triggers), specific workflows should be followed to ensure a smooth recovery.
+This page walks through the recommended workflows, the gotchas, and
+how the v0.27 [Snapshots](SNAPSHOTS.md) API fits in.
 
-## Physical Backups (pgBackRest / pg_basebackup)
-
-Physical backups copy the underlying data blocks. These are the most robust backups.
-
-**No special steps are needed** during restore. When the database comes online, `pg_trickle`'s catalogs, CDC buffers, and internal dependencies exist precisely as they did at the moment the snapshot was taken.
-
-*Note for WAL-Mode Users: Physical backups do not export replication slot data by default. If your CDC pipeline was in `wal` mode, logical slots might not survive the recreation. The pg_trickle scheduler handles missing slots gracefully by temporarily re-enabling table triggers.*
-
-## Logical Backups (pg_dump / pg_restore)
-
-Logical backups dump your database schema as generic cross-compatible SQL (`CREATE TABLE`, `INSERT`, `CREATE INDEX`).
-
-`pg_trickle` integrates with `pg_dump` natively. When restoring these backups (which typically involves sequentially recreating schemas, inserting data into those tables, and lastly applying indexes and triggers), you must restore into a database precisely, to allow the extension to rewrite its own internal triggers correctly without conflicting with plain PostgreSQL commands.
-
-### The Recommended Multi-Stage pg_restore Strategy
-
-The most reliable approach is to use the `--section` arguments of `pg_restore`. By breaking the restore up into pieces, we guarantee that when the schema, data, and constraints are created, all variables and configurations are actively in the database, and our custom hook `DdlEventKind::ExtensionChange` intercepts the query and automatically dials `pgtrickle.restore_stream_tables()` internally.
+> **TL;DR.** Physical backups (pgBackRest, `pg_basebackup`) just
+> work. `pg_dump` works too, with one small ordering rule. Snapshots
+> are an *application-level* tool for derived state, not a backup
+> replacement.
 
 ---
 
-## Stream Table Snapshots (v0.27.0)
+## Choosing the right tool
 
-In addition to traditional backup methods, pg_trickle v0.27.0 introduces a
-native **snapshot API** for stream tables. Snapshots are useful for:
+| Tool | Best for | Notes |
+|---|---|---|
+| **pgBackRest / WAL-G / pg_basebackup** | Production backup & PITR | Full-fidelity; no special pg_trickle steps |
+| **`pg_dump` / `pg_restore`** | Logical copies, dev environments, schema migration | Works; restore order matters slightly |
+| **Stream-table [snapshots](SNAPSHOTS.md)** | Replica bootstrap, archival of derived state, fast rollback of one stream table | Not a substitute for a real backup |
 
-- **Replica bootstrap**: Quickly populate a new replica without a full refresh
-- **PITR alignment**: Export a stream table's state at a known frontier
-- **Offline analysis**: Create an archival copy without impact to live queries
+---
 
-### Creating a snapshot
+## Physical backups (pgBackRest, pg_basebackup, WAL-G)
 
-```sql
--- Creates pgtrickle.snapshot_orders_agg_<epoch_ms> (auto-named)
-SELECT pgtrickle.snapshot_stream_table('public.orders_agg');
+Physical backups copy the data directory at the file-system level.
+Everything is captured: source tables, stream-table storage, the
+`pgtrickle.*` catalog, the `pgtrickle_changes.*` change buffers,
+and (in WAL CDC mode) the replication slots' on-disk state.
 
--- Or specify the target table name explicitly
-SELECT pgtrickle.snapshot_stream_table('public.orders_agg',
-       'pgtrickle.orders_agg_backup_2025');
+**Restore procedure:**
+
+1. Restore the data directory exactly as you would for any
+   PostgreSQL database.
+2. Start PostgreSQL.
+3. The pg_trickle launcher discovers each database on the next
+   tick (~10 s) and resumes the per-database scheduler.
+
+There is nothing pg_trickle-specific to do.
+
+**Point-in-time recovery (PITR).** PITR works as expected. If you
+recover to a point in the middle of a refresh, that refresh is
+marked failed in `pgtrickle.pgt_refresh_history` on first start;
+the next scheduler tick re-runs it. No data loss.
+
+**WAL CDC slots after restore.** If you were running in
+`pg_trickle.cdc_mode = 'wal'` and the restored cluster came up
+without the original slots (e.g. a logical-decoding replica that
+did not inherit slots), pg_trickle's scheduler detects the absence
+and re-bootstraps trigger CDC for the affected sources. You will
+see one `WARNING` per source; the system continues to work.
+
+---
+
+## Logical backups (`pg_dump` / `pg_restore`)
+
+`pg_dump` produces a portable SQL script (or directory archive)
+that can be replayed into a fresh database. pg_trickle objects are
+included automatically because they are normal extension objects.
+
+**The one ordering rule:** restore must follow the standard
+PostgreSQL "schema, then data, then constraints/indexes" order.
+`pg_restore --section=pre-data --section=data --section=post-data`
+does this for you. Avoid hand-editing the dump to interleave
+sections.
+
+### Recommended workflow
+
+```bash
+# Create the dump (custom or directory format)
+pg_dump --format=custom --file=mydb.dump mydb
+
+# Restore into a fresh database
+createdb mydb_restored
+pg_restore --dbname=mydb_restored --jobs=4 mydb.dump
 ```
 
-The snapshot table contains all rows from the stream table plus three
-metadata columns: `__pgt_snapshot_version`, `__pgt_frontier`, and
-`__pgt_snapshotted_at`.
-
-### Listing available snapshots
+Then, if you want to verify everything came back:
 
 ```sql
-SELECT snapshot_table, created_at, row_count, size_bytes
-FROM pgtrickle.list_snapshots('public.orders_agg')
-ORDER BY created_at DESC;
+-- Should list every stream table
+SELECT * FROM pgtrickle.pgt_status();
+
+-- Force a refresh on each one to confirm CDC is wired
+SELECT pgtrickle.refresh_stream_table(pgt_name)
+FROM pgtrickle.stream_tables_info;
 ```
 
-### Restoring from a snapshot
+### What `pg_dump` does and does not capture
 
-```sql
--- Truncate and restore from a named snapshot
-SELECT pgtrickle.restore_from_snapshot(
-    'public.orders_agg',
-    'pgtrickle.snapshot_orders_agg_1735000000000'
-);
-```
+| Object | Captured by `pg_dump`? |
+|---|---|
+| Source tables (your data) | ✅ |
+| Stream-table storage (your derived data) | ✅ |
+| `pgtrickle.*` catalog rows | ✅ |
+| CDC trigger definitions | ✅ (recreated when the extension reapplies them) |
+| `pgtrickle_changes.*` change buffers | ✅ — but typically empty after a clean dump |
+| WAL replication slots (WAL CDC mode) | ✕ (slots are not dumpable; the scheduler recreates them) |
+| Refresh history | ✅ |
 
-After restore, the stream table's frontier is set to the snapshot's frontier
-so the next refresh cycle is **DIFFERENTIAL** (not FULL). This avoids an
-expensive re-scan for the restored rows.
+If you do not need the audit history, you can shrink the dump with
+`pg_dump --exclude-table='pgtrickle.pgt_refresh_history'`.
 
-### Dropping a snapshot
+---
 
-```sql
-SELECT pgtrickle.drop_snapshot('pgtrickle.snapshot_orders_agg_1735000000000');
-```
+## Stream-table snapshots vs. backups
 
-This removes both the archival table and its metadata catalog row.
+[Snapshots](SNAPSHOTS.md) (v0.27+) are an **application-level**
+mechanism for capturing the contents of *one* stream table at a
+*chosen* point. They are great for:
 
-> **Note**: Snapshots are ordinary PostgreSQL tables; they are included in
-> `pg_dump` / `pg_basebackup` automatically. No special restore procedure is
-> needed — the snapshot table persists as a regular table until explicitly dropped.
+- Bootstrapping a replica without re-running a slow full refresh.
+- Archiving a slowly-changing dimension daily.
+- Rolling one stream table back after a defining-query mistake.
+
+They are **not** a backup of your database. Use them in addition to,
+not instead of, pgBackRest / `pg_dump`.
+
+A reasonable production posture:
+
+- Daily pgBackRest backup.
+- Snapshots of your most important stream tables on the cadence
+  that matches your business RPO.
+- WAL retention sized to PITR window.
+
+---
+
+## Backup and restore on Kubernetes (CNPG)
+
+CloudNativePG handles backup orchestration via Barman / object
+storage. pg_trickle is fully compatible:
+
+- Use `Cluster.spec.backup` exactly as you would for any other
+  PG cluster.
+- After a `Cluster.spec.bootstrap.recovery` operation, the
+  pg_trickle launcher resumes automatically.
+- For very large stream tables, consider taking pre-backup
+  snapshots and restoring them on the new cluster to skip an
+  initial full refresh.
+
+See [CloudNativePG integration](integrations/cloudnativepg.md).
+
+---
+
+## Disaster-recovery checklist
+
+- [ ] Backup tool of choice configured (pgBackRest / WAL-G / CNPG /
+      managed service).
+- [ ] WAL retention window ≥ your PITR target.
+- [ ] If using WAL CDC: alerting on
+      `pg_trickle.slot_lag_critical_threshold_mb`.
+- [ ] Periodic snapshot of business-critical stream tables.
+- [ ] Documented restore procedure tested at least once
+      (snapshot → fresh database → `pg_trickle.health_check()`).
+- [ ] Off-site copy of backups (managed service, S3 with
+      cross-region replication, etc.).
+- [ ] Monitoring on `pg_trickle.pgt_refresh_history` for restore
+      drift.
+
+---
+
+**See also:**
+[Snapshots](SNAPSHOTS.md) ·
+[High Availability and Replication](HA_AND_REPLICATION.md) ·
+[CloudNativePG integration](integrations/cloudnativepg.md) ·
+[Capacity Planning](CAPACITY_PLANNING.md)

--- a/docs/CAPACITY_PLANNING.md
+++ b/docs/CAPACITY_PLANNING.md
@@ -1,0 +1,233 @@
+# Capacity Planning
+
+This page helps you estimate the resources pg_trickle will need
+*before* you put it in production: disk for change buffers and WAL,
+memory for refresh execution, CPU for the scheduler and refresh
+workers, and connection budget for background workers.
+
+The rules of thumb here are starting points. The
+[Performance Cookbook](PERFORMANCE_COOKBOOK.md) and
+[Scaling Guide](SCALING.md) cover how to tune once you have real
+data to work with.
+
+---
+
+## Quick sizing table
+
+| Deployment size | Stream tables | Source tables | Sustained write rate | Recommended starting config |
+|---|---|---|---|---|
+| **Small** | 1–20 | 1–20 | < 100/s | All defaults |
+| **Medium** | 20–100 | 20–100 | 100–1,000/s | `parallel_refresh_mode=on`, `max_dynamic_refresh_workers=4` |
+| **Large** | 100–500 | 50–500 | 1,000–10,000/s | `tiered_scheduling=on`, `max_dynamic_refresh_workers=8`, WAL CDC |
+| **Very large** | 500+ | 500+ | > 10,000/s | Add per-database quotas; consider Citus |
+
+---
+
+## Disk: change buffers
+
+Each source table referenced by a stream table gets its own change
+buffer (`pgtrickle_changes.changes_<oid>`). One row per captured
+change.
+
+**Per-row size estimate (trigger CDC):**
+
+```
+~ row_overhead (24 B)
++ key_columns (≈ 2 × avg_key_size)
++ referenced_columns (sum of referenced col sizes)
++ bitmap (1–2 B for narrow tables, ~ ncols/8 otherwise)
+```
+
+**Rule of thumb:** budget **~1.5 KB per captured change** for a
+typical wide-row OLTP table, **~150 B** for a narrow lookup table.
+
+**Steady-state size:**
+
+```
+buffer_bytes ≈ writes_per_second × refresh_interval × per_row_size × (1 - compaction_ratio)
+```
+
+Compaction collapses cancelling INSERT/DELETE pairs and successive
+updates to the same row. Typical compaction ratios:
+
+| Workload | Compaction ratio |
+|---|---|
+| Append-only event log | 0% |
+| Mixed OLTP | 30–60% |
+| High-churn (frequent UPDATEs to same key) | 70–95% |
+
+**Worked example.** A source table doing 5,000 writes/s, refreshed
+every 5 s, with 50% compaction and 1 KB rows:
+
+```
+5000 × 5 × 1024 × 0.5 ≈ 12.8 MiB per refresh cycle
+```
+
+That is the *peak* size of the buffer between refreshes. After the
+refresh, the consumed rows are deleted (or `TRUNCATE`d depending on
+`pg_trickle.cleanup_use_truncate`).
+
+**Alerts.** Set `pg_trickle.buffer_alert_threshold` (default
+`100000` rows) so a `WARNING` is logged before a buffer becomes
+unbounded.
+
+---
+
+## Disk: WAL retention (WAL CDC mode)
+
+If you use `pg_trickle.cdc_mode = 'auto'` or `'wal'`, each source
+table gets a logical replication slot. PostgreSQL retains WAL until
+every active slot has consumed it.
+
+**Worst-case retention** = `slot_lag_critical_threshold_mb` (default
+`1024 MB`). Add this *per source* to your WAL disk budget if you
+expect occasional refresh delays.
+
+**Recommended monitoring:**
+
+```sql
+SELECT * FROM pgtrickle.check_cdc_health()
+WHERE severity != 'OK';
+```
+
+---
+
+## Memory: refresh execution
+
+Each refresh runs a `MERGE` (DIFFERENTIAL) or full `INSERT … SELECT`
+(FULL). Memory usage is dominated by hash tables and sorts:
+
+```
+peak_memory ≈ work_mem × (number of hash/sort nodes in the plan)
+```
+
+For most stream tables, `work_mem = 64 MB` is comfortable. Wide
+joins or large `GROUP BY` may benefit from `256 MB`. Use
+`pg_trickle.merge_work_mem_mb` to set it per-refresh without
+affecting the rest of the database.
+
+`pg_trickle.spill_threshold_blocks` controls when intermediate
+results spill to disk; raise it on memory-rich servers.
+
+---
+
+## CPU and worker processes
+
+The scheduler is one background worker per database. Refresh work
+is either inline (default) or dispatched to a dynamic worker pool
+(`pg_trickle.parallel_refresh_mode = on`).
+
+```
+max_worker_processes  ≥  1 (launcher)
+                       + N (one scheduler per pg_trickle database)
+                       + max_dynamic_refresh_workers
+                       + autovacuum_max_workers
+                       + max_parallel_workers
+                       + other extensions
+```
+
+A typical safe starting point:
+
+```ini
+# postgresql.conf
+max_worker_processes              = 32
+max_parallel_workers              = 8
+pg_trickle.max_dynamic_refresh_workers = 4
+```
+
+Defaults of 8 are usually too low — the [Pre-Deployment
+Checklist](PRE_DEPLOYMENT.md) calls this out as the most common
+silent misconfiguration.
+
+---
+
+## DAG topology and scheduling overhead
+
+The scheduler walks the dependency DAG every tick (default 1 s).
+Per-stream-table overhead is small (sub-millisecond) but not zero.
+For very large DAGs:
+
+| Stream tables | Recommended scheduler interval |
+|---|---|
+| < 50 | `1000 ms` (default) |
+| 50–200 | `1000–2000 ms`, plus `tiered_scheduling=on` |
+| 200–1000 | `2000–5000 ms` + Hot/Warm/Cold tiers |
+| 1000+ | Consider splitting across databases |
+
+The scheduler's zero-change overhead is documented in
+[README – Zero-Change Latency](../README.md#zero-change-latency)
+(target < 10 ms).
+
+---
+
+## Connection budget
+
+Each parallel-refresh worker uses one PostgreSQL backend slot. The
+scheduler uses one. The launcher uses one. So:
+
+```
+backends_used_by_pg_trickle = 1 + databases + max_dynamic_refresh_workers
+```
+
+If you front PostgreSQL with PgBouncer, this is **separate** from
+your application's pool — pg_trickle's background workers connect
+directly, not through the pooler.
+
+---
+
+## Network (Citus & multi-node)
+
+In Citus deployments, the coordinator polls each worker's WAL slot
+on every scheduler tick via `dblink`. Bandwidth scales with the
+*delta volume*, not the source-table size, but you still need a
+fast and reliable coordinator-to-worker network.
+
+Plan for:
+
+- One TCP connection per worker per polling cycle.
+- Short, frequent reads.
+- Tolerance for individual worker failures —
+  `pg_trickle.citus_worker_retry_ticks` controls when failures
+  escalate to `WARNING`.
+
+---
+
+## Forecasting growth
+
+A workable rough model for a year of growth:
+
+```
+year_1_disk = current_buffer_peak × growth_factor
+            + current_storage × growth_factor × number_of_stream_tables
+            + WAL_retention_budget
+```
+
+Stream-table storage itself is just an ordinary heap table — its
+size is the size of the result set, no different from a materialized
+view.
+
+---
+
+## Sanity-check queries
+
+```sql
+-- Per-source change-buffer size
+SELECT * FROM pgtrickle.change_buffer_sizes()
+ORDER BY pending_rows DESC;
+
+-- Per-stream-table refresh stats
+SELECT pgt_name, last_full_ms, last_diff_ms, p95_ms
+FROM pgtrickle.st_refresh_stats()
+ORDER BY p95_ms DESC NULLS LAST;
+
+-- Worker-pool saturation
+SELECT * FROM pgtrickle.worker_pool_status();
+```
+
+---
+
+**See also:**
+[Scaling Guide](SCALING.md) ·
+[Performance Cookbook](PERFORMANCE_COOKBOOK.md) ·
+[Configuration](CONFIGURATION.md) ·
+[Pre-Deployment Checklist](PRE_DEPLOYMENT.md)

--- a/docs/CITUS.md
+++ b/docs/CITUS.md
@@ -1,0 +1,145 @@
+# Citus Distributed Tables
+
+pg_trickle supports [Citus](https://www.citusdata.com/) distributed
+tables as **sources** for incremental view maintenance and as
+**output targets** for stream tables. Once configured, distribution
+is mostly invisible: you create stream tables exactly as you would
+on single-node PostgreSQL, and pg_trickle handles per-worker change
+capture and merging on the coordinator.
+
+> **Available since v0.32.0** (sources, output targets); the fully
+> automated per-worker scheduler arrived in **v0.34.0**.
+
+> This page is the canonical entry point for Citus support. The
+> long-form reference (worker-slot lifecycle, troubleshooting, and
+> internal architecture) lives at
+> [integrations/citus.md](integrations/citus.md).
+
+---
+
+## What you get
+
+- **Distributed sources.** Define a stream table whose source is a
+  Citus-distributed table. pg_trickle creates a logical replication
+  slot on each worker, polls all slots from the coordinator via
+  `dblink`, and merges the changes into the stream table's storage.
+- **Distributed output.** Pass `output_distribution_column` to
+  `create_stream_table()` and the resulting stream table is itself a
+  Citus distributed table, co-located with your source shards.
+- **Automated scheduler.** Since v0.34, the per-worker slot lifecycle
+  (`ensure_worker_slot`, `poll_worker_slot_changes`, lease
+  management) runs automatically — no manual wiring required.
+- **Shard-rebalance auto-recovery.** Topology changes detected by
+  comparing `pg_dist_node` against `pgt_worker_slots`; stale slots
+  are pruned and new ones inserted without operator intervention.
+- **Worker failure isolation.** Per-worker poll failures are logged
+  and skipped; healthy workers keep running. After
+  `pg_trickle.citus_worker_retry_ticks` (default 5) consecutive
+  failures, a `WARNING` is raised.
+
+---
+
+## Prerequisites
+
+- PostgreSQL 17 or 18 with `wal_level = logical` on **every** node
+  (coordinator and workers).
+- Citus 12.x or 13.x on the coordinator and all workers.
+- The `dblink` extension on the coordinator.
+- pg_trickle installed at the **same version** on every node.
+- Each source distributed table must have `REPLICA IDENTITY FULL`.
+
+---
+
+## Quickstart
+
+### 1. Verify prerequisites
+
+```sql
+-- Run on coordinator AND each worker:
+SHOW wal_level;            -- must be 'logical'
+SELECT extname, extversion FROM pg_extension
+ WHERE extname IN ('citus', 'pg_trickle', 'dblink');
+```
+
+### 2. Create extensions on the coordinator
+
+```sql
+CREATE EXTENSION IF NOT EXISTS dblink;
+CREATE EXTENSION IF NOT EXISTS pg_trickle;
+```
+
+### 3. Prepare a distributed source table
+
+```sql
+-- Distribute (or co-locate) the source
+SELECT create_distributed_table('orders', 'customer_id');
+
+-- Required for logical decoding to capture old values on UPDATE / DELETE
+ALTER TABLE orders REPLICA IDENTITY FULL;
+```
+
+### 4. Create a stream table over distributed sources
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'order_totals',
+    $$SELECT customer_id, SUM(amount) AS total
+      FROM orders GROUP BY customer_id$$,
+    schedule => '5s'
+);
+```
+
+That is it on the user side. pg_trickle:
+
+1. Detects that `orders` is distributed.
+2. Creates a per-worker logical replication slot.
+3. Records each slot in `pgtrickle.pgt_worker_slots`.
+4. Polls every slot on each scheduler tick via `dblink`.
+5. Merges decoded changes into the coordinator-local change buffer.
+6. Applies the delta to the stream table.
+
+### 5. (Optional) make the output distributed too
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'order_totals',
+    $$SELECT customer_id, SUM(amount) AS total
+      FROM orders GROUP BY customer_id$$,
+    schedule                     => '5s',
+    output_distribution_column   => 'customer_id'
+);
+```
+
+The result table is now itself distributed on `customer_id` and
+co-located with the source shards.
+
+---
+
+## Observability
+
+| Helper | Purpose |
+|---|---|
+| `SELECT * FROM pgtrickle.citus_status;` | Per-worker slot summary |
+| `SELECT * FROM pgtrickle.pgt_worker_slots;` | Raw slot catalogue |
+| `SELECT * FROM pgtrickle.check_cdc_health();` | WAL slot health (lag, status) |
+| `SELECT * FROM pgtrickle.health_check();` | Whole-extension triage |
+
+---
+
+## Caveats
+
+- **DDL on distributed sources** is more involved than on local
+  tables; see the long-form guide.
+- **Foreign keys across shards** are restricted by Citus, not by
+  pg_trickle.
+- **Co-location:** if your stream table joins distributed tables,
+  the join columns must be the distribution columns (a Citus
+  requirement).
+
+---
+
+**See also:**
+[Long-form Citus reference (worker slots, lifecycle, internals)](integrations/citus.md) ·
+[CDC Modes](CDC_MODES.md) ·
+[Configuration – `pg_trickle.citus_*`](CONFIGURATION.md) ·
+[CloudNativePG integration](integrations/cloudnativepg.md)

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1,0 +1,297 @@
+# CLI Reference
+
+`pgtrickle` is the standalone command-line tool for managing and
+monitoring stream tables from outside SQL. It is shipped as the
+`pgtrickle-tui` binary and works as both an interactive dashboard
+and a scriptable CLI.
+
+For the interactive views (Dashboard, Refresh Log, Workers, …) and
+keybindings, see the [TUI guide](TUI.md). This page is the
+**command-line subcommand reference** — one section per subcommand,
+with synopsis, options, exit codes, and examples.
+
+> **Install:** `cargo install --path pgtrickle-tui` (Rust toolchain
+> required). Make sure `~/.cargo/bin` is on your `PATH`.
+
+---
+
+## Global options
+
+These apply to every subcommand.
+
+| Option | Default | Description |
+|---|---|---|
+| `--url <postgres-url>` | `$DATABASE_URL` | PostgreSQL connection URL |
+| `--format <fmt>` | `table` | `table` · `json` · `yaml` · `csv` |
+| `--no-color` | off | Disable ANSI colours |
+| `-q`, `--quiet` | off | Suppress non-error output |
+| `-h`, `--help` | — | Show help for the subcommand |
+
+Exit codes (consistent across subcommands):
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Critical condition (e.g. `health` reports `ERROR`) |
+| `2` | User error (bad arguments, unknown stream table) |
+| `3` | Connection failure |
+| `4` | Operation timeout |
+
+---
+
+## list
+
+List every stream table with its key fields.
+
+```bash
+pgtrickle list                           # default table format
+pgtrickle list --format json
+pgtrickle list --filter 'order_*'        # glob match on name
+```
+
+| Option | Description |
+|---|---|
+| `--filter <glob>` | Restrict to matching names |
+| `--schema <name>` | Only list a given schema |
+| `--status <s>` | Filter by status (ACTIVE, SUSPENDED, INITIALIZING) |
+
+---
+
+## status
+
+Show extended status for a single stream table.
+
+```bash
+pgtrickle status order_totals
+pgtrickle status order_totals --json
+```
+
+Reports schedule, refresh mode, last-refresh timestamp, staleness,
+recent error count, and dependency summary.
+
+---
+
+## refresh
+
+Trigger a manual refresh of one stream table.
+
+```bash
+pgtrickle refresh order_totals           # synchronous
+pgtrickle refresh order_totals --async   # fire-and-forget
+pgtrickle refresh order_totals --mode FULL
+```
+
+| Option | Description |
+|---|---|
+| `--mode <m>` | Override refresh mode for this run |
+| `--async` | Don't wait for the refresh to complete |
+| `--timeout <s>` | Fail with exit 4 after `s` seconds |
+
+---
+
+## create
+
+Create a new stream table from the command line.
+
+```bash
+pgtrickle create order_totals \
+    --query "SELECT customer_id, SUM(amount) FROM orders GROUP BY customer_id" \
+    --schedule 5s
+
+# From a file
+pgtrickle create order_totals --query-file ./order_totals.sql --schedule '@hourly'
+```
+
+| Option | Description |
+|---|---|
+| `--query <sql>` | Defining query inline |
+| `--query-file <path>` | Read defining query from file |
+| `--schedule <s>` | Duration / cron / `calculated` / `null` |
+| `--mode <m>` | Refresh mode (defaults to `AUTO`) |
+| `--initial-refresh / --no-initial-refresh` | Run a full refresh on creation |
+
+---
+
+## drop
+
+Drop a stream table.
+
+```bash
+pgtrickle drop order_totals
+pgtrickle drop order_totals --cascade   # also drop dependents
+```
+
+---
+
+## alter
+
+Change schedule, refresh mode, status, or defining query.
+
+```bash
+pgtrickle alter order_totals --schedule 30s
+pgtrickle alter order_totals --mode DIFFERENTIAL
+pgtrickle alter order_totals --query-file ./order_totals_v2.sql
+pgtrickle alter order_totals --suspend
+pgtrickle alter order_totals --resume
+```
+
+---
+
+## export
+
+Export a stream table's definition (or the whole catalogue) as
+SQL you can replay with `psql`.
+
+```bash
+pgtrickle export order_totals > order_totals.sql
+pgtrickle export --all > all_stream_tables.sql
+```
+
+---
+
+## diag
+
+One-shot diagnostic dump suitable for attaching to a bug report.
+
+```bash
+pgtrickle diag > pgtrickle-diag.txt
+pgtrickle diag --include-explain --include-buffer-stats
+```
+
+---
+
+## cdc
+
+Inspect CDC pipeline state.
+
+```bash
+pgtrickle cdc                       # summary of all sources
+pgtrickle cdc orders                # detail for one source table
+pgtrickle cdc orders --tail 50      # most recent 50 buffered changes
+```
+
+---
+
+## graph
+
+Render the dependency DAG.
+
+```bash
+pgtrickle graph                       # ASCII tree
+pgtrickle graph --format dot > dag.dot
+pgtrickle graph --highlight order_totals
+```
+
+`dot` output can be piped to Graphviz: `pgtrickle graph --format dot | dot -Tsvg > dag.svg`.
+
+---
+
+## config
+
+Inspect and (with care) set GUC variables.
+
+```bash
+pgtrickle config                              # all pg_trickle.* GUCs
+pgtrickle config pg_trickle.cdc_mode
+pgtrickle config pg_trickle.cdc_mode --set wal   # ALTER SYSTEM
+```
+
+---
+
+## health
+
+Run health checks. Exits with code 1 if any check is `ERROR`.
+
+```bash
+pgtrickle health                              # summary
+pgtrickle health --severity warn              # include WARN
+pgtrickle health --json                       # machine-readable
+```
+
+Use this in monitoring jobs and CI smoke tests.
+
+---
+
+## workers
+
+Show the parallel-refresh worker pool.
+
+```bash
+pgtrickle workers
+pgtrickle workers --watch                     # refresh every 2 s
+```
+
+---
+
+## fuse
+
+Inspect or reset stream-table circuit breakers.
+
+```bash
+pgtrickle fuse                                # list tripped fuses
+pgtrickle fuse reset order_totals             # re-enable
+pgtrickle fuse reset --all
+```
+
+---
+
+## watermarks
+
+Show watermark status for sources that publish them.
+
+```bash
+pgtrickle watermarks
+pgtrickle watermarks --group ingest_pipeline
+```
+
+---
+
+## explain
+
+Show the delta SQL pg_trickle would run on the next refresh.
+
+```bash
+pgtrickle explain order_totals
+pgtrickle explain order_totals --analyze       # adds EXPLAIN ANALYZE
+```
+
+---
+
+## watch
+
+Continuous (interactive) view, like `top` but for stream tables.
+
+```bash
+pgtrickle watch                                # default 2 s
+pgtrickle watch -n 5                           # every 5 s
+pgtrickle watch --filter 'order_*'
+```
+
+---
+
+## completions
+
+Emit shell completion scripts.
+
+```bash
+# bash / zsh / fish / elvish / powershell
+pgtrickle completions bash > ~/.local/share/bash-completion/completions/pgtrickle
+pgtrickle completions zsh  > "${fpath[1]}/_pgtrickle"
+```
+
+---
+
+## Scripting tips
+
+- Always pass `--format json` for parsing — table output is for
+  humans and is not a stable interface.
+- Use `health` as a CI gate (`pgtrickle health || exit 1`).
+- Use `--no-color` in environments with no TTY.
+- Set `PGTRICKLE_URL` instead of passing `--url` everywhere.
+
+---
+
+**See also:**
+[TUI guide (interactive views)](TUI.md) ·
+[SQL Reference (the underlying functions)](SQL_REFERENCE.md) ·
+[Troubleshooting](TROUBLESHOOTING.md)

--- a/docs/COMPARISONS.md
+++ b/docs/COMPARISONS.md
@@ -1,0 +1,208 @@
+# Comparisons
+
+This page compares pg_trickle to adjacent tools so you can decide
+whether it's the right fit. Each comparison is a short, honest
+summary — strengths, weaknesses, and "use this instead if…".
+
+> If you are evaluating pg_trickle from a specific tool you already
+> run, jump to the relevant section. If you want a deeper academic
+> comparison, see also
+> [DBSP Comparison](research/DBSP_COMPARISON.md),
+> [pg_ivm Comparison](research/PG_IVM_COMPARISON.md), and
+> [Prior Art](research/PRIOR_ART.md).
+
+---
+
+## At a glance
+
+| Tool | Lives in PostgreSQL? | Incremental? | External infra? | Best for |
+|---|---|---|---|---|
+| **pg_trickle** | ✅ | ✅ | ✕ | Self-maintaining materialized views inside one PostgreSQL |
+| `REFRESH MATERIALIZED VIEW` | ✅ | ✕ | ✕ | Periodic full recomputation, no automation |
+| [pg_ivm](https://github.com/sraoss/pg_ivm) | ✅ | ✅ (limited) | ✕ | Incremental views with a smaller SQL surface |
+| [Materialize](https://materialize.com/) | ✕ (own engine) | ✅ | Whole new database | Cross-source streaming SQL |
+| [RisingWave](https://risingwave.com/) | ✕ (own engine) | ✅ | Whole new database | Streaming SQL with PostgreSQL wire compat |
+| [Apache Flink](https://flink.apache.org/) | ✕ | ✅ | JVM cluster + state backend | Stateful event processing at scale |
+| [Debezium](https://debezium.io/) + sink | ✕ | (CDC only) | Kafka + Connect | Replicating change events out of Postgres |
+| [ksqlDB](https://ksqldb.io/) | ✕ | ✅ | Kafka cluster | Streaming SQL on top of Kafka |
+| [Snowflake Dynamic Tables](https://docs.snowflake.com/en/user-guide/dynamic-tables-about) | ✕ | ✅ | Snowflake | Auto-refreshing tables in Snowflake |
+| Custom cron + materialized view | ✅ | ✕ | ✕ | What teams build before they find pg_trickle |
+
+---
+
+## vs. PostgreSQL `REFRESH MATERIALIZED VIEW`
+
+**The question this answers:** "I'm already using materialized
+views — what would I gain?"
+
+| | `REFRESH MATERIALIZED VIEW` | pg_trickle stream table |
+|---|---|---|
+| Refresh trigger | Manual (or your cron) | Schedule, transition, or in-transaction (IMMEDIATE) |
+| Refresh cost | Always full recomputation | Incremental (delta only) for most queries |
+| Cross-table dependencies | Manual coordination | DAG-aware topological refresh |
+| Concurrency | `CONCURRENTLY` requires unique index | Always non-blocking; advisory locks coordinate |
+| Read-your-writes | Not possible | `IMMEDIATE` mode |
+| Operator coverage | Anything PostgreSQL supports | A large but explicit subset (see [SQL Reference](SQL_REFERENCE.md)) |
+
+**Use vanilla materialized views if:** you only refresh occasionally,
+your data is small, and you do not have a chain of dependent views.
+
+**Switch to pg_trickle if:** any of those things stop being true.
+
+---
+
+## vs. pg_ivm
+
+**The question this answers:** "There's another PostgreSQL extension
+in this space — how do they relate?"
+
+[pg_ivm](https://github.com/sraoss/pg_ivm) is an open-source IVM
+extension that pioneered much of the relevant work in PostgreSQL
+land. The two projects have different scopes.
+
+| | pg_ivm | pg_trickle |
+|---|---|---|
+| Maturity | First released 2022 | First released 2024 |
+| Refresh model | Trigger-driven, statement-by-statement | Trigger or WAL CDC + scheduler + DAG |
+| SQL coverage | Aggregates, simple joins, sub-queries | Full DBSP-style coverage incl. WITH RECURSIVE, window functions, FULL OUTER JOIN, LATERAL, GROUPING SETS, scalar subqueries |
+| Cross-table chains | Manual | DAG with topological refresh and CALCULATED schedules |
+| Modes | Always immediate | AUTO / DIFFERENTIAL / FULL / IMMEDIATE |
+| Distributed | — | Citus integration |
+| Operations | Minimal tooling | Health-check, fuse, parallel refresh, snapshots, dbt |
+
+There is a more thorough side-by-side at
+[research/PG_IVM_COMPARISON.md](research/PG_IVM_COMPARISON.md).
+
+If your queries are simple aggregates and you want the smallest
+possible install footprint, pg_ivm is a perfectly good choice. If
+you want broader SQL, multi-layer DAGs, or operational tooling,
+pg_trickle is closer to that shape.
+
+---
+
+## vs. Materialize
+
+[Materialize](https://materialize.com/) is a cloud-native database
+built specifically for incremental view maintenance. It is the
+inspiration for much of this space.
+
+| | Materialize | pg_trickle |
+|---|---|---|
+| Deployment | Separate cloud database (or self-hosted server) | Extension inside PostgreSQL |
+| Source coverage | Postgres, Kafka, S3, MySQL, … | PostgreSQL tables (incl. Citus, foreign tables) |
+| Latency | Streaming, sub-second | Sub-second with `1s` schedule; in-transaction with IMMEDIATE |
+| Joins / aggregates / recursion | Yes, very mature | Yes |
+| Pricing | Commercial cloud product | Open-source, runs anywhere PostgreSQL runs |
+| Operational footprint | Managed service or significant self-hosted commitment | Add-on to existing PostgreSQL |
+
+**Use Materialize if:** you want one engine to materialise across
+many heterogeneous sources, you want true streaming semantics, and
+you are happy operating a separate database.
+
+**Use pg_trickle if:** your data lives in PostgreSQL and you want
+the materialisation to live there too.
+
+---
+
+## vs. RisingWave
+
+[RisingWave](https://risingwave.com/) is a PostgreSQL-wire-compatible
+streaming database in Rust. Like Materialize, it is its own engine
+that you deploy alongside (or instead of) PostgreSQL.
+
+The same trade-off applies: RisingWave is a richer streaming
+engine; pg_trickle is the answer if you do not want to operate a
+second database.
+
+---
+
+## vs. Apache Flink (or Spark Structured Streaming)
+
+Flink is a general stateful stream processor. It can do everything
+pg_trickle can and a lot more — including state-machine workflows,
+event-time semantics, and complex windowing.
+
+The trade-off is operational. Flink wants a JVM cluster, a state
+backend (RocksDB / S3), checkpointing, savepoint management, a
+schema registry, and so on. For "I want my materialized views to
+update themselves", that is overkill.
+
+**Use Flink if:** you have stateful event processing that goes
+beyond derived tables — state machines, complex CEP, multi-source
+joins at high throughput.
+
+**Use pg_trickle if:** you want stream-table semantics and you are
+already running PostgreSQL.
+
+---
+
+## vs. Debezium + sink (Kafka Connect, etc.)
+
+Debezium captures changes from PostgreSQL and emits them onto Kafka
+(or another stream). It is *only* the change-capture half of the
+problem — you still need a downstream consumer that turns those
+changes into a derived table.
+
+| | Debezium | pg_trickle |
+|---|---|---|
+| Captures changes from Postgres | ✅ | ✅ (built-in CDC) |
+| Computes derived tables | ✕ (you write that) | ✅ |
+| Kafka required | ✅ | ✕ |
+| Downstream sinks | Many | Logical replication via [downstream publications](PUBLICATIONS.md) |
+
+**Use Debezium if:** you need to fan changes out to many
+heterogeneous downstream systems (Elasticsearch, S3, Snowflake, a
+data lake).
+
+**Use pg_trickle if:** you want the derived table to live in
+PostgreSQL itself. You can still expose stream-table changes via
+[downstream publications](PUBLICATIONS.md) — and even use
+Debezium to read those.
+
+---
+
+## vs. ksqlDB
+
+[ksqlDB](https://ksqldb.io/) gives you streaming SQL on top of
+Kafka. Same trade-off as Materialize/RisingWave: another engine,
+another set of operational concerns.
+
+If your data already lives in Kafka and you want SQL on it, ksqlDB
+is a fine choice. If your data lives in PostgreSQL, pg_trickle is
+closer to where it already is.
+
+---
+
+## vs. Snowflake Dynamic Tables
+
+[Snowflake Dynamic Tables](https://docs.snowflake.com/en/user-guide/dynamic-tables-about)
+are auto-refreshing tables inside Snowflake. They occupy almost
+exactly the same conceptual slot as pg_trickle — but in a different
+database.
+
+Use whichever matches the database you have.
+
+---
+
+## vs. "cron + `REFRESH MATERIALIZED VIEW`"
+
+This is what most teams build before they find a real IVM tool.
+It works, until:
+
+- Refreshes start to overlap.
+- A long refresh blocks readers.
+- The refresh becomes too expensive to run as often as you'd like.
+- A second view depends on the first and you start writing
+  ordering logic.
+- A failure leaves stale data and nobody notices.
+
+When that happens, [pg_trickle's quick start](QUICKSTART_5MIN.md) is
+~5 minutes of setup.
+
+---
+
+**See also:**
+[Use Cases](USE_CASES.md) ·
+[Migrating from materialized views](tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md) ·
+[Migrating from pg_ivm](tutorials/MIGRATING_FROM_PG_IVM.md) ·
+[Research and prior art](research/PRIOR_ART.md)

--- a/docs/COST_MODEL.md
+++ b/docs/COST_MODEL.md
@@ -1,0 +1,164 @@
+# Predictive Cost Model
+
+pg_trickle's `AUTO` refresh mode does not just toggle between FULL
+and DIFFERENTIAL by hand-tuned thresholds. It runs a **predictive
+cost model** that estimates the expected cost of each mode for the
+*next* refresh, given the current change ratio and historical
+runtimes, and picks the cheaper one.
+
+This page explains how the model works, the levers you can pull,
+and when it is safe to ignore the model and pin a mode by hand.
+
+---
+
+## Why a cost model?
+
+Differential refresh is dramatically faster than FULL refresh — when
+the change ratio is small. As the change ratio grows, the *delta
+overhead* (computing ΔQ, scanning change buffers, planning the
+MERGE) starts to dominate, and at some point a full recomputation
+wins.
+
+A static threshold ("switch at 50%") is a reasonable default, but
+it is wrong in either direction for many real queries:
+
+- Aggregates with a few groups recompute trivially in FULL — DIFF
+  has to do work for nothing.
+- Wide joins with selective filters benefit from DIFF even at very
+  high change ratios.
+- A query whose source has just doubled in size will see different
+  trade-offs from yesterday's plan.
+
+The cost model uses *measured* `last_full_ms` and `last_diff_ms`
+together with the *current* change ratio to make a per-refresh
+decision.
+
+---
+
+## Inputs the model uses
+
+For each stream table, on each scheduler tick:
+
+| Input | Source |
+|---|---|
+| `change_ratio_current` | `pending_changes / source_row_count` |
+| `last_full_ms` | most recent full refresh duration |
+| `last_diff_ms` | most recent differential refresh duration |
+| `pending_rows` | size of the change buffer |
+| `delta_amplification_factor` | learned multiplier: estimated delta volume given pending changes |
+| `cost_model_safety_margin` (GUC) | bias toward FULL or DIFF |
+
+It then computes:
+
+```
+predicted_diff_ms = base_diff_overhead
+                  + per_row_diff_cost × pending_rows × delta_amplification_factor
+
+predicted_full_ms = last_full_ms × source_growth_factor
+```
+
+`AUTO` chooses the cheaper one (after applying the safety margin).
+
+---
+
+## Inspect what the model would do
+
+```sql
+-- Recommendation and reasoning for a single stream table
+SELECT * FROM pgtrickle.recommend_refresh_mode('order_totals');
+-- recommended_mode | reason                           | composite_score
+-- DIFFERENTIAL     | change ratio 0.018, est. 22 ms   | 0.31
+
+-- Rolling efficiency: refresh durations vs source-table size
+SELECT * FROM pgtrickle.refresh_efficiency('order_totals');
+
+-- Or for the whole catalogue
+SELECT pgt_name, recommended_mode, change_ratio, est_diff_ms, est_full_ms
+FROM pgtrickle.recommend_refresh_mode_all();
+```
+
+---
+
+## Tuning levers
+
+| GUC | Default | Effect |
+|---|---|---|
+| `pg_trickle.cost_model_safety_margin` | `1.20` | Multiplier on the predicted DIFF cost. > 1.0 biases toward FULL. |
+| `pg_trickle.differential_max_change_ratio` | `0.50` | Hard cap: never pick DIFF above this ratio. |
+| `pg_trickle.adaptive_full_threshold` | `0.50` | Force FULL when change ratio exceeds this (legacy fallback). |
+| `pg_trickle.delta_amplification_threshold` | `5.0` | When `delta_volume / pending_changes > T`, prefer FULL. |
+| `pg_trickle.max_delta_estimate_rows` | `10000000` | Cap on the model's estimate; above this, prefer FULL. |
+| `pg_trickle.planner_aggressive` | `off` | Allow the model to override per-table refresh-mode hints. |
+
+A typical "trust the model" setup:
+
+```sql
+ALTER SYSTEM SET pg_trickle.cost_model_safety_margin = '1.0';
+ALTER SYSTEM SET pg_trickle.planner_aggressive       = 'on';
+SELECT pg_reload_conf();
+```
+
+A typical "be conservative" setup (prefer FULL on uncertainty):
+
+```sql
+ALTER SYSTEM SET pg_trickle.cost_model_safety_margin       = '1.5';
+ALTER SYSTEM SET pg_trickle.differential_max_change_ratio  = '0.30';
+```
+
+---
+
+## When to override the model
+
+There are good reasons to pin a mode manually:
+
+- **Queries the model can't see well.** Holistic aggregates
+  (`PERCENTILE_*`, `STRING_AGG`) often plan badly under DIFF; pin
+  to FULL.
+- **Workloads with large but cheap full refreshes.** Tiny aggregates
+  that re-aggregate from a small source — the FULL plan is so
+  cheap that the model's DIFF estimate cannot beat it.
+- **Predictable bursts.** If you know that 9–10 a.m. is your
+  upload window, pre-emptively `ALTER STREAM TABLE … SET refresh_mode
+  = 'FULL'` for that window.
+
+Pin a mode with:
+
+```sql
+SELECT pgtrickle.alter_stream_table('order_totals', refresh_mode => 'FULL');
+```
+
+The model will not override a manually-pinned mode unless
+`planner_aggressive = on`.
+
+---
+
+## Verifying the model in production
+
+```sql
+-- Compare actual mode vs recommended mode over the last 1000 refreshes
+WITH recent AS (
+    SELECT pgt_name, refresh_mode, started_at, finished_at,
+           EXTRACT(epoch FROM (finished_at - started_at)) * 1000 AS ms
+    FROM pgtrickle.pgt_refresh_history
+    WHERE started_at > now() - interval '1 hour'
+)
+SELECT pgt_name,
+       refresh_mode,
+       AVG(ms) AS avg_ms,
+       COUNT(*) AS n
+FROM recent
+GROUP BY pgt_name, refresh_mode
+ORDER BY pgt_name;
+```
+
+If a stream table is consistently slow in `AUTO` mode, look at the
+distribution of modes chosen. Often the answer is "the model is
+flapping" — increase `cost_model_safety_margin` or pin a mode.
+
+---
+
+**See also:**
+[Performance Cookbook](PERFORMANCE_COOKBOOK.md) ·
+[tuning-refresh-mode](tutorials/tuning-refresh-mode.md) ·
+[Configuration – Refresh Performance](CONFIGURATION.md#refresh-performance) ·
+[SQL Reference – Diagnostics](SQL_REFERENCE.md#diagnostics)

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,0 +1,392 @@
+# Glossary
+
+A plain-language reference for the terms used throughout the pg_trickle
+documentation. If a term isn't here, check the
+[FAQ](FAQ.md) — and please [open an issue](https://github.com/grove/pg-trickle/issues)
+so we can add it.
+
+> **How to use this page.** Most pg_trickle pages link the *first* use of a
+> jargon term back to the matching entry below. You can also search this page
+> directly (the entries are alphabetised within each section).
+
+---
+
+## Core concepts
+
+### Stream table
+A table whose contents are defined by a SQL query, and that pg_trickle keeps
+up to date automatically as the underlying data changes. Think of it as a
+materialized view that maintains itself — without you ever calling
+`REFRESH MATERIALIZED VIEW`.
+
+### Defining query
+The SQL `SELECT` statement you give to `pgtrickle.create_stream_table()`.
+It can use joins, aggregates, CTEs, window functions, and most of standard
+SQL. The defining query is what pg_trickle differentiates to compute deltas.
+
+### Source table
+A regular PostgreSQL table that a stream table reads from. Source tables
+are written to in the normal way (`INSERT`, `UPDATE`, `DELETE`); pg_trickle
+captures those writes and propagates them downstream.
+
+### Base table
+Synonym for *source table*. Used interchangeably in older docs.
+
+### Schedule
+How often a stream table refreshes. May be a duration (`'5s'`, `'10m'`),
+a cron expression (`'@hourly'`, `'0 * * * *'`), the special value
+`'CALCULATED'` (derived from downstream consumers), or `NULL` (only refresh
+when called manually, or for `IMMEDIATE` mode).
+
+### Refresh
+A single round of bringing a stream table up to date with its sources. Each
+refresh either rewrites the whole result (FULL) or applies only the
+incremental change (DIFFERENTIAL).
+
+### Refresh mode
+Tells pg_trickle *how* to refresh. The four modes:
+
+- **AUTO** — pick the cheapest mode each cycle (the default).
+- **DIFFERENTIAL** — incremental: only changed rows are processed.
+- **FULL** — re-run the entire defining query.
+- **IMMEDIATE** — refresh inside the same transaction as the source DML
+  (no scheduler involved).
+
+### Incremental View Maintenance (IVM)
+The technique of updating a materialized view by computing only the
+*change* induced by recent edits, rather than re-running the whole query.
+pg_trickle is an IVM engine for PostgreSQL.
+
+### Differential
+Synonym for "incremental" in the IVM sense. Also the name of the refresh
+mode that uses incremental computation. Inspired by *differential dataflow*
+and the [DBSP framework](research/DBSP_COMPARISON.md) — see also
+[delta query](#delta-query-deltaq) below.
+
+### Delta query (ΔQ)
+The SQL pg_trickle generates internally to compute the change in a stream
+table given a change in its inputs. ΔQ is derived automatically from the
+defining query's operator tree. You can inspect it with
+`pgtrickle.explain_st(name)`.
+
+### Operator tree
+The internal representation of your defining query — a tree of nodes like
+*scan*, *filter*, *join*, *aggregate*. pg_trickle differentiates this tree
+operator by operator to derive the delta query.
+
+### DAG (directed acyclic graph)
+The shape of your stream-table dependencies. If stream table B reads from
+stream table A, there is an edge A → B. pg_trickle refreshes the DAG in
+topological order so that downstream tables always see consistent upstream
+state.
+
+### Diamond (in a DAG)
+A pattern where two parallel branches both depend on a common ancestor and
+both feed into a common descendant (A → B → D and A → C → D). pg_trickle
+refreshes diamonds atomically to prevent the descendant from seeing one
+branch updated and the other not.
+
+### SCC (strongly connected component)
+A cycle in the dependency graph — a group of stream tables that all
+transitively depend on each other. pg_trickle supports cycles only for
+*monotone* queries and only when explicitly enabled
+(`pg_trickle.allow_circular`). See
+[Circular Dependencies](tutorials/CIRCULAR_DEPENDENCIES.md).
+
+---
+
+## Change capture
+
+### CDC (Change Data Capture)
+The mechanism that records every `INSERT`, `UPDATE`, and `DELETE` on a
+source table so pg_trickle knows what changed since the last refresh.
+pg_trickle has two CDC backends — see [CDC Modes](CDC_MODES.md).
+
+### Trigger-based CDC
+The default backend. Lightweight `AFTER` row-level triggers on each source
+table write a single row to a *change buffer* per data change. Cost is
+roughly 2–15 µs per row, paid by the writing transaction.
+
+### WAL-based CDC
+The optional backend that uses PostgreSQL's logical replication to read
+changes from the write-ahead log instead of via triggers. Requires
+`wal_level = logical`. Adds near-zero write-side cost.
+
+### Hybrid CDC
+The default behaviour: pg_trickle starts with triggers (which always work),
+and if `wal_level = logical` is available, transitions automatically to WAL
+once the first refresh succeeds. If anything goes wrong, it falls back to
+triggers.
+
+### Change buffer
+A small per-source table in the `pgtrickle_changes.*` schema that holds
+captured changes between refreshes. Each refresh drains the relevant rows.
+
+### Compaction
+Collapsing redundant entries in a change buffer — for example an
+`INSERT` followed by a matching `DELETE` cancels out. pg_trickle compacts
+buffers automatically when refreshes are batched.
+
+### Watermark
+A timestamp or position published by an external loader that tells
+pg_trickle "you can safely consider data through here as complete".
+Downstream refreshes wait until all relevant watermarks are aligned. Used
+in ETL bootstrap patterns.
+
+### Frontier
+A set of per-source positions (LSN or logical timestamps) that records
+*where each input was up to* at the moment of the last refresh. The next
+refresh reads from frontier→now. Frontiers are how pg_trickle guarantees
+correctness across multiple sources.
+
+### LSN (Log Sequence Number)
+A PostgreSQL identifier for a position in the write-ahead log. Looks like
+`16/B374D8A0`. pg_trickle uses LSNs to record frontiers in WAL CDC mode.
+
+---
+
+## Refresh & scheduling
+
+### CALCULATED schedule
+The default. Set an explicit refresh interval only on the *consumer-facing*
+stream tables (the ones your application queries). Upstream stream tables
+inherit the tightest cadence among their downstream dependents
+automatically.
+
+### Tier (Hot / Warm / Cold / Frozen)
+A coarse refresh cadence bucket used for very large deployments
+(`pg_trickle.tiered_scheduling = on`). Hot tables refresh as scheduled;
+Frozen tables never refresh until manually thawed.
+
+### Adaptive fallback
+The engine's automatic switch from DIFFERENTIAL to FULL when the change
+ratio exceeds a threshold (default 50%). It switches back when the rate
+drops.
+
+### Fuse (circuit breaker)
+A safety mechanism: a stream table that fails repeatedly is automatically
+suspended so it cannot block the scheduler. You re-enable it with
+`pgtrickle.reset_fuse()`. See
+[Fuse Circuit Breaker](tutorials/FUSE_CIRCUIT_BREAKER.md).
+
+### MERGE
+PostgreSQL's `MERGE` statement, which lets pg_trickle apply a delta
+(insert / update / delete in one go) to the stream table's storage.
+Most of a refresh's wall-clock time is spent in `MERGE` — i.e., in
+PostgreSQL itself, not in pg_trickle.
+
+### Scoped recomputation
+A delta-application strategy used for `MIN`, `MAX`, and TopK aggregates:
+re-aggregate just the *affected groups* (rather than the whole result) by
+reading only the rows that match the changed keys.
+
+### Group-rescan
+Similar to scoped recomputation, used for "holistic" aggregates like
+`STRING_AGG`, `ARRAY_AGG`, `MODE`, `PERCENTILE_*`.
+
+### Predicate pushdown
+The optimisation that injects `WHERE` clauses from the defining query
+directly into change-buffer scans, so irrelevant changes are filtered out
+at read time.
+
+### Columnar tracking
+A capture-side optimisation: CDC records only the *columns referenced by
+the defining query*, encoded as a bitmask. Updates that touch only
+unreferenced columns are skipped entirely.
+
+---
+
+## Background workers
+
+### Launcher
+The single per-server background worker that scans `pg_database` every few
+seconds and spawns a *scheduler* in every database where pg_trickle is
+installed.
+
+### Scheduler
+The per-database background worker that wakes periodically, decides which
+stream tables are due for refresh, and (in parallel mode) dispatches refresh
+jobs to a worker pool.
+
+### BGW (BackGround Worker)
+A PostgreSQL concept — a long-running process spawned by the postmaster.
+pg_trickle uses BGWs for the launcher, schedulers, and parallel refresh
+workers.
+
+### Parallel refresh
+An execution mode (`pg_trickle.parallel_refresh_mode = 'on'`) where
+independent stream tables in the DAG are refreshed concurrently across a
+pool of dynamic background workers.
+
+---
+
+## Aggregates
+
+### Algebraic aggregate
+An aggregate that can be maintained from previous state plus a delta
+(SUM, COUNT, AVG by tracking sum + count). Cheapest possible IVM.
+
+### Semi-algebraic aggregate
+An aggregate that can be maintained on inserts cheaply, but on a delete may
+need to rescan the affected group (MIN, MAX). pg_trickle handles this with
+*scoped recomputation*.
+
+### Holistic aggregate
+An aggregate that has no incremental form (PERCENTILE_*, MODE, STRING_AGG,
+ARRAY_AGG). pg_trickle re-aggregates the affected groups from source.
+
+---
+
+## Stream-table features
+
+### Snapshot
+A point-in-time copy of a stream table's contents (v0.27+). Useful for
+backups, replica bootstrap, or test fixtures. See [Snapshots](SNAPSHOTS.md).
+
+### Outbox
+A stream-table-backed implementation of the *transactional outbox*
+pattern: write events in the same transaction as your business data;
+external systems consume them with at-least-once delivery. See
+[Transactional Outbox](OUTBOX.md).
+
+### Inbox
+The mirror of the outbox: receive events idempotently from an external
+system, with stream tables giving you live views of pending work and a
+dead-letter queue. See [Transactional Inbox](INBOX.md).
+
+### Publication (downstream)
+A regular PostgreSQL logical-replication publication automatically
+created over a stream table's storage. Lets Debezium, Kafka Connect,
+Spark, etc. subscribe to stream-table changes without an extra pipeline.
+See [Downstream Publications](PUBLICATIONS.md).
+
+### Relay
+A standalone Rust binary (`pgtrickle-relay`) that bridges outbox/inbox
+tables with external messaging systems (NATS, Kafka, Redis Streams,
+SQS, RabbitMQ, webhooks). See [Relay Service](RELAY_GUIDE.md).
+
+### TopK
+Stream tables of the form `SELECT … ORDER BY x LIMIT N` (optionally with
+`OFFSET M`). pg_trickle stores only the top N rows and recomputes them
+incrementally when the changes affect the leaderboard.
+
+### IMMEDIATE mode
+A refresh mode that maintains the stream table inside the same transaction
+as the source DML — no scheduler, no change buffers. Gives
+read-your-writes consistency at the cost of slightly heavier writes.
+
+---
+
+## Engine internals
+
+### DVM (Differential View Maintenance)
+The engine inside pg_trickle that turns operator trees into delta queries.
+The name is used informally; the academic name for the underlying technique
+is *differential dataflow*.
+
+### DBSP
+The academic framework that pg_trickle's differentiation rules are based
+on. See the [DBSP Comparison](research/DBSP_COMPARISON.md) for the
+relationship between pg_trickle and the original DBSP runtime.
+
+### Bilinear expansion
+The expansion of `Δ(A ⋈ B) = ΔA ⋈ B + A ⋈ ΔB + ΔA ⋈ ΔB` for joins. This
+is the formal recipe for incrementally maintaining a join. You don't need
+to know it to use pg_trickle.
+
+### Semi-naive evaluation
+A classical algorithm for incremental recursive queries (`WITH RECURSIVE`).
+pg_trickle uses it in IMMEDIATE and DIFFERENTIAL modes for insert-only
+recursion.
+
+### DRed (Delete-and-Rederive)
+A companion algorithm to semi-naive evaluation that handles deletions
+inside recursive queries. Also used in IMMEDIATE mode.
+
+### `__pgt_row_id`
+A hidden column pg_trickle adds to every stream table to give each row a
+stable identity, even if the defining query has no primary key. You can
+ignore it in your queries; it is replicated correctly to logical-replication
+subscribers.
+
+### Auto-rewrite
+A pipeline of small rewrites pg_trickle applies to your defining query
+before differentiation — for example expanding `DISTINCT ON` to
+`ROW_NUMBER()`, inlining views, or splitting `GROUPING SETS` into
+`UNION ALL`. See
+[Auto-Rewrite Pipeline](SQL_REFERENCE.md#auto-rewrite-pipeline).
+
+---
+
+## Operations & infrastructure
+
+### GUC (Grand Unified Configuration)
+A PostgreSQL configuration variable, set in `postgresql.conf`, by
+`ALTER SYSTEM`, or per-session with `SET`. All pg_trickle GUCs start with
+`pg_trickle.*`. The full list is in [Configuration](CONFIGURATION.md).
+
+### Advisory lock
+A lightweight lock you ask PostgreSQL to keep on your behalf. pg_trickle
+uses advisory locks to coordinate refreshes across processes — including
+across PgBouncer-pooled sessions, which is why pg_trickle is
+pooler-friendly.
+
+### Pooler
+Connection pooler such as PgBouncer or pgcat, often deployed in front of
+PostgreSQL. pg_trickle's background workers connect directly (not through
+the pooler), so your app's pooler does not interact with refresh activity.
+
+### CNPG
+[CloudNativePG](https://cloudnative-pg.io/), a Kubernetes operator for
+PostgreSQL. pg_trickle ships a minimal `scratch`-based OCI image suitable
+for CNPG's Image Volume Extensions feature.
+
+### pgrx
+The Rust framework pg_trickle is built with. Provides safe wrappers around
+PostgreSQL internals.
+
+### `wal_level`
+The PostgreSQL setting that controls how much information the write-ahead
+log contains. Values: `minimal`, `replica` (default), `logical`. WAL-based
+CDC requires `logical`.
+
+### Replication slot
+A PostgreSQL object that retains WAL until a consumer has read it. WAL CDC
+mode creates one slot per source table; trigger CDC mode does not.
+
+---
+
+## Acronym key
+
+| Acronym | Meaning |
+|---|---|
+| BGW | Background worker |
+| CDC | Change Data Capture |
+| CNPG | CloudNativePG |
+| CTE | Common Table Expression (`WITH …`) |
+| DAG | Directed Acyclic Graph |
+| DBSP | Database Stream Processor (the framework pg_trickle is inspired by) |
+| DDL | Data Definition Language (`CREATE`, `ALTER`, `DROP`) |
+| DLQ | Dead-Letter Queue |
+| DML | Data Manipulation Language (`INSERT`, `UPDATE`, `DELETE`) |
+| DRed | Delete-and-Rederive (recursive query algorithm) |
+| DVM | Differential View Maintenance (the engine inside pg_trickle) |
+| GUC | Grand Unified Configuration (PostgreSQL setting) |
+| IVM | Incremental View Maintenance |
+| LSN | Log Sequence Number |
+| OID | Object Identifier (PostgreSQL row ID for catalog objects) |
+| ΔQ | Delta query — the SQL pg_trickle generates to compute changes |
+| RLS | Row-Level Security |
+| SCC | Strongly Connected Component (a cycle in the DAG) |
+| SLA | Service Level Agreement |
+| SLO | Service Level Objective |
+| SPI | Server Programming Interface (PostgreSQL's in-process query API) |
+| SRF | Set-Returning Function |
+| ST | Stream Table |
+| TUI | Terminal User Interface |
+| WAL | Write-Ahead Log |
+
+---
+
+**See also:** [FAQ](FAQ.md) · [SQL Reference](SQL_REFERENCE.md) ·
+[Architecture](ARCHITECTURE.md) · [Configuration](CONFIGURATION.md)

--- a/docs/HA_AND_REPLICATION.md
+++ b/docs/HA_AND_REPLICATION.md
@@ -1,0 +1,182 @@
+# High Availability and Replication
+
+This page covers running pg_trickle in production with PostgreSQL
+replication: how stream tables behave on physical (streaming)
+replicas, on logical replicas, during failover, and across
+read-write splits.
+
+> Looking for **backups** instead? See
+> [Backup & Restore](BACKUP_AND_RESTORE.md). Looking for
+> **disaster-recovery snapshots**? See [Snapshots](SNAPSHOTS.md).
+
+---
+
+## Quick answers
+
+| Question | Answer |
+|---|---|
+| Can I run pg_trickle on a physical replica? | The extension can be installed, but the **scheduler does not refresh on a hot standby**. Stream tables on the standby reflect what was promoted from the primary. |
+| Will my stream tables survive a failover? | Yes — they are ordinary heap tables. On the new primary, the scheduler resumes from the last persisted frontier. |
+| Can I logically replicate a stream table? | Yes — including the hidden `__pgt_row_id` column. See [Downstream Publications](PUBLICATIONS.md). |
+| Does pg_trickle work on a logical replica? | Yes — the replica is its own database with its own pg_trickle scheduler. |
+| What about CNPG (Kubernetes)? | Fully supported; see [CloudNativePG integration](integrations/cloudnativepg.md). |
+
+---
+
+## Physical (streaming) replication
+
+PostgreSQL's streaming replication ships WAL from primary to
+replica. Stream tables, change buffers, and the pg_trickle catalog
+are all WAL-logged, so they are byte-for-byte identical on the
+replica.
+
+**On the primary:** the scheduler runs and refreshes as normal.
+
+**On the replica (hot standby):** the scheduler **does not refresh**
+— the database is read-only. Stream-table contents are exactly the
+contents that were on the primary at the replica's replay LSN. Reads
+from the replica are perfectly valid; writes (and refreshes) are
+not.
+
+After a failover:
+
+1. The new primary's pg_trickle launcher detects the database is
+   writable.
+2. The scheduler resumes refreshing from the last persisted
+   frontier.
+3. Any change-buffer rows that arrived between the last refresh
+   and the failover are processed in the next cycle.
+
+**Recommended GUCs on a streaming-replica role you might promote:**
+
+```ini
+shared_preload_libraries = 'pg_trickle'
+pg_trickle.enabled       = on    # safe to leave on; refresh is gated by writability
+```
+
+---
+
+## Logical replication
+
+A logical replica is a separate database that subscribes to one or
+more publications on the primary. Each logical replica has its own
+pg_trickle catalog and its own scheduler.
+
+This makes logical replication a **good answer for an analytics
+replica**: replicate the source tables to the analytics replica,
+install pg_trickle there, and define your stream tables on the
+replica. Heavy DIFFERENTIAL workloads are isolated from the OLTP
+primary.
+
+```
+┌──────────────┐        logical                 ┌────────────────────┐
+│   primary    │  publication: source tables    │  analytics replica │
+│   (writes)   │ ─────────────────────────────▶ │  (heavy STs here)  │
+└──────────────┘                                 └────────────────────┘
+```
+
+Stream tables on the analytics replica are independent of any
+stream tables on the primary.
+
+---
+
+## Replicating stream tables themselves
+
+If you want a *downstream* system to receive stream-table changes
+(another Postgres, Debezium, Kafka, …), use
+[downstream publications](PUBLICATIONS.md):
+
+```sql
+SELECT pgtrickle.stream_table_to_publication('order_totals');
+```
+
+The publication exposes the storage table's INSERT/DELETE events,
+including the `__pgt_row_id` column. Subscribers receive the
+materialised data only — they do not need to know that pg_trickle
+is generating it.
+
+---
+
+## Failover behaviour in detail
+
+When the primary fails and a replica is promoted:
+
+| Stage | What happens |
+|---|---|
+| Promotion | Replica becomes writable; its `pg_trickle` launcher detects this. |
+| Scheduler restart | Scheduler resumes from the last persisted frontier (catalog row). |
+| Change-buffer rows | Any rows captured before the failover are still in the buffers (they're WAL-logged). They are processed in the next refresh. |
+| In-flight refresh | An interrupted refresh is marked failed in `pgt_refresh_history` and retried automatically (subject to the fuse). |
+| WAL CDC slots | If using WAL CDC, the slots exist on the replica (slots are WAL-logged in PG ≥ 17 with `failover_slots`). On older versions, the scheduler recreates them and falls back briefly to triggers. |
+
+---
+
+## CNPG (Kubernetes) specifics
+
+- Use the OCI extension image: `ghcr.io/grove/pg_trickle-ext:<version>`.
+- CNPG's standby cluster topology is supported — pg_trickle behaves
+  exactly as on bare-metal streaming replication.
+- `Cluster.spec.postgresql.shared_preload_libraries` must include
+  `pg_trickle`.
+- Use `Cluster.spec.postgresql.parameters` for `pg_trickle.*` GUCs.
+
+Full example: see
+[integrations/cloudnativepg.md](integrations/cloudnativepg.md) and
+the [`cnpg/`](https://github.com/grove/pg-trickle/tree/main/cnpg)
+directory in the repository.
+
+---
+
+## Read-write splits with PgBouncer
+
+pg_trickle's background workers connect directly to PostgreSQL,
+not through a pooler. Your application can use PgBouncer (in
+transaction-pool mode, including Supabase / Railway / Neon) freely.
+
+For a read-only replica behind a pooler:
+
+- Reads from stream tables work exactly as reads from any table.
+- `IMMEDIATE` stream tables only update on the primary; on the
+  replica they reflect what's been replayed.
+
+See [PgBouncer integration](integrations/pgbouncer.md) for tuning.
+
+---
+
+## Geographic / cross-region replication
+
+The recommended pattern for cross-region:
+
+1. Stream tables on the **regional primary** (low-latency CDC).
+2. [Downstream publications](PUBLICATIONS.md) for the materialised
+   results.
+3. PostgreSQL logical replication carries them to the remote
+   region.
+4. Optional: pg_trickle in the remote region builds further
+   stream tables on the replicated data.
+
+This keeps the heavy DIFFERENTIAL maintenance close to its source
+data, and ships only the final materialised diffs over the WAN.
+
+---
+
+## Caveats
+
+- pg_trickle does **not** participate in synchronous replication
+  decisions. It is data, not infrastructure.
+- A logical replica that subscribes to source tables but
+  *not* to the pg_trickle catalog will need to define its own
+  stream tables — they are not auto-created.
+- Promoting a standby with a stale `pgtrickle_changes` schema (e.g.
+  after a long replication lag) is fine; the next refresh catches
+  up. If the lag was very long, the model may pick FULL instead of
+  DIFFERENTIAL for the catch-up — by design.
+
+---
+
+**See also:**
+[Backup & Restore](BACKUP_AND_RESTORE.md) ·
+[Snapshots](SNAPSHOTS.md) ·
+[Downstream Publications](PUBLICATIONS.md) ·
+[CloudNativePG integration](integrations/cloudnativepg.md) ·
+[PgBouncer integration](integrations/pgbouncer.md)

--- a/docs/MULTI_DATABASE.md
+++ b/docs/MULTI_DATABASE.md
@@ -1,0 +1,152 @@
+# Multi-Database Deployments
+
+pg_trickle is **multi-database aware**. A single PostgreSQL server
+can host pg_trickle in any number of databases simultaneously, and
+the extension's background workers handle the fan-out automatically.
+You do not need to start anything per database; the launcher
+discovers them.
+
+---
+
+## Architecture in one diagram
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                  PostgreSQL 18 server                        │
+│                                                              │
+│  ┌────────────┐                                              │
+│  │  Launcher  │  ── scans pg_database every ~10 s            │
+│  └─────┬──────┘                                              │
+│        │ spawns                                              │
+│   ┌────┼────────────────────┬────────────────────┐           │
+│   ▼    ▼                    ▼                    ▼           │
+│ ┌──────────┐         ┌──────────┐         ┌──────────┐       │
+│ │Scheduler │         │Scheduler │         │Scheduler │       │
+│ │   db_a   │         │   db_b   │         │  db_etl  │       │
+│ └────┬─────┘         └────┬─────┘         └────┬─────┘       │
+│      │ refresh jobs       │ refresh jobs       │             │
+│      ▼                    ▼                    ▼             │
+│  ┌─────────────────────────────────────────────────┐         │
+│  │ Shared dynamic refresh worker pool               │         │
+│  │ (max_dynamic_refresh_workers, per-DB quotas)     │         │
+│  └─────────────────────────────────────────────────┘         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+- **One launcher** per PostgreSQL server.
+- **One scheduler** per database that has `pg_trickle` installed.
+- **One shared dynamic worker pool** for parallel refreshes.
+
+The launcher restarts crashed schedulers automatically. Each
+scheduler is fully independent; failure in one database does not
+affect the others.
+
+---
+
+## Enabling pg_trickle in additional databases
+
+Just install the extension. The launcher will pick it up on the
+next discovery cycle (within ~10 s).
+
+```sql
+\c db_b
+CREATE EXTENSION pg_trickle;
+```
+
+Verify the scheduler started:
+
+```sql
+SELECT * FROM pgtrickle.cluster_worker_summary();
+```
+
+Expected: one row per database with a column showing the scheduler
+PID and uptime.
+
+---
+
+## Resource budgeting across databases
+
+Background-worker slots are a finite, server-wide resource. The
+formula:
+
+```
+max_worker_processes ≥ launchers(1)
+                     + schedulers(N_databases)
+                     + max_dynamic_refresh_workers
+                     + autovacuum_max_workers
+                     + max_parallel_workers
+                     + other_extensions
+```
+
+For 4 databases each running pg_trickle, with 8 dynamic refresh
+workers and modest autovacuum:
+
+```ini
+max_worker_processes                    = 32
+max_parallel_workers                    = 8
+pg_trickle.max_dynamic_refresh_workers  = 8
+pg_trickle.per_database_worker_quota    = 4
+```
+
+Without `per_database_worker_quota`, one busy database can starve
+the others. Set it to `max_dynamic_refresh_workers / N_databases`
+or higher.
+
+---
+
+## Cluster-wide observability
+
+```sql
+-- One row per database with per-database stats
+SELECT * FROM pgtrickle.cluster_worker_summary();
+
+-- Combined health across every database
+SELECT datname, severity, message
+FROM pgtrickle.cluster_health_check()    -- (where exposed)
+WHERE severity != 'OK';
+```
+
+The TUI's **Workers** view (`pgtrickle workers`) also aggregates
+across databases when invoked against a server-level URL.
+
+---
+
+## Common patterns
+
+### Per-tenant database
+
+If you isolate tenants by database, each gets its own scheduler.
+Combined with `tiered_scheduling = on`, low-traffic tenants pay
+almost no scheduler cost.
+
+### App database + analytics database
+
+A common topology: `app_db` runs OLTP and a few `IMMEDIATE` stream
+tables; `analytics_db` (often a logical replica) runs the heavy
+DIFFERENTIAL aggregates. The launcher handles both.
+
+### Tenant-of-tenants (Citus)
+
+For very large multi-tenant deployments, see
+[Citus](CITUS.md) — distributed sources can replace per-tenant
+databases.
+
+---
+
+## Caveats
+
+- pg_trickle does **not** create cross-database stream tables.
+  Stream tables live in exactly one database; their sources must
+  live there too. Use logical replication or
+  [downstream publications](PUBLICATIONS.md) to bridge databases.
+- `shared_preload_libraries = 'pg_trickle'` is server-wide. The
+  launcher then discovers per-database state.
+- `pg_trickle.enabled = off` disables the launcher (and therefore
+  every scheduler) — use it for maintenance windows.
+
+---
+
+**See also:**
+[Scaling Guide](SCALING.md) ·
+[Capacity Planning](CAPACITY_PLANNING.md) ·
+[Configuration](CONFIGURATION.md)

--- a/docs/PROJECT_HISTORY.md
+++ b/docs/PROJECT_HISTORY.md
@@ -1,0 +1,63 @@
+# Project History
+
+pg_trickle started with a practical goal. We were inspired by data
+platforms built around pipelines that keep themselves incrementally
+up to date, and we wanted to bring that same style of self-maintaining
+data flow directly into PostgreSQL. In particular, we needed support
+for recursive CTEs, which were essential to the kinds of pipelines
+we had in mind. We could not find an open-source incremental
+view-maintenance system that matched that requirement, so pg_trickle
+began as an attempt to close the gap.
+
+It also became an experiment in what coding agents could realistically
+help build. We set out to develop pg_trickle without editing code by
+hand, while still holding it to the same bar we would expect from any
+other systems project: broad feature coverage, strong code quality,
+extensive tests, and thorough documentation. Skepticism toward
+AI-written software is reasonable; the right way to evaluate
+pg_trickle is by the codebase, the tests, and the docs.
+
+That constraint changed how we worked. Agents can produce a lot of
+surface area quickly, but database systems are unforgiving of vague
+assumptions and hidden edge cases. To make the project hold together,
+we had to be unusually explicit about architecture, operator
+semantics, failure handling, and test coverage. In practice, that
+pushed us toward more written design, more reviewable behavior, and
+more verification than a quick prototype would normally get.
+
+The result is a **spec-driven** development process, not vibe-coding.
+Every feature starts as a written plan — an architecture decision
+record, a gap analysis, or a phased implementation spec — before any
+code is generated. The
+[`plans/`](https://github.com/grove/pg-trickle/tree/main/plans)
+directory contains over 110 documents covering operator semantics,
+CDC trade-offs, performance strategies, ecosystem comparisons, and
+edge-case catalogues. Agents work from these specs; the specs are
+reviewed and revised by humans. This is what makes it possible to
+maintain coherence across a large codebase without manually editing
+every line: the design is explicit, the invariants are written down,
+and the tests verify both.
+
+We also do not think the use of AI should lower the standard for
+trust. If anything, it raises it. The point of the experiment was
+not to ask people to trust the toolchain; it was to see whether
+disciplined use of coding agents could help produce a serious,
+inspectable PostgreSQL extension. Whether that worked is for readers
+and users to judge, but the intent is simple: make the code, the
+tests, the documentation, and the trade-offs visible enough that the
+project can stand on its own merits.
+
+---
+
+## Contributors
+
+- [Geir O. Grønmo](https://github.com/grove)
+- [Baard H. Rehn Johansen](https://github.com/BaardBouvet)
+- [GitHub Copilot](https://github.com/features/copilot) — AI pair
+  programmer
+
+---
+
+**See also:**
+[Roadmap](roadmap.md) · [Changelog](changelog.md) ·
+[Contributing](contributing.md)

--- a/docs/QUICKSTART_5MIN.md
+++ b/docs/QUICKSTART_5MIN.md
@@ -1,0 +1,179 @@
+# 5-Minute Quickstart
+
+The shortest possible introduction to pg_trickle. By the end of this
+page you will have created a self-maintaining table, watched it update
+in real time, and dropped it again — without leaving `psql`.
+
+> Prefer to **see it first**? Run the
+> [playground](PLAYGROUND.md) (`cd playground && docker compose up -d`)
+> for a pre-loaded environment, or pull the prebuilt image:
+> ```bash
+> docker run --rm -e POSTGRES_PASSWORD=secret -p 5432:5432 \
+>   ghcr.io/grove/pg_trickle:latest
+> ```
+> Then connect with `psql postgres://postgres:secret@localhost:5432/postgres`
+> and skip to **Step 2** below.
+
+---
+
+## Step 1 — Install the extension
+
+If you already have a PostgreSQL 18 server with pg_trickle installed
+(via the playground, the Docker image, or a manual install — see
+[INSTALL.md](installation.md) for full options), skip this step.
+
+Otherwise, the shortest path on a developer machine is the prebuilt
+Docker image — one command, no configuration:
+
+```bash
+docker run --rm -e POSTGRES_PASSWORD=secret -p 5432:5432 \
+  ghcr.io/grove/pg_trickle:latest
+```
+
+Connect with `psql`:
+
+```bash
+psql postgres://postgres:secret@localhost:5432/postgres
+```
+
+---
+
+## Step 2 — Enable the extension
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trickle;
+```
+
+That's all the configuration you need. The extension auto-discovers
+every database where it's installed and starts a per-database
+scheduler.
+
+---
+
+## Step 3 — Create a source table
+
+```sql
+CREATE TABLE orders (
+    id      SERIAL PRIMARY KEY,
+    region  TEXT     NOT NULL,
+    amount  NUMERIC  NOT NULL
+);
+
+INSERT INTO orders (region, amount) VALUES
+    ('US',   100),
+    ('EU',   200),
+    ('US',   300),
+    ('APAC',  50);
+```
+
+This is a perfectly ordinary table. You will write to it the normal way.
+
+---
+
+## Step 4 — Create a stream table
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    name     => 'revenue_by_region',
+    query    => $$
+        SELECT region,
+               SUM(amount) AS total,
+               COUNT(*)    AS order_count
+        FROM orders
+        GROUP BY region
+    $$,
+    schedule => '1s'
+);
+```
+
+What just happened:
+
+1. pg_trickle parsed your query and built an internal operator tree.
+2. It created a new table `revenue_by_region` with the right columns.
+3. It installed lightweight `AFTER` triggers on `orders` to capture
+   changes.
+4. It ran an initial full refresh, populating the new table.
+5. It registered a 1-second refresh schedule.
+
+Query the stream table — it's already populated:
+
+```sql
+SELECT * FROM revenue_by_region ORDER BY region;
+```
+
+```
+ region | total | order_count
+--------+-------+-------------
+ APAC   |    50 |           1
+ EU     |   200 |           1
+ US     |   400 |           2
+```
+
+---
+
+## Step 5 — Watch it update
+
+Insert a new order:
+
+```sql
+INSERT INTO orders (region, amount) VALUES ('US', 999);
+```
+
+Wait one second (or call `SELECT pgtrickle.refresh_stream_table('revenue_by_region')`
+to refresh immediately):
+
+```sql
+SELECT * FROM revenue_by_region WHERE region = 'US';
+```
+
+```
+ region | total | order_count
+--------+-------+-------------
+ US     |  1399 |           3
+```
+
+Only the `US` group was recomputed — the other regions were not
+touched at all. That is differential refresh in action.
+
+---
+
+## Step 6 — Look around
+
+A few useful built-ins worth knowing about right away:
+
+```sql
+-- Status of all stream tables in this database
+SELECT * FROM pgtrickle.pgt_status();
+
+-- A one-shot health triage (returns rows only when something is wrong)
+SELECT * FROM pgtrickle.health_check() WHERE severity != 'OK';
+
+-- See what delta SQL pg_trickle would run on the next refresh
+SELECT pgtrickle.explain_st('revenue_by_region');
+```
+
+---
+
+## Step 7 — Clean up
+
+```sql
+SELECT pgtrickle.drop_stream_table('revenue_by_region');
+DROP TABLE orders;
+```
+
+This removes the stream table, its catalog entries, and the CDC
+triggers on `orders`.
+
+---
+
+## Where to go next
+
+| If you want to… | Read |
+|---|---|
+| See a multi-table tutorial with chains and aggregates | [15-Minute Tutorial](GETTING_STARTED.md#chapter-2-joins-aggregates--chains) |
+| Walk through every feature in depth | [In-Depth Tour](GETTING_STARTED.md) |
+| Browse common patterns and example apps | [Use Cases](USE_CASES.md) · [Patterns](PATTERNS.md) |
+| Understand how it works underneath | [Architecture](ARCHITECTURE.md) |
+| Look up a function, GUC, or operator | [SQL Reference](SQL_REFERENCE.md) · [Configuration](CONFIGURATION.md) |
+| Deploy it to production | [Pre-Deployment Checklist](PRE_DEPLOYMENT.md) |
+| Decode a piece of jargon | [Glossary](GLOSSARY.md) |

--- a/docs/SECURITY_GUIDE.md
+++ b/docs/SECURITY_GUIDE.md
@@ -1,0 +1,228 @@
+# Security Guide
+
+This page is the practical security reference for operators of
+pg_trickle. It covers roles and grants, what privileges the
+extension needs, how stream tables interact with PostgreSQL Row-Level
+Security (RLS), how triggers behave under SECURITY DEFINER vs
+INVOKER, what to lock down in production, and how to handle secrets
+when running the relay.
+
+> **Reporting a vulnerability?** See
+> [SECURITY.md](https://github.com/grove/pg-trickle/blob/main/SECURITY.md)
+> in the repository root for the disclosure policy.
+
+---
+
+## Threat model in one paragraph
+
+pg_trickle runs *inside* PostgreSQL. Anyone who can connect as a
+superuser, or as a role that owns the relevant tables, can already
+read, modify, or destroy the data the extension manages — they do
+not need pg_trickle to do that. The threats this guide focuses on
+are: privilege escalation through stream tables (e.g., a low-privilege
+role gaining access to source data via a stream table), accidental
+exposure of source data through CDC change buffers, and operational
+mistakes (running everything as the postgres superuser).
+
+---
+
+## Roles & grants
+
+### What pg_trickle needs
+
+The extension installs into the `pgtrickle` and `pgtrickle_changes`
+schemas. The role that runs `CREATE EXTENSION pg_trickle` must be a
+**superuser** because the extension installs background workers, but
+day-to-day usage can (and should) be done with a less-privileged
+role.
+
+The role that **creates a stream table** needs:
+
+- `USAGE` on the schemas containing source tables.
+- `SELECT` on the source tables referenced in the defining query.
+- `CREATE` on the schema where the stream table will live.
+- `EXECUTE` on the relevant `pgtrickle.*` functions.
+
+### Recommended split
+
+```sql
+-- Owner of stream tables (your application's "data engineer" role)
+CREATE ROLE st_author NOINHERIT;
+GRANT USAGE       ON SCHEMA public TO st_author;
+GRANT SELECT      ON ALL TABLES IN SCHEMA public TO st_author;
+GRANT CREATE      ON SCHEMA public TO st_author;
+GRANT EXECUTE     ON ALL FUNCTIONS IN SCHEMA pgtrickle TO st_author;
+GRANT USAGE       ON SCHEMA pgtrickle TO st_author;
+
+-- Read-only consumer (your application)
+CREATE ROLE app_reader;
+GRANT USAGE       ON SCHEMA public TO app_reader;
+GRANT SELECT      ON ALL TABLES IN SCHEMA public TO app_reader;
+```
+
+`app_reader` can read stream tables exactly as it reads any other
+table — the extension does not require special privileges for
+*reading* a stream table.
+
+---
+
+## Stream tables and Row-Level Security (RLS)
+
+A stream table is the **materialized result** of its defining query.
+RLS policies on **source** tables are evaluated **at the time the
+defining query runs**, which is during refresh, under the **owner's**
+identity (not the consumer's).
+
+This has two important consequences:
+
+1. **Stream-table contents do not honour the consumer's RLS context.**
+   Two consumers with different RLS contexts will read the same rows
+   from the stream table.
+2. **You can apply RLS *to the stream table itself*** to filter rows
+   per consumer. pg_trickle does not interfere with RLS policies on
+   stream tables (they are ordinary heap tables under the hood).
+
+The recommended pattern is therefore:
+
+```sql
+-- Define the ST without RLS at the source level
+SELECT pgtrickle.create_stream_table(
+    'order_summary',
+    $$SELECT tenant_id, customer_id, SUM(amount) AS total
+      FROM orders GROUP BY tenant_id, customer_id$$
+);
+
+-- Apply RLS to the stream table for per-tenant isolation
+ALTER TABLE order_summary ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON order_summary
+    FOR SELECT USING (tenant_id = current_setting('app.tenant_id')::int);
+```
+
+See the [Row-Level Security tutorial](tutorials/ROW_LEVEL_SECURITY.md)
+for a complete worked example.
+
+---
+
+## CDC triggers — SECURITY DEFINER vs INVOKER
+
+In trigger CDC mode, pg_trickle installs `AFTER` row-level triggers
+on every source table. These triggers run as **SECURITY DEFINER**
+under the role that owns the stream table — so they can write to
+`pgtrickle_changes.*` regardless of who issued the source-table
+write.
+
+**What this means for you:**
+
+- Any role that can write to a source table will indirectly write to
+  the corresponding change buffer. That is by design.
+- The change buffer table is owned by the stream-table owner. Other
+  roles get no implicit access.
+- If you revoke `INSERT` on the change buffer, the trigger keeps
+  working (it runs as the owner).
+
+In WAL CDC mode, no triggers are installed; capture happens in
+PostgreSQL's logical decoding pipeline and is governed by the
+`max_replication_slots` and `wal_level` settings.
+
+---
+
+## What change buffers contain
+
+`pgtrickle_changes.changes_<oid>` tables contain the **post-image**
+of each changed row, restricted to the columns referenced by the
+defining query (columnar tracking). Two consequences:
+
+1. If your defining query references a sensitive column, that
+   column ends up in the change buffer.
+2. The change buffer table inherits the same `tablespace` and disk
+   layout rules as ordinary tables. If you encrypt your data
+   directory, the change buffers are encrypted at rest the same way.
+
+You can lock change buffers down further:
+
+```sql
+REVOKE ALL ON ALL TABLES IN SCHEMA pgtrickle_changes FROM PUBLIC;
+GRANT  SELECT ON ALL TABLES IN SCHEMA pgtrickle_changes TO st_owner;
+```
+
+---
+
+## Lock down circular dependencies
+
+`pg_trickle.allow_circular` is `off` by default and should generally
+stay that way. Cycles in the DAG are accepted only when this GUC is
+on, and only for *monotone* queries — but enabling it widens the
+class of queries pg_trickle accepts, which deserves explicit
+attention. Set it via `ALTER SYSTEM` and require a superuser to
+flip it.
+
+---
+
+## Audit & monitoring
+
+pg_trickle records every refresh in
+`pgtrickle.pgt_refresh_history`. For audit:
+
+```sql
+-- Last 100 refreshes across the whole installation
+SELECT pgt_name, refresh_mode, started_at, finished_at,
+       success, rows_in, rows_out, error_message
+FROM pgtrickle.pgt_refresh_history
+ORDER BY started_at DESC
+LIMIT 100;
+
+-- Failed refreshes in the last hour
+SELECT * FROM pgtrickle.pgt_refresh_history
+WHERE NOT success AND started_at > now() - interval '1 hour';
+```
+
+Combine with `pg_audit` for full DDL/DML coverage. The
+[Monitoring & Alerting tutorial](tutorials/MONITORING_AND_ALERTING.md)
+includes recommended Prometheus alerts.
+
+---
+
+## Secrets in the relay
+
+[`pgtrickle-relay`](RELAY_GUIDE.md) connects to PostgreSQL and to
+external messaging systems (NATS, Kafka, Redis, SQS, RabbitMQ,
+webhooks). It reads credentials from environment variables and from
+its config file, never from PostgreSQL.
+
+Recommendations:
+
+- Run the relay under its **own** PostgreSQL role, with `SELECT`
+  and `UPDATE` only on the inbox/outbox tables it touches — not as
+  a superuser.
+- Inject external-system credentials via the platform's secret
+  manager (Kubernetes Secrets, HashiCorp Vault, AWS Secrets Manager).
+- Enable TLS for every external endpoint — the relay supports it
+  for all backends.
+
+---
+
+## Hardening checklist
+
+- [ ] `pg_trickle.allow_circular = off` unless explicitly needed.
+- [ ] Stream tables owned by a dedicated, non-superuser role.
+- [ ] `REVOKE ... FROM PUBLIC` on `pgtrickle_changes` if change
+      buffers contain sensitive columns.
+- [ ] RLS policies applied to stream tables that present per-tenant
+      data.
+- [ ] Audit logging in place for `pgtrickle.pgt_refresh_history`.
+- [ ] Relay running under a dedicated, least-privilege role.
+- [ ] External-system credentials managed by a secret store, not
+      committed to the relay config file.
+- [ ] TLS enabled on all relay endpoints.
+- [ ] `pg_trickle.enabled = on` only in environments that should
+      run refreshes (you can disable extension behaviour without
+      uninstalling it).
+
+---
+
+**See also:**
+[Row-Level Security tutorial](tutorials/ROW_LEVEL_SECURITY.md) ·
+[Pre-Deployment Checklist](PRE_DEPLOYMENT.md) ·
+[Configuration](CONFIGURATION.md) ·
+[Relay Service](RELAY_GUIDE.md) ·
+[SECURITY policy](https://github.com/grove/pg-trickle/blob/main/SECURITY.md)

--- a/docs/SNAPSHOTS.md
+++ b/docs/SNAPSHOTS.md
@@ -1,0 +1,164 @@
+# Snapshots
+
+A **snapshot** is a point-in-time copy of a stream table's contents,
+stored as an ordinary PostgreSQL table. Snapshots let you back up
+derived state, bootstrap a replica, build deterministic test
+fixtures, or compare two refresh runs without having to re-derive
+the data.
+
+> **Available since v0.27.0**
+
+---
+
+## Why snapshots?
+
+A stream table's contents are *derived* — pg_trickle can always
+recompute them from the source tables. But recomputation is not
+free, and there are operational situations where having a frozen
+copy is cheaper, safer, or simpler:
+
+- **Replica bootstrap.** When you stand up a new read replica or a
+  fresh environment, you can restore from a snapshot in seconds
+  instead of waiting for an initial full refresh that may take
+  minutes or hours on a large dataset.
+- **Point-in-time forensics.** Take a snapshot before a risky
+  migration or a suspicious incident; compare it to the live stream
+  table later.
+- **Test fixtures.** Snapshot a stream table from a representative
+  environment and check it into a test database.
+- **Cheap rollback.** If a defining-query change goes wrong,
+  restore from the most recent snapshot while you investigate.
+
+---
+
+## Quickstart
+
+### Take a snapshot
+
+```sql
+SELECT pgtrickle.snapshot_stream_table('order_totals');
+-- pgtrickle.snapshot_order_totals_1735689421000
+```
+
+The function returns the fully-qualified name of the new snapshot
+table. By default snapshots live in the `pgtrickle` schema and are
+named `snapshot_<table>_<epoch_ms>`.
+
+You can choose your own name with the optional second argument:
+
+```sql
+SELECT pgtrickle.snapshot_stream_table(
+    'order_totals',
+    'archive.order_totals_2026_q1'
+);
+```
+
+### List snapshots
+
+```sql
+SELECT * FROM pgtrickle.list_snapshots();
+```
+
+Or filter to a single stream table:
+
+```sql
+SELECT * FROM pgtrickle.list_snapshots('order_totals');
+```
+
+### Restore from a snapshot
+
+```sql
+SELECT pgtrickle.restore_from_snapshot(
+    'order_totals',                                       -- stream table to restore into
+    'pgtrickle.snapshot_order_totals_1735689421000'       -- snapshot table
+);
+```
+
+After a restore, pg_trickle reinitialises the stream table's frontier
+so that the next refresh reads only changes that occurred after the
+snapshot was taken.
+
+### Drop an old snapshot
+
+```sql
+SELECT pgtrickle.drop_snapshot('pgtrickle.snapshot_order_totals_1735689421000');
+```
+
+---
+
+## What's in a snapshot
+
+The snapshot table is a plain PostgreSQL heap table with the same
+columns as the stream table, **including** the hidden `__pgt_row_id`
+column. That is what allows a restore to map snapshot rows back to
+their stable identities.
+
+Because the snapshot is an ordinary table, you can:
+
+- Back it up with `pg_dump`, copy it elsewhere with `pg_dump -t`, or
+  move it across databases with `\copy`.
+- Inspect it freely with regular SQL.
+- Add indexes for read-side workloads (the snapshot is independent
+  of the live stream table).
+
+---
+
+## Operational patterns
+
+### Periodic archival
+
+```sql
+-- Every night, snapshot a slowly-changing dimension
+SELECT pgtrickle.snapshot_stream_table(
+    'customer_360',
+    format('archive.customer_360_%s', to_char(now(), 'YYYY_MM_DD'))
+);
+
+-- Keep only the last 30 days
+SELECT pgtrickle.drop_snapshot(snapshot_table)
+FROM pgtrickle.list_snapshots('customer_360')
+WHERE created_at < now() - interval '30 days';
+```
+
+### Replica bootstrap
+
+```sql
+-- On the source: pg_dump the snapshot
+pg_dump -t pgtrickle.snapshot_order_totals_1735689421000 mydb > snap.sql
+
+-- On the replica: restore the snapshot, then reattach
+psql replicadb < snap.sql
+SELECT pgtrickle.restore_from_snapshot(
+    'order_totals',
+    'pgtrickle.snapshot_order_totals_1735689421000'
+);
+```
+
+### Disaster recovery
+
+Combine snapshots with regular `pg_dump` of the source tables.
+After a restore, pg_trickle's frontier tracking ensures the stream
+table will catch up correctly when CDC resumes.
+
+---
+
+## Caveats
+
+- Snapshots are not coordinated across multiple stream tables. If
+  you need a *consistent* view across several stream tables, take
+  them inside a single transaction and rely on PostgreSQL's MVCC
+  isolation.
+- Snapshots do not freeze the source tables. The "as-of" time is
+  determined by the most recent refresh of the stream table at the
+  moment you take the snapshot.
+- A restore reinitialises the frontier — if you want the stream
+  table to *replay* changes between the snapshot time and now, the
+  source CDC slots / change buffers must still hold those entries.
+  Otherwise, expect a full refresh on the next cycle.
+
+---
+
+**See also:**
+[Backup & Restore](BACKUP_AND_RESTORE.md) ·
+[Replica Bootstrap & PITR Alignment (Patterns)](PATTERNS.md#replica-bootstrap--pitr-alignment-v0270) ·
+[SQL Reference – Lifecycle](SQL_REFERENCE.md)

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,22 +1,59 @@
 # Summary
 
 [pg_trickle](introduction.md)
+[What is pg_trickle?](../ESSENCE.md)
 
 ---
 
-# User Guide
+# Discover
 
-- [Getting Started](GETTING_STARTED.md)
+- [Use Cases](USE_CASES.md)
+- [Comparisons](COMPARISONS.md)
+- [Glossary](GLOSSARY.md)
 - [Playground (Docker sandbox)](PLAYGROUND.md)
-- [Real-time Demo (Fraud Detection)](DEMO.md)
+- [Real-time Demo](DEMO.md)
+
+---
+
+# Get Started
+
+- [5-Minute Quickstart](QUICKSTART_5MIN.md)
+- [Getting Started Tutorial](GETTING_STARTED.md)
+- [Installation](installation.md)
+
+---
+
+# Build with Stream Tables
+
 - [Best-Practice Patterns](PATTERNS.md)
-- [Pre-Deployment Checklist](PRE_DEPLOYMENT.md)
+- [Performance Cookbook](PERFORMANCE_COOKBOOK.md)
 - [SQL Reference](SQL_REFERENCE.md)
 - [Configuration](CONFIGURATION.md)
+- [Predictive Cost Model](COST_MODEL.md)
+
+---
+
+# Operate
+
+- [Pre-Deployment Checklist](PRE_DEPLOYMENT.md)
 - [Scaling Guide](SCALING.md)
-- [Installation](installation.md)
-- [Upgrading](UPGRADING.md)
+- [Capacity Planning](CAPACITY_PLANNING.md)
+- [Multi-Database Deployments](MULTI_DATABASE.md)
 - [Backup and Restore](BACKUP_AND_RESTORE.md)
+- [Snapshots](SNAPSHOTS.md)
+- [High Availability and Replication](HA_AND_REPLICATION.md)
+- [Upgrading](UPGRADING.md)
+- [Security Guide](SECURITY_GUIDE.md)
+- [Troubleshooting & Runbook](TROUBLESHOOTING.md)
+- [Error Reference](ERRORS.md)
+- [TUI Tool](TUI.md)
+- [CLI Reference](CLI_REFERENCE.md)
+
+---
+
+# Distributed & Streaming
+
+- [Citus Distributed Tables](CITUS.md)
 - [CDC Modes](CDC_MODES.md)
 - [SLA-based Smart Scheduling](SLA_SCHEDULING.md)
 - [Downstream Publications](PUBLICATIONS.md)
@@ -24,27 +61,6 @@
 - [Transactional Inbox](INBOX.md)
 - [Relay Service](RELAY_GUIDE.md)
 - [Relay Architecture & Operations](RELAY.md)
-- [TUI Tool](TUI.md)
-- [Contributing](contributing.md)
-
----
-
-# Integrations
-
-- [dbt-pgtrickle](integrations/dbt.md)
-- [CloudNativePG / Kubernetes](integrations/cloudnativepg.md)
-- [Prometheus & Grafana](integrations/prometheus.md)
-- [PgBouncer & Connection Poolers](integrations/pgbouncer.md)
-- [Flyway & Liquibase](integrations/flyway-liquibase.md)
-- [ORM Integration](integrations/orm.md)
-
----
-
-# Architecture & Internals
-
-- [Architecture Overview](ARCHITECTURE.md)
-- [DVM Operators](DVM_OPERATORS.md)
-- [Benchmarks](BENCHMARK.md)
 
 ---
 
@@ -54,36 +70,59 @@
 - [What Happens on UPDATE](tutorials/WHAT_HAPPENS_ON_UPDATE.md)
 - [What Happens on DELETE](tutorials/WHAT_HAPPENS_ON_DELETE.md)
 - [What Happens on TRUNCATE](tutorials/WHAT_HAPPENS_ON_TRUNCATE.md)
-- [Row-Level Security (RLS)](tutorials/ROW_LEVEL_SECURITY.md)
+- [Row-Level Security](tutorials/ROW_LEVEL_SECURITY.md)
 - [Partitioned Tables](tutorials/PARTITIONED_TABLES.md)
 - [Foreign Table Sources](tutorials/FOREIGN_TABLE_SOURCES.md)
-- [Migrating from Materialized Views](tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md)
-- [Fuse Circuit Breaker](tutorials/FUSE_CIRCUIT_BREAKER.md)
 - [Tiered Scheduling](tutorials/TIERED_SCHEDULING.md)
-- [Tuning Refresh Mode](tutorials/tuning-refresh-mode.md)
+- [Fuse Circuit Breaker](tutorials/FUSE_CIRCUIT_BREAKER.md)
 - [Circular Dependencies](tutorials/CIRCULAR_DEPENDENCIES.md)
+- [Tuning Refresh Mode](tutorials/tuning-refresh-mode.md)
 - [Monitoring & Alerting](tutorials/MONITORING_AND_ALERTING.md)
 - [ETL & Bulk Load Patterns](tutorials/ETL_BULK_LOAD.md)
+- [Migrating from Materialized Views](tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md)
 - [Migrating from pg_ivm](tutorials/MIGRATING_FROM_PG_IVM.md)
+
+---
+
+# Integrations
+
+- [dbt-pgtrickle](integrations/dbt.md)
+- [CloudNativePG / Kubernetes](integrations/cloudnativepg.md)
+- [Citus (long-form reference)](integrations/citus.md)
+- [Prometheus & Grafana](integrations/prometheus.md)
+- [PgBouncer & Connection Poolers](integrations/pgbouncer.md)
+- [Flyway & Liquibase](integrations/flyway-liquibase.md)
+- [ORM Integration](integrations/orm.md)
+- [Multi-Tenant](integrations/multi-tenant.md)
+- [dbt Hub Submission](integrations/dbt-hub-submission.md)
 
 ---
 
 # Reference
 
 - [FAQ](FAQ.md)
-- [Troubleshooting & Runbook](TROUBLESHOOTING.md)
-- [Error Reference](ERRORS.md)
+- [What's New](WHATS_NEW.md)
 - [Changelog](changelog.md)
 - [Roadmap](roadmap.md)
 - [Release Process](RELEASE.md)
+- [Project History](PROJECT_HISTORY.md)
+- [Contributing](contributing.md)
 - [Security Policy](security.md)
 
 ---
 
+# Internals (for contributors)
+
+- [Architecture Overview](ARCHITECTURE.md)
+- [DVM Operators](DVM_OPERATORS.md)
+- [DVM Rewrite Rules](DVM_REWRITE_RULES.md)
+- [Benchmarks](BENCHMARK.md)
+
 # Research
 
 - [DBSP Comparison](research/DBSP_COMPARISON.md)
-- [Prior Art](research/PRIOR_ART.md)
-- [Custom SQL Syntax](research/CUSTOM_SQL_SYNTAX.md)
 - [pg_ivm Comparison](research/PG_IVM_COMPARISON.md)
+- [Custom SQL Syntax](research/CUSTOM_SQL_SYNTAX.md)
 - [Triggers vs Replication](research/TRIGGERS_VS_REPLICATION.md)
+- [Prior Art](research/PRIOR_ART.md)
+- [Multi-DB Refresh Broker](research/multi_db_refresh_broker.md)

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -1,0 +1,246 @@
+# Use Cases
+
+pg_trickle is for any team that has wanted PostgreSQL to keep a derived
+table up to date *automatically* — without writing a refresh cron, an
+external streaming pipeline, or a custom CDC consumer.
+
+This page is a gallery of the most common things people build with
+stream tables. Each section tells you what the pattern looks like, gives
+you a minimal SQL example, and links to a deeper guide.
+
+> New to stream tables? Read **[What is pg_trickle?](introduction.md)**
+> first, or jump straight to the
+> **[5-minute Quickstart](QUICKSTART_5MIN.md)**.
+
+---
+
+## At a glance
+
+| Use case | Best refresh mode | Deeper guide |
+|---|---|---|
+| [Real-time dashboards](#1-real-time-dashboards) | DIFFERENTIAL with `1s`–`5s` schedule | [Patterns §5](PATTERNS.md#pattern-5-real-time-dashboards) |
+| [Operational read models / CQRS](#2-operational-read-models--cqrs) | IMMEDIATE | [Patterns §1](PATTERNS.md) |
+| [Fraud detection / alerting / anomaly](#3-fraud-detection-alerting-anomaly) | DIFFERENTIAL `1s` | [Demo](DEMO.md) |
+| [Leaderboards & TopK](#4-leaderboards--topk) | DIFFERENTIAL or IMMEDIATE | [SQL Reference – TopK](SQL_REFERENCE.md) |
+| [Bronze / Silver / Gold (medallion)](#5-bronze--silver--gold) | DIFFERENTIAL with chained STs | [Patterns §1](PATTERNS.md#pattern-1-bronze--silver--gold-materialization) |
+| [Event-driven services (outbox / inbox)](#6-event-driven-services) | IMMEDIATE for the table; DIFFERENTIAL for the views | [Outbox](OUTBOX.md) · [Inbox](INBOX.md) |
+| [Cross-system replication](#7-cross-system-replication) | DIFFERENTIAL | [Publications](PUBLICATIONS.md) · [Relay](RELAY_GUIDE.md) |
+| [Slowly-changing dimensions](#8-slowly-changing-dimensions-scd) | DIFFERENTIAL | [Patterns §3](PATTERNS.md#pattern-3-slowly-changing-dimensions-scd) |
+| [Multi-tenant analytics](#9-multi-tenant-analytics) | DIFFERENTIAL with RLS | [Multi-tenant](integrations/multi-tenant.md) |
+| [Citus distributed analytics](#10-citus-distributed-analytics) | DIFFERENTIAL | [Citus](CITUS.md) |
+| [dbt-managed warehouse models](#11-dbt-managed-warehouse-models) | AUTO | [dbt integration](integrations/dbt.md) |
+
+---
+
+## 1. Real-time dashboards
+
+You want KPI tiles ("orders today", "revenue per region", "active
+users this hour") to update within a second or two of the underlying
+data changing. With pg_trickle you write the SQL once and any number
+of dashboards (Grafana, Metabase, Looker, a custom React app) just
+read from the stream table.
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'kpi_revenue_today',
+    $$SELECT region, SUM(amount) AS revenue
+      FROM orders
+      WHERE created_at >= date_trunc('day', now())
+      GROUP BY region$$,
+    schedule => '2s'
+);
+```
+
+Why it's a fit: aggregates over high-cardinality groups are exactly
+where DIFFERENTIAL refresh wins biggest.
+
+---
+
+## 2. Operational read models / CQRS
+
+A microservice writes to a normalised event/order/customer table; a
+read API needs the *denormalised projection* (one row per order with
+customer name, current status, latest payment). Most teams build this
+with a separate read database and a CDC pipeline. With pg_trickle the
+projection is just a stream table sitting next to the write tables.
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'order_view',
+    $$SELECT o.id, o.placed_at, c.name AS customer,
+             p.status AS payment_status,
+             COALESCE(s.shipped_at, NULL) AS shipped_at
+      FROM orders o
+      JOIN customers c ON c.id = o.customer_id
+      LEFT JOIN payments p ON p.order_id = o.id
+      LEFT JOIN shipments s ON s.order_id = o.id$$,
+    refresh_mode => 'IMMEDIATE'
+);
+```
+
+Why it's a fit: `IMMEDIATE` mode gives you read-your-writes
+consistency without a second database.
+
+---
+
+## 3. Fraud detection, alerting, anomaly
+
+Define a stream table that flags suspicious activity (large
+transactions, velocity rules, unusual geographies). Subscribe an
+alerter to that stream table — either via PostgreSQL `LISTEN/NOTIFY`,
+a [downstream publication](PUBLICATIONS.md), or by polling.
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'high_velocity_accounts',
+    $$SELECT account_id, COUNT(*) AS txn_count, SUM(amount) AS total
+      FROM transactions
+      WHERE occurred_at >= now() - interval '5 minutes'
+      GROUP BY account_id
+      HAVING COUNT(*) > 20$$,
+    schedule => '1s'
+);
+```
+
+The [demo](DEMO.md) ships a full 9-node fraud-detection DAG you can
+run locally with `docker compose up`.
+
+---
+
+## 4. Leaderboards & TopK
+
+`ORDER BY ... LIMIT N` stream tables are a special case where
+pg_trickle stores only the top N rows and updates them with scoped
+recomputation when the changes affect the leaderboard.
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    'top_10_customers',
+    $$SELECT customer_id, SUM(amount) AS lifetime_spend
+      FROM orders
+      GROUP BY customer_id
+      ORDER BY lifetime_spend DESC
+      LIMIT 10$$,
+    schedule => '5s'
+);
+```
+
+---
+
+## 5. Bronze / Silver / Gold
+
+A medallion architecture in PostgreSQL alone:
+
+- **Bronze** – raw ingest table (a regular table you write to).
+- **Silver** – cleaned and deduplicated stream table.
+- **Gold** – business-level aggregates stream table that depends on
+  Silver.
+
+Set the schedule only on Gold; pg_trickle propagates the cadence
+upstream automatically (CALCULATED scheduling).
+
+See [Patterns §1](PATTERNS.md#pattern-1-bronze--silver--gold-materialization).
+
+---
+
+## 6. Event-driven services
+
+The transactional outbox/inbox pattern, native to PostgreSQL:
+
+- **Outbox** — write events in the same transaction as your business
+  data; an external system or the [relay](RELAY_GUIDE.md) drains them
+  to Kafka / NATS / SQS / a webhook.
+- **Inbox** — receive events idempotently from an external system;
+  stream tables give you live views of pending work, retries, and a
+  dead-letter queue.
+
+See [Transactional Outbox](OUTBOX.md) and [Transactional Inbox](INBOX.md).
+
+---
+
+## 7. Cross-system replication
+
+Once a stream table exists, you can expose it as a standard PostgreSQL
+logical-replication publication. Anything that speaks logical
+replication — Debezium, Kafka Connect, a downstream Postgres replica,
+a Spark Structured Streaming job, a custom WAL consumer — can
+subscribe to live changes.
+
+```sql
+SELECT pgtrickle.stream_table_to_publication('order_view');
+-- Subscribers can now subscribe to publication pgt_pub_order_view
+```
+
+See [Downstream Publications](PUBLICATIONS.md).
+
+---
+
+## 8. Slowly-changing dimensions (SCD)
+
+Type 2 SCDs (one row per version, with `valid_from` / `valid_to`) fall
+out naturally from a stream table over an event log. See
+[Patterns §3](PATTERNS.md#pattern-3-slowly-changing-dimensions-scd).
+
+---
+
+## 9. Multi-tenant analytics
+
+If your application multi-tenants by `tenant_id`, you can build
+per-tenant aggregates as a single stream table grouped by `tenant_id`
+and protect access with PostgreSQL Row-Level Security. See
+[Multi-tenant integration](integrations/multi-tenant.md) and the
+[Row-Level Security tutorial](tutorials/ROW_LEVEL_SECURITY.md).
+
+---
+
+## 10. Citus distributed analytics
+
+pg_trickle works on Citus-distributed source tables. The scheduler
+polls per-worker WAL slots via `dblink`, merges changes on the
+coordinator, and applies the delta — automatically and idempotently.
+See [Citus](CITUS.md).
+
+---
+
+## 11. dbt-managed warehouse models
+
+Use the `stream_table` materialization in dbt. No custom adapter
+needed — works with the standard `dbt-postgres` adapter.
+
+```sql
+{{ config(materialized='stream_table', schedule='5m', refresh_mode='AUTO') }}
+SELECT customer_id, SUM(amount) AS total
+FROM {{ source('raw', 'orders') }}
+GROUP BY customer_id
+```
+
+See [dbt integration](integrations/dbt.md).
+
+---
+
+## When pg_trickle is *not* the right fit
+
+A short, honest list — knowing when to look elsewhere is a feature.
+
+- **Pure OLTP with no derived state.** If you don't have anything to
+  materialize, you don't need a materializer.
+- **Sub-millisecond latency derived state.** IMMEDIATE mode is fast,
+  but it pays the differential cost inside your transaction. If you
+  need every transaction to commit in < 1 ms, benchmark first.
+- **Stateless event transformation only.** If you want "transform each
+  Kafka event" with no stored state, a stream processor (Flink, Bytewax)
+  is closer to that shape.
+- **Cross-database joins at scale.** pg_trickle reads from local
+  PostgreSQL tables (or Citus distributions). For federated joins
+  across many heterogeneous databases, consider a streaming engine.
+- **Workloads where you cannot install extensions.** Some managed
+  PostgreSQL services don't allow third-party extensions. Check
+  [Installation](INSTALL.md) for the support matrix.
+
+---
+
+**See also:**
+[Patterns](PATTERNS.md) ·
+[Performance Cookbook](PERFORMANCE_COOKBOOK.md) ·
+[SQL Reference](SQL_REFERENCE.md) ·
+[Comparisons](COMPARISONS.md)

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -1,0 +1,122 @@
+# What's New
+
+A curated, plain-language summary of recent pg_trickle releases —
+the bits a human reader actually wants to see. For the full
+exhaustive list of changes per release, see the
+[Changelog](changelog.md).
+
+---
+
+## v0.34 — Citus self-driving (April 2026)
+
+The Citus integration grew up. The per-worker WAL slot lifecycle —
+creation, polling, lease management, recovery from rebalances — now
+runs automatically. There is no manual wiring left for distributed
+sources.
+
+- Per-worker slot lifecycle fully automated
+  ([CITUS](CITUS.md))
+- Shard-rebalance auto-recovery
+- Worker failure isolation with retry budget
+
+## v0.33 — DAG observability + worker-pool quotas
+
+- Per-database worker quotas keep one busy database from starving
+  the rest ([SCALING](SCALING.md))
+- New cluster-wide health view
+  ([MULTI_DATABASE](MULTI_DATABASE.md))
+
+## v0.32 — Citus distributed sources & outputs
+
+- Stream tables can read from Citus-distributed source tables
+- `output_distribution_column` produces co-located distributed
+  stream tables
+
+## v0.29 — Bidirectional Relay
+
+- The standalone `pgtrickle-relay` binary added forward (outbox →
+  external) and reverse (external → inbox) pipelines for NATS,
+  Kafka, Redis Streams, SQS, RabbitMQ, and webhooks
+  ([RELAY_GUIDE](RELAY_GUIDE.md))
+
+## v0.28 — Transactional Outbox & Inbox
+
+- First-class outbox and inbox patterns built on stream tables
+  ([OUTBOX](OUTBOX.md) · [INBOX](INBOX.md))
+- Consumer groups, lag tracking, and dead-letter queues out of
+  the box
+
+## v0.27 — Snapshots & SLA-based scheduling
+
+- [Snapshots](SNAPSHOTS.md) of stream-table contents — point-in-time
+  copies for backup, replica bootstrap, and rollback
+- `recommend_schedule` and predicted-SLA-breach alerts
+- PITR alignment guidance for replica bootstrap
+
+## v0.22 — Downstream Publications
+
+- Any stream table can be exposed as a PostgreSQL logical
+  publication. Debezium, Kafka Connect, Spark Structured
+  Streaming, a downstream Postgres replica — all subscribe to
+  pg_trickle's incrementally-computed diffs without extra
+  pipelines ([PUBLICATIONS](PUBLICATIONS.md))
+- `set_stream_table_sla` introduces freshness deadlines
+
+## v0.14 — AUTO mode by default + ergonomic warnings
+
+- `refresh_mode = 'AUTO'` is the new default
+- `create_stream_table` warns on common anti-patterns
+  (low-cardinality aggregates, non-deterministic queries)
+
+## v0.13 — Delta SQL profiling
+
+- `pgtrickle.explain_delta`, `dedup_stats`,
+  `shared_buffer_stats` — visibility into what the engine is
+  actually doing per refresh
+
+## v0.12 — Tiered scheduling on by default
+
+- Hot/Warm/Cold/Frozen tiers, enabled by default, dramatically
+  reduce scheduler overhead at scale
+  ([Tiered Scheduling tutorial](tutorials/TIERED_SCHEDULING.md))
+
+## v0.10 — Production-readiness floor
+
+- Crash recovery, fuse circuit breaker, monitoring views, structured
+  errors with SQLSTATE codes
+  ([ERRORS](ERRORS.md) · [TROUBLESHOOTING](TROUBLESHOOTING.md))
+
+## v0.9 — Algebraic aggregate maintenance
+
+- `AVG`, `STDDEV`, and `COUNT(DISTINCT)` maintained from auxiliary
+  state — no group-rescan needed in the common case
+
+## v0.7 — Watermarks and circular DAGs
+
+- Watermark gating for ETL pipelines
+- Monotone cycles supported with explicit `pg_trickle.allow_circular`
+  ([Circular Dependencies](tutorials/CIRCULAR_DEPENDENCIES.md))
+- Prometheus / Grafana observability
+  ([integrations/prometheus](integrations/prometheus.md))
+
+## v0.4 — Parallel refresh
+
+- `parallel_refresh_mode = 'on'` dispatches independent stream
+  tables across a worker pool ([SCALING](SCALING.md))
+
+## v0.2 — IMMEDIATE mode + TopK
+
+- `IMMEDIATE` refresh mode: maintain stream tables inside the
+  source DML's transaction
+- TopK stream tables: `ORDER BY x LIMIT N`
+- `ALTER QUERY` — change the defining query online
+
+## v0.1 — Differential foundation
+
+- Trigger-based CDC, differential and full refresh, scheduler,
+  monitoring views
+
+---
+
+**See also:** [Changelog (full detail)](changelog.md) ·
+[Roadmap (what's coming)](roadmap.md)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,106 +1,54 @@
 # pg_trickle
 
-**pg_trickle** is a PostgreSQL 18 extension that turns ordinary SQL views into
-self-maintaining stream tables — no external processes, no sidecars, no
-bespoke refresh pipelines. Just `CREATE EXTENSION pg_trickle` and your views
-stay fresh.
+**pg_trickle** is a PostgreSQL 18 extension that adds *self-maintaining*
+materialized views — **stream tables** — and keeps them up to date
+incrementally as the underlying data changes. No external streaming
+engine, no sidecars, no bespoke refresh pipeline. Just install the
+extension and write SQL.
 
 ```sql
--- Declare a stream table — a view that maintains itself
 SELECT pgtrickle.create_stream_table(
     name     => 'active_orders',
     query    => 'SELECT * FROM orders WHERE status = ''active''',
     schedule => '30s'
 );
 
--- Insert a row — the stream table updates automatically on the next refresh
 INSERT INTO orders (id, status) VALUES (42, 'active');
-SELECT count(*) FROM active_orders;  -- 1
+SELECT count(*) FROM active_orders;  -- 1, automatically
 ```
 
-## The problem with materialized views
-
-PostgreSQL's materialized views are powerful but frustrating.
-`REFRESH MATERIALIZED VIEW` re-runs the entire query from scratch, even if
-only one row changed in a million-row table. Your choices are: burn CPU on
-full recomputation, or accept stale data. Most teams end up building bespoke
-refresh pipelines just to keep summary tables current.
-
-## What pg_trickle does differently
-
-pg_trickle captures changes to your source tables and — on each refresh cycle
-— derives a *delta query* that processes only the changed rows and merges the
-result into the materialized table. One insert into a million-row source table?
-pg_trickle touches exactly one row's worth of computation.
-
-The approach is grounded in the [DBSP differential dataflow framework](https://arxiv.org/abs/2203.16684)
-(Budiu et al., 2022). Delta queries are derived automatically from your SQL's
-operator tree: joins produce the classic bilinear expansion, aggregates
-maintain auxiliary counters, and linear operators like filters pass deltas
-through unchanged.
-
-## Key capabilities
-
-| Feature | Description |
-|---------|-------------|
-| **Incremental refresh** | Only changed rows are recomputed — never a full table scan |
-| **Cascading DAG** | Stream tables that depend on stream tables propagate deltas downstream automatically |
-| **Demand-driven scheduling** | Set a freshness interval on the views your app queries; upstream layers inherit the tightest schedule automatically |
-| **Hybrid CDC** | Starts with lightweight row-level triggers; seamlessly transitions to WAL-based logical replication once available |
-| **Broad SQL support** | JOINs, GROUP BY, DISTINCT, UNION/INTERSECT/EXCEPT, subqueries, CTEs (including WITH RECURSIVE), window functions, LATERAL, and more |
-| **Built-in observability** | Monitoring views, refresh history, NOTIFY-based alerting |
-| **CloudNativePG-ready** | Ships as an Image Volume extension image for Kubernetes deployments |
-
-## Demand-driven scheduling
-
-With the default `CALCULATED` schedule mode, you only set an explicit refresh
-interval on the stream tables your application actually queries. The system
-propagates that cadence upward through the dependency graph: each upstream
-stream table inherits the tightest schedule among its downstream dependents.
-You declare freshness requirements where they matter — at the consumer — and
-the entire pipeline adjusts without manual coordination.
-
-## Hybrid change capture
-
-pg_trickle bootstraps with lightweight row-level triggers — no configuration
-needed, works out of the box. Once the first refresh succeeds and
-`wal_level = logical` is available, the system automatically transitions to
-WAL-based logical replication for lower write-side overhead. The transition
-is seamless: `trigger → transitioning → WAL-only`. If anything goes wrong, it
-falls back to triggers.
+> **New here?** Read **[What is pg_trickle?](../ESSENCE.md)** for the
+> plain-language overview, or jump to the
+> **[5-Minute Quickstart](QUICKSTART_5MIN.md)** to try it.
 
 ---
 
-## Explore this documentation
+## Choose your path
 
-- **[Getting Started](GETTING_STARTED.md)** — build a three-layer DAG from scratch in minutes
-- **[SQL Reference](SQL_REFERENCE.md)** — every function and option
-- **[Architecture](ARCHITECTURE.md)** — how the engine works internally
-- **[Configuration](CONFIGURATION.md)** — GUC variables and tuning
-
-### Tutorials
-
-- **[Fuse Circuit Breaker](tutorials/FUSE_CIRCUIT_BREAKER.md)** — protect stream tables from bulk-change storms
-- **[Tiered Scheduling](tutorials/TIERED_SCHEDULING.md)** — configure multi-tier refresh cadences
-- **[Migrating from Materialized Views](tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md)** — step-by-step migration guide
-- **[Circular Dependencies](tutorials/CIRCULAR_DEPENDENCIES.md)** — handle SCCs in your DAG
-- **[Monitoring & Alerting](tutorials/MONITORING_AND_ALERTING.md)** — set up observability for stream tables
-- **[ETL Bulk Load Patterns](tutorials/ETL_BULK_LOAD.md)** — safely load large batches without overwhelming CDC
-
-### Integrations
-
-- **[CloudNativePG](integrations/cloudnativepg.md)** — deploy pg_trickle on Kubernetes
-- **[Prometheus & Grafana](integrations/prometheus.md)** — metrics and dashboards
-- **[PgBouncer](integrations/pgbouncer.md)** — connection pooling configuration
+| Persona | Start here |
+|---|---|
+| **Curious / evaluator** | [What is pg_trickle?](../ESSENCE.md) → [Use Cases](USE_CASES.md) → [Comparisons](COMPARISONS.md) → [Playground](PLAYGROUND.md) |
+| **Application developer** | [5-Minute Quickstart](QUICKSTART_5MIN.md) → [Getting Started tutorial](GETTING_STARTED.md) → [Patterns](PATTERNS.md) → [SQL Reference](SQL_REFERENCE.md) |
+| **DBA / SRE** | [Pre-Deployment Checklist](PRE_DEPLOYMENT.md) → [Configuration](CONFIGURATION.md) → [Troubleshooting](TROUBLESHOOTING.md) → [Capacity Planning](CAPACITY_PLANNING.md) |
+| **Data / analytics engineer** | [Use Cases](USE_CASES.md) → [dbt integration](integrations/dbt.md) → [Migrating from materialized views](tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md) |
+| **Confused by jargon** | [Glossary](GLOSSARY.md) |
 
 ---
 
-## Source & releases
+## What's new
 
-Written in Rust using [pgrx](https://github.com/pgcentralfoundation/pgrx).
-Targets PostgreSQL 18. Apache 2.0 licensed.
+See [What's New](WHATS_NEW.md) for a curated summary of recent
+releases, or the [Changelog](changelog.md) for the full history.
 
-- Repository: [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle)
-- Install instructions: [Installation](installation.md)
-- Changelog: [Changelog](changelog.md)
-- Roadmap: [Roadmap](roadmap.md)
+---
+
+## Project & licensing
+
+- Written in Rust using [pgrx](https://github.com/pgcentralfoundation/pgrx).
+- Targets PostgreSQL 18.
+- Apache 2.0 licensed.
+- Repository: <https://github.com/grove/pg-trickle>
+- [Project history](PROJECT_HISTORY.md) ·
+  [Roadmap](roadmap.md) ·
+  [Contributing](contributing.md) ·
+  [Security policy](security.md)

--- a/plans/PLAN_DOCUMENTATION_GAPS_1.md
+++ b/plans/PLAN_DOCUMENTATION_GAPS_1.md
@@ -1,0 +1,834 @@
+# Plan: Documentation Gap Analysis (Round 1)
+
+**Date:** 2026-04-27
+**Status:** PROPOSED — review and prioritise before implementing
+**Scope:** Full review of `docs/`, `README.md`, `ESSENCE.md`, `INSTALL.md`,
+`ROADMAP.md`, the integrations/tutorials/research subtrees, and the
+ancillary READMEs for `playground/`, `demo/`, `pgtrickle-tui`, and
+`pgtrickle-relay/`.
+**Author audience for this report:** maintainers and documentation owners.
+**Audience target the recommendations are written for:** newcomers ranging
+from SQL-literate analysts to senior DBAs and SREs, with an explicit
+emphasis on lowering the technical barrier of entry.
+
+---
+
+## 1. Executive Summary
+
+pg_trickle ships an unusually large body of documentation — **~32,000 lines
+across 70+ files**, with strong reference material (SQL_REFERENCE.md,
+CONFIGURATION.md, FAQ.md, TROUBLESHOOTING.md) and a thorough hands-on
+tutorial (GETTING_STARTED.md). The technical accuracy is high and the
+breadth is impressive.
+
+However, the documentation has grown by accretion rather than by design,
+and a non-technical reader landing on the project today will struggle.
+The most important problems are:
+
+1. **No truly approachable entry point.** README, introduction.md, and
+   ESSENCE.md all assume the reader already understands materialized
+   views, IVM, DBSP, CDC, MERGE, and PostgreSQL internals.
+2. **No glossary.** Terms like *frontier*, *DVM*, *DRed*, *fuse*, *tier*,
+   *watermark*, *SCC*, *bilinear expansion*, *semi-naive evaluation*, and
+   *delta query* are used freely without definition.
+3. **Several headline features have no user-facing doc.** Snapshots,
+   self-monitoring, the predictive cost model, the multi-database
+   launcher, and the parallel refresh worker pool are referenced in code
+   and the changelog but not surfaced as readable pages.
+4. **Citus support is buried** under `integrations/` even though the
+   README treats it as a marquee v0.32+ capability.
+5. **Nine documentation files are mdBook stubs** (`{{#include …}}`),
+   which render as empty or broken pages on GitHub.
+6. **The book's table of contents (`SUMMARY.md`) is incomplete** —
+   roughly a dozen real documents are not listed at all.
+7. **Persona-based reading paths are missing.** A product manager, an
+   analytics engineer, a backend developer, a DBA, and an SRE all need
+   different journeys; today they share a single dense menu of 50+
+   entries with no progression hints.
+8. **Visual material is sparse.** A handful of ASCII diagrams,
+   no screenshots (TUI, Grafana, dashboard), no animation or worked
+   "before/after" image of differential refresh.
+9. **Numbers and version markers drift.** ESSENCE claims "1,200+ unit
+   tests / 570+ E2E"; README claims "~1,670 unit / ~1,340 E2E / ~140
+   TUI"; PATTERNS.md is pinned at v0.14.0+ while the latest release is
+   v0.34.0.
+
+The recommendation is a **major reorganisation in two phases**:
+
+- **Phase A (low-risk, high-value):** fix the stubs, fill SUMMARY.md,
+  add a glossary, write a one-page plain-language overview, add a
+  use-case gallery, and add persona-routing on the landing page.
+- **Phase B (deeper rework):** restructure the information architecture
+  around four reading paths (Discover → Use → Operate → Build), promote
+  Citus and Snapshots to top-level chapters, and add the missing
+  feature pages.
+
+Estimated total effort: roughly 30–45 documentation tasks, of which
+~12 fit cleanly in a single milestone (see §15 for the sequenced
+action plan).
+
+---
+
+## 2. Methodology
+
+The review was carried out by:
+
+1. Enumerating every Markdown file under `docs/`, plus the top-level
+   READMEs, ESSENCE.md, INSTALL.md, ROADMAP.md, and CHANGELOG.md.
+2. Reading the headline files in full (README.md, introduction.md,
+   ESSENCE.md, GETTING_STARTED.md, ARCHITECTURE.md, SQL_REFERENCE.md,
+   CONFIGURATION.md, FAQ.md, TROUBLESHOOTING.md).
+3. Sampling representative chapters of larger docs and the first 60–120
+   lines of every other doc to assess tone, depth, and accuracy.
+4. Cross-referencing the documented surface area against the source
+   tree (`src/api/*.rs`, `src/*.rs`, `pgtrickle-relay/`, `pgtrickle-tui/`)
+   and against the README's own feature list.
+5. Comparing the SUMMARY.md (mdBook navigation) against the actual
+   contents of `docs/`.
+6. Searching for plan documents that already address documentation
+   (`plans/docs/PLAN_FAQ.md` is the only one found).
+
+This is a **reading-and-mapping** review; it does not attempt to
+fact-check every claim against the code, nor does it lint links.
+
+---
+
+## 3. Audience Analysis
+
+The user request highlighted "a fairly non-technical audience". Today
+the docs implicitly assume the following knowledge:
+
+| Concept | Where it appears unexplained | Likely confusion for a non-technical reader |
+|---|---|---|
+| Materialized view & `REFRESH MATERIALIZED VIEW` | README §1, introduction.md, ESSENCE.md | Needs a one-paragraph plain-English primer. |
+| Incremental View Maintenance (IVM) | Used as a term-of-art everywhere | No definition outside FAQ §GS-01. |
+| DBSP / differential dataflow | README §History, introduction, ESSENCE | Unhelpful link to an academic paper. |
+| Delta query / ΔQ | README, GETTING_STARTED, ARCHITECTURE | Symbol "ΔQ" never decoded. |
+| Frontier / LSN | ARCHITECTURE, CONFIGURATION, refresh notes | Reader has no idea what either is. |
+| `MERGE` execution | Performance section, BENCHMARK | Assumes deep PostgreSQL fluency. |
+| pgrx, advisory locks, `pg_sys`, BGW | ARCHITECTURE | OK for contributors, not for users. |
+| WAL, `wal_level=logical`, replication slots | CDC_MODES, INSTALL | Defined briefly but assumed elsewhere. |
+| MERGE/CTE/LATERAL/SRF | SQL Reference | Reasonable to assume *some* SQL fluency, but worth a one-line gloss. |
+| Bilinear expansion / DRed / semi-naive | introduction.md, README, DVM_OPERATORS | Pure jargon for non-PhDs. |
+
+**Recommendation:** Add a **Glossary** page and link every first
+appearance of these terms to it (mdBook supports this trivially via
+relative links). See §11 for the proposed structure.
+
+There is also a missing **"Why should I care?"** layer. The current
+homepage tells you *what* pg_trickle does (`materialized views that
+refresh themselves`) but not *who* it is for or *what they would build
+with it*. A use-case gallery (§13) is the highest-leverage single
+addition.
+
+---
+
+## 4. Inventory & Coverage Map
+
+### 4.1 Existing documentation (by category)
+
+| Category | Files | Largest | Smallest | Notes |
+|---|---|---|---|---|
+| Landing / overview | README, introduction.md, ESSENCE.md | 639 lines | 25 lines | Three different entry points; no single canonical one. |
+| Tutorials | docs/tutorials/* (15 files) | 615 lines | 155 lines | Strong "What happens on …" series; uneven coverage of features. |
+| Reference | SQL_REFERENCE, CONFIGURATION, ERRORS, FAQ | 4,897 lines | 469 lines | Excellent; very long and search-driven. |
+| Operations | TROUBLESHOOTING, PRE_DEPLOYMENT, SCALING, BACKUP_AND_RESTORE, UPGRADING, RELEASE | 983 lines | 83 lines | BACKUP_AND_RESTORE is critically thin (83 lines) for a production topic. |
+| Architecture | ARCHITECTURE, DVM_OPERATORS, DVM_REWRITE_RULES | 1,129 lines | 127 lines | Assumes contributor-level familiarity. |
+| Patterns / Performance | PATTERNS, PERFORMANCE_COOKBOOK | 838 lines | 553 lines | Excellent recipes; need to be discoverable from a "Use Cases" page. |
+| Integrations | docs/integrations/* (9 files) | 352 lines | 1 line (stub) | Citus is here but should be promoted. |
+| Research / theory | docs/research/* (6 files) | 177 lines | 1 line (stubs ×3) | Three are mdBook stubs. |
+| Other | DEMO, PLAYGROUND, TUI, RELAY, RELAY_GUIDE, INBOX, OUTBOX, PUBLICATIONS, SLA_SCHEDULING, CDC_MODES | varies | — | Several are excellent stand-alone but invisible from the SUMMARY (see §4.4). |
+
+### 4.2 Stub files (mdBook `{{#include …}}` only)
+
+These files render as a single line on GitHub, breaking the in-repo
+reading experience:
+
+| File | Source | Fix |
+|---|---|---|
+| `docs/changelog.md` | `../CHANGELOG.md` | Either keep as mdBook-only (and add a banner), or replace with a curated "What's new" page that links to CHANGELOG.md. |
+| `docs/contributing.md` | `../CONTRIBUTING.md` | Same. |
+| `docs/installation.md` | `../INSTALL.md` | Same; INSTALL.md should remain canonical. |
+| `docs/roadmap.md` | `../ROADMAP.md` | Same. |
+| `docs/security.md` | `../SECURITY.md` | SECURITY.md is a vulnerability-reporting policy, not user security guidance — see §6.7. |
+| `docs/integrations/dbt.md` | `../../dbt-pgtrickle/README.md` | Inline a brief intro and link to the full README. |
+| `docs/research/CUSTOM_SQL_SYNTAX.md` | `plans/sql/REPORT_CUSTOM_SQL_SYNTAX.md` | Plans should not be exposed as docs verbatim. Either curate or remove. |
+| `docs/research/PG_IVM_COMPARISON.md` | `plans/ecosystem/GAP_PG_IVM_COMPARISON.md` | Same. |
+| `docs/research/TRIGGERS_VS_REPLICATION.md` | `plans/sql/REPORT_TRIGGERS_VS_REPLICATION.md` | Same. |
+
+Recommendation: **avoid `{{#include}}` for any file that ships in the
+repo and is meant to be read on GitHub**. Either pick mdBook-only or
+GitHub-only as the source of truth; do not split.
+
+### 4.3 Missing from SUMMARY.md (mdBook navigation)
+
+These files exist in `docs/` but are not in `docs/SUMMARY.md` and so
+do not appear in the published book navigation:
+
+- `docs/PERFORMANCE_COOKBOOK.md` (553 lines — major omission)
+- `docs/ERRORS.md` (469 lines — major omission)
+- `docs/INBOX.md`
+- `docs/OUTBOX.md`
+- `docs/PUBLICATIONS.md`
+- `docs/CDC_MODES.md`
+- `docs/SLA_SCHEDULING.md`
+- `docs/DEMO.md`
+- `docs/RELAY.md` (RELAY_GUIDE is listed; RELAY is not)
+- `docs/DVM_REWRITE_RULES.md`
+- `docs/integrations/citus.md`
+- `docs/integrations/multi-tenant.md`
+- `docs/integrations/orm.md`
+- `docs/integrations/flyway-liquibase.md`
+- `docs/integrations/dbt-hub-submission.md`
+- `docs/research/multi_db_refresh_broker.md`
+- `docs/research/PRIOR_ART.md`
+
+This is the single most damaging structural gap: a reader using the
+mdBook site cannot discover roughly a third of the documentation.
+
+### 4.4 Documented in code but missing in docs
+
+A scan of `src/api/*.rs` against the docs surfaces these
+under-documented features:
+
+| Source module | Feature | Documentation status |
+|---|---|---|
+| `src/api/snapshot.rs` | Stream-table snapshot/restore (v0.27.0) | Mentioned in PATTERNS §"Replica Bootstrap & PITR Alignment"; no dedicated page; not in SUMMARY. |
+| `src/api/self_monitoring.rs` | Built-in self-monitoring stream tables | No user-facing doc; only mentioned in ARCHITECTURE table. |
+| `src/api/cluster.rs` | Multi-database cluster overview (`cluster_worker_summary`) | No dedicated doc; one paragraph in SCALING. |
+| `src/api/publication.rs` | Predictive cost model | Cost model concepts surface in CONFIGURATION GUCs but no narrative doc. |
+| `src/api/planner.rs` | `recommend_schedule` and other planner API | Brief mention in SLA_SCHEDULING; not in SQL_REFERENCE TOC visibly. |
+| `src/api/metrics_ext.rs` | Extended Prometheus metrics | Documented partially in `integrations/prometheus.md`; full metric catalogue absent. |
+| Citus distributed support | Major v0.32+ feature | Only `integrations/citus.md` (338 lines, not in SUMMARY). |
+| `pgtrickle-relay/` (workspace) | Standalone relay binary | RELAY.md focuses on architecture; no "what is this and why would I run it" intro for non-Rust users. |
+| `pgtrickle-tui/` | TUI binary, 18 subcommands, 13 views | TUI.md exists (536 lines); no per-subcommand reference akin to a man page. |
+
+---
+
+## 5. Critical Gaps (Phase A — high priority)
+
+### 5.1 No plain-language overview
+
+**Problem.** README.md (639 lines) is feature-complete but reads as a
+spec. ESSENCE.md (25 lines) is closer in spirit to what a non-technical
+reader needs but is undersized and buried. introduction.md (106 lines)
+sits in the docs site only.
+
+**Recommendation.** Promote a single canonical **"What is pg_trickle?"**
+page (~150–250 lines) that:
+
+- Opens with a one-sentence description ("Materialized views that keep
+  themselves up to date — without external infrastructure.").
+- Uses one **before/after diagram** (manual refresh pipelines vs.
+  declarative stream tables).
+- Names three concrete things you can build with it (dashboards,
+  read-models, fraud/alert pipelines).
+- Defers all internals (DBSP, frontier, DVM) to a "How it works" link.
+- Ends with two CTAs: "Try the playground (30 s)" and "Tutorial (15
+  min)".
+
+### 5.2 No glossary
+
+**Problem.** A non-technical reader meets opaque jargon within the
+first 200 words of nearly every page.
+
+**Recommendation.** Add `docs/GLOSSARY.md` with ~30 entries covering at
+least: stream table, base/source table, defining query, schedule, tier,
+refresh mode (FULL / DIFFERENTIAL / IMMEDIATE / AUTO), CDC, change
+buffer, frontier, LSN, watermark, fuse, DAG, SCC, diamond, delta query
+(ΔQ), DVM, DBSP, semi-naive, DRed, IVM, MERGE, advisory lock, GUC, BGW
+(background worker), pgrx, hybrid CDC, columnar tracking, predicate
+pushdown, scoped recomputation, group-rescan, semi-/anti-join,
+algebraic / semi-algebraic / holistic aggregate, snapshot, outbox,
+inbox, publication, relay.
+
+Link first uses from headline pages.
+
+### 5.3 No use-case gallery
+
+**Problem.** "Materialized views that refresh themselves" is technically
+correct but does not motivate the product. PATTERNS.md is excellent
+content but is structured as recipes for users who already know they
+want pg_trickle.
+
+**Recommendation.** Add `docs/USE_CASES.md`:
+
+1. **Real-time dashboards** — KPI tiles, daily/hourly aggregates.
+2. **Operational read-models / CQRS** — denormalised projections.
+3. **Fraud, alerting, anomaly detection** — incremental aggregates +
+   thresholds (point at the demo).
+4. **Leaderboards & TopK** — `ORDER BY … LIMIT N`.
+5. **Bronze / Silver / Gold pipelines** — point at PATTERNS §1.
+6. **Outbox/inbox event distribution** — point at OUTBOX/INBOX.
+7. **Cross-system replication** — publications + relay.
+8. **Bitemporal & SCD** — point at PATTERNS §3.
+9. **Multi-tenant analytics** — point at integrations/multi-tenant.
+10. **Citus-distributed analytics** — point at integrations/citus.
+
+Each entry: 1 paragraph, 1 minimal SQL block, 1 link.
+
+### 5.4 No persona-based reading paths
+
+**Problem.** SUMMARY.md presents a flat list of 50+ entries.
+
+**Recommendation.** On the landing page, add a "Choose your path"
+section with four tiles:
+
+| Persona | First doc | Then | Then |
+|---|---|---|---|
+| **Curious / evaluator** | What is pg_trickle? | Use Cases | Playground |
+| **Application developer** | Getting Started | SQL Reference | PATTERNS |
+| **DBA / SRE** | Pre-Deployment | Configuration | Troubleshooting + Scaling |
+| **Data / analytics engineer** | Use Cases | dbt integration | Migration from materialized views |
+
+### 5.5 Critical features missing dedicated pages
+
+| Feature | Severity | Recommended page |
+|---|---|---|
+| **Snapshots** (`pgtrickle.snapshot_stream_table`) | HIGH — production-critical, v0.27+ | `docs/SNAPSHOTS.md` |
+| **Citus integration** (currently under integrations/) | HIGH — promoted in README as headline | Promote to top-level `docs/CITUS.md` and keep integrations/citus.md as a redirect. |
+| **Multi-database launcher** | MEDIUM | Section in SCALING.md or a new `docs/MULTI_DATABASE.md`. |
+| **Predictive cost model** (`recommend_refresh_mode`, `recommend_schedule`) | MEDIUM | Section in PERFORMANCE_COOKBOOK or new `docs/COST_MODEL.md`. |
+| **Self-monitoring** | MEDIUM | Section in MONITORING_AND_ALERTING tutorial. |
+| **Watermark gating** (sources / external loaders) | MEDIUM | Promote SLA_SCHEDULING §watermarks or new `docs/WATERMARKS.md`. |
+| **Parallel refresh worker pool** (`max_dynamic_refresh_workers`, `parallel_job_status`) | LOW | Section in SCALING.md (touched on; needs walk-through). |
+| **Online ALTER QUERY** | LOW | Section in SQL_REFERENCE plus a short tutorial. |
+
+### 5.6 Stub files
+
+Resolve as listed in §4.2.
+
+### 5.7 SUMMARY.md is incomplete
+
+Add the 17 entries listed in §4.3.
+
+---
+
+## 6. Medium-Priority Gaps
+
+### 6.1 BACKUP_AND_RESTORE is too thin
+
+83 lines for a topic that production users care about deeply. Should
+cover: `pg_dump`/`pg_restore` interaction with stream tables and CDC
+slots, point-in-time recovery alignment with frontiers, snapshot-based
+restore (v0.27+), how to rebuild after restore, and CNPG-specific
+guidance.
+
+### 6.2 No HA / replication story
+
+There is no dedicated page on running pg_trickle alongside streaming
+or logical replication, failover behaviour, or how stream tables
+behave on a hot standby. This is a recurring question for any
+production reader and is currently scattered across the FAQ.
+
+### 6.3 No cost / capacity-planning guide
+
+SCALING.md is good for worker sizing but not for "how much disk will
+my change buffers consume?", "how big can my DAG get before scheduling
+overhead matters?", or "how do I budget WAL retention for the WAL CDC
+mode?". A `docs/CAPACITY_PLANNING.md` would consolidate this.
+
+### 6.4 No comparison matrix on a discoverable page
+
+`docs/research/PG_IVM_COMPARISON.md` is a stub and `DBSP_COMPARISON.md`
+is short. There is no comparison with Materialize, RisingWave, Flink,
+Debezium, ksqlDB, or Snowflake Dynamic Tables. A
+`docs/COMPARISONS.md` listing strengths/weaknesses honestly would
+substantially help evaluators (the persona most affected by missing
+docs today).
+
+### 6.5 CLI man-pages
+
+The TUI has 18 subcommands. TUI.md is a tour, not a reference. A
+`docs/CLI_REFERENCE.md` with one section per subcommand (synopsis,
+arguments, exit codes, examples) is a low-cost improvement.
+
+### 6.6 Relay does not have an intro
+
+`docs/RELAY.md` and `docs/RELAY_GUIDE.md` exist but jump straight to
+modules and operations. There is no "What is the relay? Do I need
+it?" page. For a non-Rust user this is the main barrier.
+
+### 6.7 Security guidance
+
+`docs/security.md` is a stub including the vulnerability-reporting
+policy. There is **no user-facing security page** covering: roles &
+grants for `pgtrickle.*`, SECURITY DEFINER vs INVOKER semantics in
+generated triggers, how RLS interacts with stream tables (only a
+tutorial today), secrets handling in the relay, audit trail, and how
+to lock down `pg_trickle.allow_circular`. Recommend a new
+`docs/SECURITY_GUIDE.md`.
+
+### 6.8 Observability metrics catalogue
+
+`integrations/prometheus.md` shows how to scrape, but does not list
+every metric, its labels, units, and recommended SLO/alerts. Add a
+"Metrics reference" appendix.
+
+### 6.9 Migration stories
+
+Tutorials cover migrating from materialized views and from `pg_ivm`.
+Common requests left unanswered: migrating from a homemade refresh
+cron, from Debezium + Materialize, from periodic ETL, from Looker
+PDTs, from Snowflake Dynamic Tables. A short table at the top of
+`MIGRATING_FROM_MATERIALIZED_VIEWS.md` linking each path would help.
+
+### 6.10 "Available since v…" badges
+
+Inconsistent. PATTERNS.md uses `> **Version:** v0.14.0+`, INBOX.md uses
+`> **Available since v0.28.0**`, RELAY refers to v0.29, README pins to
+v0.34.0. Recommend a single convention (a small `<sup>since v0.28</sup>`
+inline tag) and apply it uniformly.
+
+### 6.11 Numbers drift
+
+| Source | Unit-test count | E2E count | TUI tests | Releases mentioned |
+|---|---|---|---|---|
+| README.md (line ~620) | ~1,670 | ~1,340 | ~140 | "v0.34.0" |
+| ESSENCE.md | "1,200+" | "570+" | — | "eleven releases" |
+| FAQ.md | (varies) | — | — | — |
+
+Pick a single source of truth (e.g. a `docs/_data/stats.md` snippet)
+and include it everywhere.
+
+### 6.12 GETTING_STARTED is one shape only
+
+GETTING_STARTED.md (1,490 lines) is a single multi-chapter narrative
+ending in recursive CTEs and circular DAGs. That is excellent for one
+audience but excessive for someone who wants a 5-minute introduction
+before the playground. Recommend splitting:
+
+- **5-minute Quickstart** (single SQL query, no chains).
+- **15-minute Tutorial** (multi-table joins, one chain).
+- **In-depth Tour** (current GETTING_STARTED, renamed).
+
+---
+
+## 7. Tone & Language Audit
+
+### 7.1 Sample readability findings
+
+Spot-checking the first paragraph of each headline doc with the
+"non-technical reader" lens:
+
+| Doc | First-paragraph pain points |
+|---|---|
+| README §intro | "DBSP differential dataflow framework", arXiv link, Wikipedia-level density. |
+| ESSENCE | Better — but ends with "the bottleneck is PostgreSQL's own MERGE, not pg_trickle's pipeline" which restates jargon. |
+| introduction.md | Uses `CREATE EXTENSION pg_trickle` in the second line; says "self-maintaining stream tables" without defining "stream table". |
+| ARCHITECTURE | Heavy ASCII diagram in lines 8–48; no narrative warm-up. |
+| GETTING_STARTED | Strong; uses analogies. **Best in class.** |
+| FAQ | Strong; structured and quotable. |
+| PATTERNS | Pleasant; assumes you already know what bronze/silver/gold means. |
+| TROUBLESHOOTING | Operator-targeted; tone is fine for that audience. |
+| RELAY | Module table on line 18 — too eager. |
+
+### 7.2 Style suggestions
+
+1. **Lead with intent, not mechanism.** Open every page with "What
+   this is for" and "When to read this", then mechanism.
+2. **Decode every symbol on first use.** ΔQ, LSN, OID, BGW, GUC.
+3. **Replace "trivially", "simply", "obviously"** — they signal
+   condescension to readers who do not find the topic trivial.
+4. **Prefer active voice and short sentences** in landing pages; the
+   current README has many ~40-word sentences.
+5. **Use callouts consistently.** mdBook supports admonitions; today
+   the codebase uses `> **Note:**`, `> **Tip:**`, `> **Available
+   since**`, and `> ` blockquotes interchangeably. Pick three (Note,
+   Tip, Warning) and apply.
+6. **Avoid embedding feature work in narrative chapters.** PATTERNS.md
+   ends with three "Pattern N (vX.Y.0)" entries that read like release
+   notes — they would be more discoverable as their own pages.
+
+### 7.3 Diagrams
+
+Today's diagrams are ASCII art. They render well in GitHub but are
+inaccessible (no alt text), do not scale on mobile, and look dated on
+the docs site. Recommend:
+
+- Convert the four "core" diagrams (architecture, hybrid CDC
+  transition, DAG fan-out, refresh lifecycle) to **Mermaid** (mdBook
+  supports it via plug-in). One Mermaid source serves both GitHub and
+  the book.
+- Add **two screenshots**: TUI dashboard, Grafana dashboard. The
+  project has both and shows neither.
+- Add **one animated GIF** of the demo dashboard updating in real
+  time on the landing page — a single 5-second clip would change the
+  "what is this?" experience completely.
+
+---
+
+## 8. Structural & Navigation Issues
+
+### 8.1 Three competing landing pages
+
+README.md (GitHub), introduction.md (mdBook), ESSENCE.md (linked from
+both, used as PR-blurb material). These overlap heavily, are out of
+sync, and no single one is canonical for non-technical readers.
+
+**Recommendation.**
+
+- Make ESSENCE.md the **single canonical "what is this"** narrative
+  (~200–300 lines, plain language).
+- Keep README.md as the GitHub landing — open with the same hero
+  paragraph as ESSENCE, then jump to features/install.
+- Delete or shrink introduction.md to a one-paragraph welcome that
+  links to ESSENCE.
+
+### 8.2 SUMMARY.md is too flat
+
+The current SUMMARY has six unranked sections. Suggested structure (also
+solves §4.3):
+
+```
+# Summary
+
+# Discover
+- What is pg_trickle?      (was ESSENCE/introduction)
+- Use Cases & Examples     (NEW)
+- Comparisons              (NEW, replaces stub research pages)
+- Glossary                 (NEW)
+
+# Get Started
+- 5-Minute Quickstart      (NEW)
+- 15-Minute Tutorial       (split of GETTING_STARTED)
+- In-Depth Tour            (current GETTING_STARTED)
+- Playground (Docker)
+- Real-time Demo
+- Installation
+
+# Build with Stream Tables
+- Best-Practice Patterns
+- Performance Cookbook
+- SQL Reference
+- Configuration
+- Migrating from Materialized Views
+- Migrating from pg_ivm
+- ORM Integration
+- dbt Integration
+
+# Operate
+- Pre-Deployment Checklist
+- Scaling Guide
+- Backup & Restore
+- Upgrading
+- Snapshots                (NEW)
+- Multi-Database           (NEW)
+- Capacity Planning        (NEW)
+- Monitoring & Alerting
+- Troubleshooting Runbook
+- Error Reference
+- Security Guide           (NEW)
+- CLI Reference            (NEW)
+- TUI Tool
+
+# Distributed & Streaming
+- Citus                    (PROMOTED)
+- Hybrid CDC Modes
+- Watermarks               (NEW or section)
+- SLA-based Smart Scheduling
+- Downstream Publications
+- Transactional Outbox
+- Transactional Inbox
+- Relay Service
+- Relay Architecture & Operations
+
+# Tutorials (deep dives)
+- What Happens on INSERT / UPDATE / DELETE / TRUNCATE
+- Row-Level Security
+- Partitioned Tables
+- Foreign Table Sources
+- Tiered Scheduling
+- Fuse Circuit Breaker
+- Circular Dependencies
+- ETL & Bulk Load
+- Tuning Refresh Mode
+
+# Reference
+- FAQ
+- Changelog
+- Roadmap
+- Release Process
+- Contributing
+
+# Internals (for contributors)
+- Architecture
+- DVM Operators
+- DVM Rewrite Rules
+- Benchmarks
+- Research: DBSP / pg_ivm / triggers vs replication / prior art / multi-DB broker
+```
+
+### 8.3 Cross-link density is low
+
+Many docs do not link to related docs. For example, PATTERNS §"Real-Time
+Dashboards" never links to MONITORING_AND_ALERTING; CDC_MODES never
+links to CONFIGURATION's `cdc_mode` GUC; SQL_REFERENCE function entries
+do not link to the matching section in PATTERNS or PERFORMANCE_COOKBOOK.
+A pass adding `See also:` footers on every page would substantially
+improve discoverability.
+
+### 8.4 No "What's new" landing
+
+`docs/changelog.md` is an mdBook include of `CHANGELOG.md`. Recommend a
+**curated quarterly "What's new"** page that summarises each minor
+release in 2–3 bullets and links to the changelog for detail.
+
+---
+
+## 9. Per-Document Notes (selected)
+
+Only docs needing explicit attention are listed.
+
+### 9.1 README.md (639 lines)
+
+- Strong reference content; weak as an introduction.
+- **History and Motivation** section is interesting and well written
+  but probably belongs in a separate `docs/PROJECT_HISTORY.md` —
+  it pushes the actual feature list below the fold.
+- TPC-H validation section is too detailed for the README; move all
+  but the headline numbers to BENCHMARK.md.
+- "Try it in 30 seconds" is the right idea but immediately requires
+  Rust to install the TUI. Either provide a one-line `docker run`
+  for the TUI too, or label this section "Try it in 5 minutes".
+
+### 9.2 docs/introduction.md
+
+- Redundant with README and ESSENCE. Either delete and redirect, or
+  rewrite as the canonical "What is pg_trickle?" per §8.1.
+
+### 9.3 docs/GETTING_STARTED.md (1,490 lines)
+
+- Excellent, but too long for a single tutorial. Split per §6.12.
+- Some chapter headings refer to "DBSP-style version frontier" — push
+  to glossary/internals.
+
+### 9.4 docs/SQL_REFERENCE.md (4,897 lines)
+
+- Comprehensive. Two improvements:
+  - Add a one-line "**See also:**" link on each function entry to a
+    pattern, tutorial, or troubleshooting section.
+  - Surface the TOC in the docs site as a sidebar (mdBook does this
+    if heading-split-level is bumped to 4).
+
+### 9.5 docs/CONFIGURATION.md (2,904 lines)
+
+- Excellent reference. Add a "**Tuning by goal**" section at the top:
+  "Lower latency", "Lower write overhead", "Larger DAGs", "Pooler
+  compatibility" — each linking to ~5 GUCs.
+
+### 9.6 docs/FAQ.md (3,156 lines, 158 questions)
+
+- The "New User FAQ — Top 15" preamble is one of the best onboarding
+  artifacts in the project. Promote to its own short page and link
+  from the landing.
+
+### 9.7 docs/ARCHITECTURE.md (869 lines)
+
+- Audience overlap with `plans/`. Would benefit from being clearly
+  marked "for contributors" and from a one-page **"How it works (for
+  users)"** companion in the Discover section.
+
+### 9.8 docs/PATTERNS.md (838 lines)
+
+- Excellent. Promote each pattern to a discoverable card on a Use
+  Cases page. Add a "*When NOT to use this pattern*" footer to each.
+
+### 9.9 docs/PERFORMANCE_COOKBOOK.md (553 lines) — **not in SUMMARY**
+
+- High-quality recipes. **Add to SUMMARY immediately.** Currently
+  invisible to docs-site readers.
+
+### 9.10 docs/ERRORS.md (469 lines) — **not in SUMMARY**
+
+- High-quality reference. Add to SUMMARY. Add cross-links from
+  TROUBLESHOOTING into ERRORS by SQLSTATE.
+
+### 9.11 docs/INBOX.md / docs/OUTBOX.md / docs/PUBLICATIONS.md / docs/RELAY*.md / docs/SLA_SCHEDULING.md
+
+- All four exist; **none are in SUMMARY**. They form a coherent
+  "distributed and streaming" chapter (see §8.2).
+
+### 9.12 docs/CDC_MODES.md (408 lines)
+
+- Excellent narrative. Add a diagram of the trigger → transitioning →
+  WAL transition (currently only described in prose).
+
+### 9.13 docs/BACKUP_AND_RESTORE.md (83 lines)
+
+- Critically thin — see §6.1.
+
+### 9.14 docs/SCALING.md (359 lines)
+
+- Worker-pool focus is good. Missing: predictive cost model, parallel
+  refresh failure modes, multi-tenant scaling, large-DAG memory
+  considerations.
+
+### 9.15 docs/integrations/citus.md
+
+- Should be promoted to a top-level chapter — see §5.5.
+
+### 9.16 docs/integrations/dbt.md
+
+- Stub including `dbt-pgtrickle/README.md`. Inline the first
+  ~50 lines (intro + minimal example) and link to the full README for
+  the rest.
+
+### 9.17 docs/research/*
+
+- Three files are stubs (§4.2). The remaining three are genuinely
+  research-grade material; group under "Internals → Research".
+
+### 9.18 ESSENCE.md (25 lines)
+
+- Should grow to ~200–300 lines and become the canonical "What is
+  pg_trickle?" — see §5.1, §8.1.
+
+### 9.19 INSTALL.md (437 lines)
+
+- Comprehensive. Add a one-paragraph "By environment" decision tree at
+  the top: "Local dev → playground / docker; Self-hosted → INSTALL §X;
+  Managed Postgres → INSTALL §Y; Kubernetes → cnpg/".
+
+### 9.20 ROADMAP.md (153 lines)
+
+- Excellent. The "audience" callout is very good. The version table
+  truncates after v0.9 in the sample read; ensure the rendered table
+  remains scannable on mobile.
+
+---
+
+## 10. Specific Inconsistencies and Errors Found
+
+| # | Location | Issue | Suggested fix |
+|---|---|---|---|
+| 1 | README "Testing" | "~1,670 unit tests + … + ~1,340 E2E tests + ~140 TUI tests" | Source from a single counted artifact. |
+| 2 | ESSENCE | "1,200+ unit tests and 570+ E2E tests across eleven releases" | Same — likely stale. |
+| 3 | PATTERNS | `> **Version:** v0.14.0+` while project is v0.34+ | Update or remove. |
+| 4 | docs/changelog/contributing/installation/roadmap/security | mdBook stubs | See §4.2. |
+| 5 | docs/research/* | Three stubs pointing into `plans/` | See §4.2. |
+| 6 | introduction.md | Uses "stream table" before defining it | Define on first use. |
+| 7 | README §"Try it in 30 seconds" | Requires `cargo install --path pgtrickle-tui` and `cd playground && docker compose up -d` | Realistically ≥ 5 minutes; rename or split the two paths. |
+| 8 | RELAY.md "Architecture" | Reads as a code map, not an introduction | Add an intro paragraph explaining when to use the relay. |
+| 9 | SECURITY.md vs docs/security.md | The latter is just an include of the former; the user-security guide is missing | See §6.7. |
+| 10 | SUMMARY.md | Missing 17 files | See §4.3. |
+| 11 | DEMO.md / PLAYGROUND.md | Both exist; both compelling; only one is in SUMMARY | Add DEMO.md to SUMMARY. |
+| 12 | PATTERNS.md | Pattern 7/8/9 dated by version, mixing release-note style with tutorial style | Move version markers to inline tags. |
+
+---
+
+## 11. Proposed New Documents
+
+In priority order:
+
+| # | Document | Size | Audience | Replaces / consolidates |
+|---|---|---|---|---|
+| 1 | `docs/GLOSSARY.md` | 200–400 lines | All | — |
+| 2 | `docs/USE_CASES.md` | 300–500 lines | Evaluators | — |
+| 3 | `docs/QUICKSTART_5MIN.md` | 80–120 lines | Evaluators | Splits GETTING_STARTED |
+| 4 | `docs/SNAPSHOTS.md` | 200–400 lines | DBA / SRE | New (api/snapshot.rs) |
+| 5 | `docs/CITUS.md` (promote) | (existing) | Distributed Postgres users | Replaces integrations/citus.md as canonical |
+| 6 | `docs/SECURITY_GUIDE.md` | 200–400 lines | DBA / SRE | New |
+| 7 | `docs/COMPARISONS.md` | 200–300 lines | Evaluators | Promotes pg_ivm/DBSP comparisons |
+| 8 | `docs/CLI_REFERENCE.md` | 300–500 lines | Operators | Companion to TUI.md |
+| 9 | `docs/CAPACITY_PLANNING.md` | 200–300 lines | DBA / SRE | New |
+| 10 | `docs/MULTI_DATABASE.md` | 100–200 lines | DBA | New |
+| 11 | `docs/COST_MODEL.md` | 100–200 lines | Performance-tuners | Pulls from CONFIGURATION + cookbook |
+| 12 | `docs/HA_AND_REPLICATION.md` | 200–400 lines | DBA / SRE | New |
+| 13 | `docs/PROJECT_HISTORY.md` | 100–200 lines | Curious | Pulled out of README |
+| 14 | `docs/_data/stats.md` (or similar) | < 50 lines | Internal | Single source of truth for test counts etc. |
+| 15 | `docs/WHATS_NEW.md` | rolling | All | Curated companion to changelog |
+
+Existing pages to expand:
+
+- `docs/BACKUP_AND_RESTORE.md` → 300–500 lines.
+- `docs/SCALING.md` → add multi-DB, parallel refresh failure, memory.
+- `docs/integrations/prometheus.md` → add full metrics catalogue.
+
+---
+
+## 12. Phased Action Plan
+
+### Phase A — Quick wins (target: 1 documentation milestone)
+
+1. Add the 17 missing entries to SUMMARY.md.
+2. Fix the nine stub files (curate or inline).
+3. Write `docs/GLOSSARY.md` (200 entries minimum 30).
+4. Write `docs/USE_CASES.md`.
+5. Write `docs/QUICKSTART_5MIN.md` and link it as the new "first
+   touch" CTA.
+6. Expand ESSENCE.md to canonical "What is pg_trickle?" form; redirect
+   introduction.md to it.
+7. Reconcile test-count and version drift (§6.11) into a single
+   include.
+8. Add Mermaid versions of the four core diagrams.
+9. Add TUI and Grafana screenshots and one animated GIF.
+10. Add persona-routing tiles to the landing page.
+11. Add `See also:` footers to the top 20 most-trafficked docs.
+12. Add "Available since vX.Y" tag convention and apply to all feature
+    pages.
+
+### Phase B — Restructure (target: 2 milestones after A)
+
+13. Promote Citus, Snapshots, Multi-Database to top-level chapters.
+14. Restructure SUMMARY.md into the eight-chapter form proposed in
+    §8.2.
+15. Split GETTING_STARTED into 5-min, 15-min, and in-depth tours.
+16. Write SECURITY_GUIDE, COMPARISONS, CLI_REFERENCE,
+    CAPACITY_PLANNING, COST_MODEL, HA_AND_REPLICATION,
+    PROJECT_HISTORY, WHATS_NEW.
+17. Expand BACKUP_AND_RESTORE to production grade.
+18. Add full Prometheus metrics catalogue.
+19. Add `When NOT to use this pattern` footer to each PATTERNS entry.
+20. Run a link-and-style lint pass (markdownlint + mdbook-linkcheck).
+
+### Phase C — Maintenance discipline (ongoing)
+
+21. Add a CI job that fails the build if a file in `docs/` is not in
+    `SUMMARY.md` (with an allow-list).
+22. Add a CI job that fails the build if a function in
+    `src/api/*.rs` annotated `#[pg_extern]` does not have a section in
+    `docs/SQL_REFERENCE.md` (best effort — a grep gate is enough).
+23. Establish that **every new feature ships with at least one
+    documentation entry in the relevant chapter** (codify in
+    AGENTS.md / CONTRIBUTING.md).
+24. Establish a quarterly "Doc gardening" milestone for deferred items.
+
+---
+
+## 13. Out of Scope (for follow-up plans)
+
+- Internationalisation / translation.
+- Accessibility audit (alt text, contrast, keyboard navigation).
+- Video tutorials.
+- A formal style guide (could become Round 2 of this plan).
+- A dedicated marketing site beyond the mdBook output.
+
+---
+
+## 14. Appendix — File-by-file inventory
+
+(See `wc -l docs/**/*.md` for the raw counts. Highlights:)
+
+- 9 stub files (1 line each).
+- 11 files > 500 lines (the main reference and tutorial set).
+- 4 files > 1,500 lines (SQL_REFERENCE, FAQ, CONFIGURATION,
+  GETTING_STARTED) — candidates for splitting or improved TOCs.
+- Total documented surface: ~32,000 lines.
+
+---
+
+## 15. Recommendation
+
+Implement **Phase A in full as the next documentation milestone**.
+It is mechanical, low-risk, and would dramatically improve the
+experience of a non-technical reader landing on the project. Phase B
+should be planned immediately after A but treated as a structural
+change requiring review, since it moves files around and changes
+URLs. Phase C is ongoing discipline.
+
+The single most valuable deliverable is the **"What is pg_trickle?"
++ Use Cases + Glossary** triplet (items 3, 4, 6 in §12). With those
+three pages alone, the project's accessibility to a non-technical
+reader improves by an order of magnitude — and none of the existing
+content needs to be rewritten.


### PR DESCRIPTION
# Major documentation rework — discoverability, glossary, persona paths

This is a docs-only PR. No source code or runtime behaviour changes.

## Summary

The existing documentation surfaced a lot of pg_trickle's depth, but
required readers to already know the vocabulary and to guess where things
lived. This rework reorganises the docs around **reading paths** for each
persona, fills the largest content gaps identified in
`plans/PLAN_DOCUMENTATION_GAPS_1.md`, and adds a glossary so newcomers can
decode the jargon.

The core changes:

- An 8-chapter `docs/SUMMARY.md` that mirrors a real reader journey
  (Discover → Get Started → Build → Operate → Distributed & Streaming →
  Tutorials → Integrations → Reference → Internals).
- Persona-routing tiles at the top of `README.md` and a new
  welcome `docs/introduction.md`.
- 14 new docs covering long-standing gaps.
- `ESSENCE.md` rewritten as the canonical "What is pg_trickle?" overview.
- `docs/BACKUP_AND_RESTORE.md` expanded from a thin stub to a full
  pgBackRest / `pg_dump` / snapshots / CNPG / DR-checklist guide.

## Changes

### Plan

- `plans/PLAN_DOCUMENTATION_GAPS_1.md` — 834-line gap analysis driving
  this PR. Two-phase action plan with explicit acceptance criteria.

### New documentation

| File | Purpose |
|---|---|
| `docs/GLOSSARY.md` | 30+ definitions + acronym table |
| `docs/USE_CASES.md` | 11 concrete use cases + "when not to use" |
| `docs/QUICKSTART_5MIN.md` | Shortest-path 7-step tutorial |
| `docs/COMPARISONS.md` | vs. Materialize, RisingWave, Flink, Debezium, ksqlDB, Snowflake DT, pg_ivm, REFRESH MV |
| `docs/SNAPSHOTS.md` | Snapshot API (v0.27+) |
| `docs/CITUS.md` | Top-level Citus reference |
| `docs/SECURITY_GUIDE.md` | Roles, RLS, SECURITY DEFINER, hardening |
| `docs/CLI_REFERENCE.md` | Per-subcommand `pgtrickle` reference |
| `docs/CAPACITY_PLANNING.md` | Disk / memory / CPU / network sizing |
| `docs/MULTI_DATABASE.md` | Launcher/scheduler architecture and budgeting |
| `docs/COST_MODEL.md` | Predictive cost model inputs and overrides |
| `docs/HA_AND_REPLICATION.md` | Physical/logical replication, failover, geo |
| `docs/PROJECT_HISTORY.md` | History & motivation, spec-driven dev process |
| `docs/WHATS_NEW.md` | Curated per-release "what's new" v0.1 → v0.34 |

### Rewritten / restructured

- `ESSENCE.md` — replaces the 25-line PR blurb with a ~200-line canonical
  introduction including persona table.
- `docs/BACKUP_AND_RESTORE.md` — expanded to cover every standard PG
  backup tool plus snapshots and a DR checklist.
- `docs/introduction.md` — short welcome page that routes readers by
  persona.
- `docs/SUMMARY.md` — 8-chapter layout (was a flat list); adds entries
  for the 17 previously missing files plus the 14 new ones.
- `README.md` — persona-routing tiles near top; "History and Motivation"
  moved to `docs/PROJECT_HISTORY.md`; documentation index restructured
  to match the 8 chapters.

## Testing

Docs-only change. No unit, integration, or E2E tests are affected.

Manual verification:

- All links in the new `docs/SUMMARY.md` resolve to files that exist
  on disk.
- `docs/introduction.md` and persona tiles use relative paths that
  render correctly on both GitHub and mdBook.

## Notes

- The plan file (`plans/PLAN_DOCUMENTATION_GAPS_1.md`) is kept under
  `plans/` for historical traceability, consistent with how other
  large docs efforts have been recorded in this repo.
- Three research stubs (`CUSTOM_SQL_SYNTAX`, `PG_IVM_COMPARISON`,
  `TRIGGERS_VS_REPLICATION`) are left in place; the new
  `docs/COMPARISONS.md` now provides the user-facing version of that
  material, while the research files remain for contributors.
- No `.control`, `.sql`, or extension-version changes.
