### PR TITLE
docs: fix remaining plan gaps — stubs, When NOT to use, tuning guide, relay intro, doc policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,20 @@ docs: document JOIN key change limitation in SQL_REFERENCE
 test: add E2E test for keyless table duplicate-row behaviour
 ```
 
+## Documentation Policy
+
+**Every new feature ships with documentation.** This is a hard requirement,
+not a nice-to-have.
+
+- New SQL functions → entry in `docs/SQL_REFERENCE.md`.
+- New GUC variable → entry in `docs/CONFIGURATION.md`.
+- New user-facing capability → at minimum a paragraph in the relevant
+  chapter; for headline features, a dedicated page.
+- New page → add it to `docs/SUMMARY.md` in the correct chapter.
+
+PRs that introduce a `#[pg_extern]` function or a new GUC without
+documentation will be asked to add it before merge.
+
 ## License
 
 By contributing you agree that your contributions will be licensed under the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,5 +1,17 @@
 # Installation Guide
 
+## Choose your installation path
+
+| Environment | Recommended approach |
+|---|---|
+| **Local development / quick evaluation** | [Docker sandbox](playground/) — `docker compose up -d` in `playground/` gets you a running pg_trickle instance in ~60 seconds with no build step. |
+| **Self-hosted Linux server** | [Pre-built release](#installing-from-a-pre-built-release) — download the `.tar.gz`, copy two directories, `CREATE EXTENSION`. |
+| **macOS development** | [Build from source](#building-from-source) using `cargo pgrx install`, or use the Docker sandbox above. |
+| **Kubernetes / CNPG** | [CloudNativePG](docs/integrations/cloudnativepg.md) — use the `Dockerfile.ghcr` image or the CNPG extension manifest. |
+| **Managed PostgreSQL** | Check your provider's extension list. If pg_trickle is not available, the Docker or Kubernetes path is your best option. |
+
+---
+
 ## Prerequisites
 
 | Requirement | Version |

--- a/README.md
+++ b/README.md
@@ -702,7 +702,9 @@ just test-all            # All of the above + pgrx tests
 just bench               # Criterion benchmarks
 ```
 
-**Test counts:** ~1,670 unit tests + integration tests + ~1,340 E2E tests + ~140 TUI tests.
+**Test counts:** Current test counts are reported by CI on every push to `main`.
+Run `just test-all` locally or check the latest
+[GitHub Actions run](../../actions/workflows/ci.yml) for the live numbers.
 
 ## Contributors
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -4,6 +4,26 @@ Complete reference for all pg_trickle GUC (Grand Unified Configuration) variable
 
 ---
 
+## Quick-tuning by goal
+
+Not sure which GUC to change? Start here.
+
+| Goal | GUCs to adjust |
+|---|---|
+| **Lower refresh latency** | `scheduler_interval_ms`, `event_driven_wake`, `wake_debounce_ms`, `min_schedule_seconds` |
+| **Reduce write overhead on busy tables** | `compact_threshold`, `max_buffer_rows`, `cleanup_use_truncate`, `user_triggers` |
+| **Handle larger DAGs without timeouts** | `max_workers`, `max_dynamic_refresh_workers`, `scheduler_interval_ms` |
+| **Connection-pooler compatibility (PgBouncer)** | `pooler_compatibility_mode`, `use_prepared_statements` |
+| **Lower memory usage during refresh** | `merge_work_mem_mb`, `max_delta_estimate_rows` |
+| **Improve cost-model accuracy** | `cost_model_safety_margin`, `planner_aggressive`, `differential_max_change_ratio` |
+| **Enable WAL-based CDC** | `cdc_mode`, `wal_transition_timeout`, `slot_lag_warning_threshold_mb` |
+| **Prevent a runaway stream table** | `max_consecutive_errors`, `fuse_threshold`, `buffer_alert_threshold` |
+
+See the full reference below for each variable's defaults, valid values, and
+notes. Use `pgtrickle.recommend_refresh_mode()` for per-table advice.
+
+---
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -3154,3 +3154,12 @@ pg_trickle uses the following PostgreSQL connections:
 **`max_worker_processes`**: pg_trickle registers 1 background worker per database during `_PG_init()`. Ensure `max_worker_processes` (default 8) has room for the pg_trickle worker plus any other extensions.
 
 **Advisory locks**: The scheduler holds a session-level advisory lock per actively-refreshing ST. These are released immediately after each refresh completes.
+
+---
+
+**See also:**
+[Troubleshooting](TROUBLESHOOTING.md) ·
+[Error Reference](ERRORS.md) ·
+[Configuration](CONFIGURATION.md) ·
+[SQL Reference](SQL_REFERENCE.md) ·
+[Glossary](GLOSSARY.md)

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -98,6 +98,14 @@ SELECT pgtrickle.create_stream_table(
 - **Don't use IMMEDIATE mode for Gold.** Aggregate maintenance on every
   DML row is expensive — batched DIFFERENTIAL is more efficient.
 
+### When NOT to use this pattern
+
+- Your data never changes after insert — a single stream table is simpler.
+- The Bronze source is external (foreign table, `dblink`) — CDC triggers
+  cannot be attached to foreign tables; use WAL CDC mode or FULL refresh.
+- You have fewer than ~10,000 rows in Silver — the overhead of three layers
+  is not justified; use one or two tables instead.
+
 ---
 
 ## Pattern 2: Event Sourcing with Stream Tables
@@ -160,6 +168,15 @@ SELECT pgtrickle.create_stream_table(
 - **Don't use `append_only => true` with UPDATE/DELETE patterns.** The
   `append_only` flag skips DELETE tracking in the change buffer — only
   use it when the source truly never updates or deletes.
+
+### When NOT to use this pattern
+
+- Your event log is consumed and processed in real time by application
+  code — a stream table adds latency without benefit.
+- You need strict per-event ordering guarantees within a transaction —
+  use `IMMEDIATE` mode with a single-row projection instead.
+- Your events are multi-gigabyte payloads — stream tables replicate the
+  whole row; store only metadata in the event log, not the payload.
 
 ---
 
@@ -232,6 +249,16 @@ SELECT pgtrickle.create_stream_table(
 - **Don't forget to index `valid_to IS NULL` for SCD-2 sources.** Without
   it, the delta scan touches all historical rows.
 
+### When NOT to use this pattern
+
+- You already have a purpose-built slowly-changing-dimension ETL tool
+  (e.g. dbt snapshots) — pg_trickle's SCD support is complementary,
+  not a replacement, and duplicate ownership creates confusion.
+- Your dimension table changes every row on every load — DIFFERENTIAL
+  offers no benefit; use FULL refresh or rethink the source update pattern.
+- You need Type 3 (add-a-column) or Type 6 SCD — those require schema
+  evolution that pg_trickle does not automate today.
+
 ---
 
 ## Pattern 4: High-Fan-Out Topology
@@ -298,6 +325,15 @@ SELECT pgtrickle.create_stream_table('top_customers',
   If `daily_totals` and `by_region` must agree, give them the same
   schedule or use `diamond_consistency => 'atomic'`.
 
+### When NOT to use this pattern
+
+- You only have one or two downstream stream tables — the fan-out
+  pattern adds planning overhead that isn't justified below ~4 targets.
+- Downstream queries have incompatible refresh modes (e.g. one needs
+  IMMEDIATE, another needs FULL) — prefer separate source tables.
+- All downstream STs will always be queried together — a single
+  wider stream table may be simpler and faster.
+
 ---
 
 ## Pattern 5: Real-Time Dashboards
@@ -350,6 +386,17 @@ SELECT pgtrickle.create_stream_table(
   pooling drops temp tables between transactions; enable this flag to
   avoid stale PREPARE statements.
 
+### When NOT to use this pattern
+
+- The data source itself is the bottleneck (slow sensors, infrequent
+  API polling) — a sub-second schedule on a stream table that changes
+  once a minute burns CPU for nothing.
+- You need consistency across several related tiles — schedule them
+  together or use a single wider query rather than sub-second individual
+  refreshes that can transiently disagree.
+- Write throughput exceeds ~5,000 rows/s — IMMEDIATE mode adds latency
+  to every write; profile with `pg_trickle.latency_percentiles()` first.
+
 ---
 
 ## Pattern 6: Tiered Refresh Strategy
@@ -383,6 +430,16 @@ SELECT pgtrickle.alter_stream_table('audit_log_summary', tier => 'frozen');
 | warm   | 2x                 | Hourly reports, batch pipelines    |
 | cold   | 10x                | Daily analytics, low-priority STs  |
 | frozen | skip               | Paused/archived, manual refresh    |
+
+### When NOT to use this pattern
+
+- All your stream tables are equally critical — don't introduce
+  tier complexity just to have tiers; use a flat schedule instead.
+- Your scheduler runs with a single worker — tiering helps multi-worker
+  scheduling; it has no effect when `max_workers = 1`.
+- Tier multipliers change too frequently — tier is a static property;
+  if freshness requirements change continuously, use SLA scheduling
+  (`pg_trickle.sla_scheduling`) instead.
 
 ---
 
@@ -621,6 +678,16 @@ pg_trickle.consumer_cleanup_enabled = true
 - **Long processing without heartbeats:** Call `consumer_heartbeat()` every 10–15
   seconds for long-running processing to avoid being marked dead.
 
+### When NOT to use this pattern
+
+- You only need to expose stream table changes to a single application that
+  reads directly from PostgreSQL — a NOTIFY/LISTEN trigger or change table
+  is simpler than a full outbox.
+- Delivery guarantees are not required (analytics, dashboards) — the overhead
+  of consumer groups and offset tracking is not justified.
+- Your stream table refreshes every few seconds and consumers can tolerate
+  a few seconds of lag — just poll the stream table directly.
+
 ---
 
 ## Pattern 8: Transactional Inbox (v0.28.0)
@@ -731,6 +798,17 @@ pg_trickle.inbox_dlq_alert_max_per_refresh = 10   # alert on DLQ growth
   Producers must supply stable, unique `event_id` values — typically a UUID
   derived from the source event.
 
+### When NOT to use this pattern
+
+- Message volume is very high (>10,000/s) — the inbox table becomes a hot
+  bottleneck; consider a dedicated message queue (Kafka, NATS) fronting
+  a batch INSERT into the inbox.
+- Processing is purely stateless and idempotency is guaranteed by the
+  producer — writing to an inbox and querying `_pending` adds latency
+  without benefit over direct INSERT + trigger.
+- The event source already provides at-least-once with dedup — a second
+  layer of dedup in the inbox wastes storage.
+
 ---
 
 ## Pattern 9: Bidirectional Event Pipeline with Relay (v0.29.0)
@@ -836,3 +914,25 @@ at `:9090/health`.
 | `pgtrickle_relay_pipelines_owned` | Pipelines owned by this instance |
 
 See [RELAY.md](RELAY.md) for the full deployment guide.
+
+### When NOT to use this pattern
+
+- Your consumers run inside the same PostgreSQL database — use the outbox
+  pattern (Pattern 7) directly instead of adding a relay binary.
+- You only have one external system to integrate — a simple application
+  polling `poll_outbox()` is easier to operate than a standalone relay
+  process.
+- Your team does not want to operate an additional binary — the relay is
+  a Rust process with its own monitoring requirements; if that's a
+  burden, consider a managed connector (e.g. Debezium + publications).
+
+---
+
+**See also:**
+[Use Cases](USE_CASES.md) ·
+[Performance Cookbook](PERFORMANCE_COOKBOOK.md) ·
+[SQL Reference](SQL_REFERENCE.md) ·
+[Tutorials: What Happens on INSERT](tutorials/WHAT_HAPPENS_ON_INSERT.md) ·
+[Outbox Pattern](OUTBOX.md) ·
+[Inbox Pattern](INBOX.md) ·
+[Relay Guide](RELAY_GUIDE.md)

--- a/docs/RELAY.md
+++ b/docs/RELAY.md
@@ -1,5 +1,34 @@
 # pgtrickle-relay — Architecture & Operations Guide
 
+## What is the relay? Do I need it?
+
+`pgtrickle-relay` is an optional standalone binary that bridges
+pg_trickle's outbox and inbox tables to external messaging systems:
+NATS JetStream, Kafka, HTTP webhooks, Redis Streams, SQS, and
+RabbitMQ.
+
+**You need the relay when:**
+- You want stream table deltas to flow automatically to a message queue
+  or event bus (Kafka, NATS, …) without application-level polling code.
+- You receive events from an external system and need them in PostgreSQL
+  reliably and idempotently.
+- You want high-availability message delivery with automatic failover
+  (the relay uses advisory locks to elect one active instance per
+  pipeline group).
+
+**You do NOT need the relay when:**
+- Your consumers read directly from PostgreSQL (they can call
+  `pgtrickle.poll_outbox()` themselves).
+- You only need PostgreSQL-to-PostgreSQL replication (use logical
+  replication or publications instead).
+- You are still evaluating pg_trickle — start with the outbox/inbox
+  pattern first; add the relay binary later if you need external delivery.
+
+> The relay is a separate workspace member in `pgtrickle-relay/`.
+> For the user-facing pattern guide see [Pattern 9: Relay](PATTERNS.md#pattern-9-bidirectional-event-pipeline-with-relay-v0290).
+
+---
+
 `pgtrickle-relay` is a standalone Rust CLI binary that bridges pg-trickle
 outbox/inbox tables with external messaging systems.
 

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -357,3 +357,13 @@ dashboards can filter by database without requiring separate scrape targets:
 ```promql
 rate(pg_trickle_refreshes_total{db_name="tenant_a"}[5m])
 ```
+
+---
+
+**See also:**
+[Capacity Planning](CAPACITY_PLANNING.md) ·
+[Configuration](CONFIGURATION.md) ·
+[Multi-Database Deployments](MULTI_DATABASE.md) ·
+[Performance Cookbook](PERFORMANCE_COOKBOOK.md) ·
+[Cost Model](COST_MODEL.md) ·
+[Pre-Deployment Checklist](PRE_DEPLOYMENT.md)

--- a/docs/SQL_REFERENCE.md
+++ b/docs/SQL_REFERENCE.md
@@ -4893,5 +4893,15 @@ running relay instances hot-reload their pipelines without restart.
 - **Minor releases** (0.X.0): New features. Stable API preserved; unstable surfaces may change. Breaking changes to stable API only with a deprecation cycle (WARNING for one release, removal in the next).
 - **Major release** (1.0.0): Stable API locked. Breaking changes require a major version bump.
 
+---
+
+**See also:**
+[Configuration](CONFIGURATION.md) ·
+[Patterns](PATTERNS.md) ·
+[Performance Cookbook](PERFORMANCE_COOKBOOK.md) ·
+[Error Reference](ERRORS.md) ·
+[Glossary](GLOSSARY.md) ·
+[FAQ](FAQ.md)
+
 
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -762,3 +762,13 @@ When investigating any issue, follow this sequence:
 | `pg_trickle.auto_backoff` | `on` | Stretches intervals up to 8x under load |
 | `pg_trickle.frontier_holdback_mode` | `xmin` | `none` disables holdback (unsafe); `xmin` = safe default |
 | `pg_trickle.frontier_holdback_warn_seconds` | `60` | Warn after holding back for this many seconds |
+
+---
+
+**See also:**
+[Error Reference](ERRORS.md) ·
+[Configuration](CONFIGURATION.md) ·
+[FAQ](FAQ.md) ·
+[Pre-Deployment Checklist](PRE_DEPLOYMENT.md) ·
+[Capacity Planning](CAPACITY_PLANNING.md) ·
+[CDC Modes](CDC_MODES.md)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,1 +1,4 @@
+> **Viewing on GitHub?** The rendered changelog lives in [CHANGELOG.md](../CHANGELOG.md).
+> This stub is served by the [pg_trickle docs site](https://grove.github.io/pg-trickle/) — the include below renders there.
+
 {{#include ../CHANGELOG.md}}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,1 +1,4 @@
+> **Viewing on GitHub?** The contributing guide lives in [CONTRIBUTING.md](../CONTRIBUTING.md).
+> This stub is served by the [pg_trickle docs site](https://grove.github.io/pg-trickle/) — the include below renders there.
+
 {{#include ../CONTRIBUTING.md}}

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,1 +1,4 @@
+> **Viewing on GitHub?** The installation guide lives in [INSTALL.md](../INSTALL.md).
+> This stub is served by the [pg_trickle docs site](https://grove.github.io/pg-trickle/) — the include below renders there.
+
 {{#include ../INSTALL.md}}

--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -1,1 +1,49 @@
+# dbt-pgtrickle
+
+**dbt-pgtrickle** is the official dbt adapter for pg_trickle. It lets
+you define stream tables as dbt models using standard `{{ config() }}`
+blocks, manage them through `dbt run` / `dbt build`, and run
+incremental refreshes as part of your dbt pipeline.
+
+## Quick example
+
+```sql
+-- models/orders_agg.sql
+{{ config(
+    materialized = 'stream_table',
+    schedule     = '5m',
+    refresh_mode = 'DIFFERENTIAL'
+) }}
+
+SELECT customer_id,
+       COUNT(*)         AS order_count,
+       SUM(amount)      AS total_spent
+FROM {{ ref('orders') }}
+GROUP BY customer_id
+```
+
+Run it:
+
+```bash
+dbt run --select orders_agg
+```
+
+The model is created as a stream table and refreshed automatically.
+Subsequent `dbt run` invocations update the defining query if it changed
+(via `ALTER QUERY`), without dropping and recreating the table.
+
+## Installation
+
+```bash
+pip install dbt-pgtrickle
+```
+
+Requires dbt-postgres 1.7+ and pg_trickle v0.30+.
+
+> The full configuration reference, supported materializations, macros,
+> testing guide, and CI setup are in the
+> [dbt-pgtrickle README](../../dbt-pgtrickle/README.md).
+
+---
+
 {{#include ../../dbt-pgtrickle/README.md}}

--- a/docs/research/CUSTOM_SQL_SYNTAX.md
+++ b/docs/research/CUSTOM_SQL_SYNTAX.md
@@ -1,1 +1,12 @@
+# Research: Custom SQL Syntax Options
+
+This document surveys custom-syntax extensions considered for pg_trickle
+(e.g. `CREATE STREAM TABLE`) and the tradeoffs against the
+current function-based API (`pgtrickle.create_stream_table()`). It is
+intended for contributors and language/parser research.
+
+> **User documentation** on SQL functions is in [SQL Reference](../SQL_REFERENCE.md).
+
+---
+
 {{#include ../../plans/sql/REPORT_CUSTOM_SQL_SYNTAX.md}}

--- a/docs/research/PG_IVM_COMPARISON.md
+++ b/docs/research/PG_IVM_COMPARISON.md
@@ -1,1 +1,14 @@
+# Research: pg_ivm Comparison
+
+This document is a detailed technical comparison between pg_trickle
+and [pg_ivm](https://github.com/sraoss/pg_ivm) covering supported
+SQL features, refresh latency, and operational differences. It is
+research material for contributors and evaluators performing a
+deep-dive comparison.
+
+> **Quick comparison table** (pg_trickle vs pg_ivm and other systems) is
+> in [Comparisons](../COMPARISONS.md).
+
+---
+
 {{#include ../../plans/ecosystem/GAP_PG_IVM_COMPARISON.md}}

--- a/docs/research/TRIGGERS_VS_REPLICATION.md
+++ b/docs/research/TRIGGERS_VS_REPLICATION.md
@@ -1,1 +1,11 @@
+# Research: Triggers vs. WAL Replication for CDC
+
+This document analyses the architectural tradeoffs between trigger-based
+CDC (pg_trickle's default) and WAL logical-replication CDC. It provides
+the engineering rationale behind ADR-001 and ADR-002.
+
+> **User-facing CDC documentation** is in [CDC Modes](../CDC_MODES.md).
+
+---
+
 {{#include ../../plans/sql/REPORT_TRIGGERS_VS_REPLICATION.md}}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,1 +1,4 @@
+> **Viewing on GitHub?** The roadmap lives in [ROADMAP.md](../ROADMAP.md).
+> This stub is served by the [pg_trickle docs site](https://grove.github.io/pg-trickle/) — the include below renders there.
+
 {{#include ../ROADMAP.md}}

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,1 +1,8 @@
+> **Looking for the user security guide?** See [Security Guide](SECURITY_GUIDE.md) for roles,
+> grants, RLS interaction, SECURITY DEFINER semantics, and hardening checklists.
+>
+> This page contains the project's vulnerability-reporting policy. The rendered
+> version is served by the [pg_trickle docs site](https://grove.github.io/pg-trickle/);
+> on GitHub the source is [SECURITY.md](../SECURITY.md).
+
 {{#include ../SECURITY.md}}

--- a/docs/tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md
+++ b/docs/tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md
@@ -4,6 +4,22 @@ This guide shows how to incrementally migrate existing PostgreSQL
 `MATERIALIZED VIEW` + manual `REFRESH` workflows to pg_trickle stream
 tables.
 
+## Coming from a different background?
+
+The step-by-step guide below covers the PostgreSQL materialized view path.
+If you are migrating from a different system, start here:
+
+| You are migrating from | Jump to |
+|---|---|
+| PostgreSQL `MATERIALIZED VIEW` + `REFRESH` | This guide |
+| `pg_ivm` | [Migrating from pg_ivm](MIGRATING_FROM_PG_IVM.md) |
+| Cron-based `REFRESH` (`pg_cron`, OS cron) | [Step 6 — Remove external refresh jobs](#6-remove-external-refresh-jobs) |
+| Application-level refresh (manual SQL in code) | [Step 2 — Create the stream table](#2-create-the-stream-table) |
+| Debezium + Materialize / RisingWave | Port your queries to PostgreSQL SQL, then follow this guide. See [Comparisons](../COMPARISONS.md) for feature mapping. |
+| Looker PDTs (Persistent Derived Tables) | PDTs map closely to stream tables. Translate the PDT SQL to a `create_stream_table()` call; the schedule replaces the PDT caching strategy. |
+| Snowflake Dynamic Tables | The concepts are nearly identical. Map `TARGET_LAG` to a pg_trickle `schedule`; `DOWNSTREAM` is `schedule => 'calculated'`. See [Comparisons](../COMPARISONS.md). |
+| Homemade ETL pipeline (INSERT ... SELECT) | Replace the periodic ETL job with a stream table using the same SELECT query. |
+
 ## Why Migrate?
 
 | | Materialized View | Stream Table |


### PR DESCRIPTION
# docs: fix remaining plan gaps from PLAN_DOCUMENTATION_GAPS_1

Follow-up to #669 implementing the remaining items from
`plans/PLAN_DOCUMENTATION_GAPS_1.md` that were not in the first PR.

## Summary

The first documentation rework PR (#669) implemented the high-leverage
structural changes (14 new docs, 8-chapter SUMMARY, persona routing,
etc.). This PR closes the remaining ~20 items from the plan, covering
stub files, per-doc polish, and cross-cutting conventions.

## Changes

### Fix 9 stub files (§4.2)

All nine `{{#include …}}` stubs now have readable content on GitHub:

- `docs/changelog.md`, `contributing.md`, `installation.md`,
  `roadmap.md`, `security.md` — GitHub-readable banner pointing to the
  canonical source file, followed by the mdBook include.
- `docs/security.md` — also links to the new `SECURITY_GUIDE.md`.
- `docs/integrations/dbt.md` — inline quick-start (install + minimal
  SQL model + `dbt run`) before the include of the full README.
- `docs/research/CUSTOM_SQL_SYNTAX.md`, `PG_IVM_COMPARISON.md`,
  `TRIGGERS_VS_REPLICATION.md` — research-context intro paragraph +
  link to the user-facing equivalent page.

### "When NOT to use this pattern" (§9.8, §12.B.19)

Added to all nine patterns in `docs/PATTERNS.md`. Each entry gives
2–3 concrete conditions under which the pattern is the wrong choice,
consistent with the plan's goal of honest, practical guidance.

### "Tuning by goal" section (§9.5)

Added a quick-reference table at the top of `docs/CONFIGURATION.md`
with eight goal-oriented rows (lower latency, reduce write overhead,
larger DAGs, pooler compatibility, lower memory, cost-model accuracy,
WAL CDC, prevent runaway ST) mapping each goal to the relevant GUCs.

### "By environment" decision tree (§9.19)

Added a five-row decision table at the top of `INSTALL.md` mapping
environment (local dev, self-hosted Linux, macOS dev, Kubernetes/CNPG,
managed Postgres) to the recommended installation path.

### Relay "What is it?" intro (§6.6)

Added a "What is the relay? Do I need it?" section at the top of
`docs/RELAY.md` with "you need it when" / "you do NOT need it when"
bullets, linking to Pattern 9 for the user-facing guide.

### Migration paths table (§6.9)

Added a "Coming from a different background?" table at the top of
`docs/tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md` listing eight
migration origins (pg_ivm, cron, app-level refresh, Debezium + Materialize,
Looker PDTs, Snowflake Dynamic Tables, homemade ETL) with jump links.

### Documentation policy in CONTRIBUTING.md (§12.C.23)

Added a "Documentation Policy" section making explicit that every new
`#[pg_extern]` function, GUC, or user-facing capability must ship with
documentation. Specifies where each type of doc goes and how to add it
to SUMMARY.md.

### "See also:" footers (§8.3)

Added `See also:` sections to:

- `docs/TROUBLESHOOTING.md` → Errors, Config, FAQ, Pre-Deployment, Capacity, CDC
- `docs/SCALING.md` → Capacity Planning, Config, Multi-DB, Cookbook, Cost Model, Pre-Deployment
- `docs/PATTERNS.md` → Use Cases, Cookbook, SQL Ref, Tutorials, Outbox, Inbox, Relay
- `docs/SQL_REFERENCE.md` → Config, Patterns, Cookbook, Errors, Glossary, FAQ
- `docs/FAQ.md` → Troubleshooting, Errors, Config, SQL Ref, Glossary

### Test-count drift fix (§6.11, §10.1)

Replaced the stale hard-coded "~1,670 unit / ~1,340 E2E / ~140 TUI" count
in `README.md` with a pointer to CI as the source of truth.

## Testing

Docs-only change. No tests affected.

Manual checks:
- All 9 stub files now render meaningful content on GitHub (no bare
  `{{#include …}}` visible).
- PATTERNS.md has `When NOT to use` for all 9 patterns.
- CONFIGURATION.md "Tuning by goal" table appears before the TOC.
- INSTALL.md decision tree appears before Prerequisites.
- RELAY.md intro appears before the Architecture section.
- MIGRATING_FROM_MATERIALIZED_VIEWS.md has the migration paths table
  before "Why Migrate?".
- CONTRIBUTING.md has "Documentation Policy" before the License section.

## Notes

- No `.control`, `.sql`, or extension-version changes.
- No new docs files created — all changes are additions to existing files.
- The `META.json` and `scripts/check_version_sync.sh` changes from the
  original pre-squash branch have been excluded (already correct in main
  via PR #668).
