### PR TITLE
roadmap(v0.38-v0.39): add relay Phase 2 — cloud backends and operational excellence

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,6 +83,8 @@
 | [v0.35.0](roadmap/v0.35.0.md) | EC-01 correctness closeout, Citus chaos hardening, reactive subscriptions, zero-downtime schema changes | Released | Large | [Full details](roadmap/v0.35.0.md-full.md) |
 | [v0.36.0](roadmap/v0.36.0.md) | Structural hardening, L0 cache, WAL backpressure, temporal IVM, columnar storage | Planned | Large | [Full details](roadmap/v0.36.0.md-full.md) |
 | [v0.37.0](roadmap/v0.37.0.md) | Scheduler modularisation, pgVectorMV, OpenTelemetry trace propagation | Planned | Medium | [Full details](roadmap/v0.37.0.md-full.md) |
+| [v0.38.0](roadmap/v0.38.0.md) | Relay Phase 2a+2b — GCP Pub/Sub, Kinesis, Azure Service Bus, Elasticsearch, MQTT, Event Hubs, S3/GCS/Blob, ClickHouse | Planned | Large | [Full details](roadmap/v0.38.0.md-full.md) |
+| [v0.39.0](roadmap/v0.39.0.md) | Relay Phase 2c — DLQ, schema registry, JMESPath transforms, routing, rate limiting, circuit breaker, OTel, webhook sig | Planned | Large | [Full details](roadmap/v0.39.0.md-full.md) |
 
 ### Beyond v1.0
 
@@ -129,6 +131,10 @@ v0.36    ─── L0 cache, WAL backpressure, api split, temporal IVM, columnar
     │
 v0.37    ─── Scheduler split, pgVectorMV, OpenTelemetry, pg_partman compat
     │
+v0.38    ─── Relay Phase 2a+2b: GCP, Kinesis, Azure, Elasticsearch, MQTT, S3, ClickHouse
+    │
+v0.39    ─── Relay Phase 2c: DLQ, schema registry, transforms, routing, rate limit, OTel
+    │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries
 ```
 
@@ -150,4 +156,11 @@ performance hardening (L0 cache, WAL backpressure), structural refactoring
 (`src/api/mod.rs` split, `RowIdSchema` type), and temporal IVM / columnar
 storage. v0.37.0 completes the modularisation arc (scheduler and merge splits),
 adds pgVectorMV for AI/RAG workloads, and threads OpenTelemetry traces through
-the refresh pipeline.
+the refresh pipeline. v0.38.0 broadens the relay backend catalogue with eight
+new sinks and sources: GCP Pub/Sub, Amazon Kinesis, Azure Service Bus,
+Elasticsearch/OpenSearch, MQTT v5, Azure Event Hubs, object storage
+(S3/GCS/Azure Blob), and ClickHouse. v0.39.0 completes the relay Phase 2 plan
+with ten production-grade operational features: dead-letter queues, schema
+registry, JMESPath transforms, content-based routing, rate limiting, circuit
+breakers, SIGHUP reload, dry-run/replay, OpenTelemetry tracing, and webhook
+signature verification.

--- a/roadmap/v0.37.0.md
+++ b/roadmap/v0.37.0.md
@@ -97,4 +97,4 @@ no impact on existing stream tables.
 ---
 
 *Previous: [v0.36.0 — Structural Hardening, Performance & Temporal IVM](v0.36.0.md)*
-*Next: [v1.0.0 — Stable Release](../roadmap/v1.0.0.md-full.md)*
+*Next: [v0.38.0 — Relay Phase 2a+2b: Cloud & Analytics Backends](v0.38.0.md)*

--- a/roadmap/v0.38.0.md
+++ b/roadmap/v0.38.0.md
@@ -1,0 +1,88 @@
+# v0.38.0 — Relay Phase 2a+2b: Cloud & Analytics Backends
+
+> **Full technical details:** [v0.38.0.md-full.md](v0.38.0.md-full.md)
+
+**Status: Planned** | **Scope: Large**
+
+> Eight new relay backends covering the three major cloud platforms, IoT,
+> search, analytics databases, and data lake object storage — making
+> pg_trickle's relay the most complete CDC connector for PostgreSQL.
+
+---
+
+## What is this?
+
+v0.38.0 delivers the backend half of the relay Phase 2 plan
+([plans/relay/PLAN_RELAY_CLI_PHASE_2.md](../plans/relay/PLAN_RELAY_CLI_PHASE_2.md)).
+Phase 1 shipped eight sinks and seven sources (v0.29.0). Phase 2a+2b adds
+eight more backends, closing the gap with every major cloud messaging platform,
+the IoT ecosystem, search engines, analytics databases, and data lake storage.
+
+---
+
+## New sink and source backends
+
+### Cloud provider parity (Phase 2a)
+
+- **Google Cloud Pub/Sub** (sink + source) — the primary managed messaging
+  service on GCP. Pull subscriptions with `pgt_dedup_key` attribute, ordering
+  key support, and emulator-compatible configuration.
+
+- **Amazon Kinesis Data Streams** (sink + source) — AWS's high-throughput
+  ordered streaming platform. `PutRecords` batching with KPL-compatible
+  aggregation; consumer side uses `GetShardIterator` + `GetRecords` with
+  PostgreSQL-backed checkpoints.
+
+- **Azure Service Bus** (sink + source) — the primary enterprise messaging
+  service on Azure. `PeekLock` receive mode with native `MessageId` dedup;
+  sessions, topics, and subscriptions all supported.
+
+- **Elasticsearch / OpenSearch** (sink only) — bulk API with upsert-by-id
+  semantics for CDC events. Full-refresh batches use atomic alias rotation
+  (create timestamped index → bulk load → swap alias → delete old index).
+
+### IoT, analytics & data lake (Phase 2b)
+
+- **Azure Event Hubs** (sink + source) — native Azure SDK (better identity
+  integration than the Kafka protocol path). Partition checkpoints stored in
+  PostgreSQL.
+
+- **MQTT v5** (sink + source) — bridges pg_trickle stream tables to IoT device
+  telemetry. QoS 0/1/2, TLS, and configurable topic templates. Enables
+  device-data-to-analytics pipelines without a separate ETL layer.
+
+- **Object Storage — S3 / GCS / Azure Blob** (sink only) — JSONL and Parquet
+  output for data lake integration. Compatible with Spark, dbt, Trino,
+  DuckDB, and any other tool that reads object storage. Configurable file
+  rolling by time or size.
+
+- **ClickHouse** (sink only) — HTTP-based bulk insert targeting
+  `ReplacingMergeTree` tables. Full-refresh batches use a staged-insert
+  + `OPTIMIZE TABLE FINAL` swap. Ideal for real-time OLAP over pg_trickle
+  stream tables.
+
+---
+
+## Testing
+
+Each backend ships with:
+
+- **Testcontainers integration tests** — real service (or emulator) launched
+  per test: Pub/Sub emulator, LocalStack (Kinesis + S3), Elasticsearch Docker,
+  MQTT Mosquitto, MinIO, ClickHouse.
+- **Unit tests** — sink/source configuration parsing and error path coverage.
+- **Benchmarks** — throughput and latency overhead vs. the stdout no-op sink.
+
+---
+
+## Scope
+
+v0.38.0 is a large release — roughly 16.5 days of implementation work across
+eight backends. The pluggable sink architecture introduced in v0.36.0 provides
+the foundation that makes each backend a self-contained cargo feature flag with
+no coupling to other backends.
+
+---
+
+*Previous: [v0.37.0 — Scheduler Modularisation, pgVectorMV & OpenTelemetry](v0.37.0.md)*
+*Next: [v0.39.0 — Relay Phase 2c: Operational Excellence](v0.39.0.md)*

--- a/roadmap/v0.38.0.md-full.md
+++ b/roadmap/v0.38.0.md-full.md
@@ -1,0 +1,225 @@
+> **Plain-language companion:** [v0.38.0.md](v0.38.0.md)
+
+## v0.38.0 — Relay Phase 2a+2b: Cloud & Analytics Backends
+
+**Status: Planned.** Derived from [plans/relay/PLAN_RELAY_CLI_PHASE_2.md](../plans/relay/PLAN_RELAY_CLI_PHASE_2.md) Parts A and C (backend items).
+
+> **Release Theme**
+> v0.38.0 delivers Phase 2a (cloud provider parity) and Phase 2b (IoT,
+> analytics & data lake) of the relay plan: eight new sink/source backends
+> that cover GCP Pub/Sub, Amazon Kinesis, Azure Service Bus, Azure Event
+> Hubs, Elasticsearch/OpenSearch, MQTT v5, object storage (S3/GCS/Blob),
+> and ClickHouse.
+
+---
+
+### Backend items
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| RELAY-P2-1 | Sink + Source: Google Cloud Pub/Sub | 2d | P1 |
+| RELAY-P2-2 | Sink + Source: Amazon Kinesis Data Streams | 2.5d | P1 |
+| RELAY-P2-3 | Sink + Source: Azure Service Bus | 2d | P1 |
+| RELAY-P2-4 | Sink: Elasticsearch / OpenSearch | 2.5d | P1 |
+| RELAY-P2-5 | Sink + Source: MQTT v5 | 1.5d | P2 |
+| RELAY-P2-6 | Sink + Source: Azure Event Hubs (native SDK) | 1.5d | P2 |
+| RELAY-P2-7 | Sink: Object Storage (S3 / GCS / Azure Blob) with JSONL + Parquet | 3d | P2 |
+| RELAY-P2-8 | Sink: ClickHouse (HTTP, ReplacingMergeTree support) | 1.5d | P2 |
+
+**Deferred to Phase 3:** Apache Pulsar (RELAY-P2-9) and Arrow Flight / gRPC
+(RELAY-P2-10) — lower demand; deferred per the plan's priority matrix.
+
+---
+
+### RELAY-P2-1 — Google Cloud Pub/Sub
+
+**Crate:** `google-cloud-pubsub`
+
+**Sink** — publishes one Pub/Sub message per relay envelope.
+- `project_id`, `topic` (or `topic_template = "pgtrickle.{stream_table}"`)
+- Ordering key support via `ordering_key_template`
+- Dedup: `pgt_dedup_key` Pub/Sub message attribute
+- Credentials: `GOOGLE_APPLICATION_CREDENTIALS` or explicit `credentials_file`
+- Emulator: `endpoint = "localhost:8085"`
+- Batching: `batch_max_messages` (default 1 000), `batch_max_bytes` (default 10 MiB)
+
+**Source** — pull subscription consumer.
+- `project_id`, `subscription`
+- Ack-on-commit: messages acknowledged only after successful inbox write
+- Nacked messages redelivered after ack deadline
+- Dedup key: `pgt_dedup_key` attribute if present; otherwise Pub/Sub `message_id`
+
+**Tests:** Pub/Sub emulator (`google/cloud-sdk`) in Testcontainers.
+
+---
+
+### RELAY-P2-2 — Amazon Kinesis Data Streams
+
+**Crate:** `aws-sdk-kinesis`
+
+**Sink** — `PutRecords` batching.
+- `stream_name`, `region`
+- `partition_key_template` (default `{stream_table}`)
+- `batch_size` up to 500 records per `PutRecords` call
+- KPL-compatible aggregation (`aggregation = true`)
+- Dedup: `pgt_dedup_key` field in record data (consumer-side dedup required)
+
+**Source** — `GetShardIterator` + `GetRecords` polling.
+- `iterator_type`: `TRIM_HORIZON` | `LATEST` | `AT_TIMESTAMP`
+- Checkpoints stored in a PostgreSQL table (`pgtrickle_kinesis_checkpoints`)
+- Handles shard splits and merges transparently
+
+**Tests:** LocalStack in Testcontainers.
+
+---
+
+### RELAY-P2-3 — Azure Service Bus
+
+**Crate:** `azure_messaging_servicebus`
+
+**Sink** — batch send to queue or topic.
+- `connection_string` or managed-identity (`namespace` + Azure workload identity)
+- `queue_or_topic`, optional `session_id`
+- `message_ttl_seconds`, `batch_size`
+- Dedup: native `MessageId` = dedup key (requires `RequiresDuplicateDetection` on queue)
+
+**Source** — `PeekLock` consumer.
+- `queue_or_topic`, optional `subscription` (for topic subscriptions)
+- Messages completed only after successful inbox write
+- Abandoned messages returned to queue for redelivery
+
+**Tests:** Azure Service Bus emulator (limited) or dedicated test namespace.
+
+---
+
+### RELAY-P2-4 — Elasticsearch / OpenSearch
+
+**Crate:** `elasticsearch` (official) — same code path for OpenSearch via `flavor = "opensearch"`
+
+**Sink only.**
+- `url`, `index_template` (e.g. `"pgtrickle-{stream_table}"`)
+- Optional date-pattern suffix for monthly/daily indices
+- `doc_id_template` sets Elasticsearch `_id` for upserts
+- Bulk API: `bulk_max_actions` (default 1 000), `bulk_max_bytes` (default 5 MiB)
+- `refresh_policy`: `false` | `true` | `wait_for`
+
+**Operations mapping:**
+- `op = "insert"` / `op = "update"` → `index` (upsert by `_id`)
+- `op = "delete"` → `delete` (by `_id`)
+- `is_full_refresh = true` → atomic alias rotation:
+  1. Create timestamped index
+  2. Bulk-index all rows
+  3. Swap alias atomically (`POST _aliases`)
+  4. Delete old index
+
+**Tests:** Elasticsearch 8.x Docker image in Testcontainers.
+
+---
+
+### RELAY-P2-5 — MQTT v5
+
+**Crate:** `rumqttc`
+
+**Sink** — publish per relay message.
+- `url` (`mqtt://` or `mqtts://`), `topic_template`
+- `qos`: 0 (at-most-once), 1 (at-least-once, default), 2 (exactly-once)
+- `retain`, `username`, `password`, TLS (`tls_ca`, `tls_cert`, `tls_key`)
+- MQTT v5 user property `pgt_dedup_key` set on each message
+
+**Source** — subscribe with MQTT topic filter (supports `+` and `#` wildcards).
+- `qos`, `clean_start = false` for persistent offline sessions
+- Messages processed on arrival; QoS 1+ broker retransmits on timeout
+
+**Use-cases:** IoT device telemetry → pg_trickle inbox → stream table analytics.
+
+**Tests:** Mosquitto 2.x Docker image in Testcontainers.
+
+---
+
+### RELAY-P2-6 — Azure Event Hubs (native SDK)
+
+**Crate:** `azure_messaging_eventhubs`
+
+**Sink + Source** — native SDK for better Azure identity and diagnostics
+integration. Kafka-protocol path is documented as an alternative (reuse
+existing Kafka sink/source with Event Hubs connection details).
+
+**Sink:**
+- `connection_string` or managed identity, `event_hub_name`
+- `partition_key_template`, `batch_max_bytes` (1 MiB)
+
+**Source:**
+- `consumer_group` (default `$Default`)
+- Partition ownership and checkpointing stored in PostgreSQL
+- `starting_position`: `earliest` | `latest`
+
+**Tests:** LocalStack or Azure Event Hubs emulator.
+
+---
+
+### RELAY-P2-7 — Object Storage (S3 / GCS / Azure Blob)
+
+**Crates:** `aws-sdk-s3`, `google-cloud-storage`, `azure_storage_blobs`
+
+**Sink only.**
+- `provider`: `s3` | `gcs` | `azure-blob`
+- `bucket`, `prefix` (e.g. `"pgtrickle/{stream_table}"`)
+- `format`: `jsonl` (default) | `parquet`
+- File rolling: `roll_every_seconds` (default 300) and/or `roll_every_bytes` (default 128 MiB)
+- `compression`: `none` | `gzip` | `zstd`
+- Partition layout: `{stream_table}/year={Y}/month={M}/day={D}/hour={H}/`
+
+**Full-refresh handling:** emits a manifest file (`_FULL_REFRESH_{refresh_id}.manifest`)
+so downstream consumers (Spark, dbt, Trino) can distinguish deltas from snapshots.
+
+**Tests:** MinIO (S3-compatible) in Testcontainers.
+
+---
+
+### RELAY-P2-8 — ClickHouse
+
+**Crate:** `clickhouse` (HTTP client)
+
+**Sink only.**
+- `url`, `database`, `table_template`
+- `engine`: `ReplacingMergeTree` (default) | `MergeTree`
+- HTTP bulk insert: `batch_size` (default 10 000 rows)
+- `compression`: `lz4` (default) | `none`
+- Auth: `username`, `password` or X-ClickHouse-Key header
+
+**Full-refresh handling:** staged insert into a shadow table +
+`INSERT INTO target SELECT * FROM shadow` swap + `OPTIMIZE TABLE FINAL`.
+
+**Tests:** ClickHouse official Docker image in Testcontainers.
+
+---
+
+### Testing strategy (RELAY-P2-23)
+
+All eight backends have Testcontainers-based integration tests in
+`tests/relay_p2_backends_tests.rs`:
+
+| Backend | Test infrastructure |
+|---------|-------------------|
+| GCP Pub/Sub | `google/cloud-sdk` emulator |
+| Kinesis | LocalStack |
+| Azure Service Bus | Dedicated test namespace (or emulator) |
+| Elasticsearch | `elasticsearch:8` Docker image |
+| MQTT | `eclipse-mosquitto:2` Docker image |
+| Event Hubs | LocalStack (Kafka protocol) |
+| Object Storage | MinIO Docker image |
+| ClickHouse | `clickhouse/clickhouse-server` Docker image |
+
+Benchmarks (`benches/relay_backends_bench.rs`) measure throughput and
+latency overhead for each backend vs. the stdout no-op sink.
+
+---
+
+### Effort summary
+
+| Phase | Items | Effort |
+|-------|-------|--------|
+| 2a — Cloud Provider Parity | 4 | 9d |
+| 2b — IoT, Analytics & Data Lake | 4 | 7.5d |
+| Testing & benchmarks | — | 3d |
+| **Total** | **8 backends** | **~19.5d** |

--- a/roadmap/v0.39.0.md
+++ b/roadmap/v0.39.0.md
@@ -1,0 +1,133 @@
+# v0.39.0 — Relay Phase 2c: Operational Excellence
+
+> **Full technical details:** [v0.39.0.md-full.md](v0.39.0.md-full.md)
+
+**Status: Planned** | **Scope: Large**
+
+> Ten production-grade operational features that make the relay safe at scale:
+> dead-letter queues, schema registry, JMESPath transforms, content-based
+> routing, rate limiting, circuit breakers, SIGHUP reload, dry-run/replay
+> mode, OpenTelemetry tracing, and webhook signature verification.
+
+---
+
+## What is this?
+
+v0.39.0 delivers the operational half of the relay Phase 2 plan
+([plans/relay/PLAN_RELAY_CLI_PHASE_2.md](../plans/relay/PLAN_RELAY_CLI_PHASE_2.md)).
+Where v0.38.0 broadened the backend catalogue, v0.39.0 deepens the relay's
+production readiness: every feature here addresses a failure mode or
+operational gap that emerges when running the relay at scale in production.
+
+---
+
+## Operational features
+
+### Dead-letter queue (DLQ)
+
+Messages that exhaust retry attempts are written to a
+`pgtrickle.relay_dlq` table instead of crashing the pipeline. The full
+SQL API (`pgtrickle.relay_dlq_replay()`, `pgtrickle.relay_dlq_discard()`,
+`pgtrickle.relay_dlq_stats()`) lets operators inspect, replay, or discard
+failed messages without stopping the relay.
+
+### Schema Registry integration (Avro + Protobuf)
+
+Confluent Schema Registry support for Avro and Protobuf serialisation.
+Schemas are registered automatically on first publish. Consumer-side
+deserialization uses the schema ID embedded in the wire format. Enables
+strongly-typed event contracts across teams without out-of-band schema
+management.
+
+### JMESPath message transforms
+
+A `transforms` array in the pipeline config applies JMESPath expressions
+to each message payload before publishing. Supports field extraction,
+renaming, filtering, and computed fields. Transforms run in the relay
+process — no external side-cars required.
+
+### Content-based routing
+
+A `routing_rules` array routes messages to different sinks based on
+payload content. Rules are evaluated top-down; the first match wins.
+A `fallback_sink` handles non-matching messages. All sink and routing
+config is stored in `pgtrickle.relay_outbox_config` — no CLI changes.
+
+### Rate limiting & back-pressure
+
+A token-bucket rate limiter (`max_messages_per_second`, `burst`) prevents
+the relay from overwhelming downstream systems. When the bucket is empty,
+the relay applies back-pressure to the outbox poll loop rather than
+dropping messages. Counters are exposed in the Prometheus metrics endpoint.
+
+### Circuit breaker
+
+A configurable circuit breaker (failure threshold → open → half-open →
+closed) protects the relay from cascading failures. When the circuit
+opens, new messages are routed to the DLQ (if configured) or held in
+the outbox until the circuit recovers. Success threshold closes the
+circuit automatically.
+
+### SIGHUP config reload
+
+`SIGHUP` triggers a full re-read of all pipeline configuration from the
+database, applying changes without restarting the relay process. This
+extends the existing `NOTIFY pgtrickle_relay_config` hot-reload to cover
+all configuration fields, including sink credentials and transform rules.
+
+### Dry-run & replay mode
+
+`dry_run = true` in the pipeline config makes the relay consume from the
+source and apply all transforms and routing logic, but skips the actual
+sink publish. Useful for validating config changes before applying them
+to production. `replay_from` restarts the outbox cursor from a specific
+`outbox_id`, enabling re-processing of historical events.
+
+### OpenTelemetry tracing
+
+OTLP/gRPC trace export from the relay binary. Each message publish is
+wrapped in a span with attributes: `relay.pipeline_id`, `relay.sink_type`,
+`relay.batch_size`, `relay.latency_ms`. W3C `traceparent` headers are
+propagated to HTTP webhook sinks, enabling end-to-end distributed traces
+from the PostgreSQL write through the relay to the downstream consumer.
+
+### Webhook signature verification
+
+Inbound webhook sources (RELAY-P2-21) verify request signatures before
+writing to the inbox. Supported schemes: HMAC-SHA256 (generic), GitHub
+(`X-Hub-Signature-256`), Stripe (`Stripe-Signature`), and Svix
+(`svix-signature`). Invalid signatures are rejected with HTTP 401 and
+counted in the metrics endpoint.
+
+---
+
+## Testing
+
+- `tests/relay_p2_extensions_tests.rs` — integration tests for all ten
+  features using Testcontainers where a real service is needed.
+- Unit tests for transform JMESPath evaluation, routing rule matching,
+  circuit breaker state machine, and DLQ write/replay logic.
+
+---
+
+## Documentation & distribution
+
+- Updated relay configuration reference in `docs/RELAY_GUIDE.md`
+- New `docs/RELAY_TRANSFORMS.md` — JMESPath transform cookbook
+- New `docs/RELAY_ROUTING.md` — content-based routing reference
+- New `docs/RELAY_DLQ.md` — dead-letter queue operations guide
+- Docker image update: all Phase 2 features enabled in default image
+- CI matrix: new light-E2E jobs for each operational feature
+
+---
+
+## Scope
+
+v0.39.0 is a large release — roughly 15 days of implementation work.
+All ten features are additive: they extend the pipeline config schema
+without any breaking changes to existing pipelines.
+
+---
+
+*Previous: [v0.38.0 — Relay Phase 2a+2b: Cloud & Analytics Backends](v0.38.0.md)*
+*Next: [v1.0.0 — Stable Release](../roadmap/v1.0.0.md-full.md)*

--- a/roadmap/v0.39.0.md-full.md
+++ b/roadmap/v0.39.0.md-full.md
@@ -1,0 +1,347 @@
+> **Plain-language companion:** [v0.39.0.md](v0.39.0.md)
+
+## v0.39.0 — Relay Phase 2c: Operational Excellence
+
+**Status: Planned.** Derived from [plans/relay/PLAN_RELAY_CLI_PHASE_2.md](../plans/relay/PLAN_RELAY_CLI_PHASE_2.md) Part B and Parts D/E (operational items, testing, documentation).
+
+> **Release Theme**
+> v0.39.0 completes Phase 2 of the relay plan by delivering the ten
+> operational features from Phase 2c: dead-letter queues, schema registry,
+> JMESPath transforms, content-based routing, rate limiting, circuit breaker,
+> SIGHUP reload, dry-run/replay, OpenTelemetry tracing, and webhook signature
+> verification. Also includes Phase 2d testing and Phase 2e documentation.
+
+---
+
+### Operational items
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| RELAY-P2-11 | Dead-letter queue (DLQ table + SQL API + auto-retry) | 2d | P1 |
+| RELAY-P2-12 | Schema Registry integration (Avro + Protobuf, Confluent SR) | 3d | P1 |
+| RELAY-P2-13 | JMESPath message transforms (payload transforms + filter) | 1.5d | P1 |
+| RELAY-P2-14 | Content-based routing (match rules + fallback) | 1d | P2 |
+| RELAY-P2-15 | Rate limiting & back-pressure (token bucket) | 1d | P2 |
+| RELAY-P2-16 | Circuit breaker (failure/success thresholds, DLQ integration) | 1d | P2 |
+| RELAY-P2-18 | SIGHUP reload (force full config re-read from database) | 0.5d | P2 |
+| RELAY-P2-19 | Dry-run & replay mode (pipeline config flags) | 1d | P2 |
+| RELAY-P2-20 | OpenTelemetry tracing (OTLP export + context propagation) | 1.5d | P2 |
+| RELAY-P2-21 | Webhook signature verification (HMAC, GitHub, Stripe, Svix) | 1d | P2 |
+
+**Deferred to Phase 3:** Relay TUI dashboard (RELAY-P2-22, B.11), plugin
+system/WASM backends (RELAY-P3-4), payload encryption envelope (RELAY-P3-5).
+
+---
+
+### RELAY-P2-11 — Dead-Letter Queue
+
+A `pgtrickle.relay_dlq` table captures messages that have exhausted all
+retry attempts (configurable via `max_retries` in the pipeline config).
+
+**Schema:**
+```sql
+CREATE TABLE pgtrickle.relay_dlq (
+    id            bigserial PRIMARY KEY,
+    pipeline_id   text       NOT NULL,
+    outbox_id     bigint,
+    payload       jsonb      NOT NULL,
+    error_message text       NOT NULL,
+    retry_count   int        NOT NULL DEFAULT 0,
+    failed_at     timestamptz NOT NULL DEFAULT now(),
+    replayed_at   timestamptz,
+    discarded_at  timestamptz
+);
+```
+
+**SQL API:**
+```sql
+-- Replay all DLQ entries for a pipeline
+SELECT pgtrickle.relay_dlq_replay('pipeline_name');
+
+-- Replay a single entry by id
+SELECT pgtrickle.relay_dlq_replay_one(dlq_id := 42);
+
+-- Discard (mark as resolved without replaying)
+SELECT pgtrickle.relay_dlq_discard(dlq_id := 42);
+
+-- Stats per pipeline
+SELECT * FROM pgtrickle.relay_dlq_stats();
+```
+
+**Circuit breaker integration:** when `circuit_breaker.on_open = "dlq"`,
+messages written while the circuit is open are routed to the DLQ rather
+than dropped.
+
+---
+
+### RELAY-P2-12 — Schema Registry Integration
+
+Confluent Schema Registry support for Avro and Protobuf wire formats.
+
+**Config:**
+```json
+{
+  "schema_registry": {
+    "url": "http://localhost:8081",
+    "format": "avro",
+    "subject_template": "pgtrickle-{stream_table}-value",
+    "auto_register": true,
+    "compatibility": "BACKWARD"
+  }
+}
+```
+
+**Avro** serialisation uses `apache-avro` crate. Schemas are derived
+automatically from the stream table column list and registered on first
+publish. The 5-byte Confluent wire format prefix (magic byte + schema ID)
+is prepended to every message.
+
+**Protobuf** serialisation uses `prost`. The relay generates a `.proto`
+definition from the stream table schema and registers the file descriptor
+with the schema registry.
+
+**Consumer-side:** schema ID is decoded from the wire prefix; schema
+fetched from registry on cache miss. Compatible with Confluent Platform,
+Apicurio Registry, and AWS Glue Schema Registry.
+
+---
+
+### RELAY-P2-13 — JMESPath Message Transforms
+
+A `transforms` array in the pipeline JSONB config applies ordered
+JMESPath expressions to each message payload before publishing.
+
+**Config:**
+```json
+{
+  "transforms": [
+    { "type": "jmespath", "expression": "{id: id, event: op, ts: committed_at}" },
+    { "type": "filter",   "expression": "op != 'delete'" }
+  ]
+}
+```
+
+**Transform types:**
+- `jmespath` — reshape the payload using a JMESPath projection
+- `filter` — drop messages where the JMESPath expression evaluates falsy
+- `add_field` — inject a static field (e.g. `{"field": "env", "value": "prod"}`)
+- `remove_field` — remove a field from the payload
+
+**Crate:** `jmespath` (Rust port of JMESPath).
+
+**Error handling:** transform errors route to DLQ if configured; otherwise
+the pipeline halts and requires operator intervention.
+
+---
+
+### RELAY-P2-14 — Content-Based Routing
+
+Routes messages to different sinks based on payload content evaluation.
+
+**Config:**
+```json
+{
+  "routing_rules": [
+    { "match": "stream_table == 'orders'",    "sink": "kafka-orders" },
+    { "match": "stream_table == 'customers'", "sink": "kafka-customers" },
+    { "match": "op == 'delete'",              "sink": "audit-log" }
+  ],
+  "fallback_sink": "default-kafka"
+}
+```
+
+Rules are evaluated top-down using JMESPath (reuses the transform
+infrastructure). The first matching rule wins. Messages with no matching
+rule go to `fallback_sink`; if no fallback is configured they are dropped
+and counted in the `relay_routed_dropped_total` metric.
+
+---
+
+### RELAY-P2-15 — Rate Limiting & Back-Pressure
+
+Token-bucket rate limiter applied per pipeline.
+
+**Config:**
+```json
+{
+  "rate_limit": {
+    "max_messages_per_second": 10000,
+    "burst": 50000
+  }
+}
+```
+
+When the bucket is empty, the relay sleeps for one token-fill interval
+rather than dropping messages or overflowing the sink. Back-pressure
+propagates to the outbox poll loop — the relay simply polls less
+frequently until capacity is available.
+
+**Metrics:** `relay_rate_limited_sleep_total` counter per pipeline.
+
+---
+
+### RELAY-P2-16 — Circuit Breaker
+
+Protects downstream systems from the relay flooding them during outages.
+
+**Config:**
+```json
+{
+  "circuit_breaker": {
+    "failure_threshold": 5,
+    "success_threshold": 2,
+    "open_duration_seconds": 30,
+    "on_open": "dlq"
+  }
+}
+```
+
+**States:** Closed (normal) → Open (failures ≥ threshold) → Half-open
+(probe) → Closed (successes ≥ threshold) or Open (probe failed).
+
+**`on_open`:** `"dlq"` (route to DLQ), `"hold"` (pause polling, do not
+discard), or `"drop"` (increment counter and continue).
+
+**Metrics:** `relay_circuit_breaker_state` gauge (0=closed, 1=half-open,
+2=open) per pipeline.
+
+---
+
+### RELAY-P2-18 — SIGHUP Config Reload
+
+`kill -HUP <relay-pid>` triggers a full re-read of all pipeline
+configurations from `pgtrickle.relay_outbox_config` and
+`pgtrickle.relay_inbox_config`.
+
+**What reloads:** sink credentials, topic templates, transform rules,
+routing rules, rate limits, circuit breaker thresholds.
+
+**What does not reload:** pipeline `mode` (`forward` / `reverse` /
+`bidirectional`) — changing mode requires a restart to avoid double-processing.
+
+**Implementation:** the existing `NOTIFY pgtrickle_relay_config` hot-reload
+already reloads pipeline metadata. SIGHUP extends it to cover the full
+config JSONB column, using the same `Coordinator::reload_pipelines()` path.
+
+---
+
+### RELAY-P2-19 — Dry-Run & Replay Mode
+
+**Dry-run** — set `dry_run = true` in the pipeline config. The relay
+processes messages through the full pipeline (transforms, routing,
+serialisation) but skips the sink `publish()` call. Useful for config
+validation. A `relay_dryrun_messages_total` counter tracks processed messages.
+
+**Replay** — set `replay_from_outbox_id = <id>` in the pipeline config.
+On next startup (or SIGHUP), the relay resets the outbox cursor to that ID
+and re-processes all messages from that point. The config field is cleared
+automatically after the cursor has advanced past the replay point.
+
+Both flags are stored in the pipeline JSONB config — no CLI subcommand
+changes are needed.
+
+---
+
+### RELAY-P2-20 — OpenTelemetry Tracing
+
+OTLP/gRPC span export from the relay binary.
+
+**Config:**
+```json
+{
+  "otel": {
+    "endpoint": "http://localhost:4317",
+    "service_name": "pgtrickle-relay",
+    "sample_rate": 1.0
+  }
+}
+```
+
+**Spans emitted per message batch:**
+- `relay.poll` — outbox/source poll duration
+- `relay.transform` — transform pipeline duration
+- `relay.route` — routing rule evaluation
+- `relay.publish` — sink publish duration and batch size
+
+**W3C Trace Context propagation:**
+- HTTP webhook sink: `traceparent` header added to each request
+- Kafka sink: `traceparent` header in Kafka record headers
+- NATS sink: `traceparent` in NATS message header
+
+The span is linked to the `pg_trickle.trace_id` session GUC introduced
+in v0.37.0, enabling end-to-end traces from the PostgreSQL write through
+the relay to the downstream consumer.
+
+**Crate:** `opentelemetry` + `opentelemetry-otlp` + `tracing-opentelemetry`.
+
+---
+
+### RELAY-P2-21 — Webhook Signature Verification
+
+Inbound webhook sources verify the request signature before writing to
+the inbox. Configured via `signature_verification` in the source config:
+
+```json
+{
+  "signature_verification": {
+    "scheme": "github",
+    "secret": "my-webhook-secret"
+  }
+}
+```
+
+**Supported schemes:**
+
+| Scheme | Header | Algorithm |
+|--------|--------|-----------|
+| `hmac-sha256` | `X-Signature-256` | HMAC-SHA256 (generic) |
+| `github` | `X-Hub-Signature-256` | HMAC-SHA256 |
+| `stripe` | `Stripe-Signature` | HMAC-SHA256 + timestamp tolerance |
+| `svix` | `svix-signature` | HMAC-SHA256 (Svix v1) |
+
+Invalid signatures return HTTP 401 and increment
+`relay_webhook_signature_rejected_total`. Secrets are stored in the
+pipeline config JSONB (masked in `relay_dlq_stats()` output).
+
+---
+
+### Testing (RELAY-P2-24)
+
+All ten features have integration tests in
+`tests/relay_p2_extensions_tests.rs`:
+
+| Feature | Test approach |
+|---------|---------------|
+| DLQ | Inject sink failures; verify DLQ entries; test replay + discard |
+| Schema Registry | Confluent Schema Registry Docker image; verify wire format |
+| JMESPath transforms | Table-driven tests for all transform types |
+| Content routing | Multiple sink stubs; verify routing decisions |
+| Rate limiting | Token bucket unit tests + integration throughput check |
+| Circuit breaker | State machine unit tests + integration with DLQ |
+| SIGHUP reload | Send SIGHUP mid-run; verify config change applied |
+| Dry-run | Assert sink publish not called; verify counter incremented |
+| Replay | Insert rows, advance cursor, replay, verify re-delivery |
+| OTel tracing | OTLP collector stub; verify span attributes |
+| Webhook sig | Send valid + invalid signatures; verify accept/reject |
+
+---
+
+### Documentation & distribution (RELAY-P2-26, RELAY-P2-27)
+
+- `docs/RELAY_GUIDE.md` — updated with all Phase 2 config options
+- `docs/RELAY_DLQ.md` — dead-letter queue operations (inspect, replay, discard)
+- `docs/RELAY_TRANSFORMS.md` — JMESPath transform cookbook with examples
+- `docs/RELAY_ROUTING.md` — content-based routing reference
+- Docker image: rebuild with all Phase 2 features enabled (`--all-features`)
+- CI: new light-E2E jobs for DLQ, transforms, routing, rate limiting, OTel
+
+---
+
+### Effort summary
+
+| Phase | Items | Effort |
+|-------|-------|--------|
+| 2c — Operational Excellence | 10 | 13d |
+| 2d — Testing (extensions) | — | 2d |
+| 2e — Documentation & Distribution | — | 2d |
+| **Total** | **10 features** | **~17d** |


### PR DESCRIPTION
## Summary

Adds relay Phase 2 to the roadmap across two new releases (v0.38.0 and
v0.39.0), sourced directly from
[plans/relay/PLAN_RELAY_CLI_PHASE_2.md](plans/relay/PLAN_RELAY_CLI_PHASE_2.md).
The plan recommends splitting Phase 2 into a backends release and an
operational-excellence release to reduce risk — this PR follows that split.

## Changes

- `roadmap/v0.38.0.md` + `roadmap/v0.38.0.md-full.md` — **Relay Phase 2a+2b:
  Cloud & Analytics Backends** (8 new backends: GCP Pub/Sub, Amazon Kinesis,
  Azure Service Bus, Elasticsearch/OpenSearch, Azure Event Hubs, MQTT v5,
  Object Storage S3/GCS/Blob, ClickHouse; ~19.5 days)

- `roadmap/v0.39.0.md` + `roadmap/v0.39.0.md-full.md` — **Relay Phase 2c:
  Operational Excellence** (10 operational features: DLQ, Schema Registry,
  JMESPath transforms, content-based routing, rate limiting, circuit breaker,
  SIGHUP reload, dry-run/replay, OpenTelemetry tracing, webhook signature
  verification; Phase 2d testing + Phase 2e docs; ~17 days)

- `ROADMAP.md` — added v0.38.0 and v0.39.0 rows to the "Toward Stable"
  table, updated the ASCII dependency diagram, and extended the narrative
  paragraph

- `roadmap/v0.37.0.md` — updated *Next:* pointer from v1.0.0 to v0.38.0

## Testing

Documentation-only change — no code modified. No tests to run.

## Notes

- Apache Pulsar (RELAY-P2-9), Arrow Flight/gRPC (RELAY-P2-10), relay TUI
  dashboard (B.11), plugin system (B.12), and encryption envelope (B.13)
  remain deferred to Phase 3, per the plan's priority matrix.
- v0.38.0 depends on the pluggable sink architecture item already listed in
  v0.36.0 — that item should be confirmed complete before starting v0.38.0.
- v0.39.0's OpenTelemetry tracing (RELAY-P2-20) reuses the OTel
  infrastructure introduced in the core engine in v0.37.0.
