### PR TITLE
docs(blog): pgvector ecosystem blog posts — silent failures and tooling landscape

### DIFF
--- a/blog/README.md
+++ b/blog/README.md
@@ -1,0 +1,56 @@
+# pg_trickle Blog
+
+> **Note:** This blog directory is an experiment. All posts were generated with
+> AI assistance (GitHub Copilot / Claude) as a way to explore how well
+> LLM-generated technical writing holds up for a niche systems engineering
+> topic. The technical content has been reviewed for accuracy, but treat the
+> posts as drafts — not as officially reviewed documentation.
+
+---
+
+## Posts
+
+### Core Concepts
+
+| Post | Summary |
+|------|---------|
+| [Why Your Materialized Views Are Always Stale](stale-materialized-views.md) | Explains why `REFRESH MATERIALIZED VIEW` fails at scale — locking, cost, and the full-scan ceiling — and how switching to a stream table with `DIFFERENTIAL` mode fixes staleness in 5 lines of SQL. |
+| [Differential Dataflow for the Rest of Us](differential-dataflow-explained.md) | A plain-language walkthrough of the mathematics behind incremental view maintenance: delta rules for filters, joins, aggregates, the MERGE application step, and why some aggregates (MEDIAN, RANK) can't be made incremental. |
+| [Incremental Aggregates in PostgreSQL: No ETL Required](incremental-aggregates-no-etl.md) | How `SUM`, `COUNT`, `AVG`, and (in v0.37) `vector_avg` are maintained as running algebraic state rather than full scans. Covers multi-table aggregates, conditional aggregates, and the non-differentiable cases. |
+
+### Operational Deep Dives
+
+| Post | Summary |
+|------|---------|
+| [The Hidden Cost of Trigger-Based Denormalization](trigger-denormalization-cost.md) | Four failure modes of hand-rolled trigger sync — blind UPDATE divergence, statement vs. row trigger semantics, invisible deletes, and multi-row races — and how declarative IVM avoids all of them. |
+| [How We Replaced a Celery Pipeline with 3 SQL Statements](replaced-celery-with-sql.md) | A before/after case study of a Celery + Elasticsearch product search pipeline across three generations of growing complexity, and the pg_trickle stream table that replaced it. Includes benchmark numbers. |
+| [Stop Rebuilding Your Search Index at 3am](stop-rebuilding-search-index.md) | How pg_trickle's scheduler, SLA tiers (`critical` / `standard` / `background`), backpressure, and parallel workers let you tune refresh behaviour per workload — and why the 3am maintenance window disappears with continuous incremental refresh. |
+
+### pgvector Integration
+
+| Post | Summary |
+|------|---------|
+| [Your pgvector Index Is Lying to You](incremental-pgvector.md) | Four silent failure modes of unmanaged pgvector deployments: stale embedding corpora, drifting aggregates, IVFFlat recall loss, and over-fetching. How pg_trickle's differential IVM and drift-aware reindexing closes each gap. |
+| [HNSW Recall Is a Lie: Distribution Drift Explained](hnsw-recall-distribution-drift.md) | Deep dive on IVFFlat centroid staleness and HNSW tombstone accumulation — how to measure drift, what the right threshold is, and how `post_refresh_action => 'reindex_if_drift'` (v0.38) automates the fix. |
+| [The pgvector Tooling Landscape in 2026](pgvector-tooling-landscape.md) | Honest comparison of pg_trickle against pgai (archived Feb 2026), pg_vectorize, DIY batch pipelines, and Debezium. Introduces the two-layer model: Layer 1 = embedding generation, Layer 2 = derived-state maintenance. |
+
+### Advanced Patterns
+
+| Post | Summary |
+|------|---------|
+| [Reactive Alerts Without Polling](reactive-alerts-without-polling.md) | How pg_trickle's reactive subscriptions (v0.39) replace polling loops: SLA breach detection, inventory alerts, fraud velocity checks, and vector distance subscriptions. Covers `OLD.*`/`NEW.*` transition semantics and PostgreSQL `LISTEN`. |
+| [Multi-Tenant Vector Search with Row-Level Security](multi-tenant-vector-search-rls.md) | Zero cross-tenant data leakage using RLS policies on stream tables, tiered tenancy (large / medium / small tenant strategies), per-tenant partial HNSW indexes, and drift-aware reindexing per partition. |
+| [The Outbox Pattern, Turbocharged](outbox-pattern-turbocharged.md) | Using stream tables as transactionally consistent event sources for the outbox pattern — derived aggregate events, fat payloads, transition-based routing, and why stream tables naturally debounce high-frequency changes into fewer events. |
+
+### Benchmarks & Infrastructure
+
+| Post | Summary |
+|------|---------|
+| [TPC-H at 1GB in 40ms](tpch-benchmarking-ivm.md) | Reproducible benchmark of differential vs. full refresh across five TPC-H queries (Q1, Q3, Q5, Q6, Q12). Results: 13–22× faster per refresh cycle, with differential lag under 2.5 seconds vs. 186 seconds at 5,000 rows/second sustained write load. |
+| [pg_trickle on CloudNativePG](pg-trickle-cloudnativepg-kubernetes.md) | Production Kubernetes deployment using the CloudNativePG operator: Dockerfile, Cluster manifest, GUC configuration, HA failover behaviour, Prometheus metrics ConfigMap, alerting rules, upgrade procedure, and sizing guidance. |
+
+---
+
+## Contributing
+
+These posts are deliberately rough-edged — they're drafts exploring how the extension works, not polished marketing copy. If you spot a technical inaccuracy, open an issue or PR. If you want to write a post, open a discussion first to avoid duplication.

--- a/blog/differential-dataflow-explained.md
+++ b/blog/differential-dataflow-explained.md
@@ -1,0 +1,280 @@
+# Differential Dataflow for the Rest of Us
+
+## The mathematics behind incremental view maintenance, explained without a PhD
+
+---
+
+pg_trickle maintains query results incrementally. When one row changes, it updates the result without recomputing everything. That sounds simple, but it requires some careful mathematics to get right.
+
+This post explains how that mathematics works — in plain language, without assuming a background in database theory or systems research. The goal is to build enough intuition that you can reason about when incremental maintenance is possible, when it isn't, and why.
+
+If you just want to use pg_trickle, you don't need this. If you want to understand why it works, read on.
+
+---
+
+## The Problem With "Just Recompute"
+
+Start with a concrete example. You're tracking e-commerce orders and maintaining a `revenue_by_region` table:
+
+```sql
+-- The query
+SELECT region, SUM(total) AS revenue
+FROM orders
+JOIN customers ON customers.id = orders.customer_id
+GROUP BY region;
+```
+
+This query scans every row in `orders`, joins with `customers`, and computes sums per group. If `orders` has 100 million rows, this query reads 100 million rows every time you run it. If you run it every 5 seconds to stay fresh, you're reading 100 million rows every 5 seconds. At any realistic row size, that's gigabytes per second of I/O.
+
+The observation that makes incremental maintenance possible is: **most of the time, very little changes.**
+
+If 10 new orders come in over 5 seconds, only those 10 orders affect the result. The other 99,999,990 orders haven't changed. Recomputing the full aggregate is wasteful by a factor of 10 million.
+
+Incremental view maintenance answers the question: given that `orders` changed by some set of rows, what's the corresponding change to `revenue_by_region`?
+
+---
+
+## Collections and Multisets
+
+Before getting to the math, a quick terminology note.
+
+In differential dataflow, data is represented as *multisets* — collections where each element has a *weight*. A weight of `+1` means the element is present. A weight of `-1` means it was removed. A weight of `+2` means it appears twice.
+
+For a SQL table with distinct rows, every present row has weight `+1`.
+
+When you insert a row, you add it to the multiset with weight `+1`.
+When you delete a row, you add the same row with weight `-1`. (The net effect: the row is no longer present.)
+When you update a row, you add the old value with weight `-1` and the new value with weight `+1`. (The net effect: the old value is removed, the new value is added.)
+
+This weight-based representation turns updates into insertions and deletions. It simplifies the mathematics considerably — you only need rules for how insertions and deletions propagate.
+
+---
+
+## The Δ Notation
+
+In differential dataflow, we use Δ (delta) to mean "the change to."
+
+If `T` is a table (multiset), then `ΔT` is the set of rows added and removed from `T` since some reference point. Each row in `ΔT` has a weight: `+1` for insertions, `-1` for deletions.
+
+For a query `Q(T)` that produces result `R`, we want to compute `ΔR` (the change to the result) from `ΔT` (the change to the input), *without* touching the unchanged rows in `T`.
+
+The question is: for each type of query operation, what's the delta rule?
+
+---
+
+## Delta Rules for SQL Operations
+
+### Filter (WHERE)
+
+```sql
+-- Query
+SELECT * FROM orders WHERE total > 100;
+
+-- Delta rule
+Δresult = { row ∈ ΔT | row.total > 100 }
+```
+
+If a row is inserted and it satisfies the filter, it appears in the result. If it doesn't, it's ignored. This is the simplest rule — delta of a filter is just filtering the delta.
+
+### Projection (SELECT columns)
+
+```sql
+-- Query
+SELECT customer_id, total FROM orders;
+
+-- Delta rule
+Δresult = { (row.customer_id, row.total) : row ∈ ΔT }
+```
+
+Project each delta row onto the selected columns. Also simple.
+
+### Join
+
+Joins are where it gets interesting.
+
+```sql
+-- Query
+SELECT o.*, c.region
+FROM orders o
+JOIN customers c ON c.id = o.customer_id;
+```
+
+If we change `orders` (Δorders) or `customers` (Δcustomers), how does the result change?
+
+The delta rule for a join has two parts:
+
+**Part 1 (orders change):**
+```
+Δresult += Δorders ⋈ customers
+```
+For each changed order, join it with the *current* (unchanged) customer data. The result is the set of new/deleted joined rows contributed by the order changes.
+
+**Part 2 (customers change):**
+```
+Δresult += orders ⋈ Δcustomers
+```
+For each changed customer, join it with the *current* order data. The result is the set of rows that need to be updated because the customer's region changed.
+
+**Part 3 (both change simultaneously):**
+```
+Δresult += Δorders ⋈ Δcustomers
+```
+If both change in the same batch, this cross-term captures rows affected by both changes simultaneously. For most workloads, this term is small (it requires a customer and one of their orders to change in the same batch).
+
+In pg_trickle, "current data" in parts 1 and 2 is accessed from the live table, usually via an index lookup on the join key. This is why joins across tables with good indexes are handled efficiently: each delta lookup is a point query, not a scan.
+
+---
+
+### Aggregation (GROUP BY + aggregate functions)
+
+This is the most important delta rule for most analytical use cases.
+
+```sql
+-- Query
+SELECT region, SUM(total) AS revenue, COUNT(*) AS order_count
+FROM orders o
+JOIN customers c ON c.id = o.customer_id
+GROUP BY region;
+```
+
+When an order is inserted for a customer in `europe`:
+- `region = 'europe'`
+- `delta_revenue = +order.total`
+- `delta_order_count = +1`
+
+The delta rule for `SUM`:
+```
+new_sum(g) = old_sum(g) + delta_sum(g)
+           = old_sum(g) + SUM(weight × value for changed rows in group g)
+```
+
+For `COUNT`:
+```
+new_count(g) = old_count(g) + delta_count(g)
+             = old_count(g) + SUM(weight for changed rows in group g)
+```
+
+For `AVG`:
+```
+-- AVG is maintained as (running_sum, running_count)
+new_avg(g) = new_sum(g) / new_count(g)
+```
+
+The key property: these aggregates are *linear*. Their delta is a function of the delta inputs, not of the full input. The mathematical name for this is being a *monoid homomorphism* — the aggregate is a homomorphism from the monoid of multisets to the monoid of aggregate values.
+
+`SUM` is linear: `SUM(A ∪ B) = SUM(A) + SUM(B)`.
+`COUNT` is linear: `COUNT(A ∪ B) = COUNT(A) + COUNT(B)`.
+`AVG` is *not* directly linear but can be decomposed into linear components (sum and count).
+
+---
+
+### The Non-Differentiable Cases
+
+Not every aggregate is linear.
+
+**`MEDIAN` (PERCENTILE_CONT(0.5)):** You can't compute the median of a union from the medians of the parts. `MEDIAN([1,3,5]) = 3`. `MEDIAN([2,4]) = 3`. `MEDIAN([1,2,3,4,5]) = 3`. But generally, `MEDIAN(A ∪ B) ≠ f(MEDIAN(A), MEDIAN(B))`. Computing the median incrementally requires knowing the *sorted order* of all elements, which requires O(n) state.
+
+**`RANK() OVER (ORDER BY x)`:** Inserting one row can change the rank of every other row. The delta rule is `Δrank(row) = COUNT(new rows that rank higher than row)`. Computing this requires knowing where in the ordering the new row falls, which requires a sorted data structure. The update is O(log n) per changed row, but it's not O(1) per change batch.
+
+**`DISTINCT` counting (COUNT DISTINCT):** Removing an element from a DISTINCT count requires knowing whether the element appears elsewhere. This is the "set membership" problem — you need to maintain the full set, not just a count. Approximate cardinality (HyperLogLog) is differentiable; exact DISTINCT counting is not.
+
+**`MAX` and `MIN` with deletions:** Adding a new maximum is easy (`new_max = max(old_max, new_value)`). Removing the current maximum is hard — you need to find the *second* largest value. This requires a sorted structure.
+
+pg_trickle is transparent about these limitations. If you create a stream table with a non-differentiable query, it either rejects the `DIFFERENTIAL` mode or falls back to `FULL` with a warning. The extension's query analyzer classifies each aggregate and operator before deciding the refresh mode.
+
+---
+
+## The Operator Pipeline
+
+In differential dataflow, a query is represented as a pipeline of operators, each with its own delta rule:
+
+```
+ΔT (raw change from CDC)
+    │
+    ▼ Filter operator (apply WHERE clauses)
+    │
+    ▼ Join operator (propagate through JOINs)
+    │
+    ▼ Project operator (select columns)
+    │
+    ▼ Aggregate operator (GROUP BY + aggregate functions)
+    │
+    ▼ ΔR (change to apply to the stream table)
+```
+
+Each operator transforms the incoming delta using its delta rule. The output of each operator is itself a delta — a set of weighted rows to insert or remove.
+
+The final delta `ΔR` is applied to the stream table using standard SQL `INSERT`, `UPDATE`, `DELETE` — or more efficiently, a single `MERGE` statement that handles all three cases.
+
+---
+
+## Why This Is Faster Than It Sounds
+
+The pipeline is only computed for the rows in `ΔT` — the rows that actually changed. Every other row in the source tables is untouched.
+
+For the join operator, "current customer data" is fetched via index lookups on the join key. If 10 orders changed, that's 10 index lookups. Not a table scan.
+
+For the aggregate operator, only the affected groups are recomputed. If 10 orders changed, and they're all from `europe`, only the `europe` row in `revenue_by_region` is updated.
+
+The cost of a refresh cycle scales with:
+1. The number of rows changed in the source tables during the cycle
+2. The number of distinct groups affected in each aggregate
+3. The number of join hops required to propagate the change to the result
+
+For typical OLTP workloads with hundreds of changes per cycle and stable aggregate groups, refresh cycles complete in 10–50ms regardless of total table size.
+
+---
+
+## The Consistency Guarantee
+
+One subtle point: the delta computation must be consistent.
+
+When computing `Δorders ⋈ customers` (part 1 of the join delta rule), "current customers" should be the customers table *after* any changes in the current batch have been applied.
+
+pg_trickle handles this by processing deltas in topological order when multiple source tables change simultaneously. If both `orders` and `customers` change in the same batch, the join delta is computed with both changes applied, not with a mix of old and new values.
+
+This is the correctness property that makes IVM hard in practice. pg_trickle's engine handles it by processing each refresh cycle as a single transaction that sees a consistent snapshot of all source changes.
+
+---
+
+## The MERGE Application
+
+After computing `ΔR`, pg_trickle applies it to the stream table using a single `MERGE` statement:
+
+```sql
+MERGE INTO revenue_by_region AS target
+USING delta_revenue AS source
+ON target.region = source.region
+WHEN MATCHED AND source.revenue != 0 THEN
+  UPDATE SET revenue = target.revenue + source.revenue,
+             order_count = target.order_count + source.order_count
+WHEN MATCHED AND source.revenue = 0 AND source.order_count = 0 THEN
+  DELETE
+WHEN NOT MATCHED AND source.revenue != 0 THEN
+  INSERT (region, revenue, order_count)
+  VALUES (source.region, source.revenue, source.order_count);
+```
+
+A group with a positive delta gets updated. A group that drops to zero (all orders removed) gets deleted. A new group gets inserted.
+
+The `MERGE` is atomic — it either fully applies or not at all. This is what makes pg_trickle's consistency guarantee possible: the stream table is always in a state consistent with some version of the source tables.
+
+---
+
+## What This Means for You
+
+The practical implications of the differential dataflow mathematics:
+
+**Query design:** Stick to filters, joins, projections, and linear aggregates (SUM, COUNT, AVG). These are fully differentiable. Use `DIFFERENTIAL` mode.
+
+**Non-linear aggregates:** Use PERCENTILE, RANK, or COUNT DISTINCT? Use `FULL` mode for those tables. The stream table infrastructure is still useful — scheduling, monitoring, the catalog — but the refresh will scan the full source.
+
+**Index design:** The join delta rules (`Δorders ⋈ customers`) require efficient index lookups on join keys. Ensure your source tables have indexes on the columns used in `JOIN ON` conditions. Missing join indexes make pg_trickle fall back to sequential scans during delta computation.
+
+**Change volume:** The cost of a refresh cycle scales with the number of changed rows. High-frequency small changes (1–100 rows/cycle) are very cheap. High-frequency bulk operations (10k rows/cycle from batch imports) are more expensive — the delta is large. Use pg_trickle's `change_buffer_size` GUC to tune how much change is batched before a forced refresh.
+
+The mathematics is not magic — it's a formal system with well-defined properties and limitations. Understanding those properties lets you build stream tables that are fast, correct, and predictable.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/hnsw-recall-distribution-drift.md
+++ b/blog/hnsw-recall-distribution-drift.md
@@ -1,0 +1,225 @@
+# HNSW Recall Is a Lie
+
+## How Distribution Drift Silently Breaks Similarity Search (and What to Do About It)
+
+---
+
+You built a similarity search feature. You measured recall at launch: 94% — excellent. You ship it, add it to the demo, put it on the homepage.
+
+Six months later, a user complains that the results feel "off." You run the same recall measurement: 71%. You've been serving degraded results for months and had no idea.
+
+This is distribution drift. It's real, it's common, and it's almost never discussed in tutorials. Here's what it is, why it happens, how to measure it, and what pg_trickle's drift-aware reindex policy does about it.
+
+---
+
+## What IVFFlat Actually Does (and Why That's a Problem)
+
+IVFFlat (Inverted File with Flat quantization) is a classical approximate nearest-neighbor algorithm. It works in two phases:
+
+**Build phase:** Train a k-means clustering on your vectors. Divide them into `lists` groups (centroids). Each vector is assigned to its nearest centroid. The index stores, for each centroid, the list of vectors in that group.
+
+**Query phase:** Given a query vector, find the `probes` nearest centroids. Search only the vectors assigned to those centroids.
+
+The speed comes from only searching `probes / lists` fraction of your data. The recall comes from the assumption that your query vector's nearest neighbors are in the nearest centroids.
+
+**The problem:** The centroid assignments are computed from the data distribution *at build time*. As your data distribution changes, the centroid assignments become stale.
+
+Imagine you're building a product recommendation system in January. Your product catalog skews toward winter items: coats, heaters, boots. You build the IVFFlat index. The centroids reflect a winter distribution.
+
+By June, you've added thousands of summer items: swimwear, grills, sunscreen. These items get assigned to the nearest *existing* centroid at insertion time — but those centroids were trained on winter data. Your summer items end up crowded into a handful of winter centroids that happen to be geometrically nearest.
+
+Now when someone searches for "outdoor summer activities," the query vector points toward the summer region of the embedding space. The two nearest centroids happen to be the winter outdoor centroid and the spring gardening centroid (geometrically closest to the summer space). The actual summer items are scattered across three other centroids that were *not* searched. Recall degrades.
+
+The degradation is gradual and silent. Each new insert makes it slightly worse. Users experience it as "the search feels off" before you ever measure it.
+
+---
+
+## HNSW: The Tombstone Problem
+
+HNSW (Hierarchical Navigable Small World graph) has a different problem.
+
+HNSW is a graph-based index. Each vector is a node. Edges connect nearby nodes across multiple layers, enabling logarithmic-time traversal. Unlike IVFFlat, HNSW doesn't need retraining as data changes — new nodes are inserted by connecting them into the existing graph.
+
+But HNSW doesn't actually *delete* nodes. When you delete a vector, the node is marked as dead (a tombstone) but its edges remain in the graph. Graph traversal still has to navigate through and around tombstones.
+
+The consequences:
+
+**Build slowdown:** As tombstones accumulate, inserting new nodes requires connecting through more dead nodes. Insertion time increases.
+
+**Query slowdown:** Traversal visits tombstones and has to backtrack more often. Query latency increases.
+
+**Index size:** The index doesn't shrink when rows are deleted. Tombstones consume space.
+
+The pgvector documentation addresses this: "Vacuuming can take a while for HNSW indexes. Speed it up by reindexing first." But this is reactive advice — the documentation doesn't tell you *when* to reindex, how to measure when you need to, or how to automate it.
+
+The answer for most teams is a scheduled `REINDEX CONCURRENTLY` — weekly, or monthly, or "when someone notices it's slow." This is a blunt instrument.
+
+---
+
+## Measuring Distribution Drift
+
+The right metric for IVFFlat drift is recall — the fraction of true nearest neighbors returned by approximate search.
+
+The standard measurement procedure:
+
+```sql
+-- 1. Sample query vectors
+SELECT id, embedding FROM items ORDER BY random() LIMIT 1000;
+
+-- 2. For each sample, run exact search (seq scan)
+-- and approximate search (index scan), compare results
+BEGIN;
+SET LOCAL enable_indexscan = off;   -- force exact search
+SELECT id, embedding <=> $query AS distance
+FROM items ORDER BY distance LIMIT 10;
+COMMIT;
+
+-- vs.
+SELECT id, embedding <=> $query AS distance
+FROM items ORDER BY distance LIMIT 10;  -- uses index
+
+-- Recall = |exact_results ∩ approx_results| / |exact_results|
+```
+
+Running this for 1,000 sample queries gives a statistically reliable recall estimate. Do it once a week. When recall drops below your target (say, 85%), rebuild the index.
+
+The problem is that this procedure is expensive (1,000 queries × 2 modes), requires a separate monitoring job, and produces a number that you then have to act on manually.
+
+---
+
+## A Simpler Proxy: Row Change Rate
+
+Exact recall measurement is the ground truth. But there's a cheaper proxy that correlates well with drift: the fraction of rows that have changed since the last index build.
+
+If 30% of your vectors have been inserted, updated, or deleted since the last `REINDEX`, your index reflects a very different distribution than what's currently in the table. The centroid assignments are stale for 30% of the data. The tombstone fraction is significant.
+
+This isn't a perfect predictor of recall degradation — the actual impact depends on whether the changes are uniformly distributed or concentrated in specific regions of the embedding space. But as a heuristic for "this index needs attention," it's reliable.
+
+pg_trickle tracks this metric as `rows_changed_since_last_reindex` per stream table. The `pgtrickle.vector_status()` view (v0.38) exposes it:
+
+```sql
+SELECT
+  stream_table,
+  total_rows,
+  rows_changed_since_reindex,
+  ROUND(rows_changed_since_reindex::numeric / total_rows * 100, 1) AS drift_pct,
+  last_reindex_at,
+  last_refresh_at
+FROM pgtrickle.vector_status();
+```
+
+```
+stream_table     | total_rows | rows_changed | drift_pct | last_reindex_at
+-----------------+------------+--------------+-----------+----------------
+product_corpus   | 2,400,000  | 312,000      |      13.0 | 2026-04-01
+user_taste       | 850,000    |  51,000      |       6.0 | 2026-04-20
+doc_embeddings   | 125,000    |  42,000      |      33.6 | 2026-03-15
+```
+
+`doc_embeddings` at 33.6% drift is the one to worry about. It was last reindexed 6 weeks ago and has had significant churn.
+
+---
+
+## Drift-Aware Automatic Reindexing
+
+Manual monitoring and scheduled rebuilds are operational debt. pg_trickle v0.38 introduces a policy-based approach:
+
+```sql
+SELECT pgtrickle.alter_stream_table(
+  'doc_embeddings',
+  post_refresh_action     => 'reindex_if_drift',
+  reindex_drift_threshold => 0.15  -- trigger at 15% drift
+);
+```
+
+After each refresh cycle, the scheduler checks whether `rows_changed_since_reindex / total_rows > 0.15`. If so, it enqueues a `REINDEX CONCURRENTLY` for the vector column's index in a background worker tier with lower priority than the refresh worker.
+
+`REINDEX CONCURRENTLY` doesn't lock the table for reads. Queries continue executing against the old index while the new index is built. When the build completes, PostgreSQL atomically swaps the indexes. The downtime window is zero.
+
+The sequence:
+1. Drift exceeds 15%.
+2. pg_trickle enqueues `REINDEX CONCURRENTLY` in a low-priority tier.
+3. The reindex starts. Queries use the old index.
+4. The reindex completes (time proportional to table size and available parallelism).
+5. Indexes are swapped atomically.
+6. `rows_changed_since_reindex` resets to 0.
+
+No oncall page. No manual `REINDEX` command. No recall degradation that goes undetected for months.
+
+---
+
+## Choosing the Threshold
+
+15% is a reasonable starting point, but the right threshold depends on your data and quality requirements.
+
+**High-recall requirements (>90%):** Use a lower threshold — 5–10%. Accept more frequent reindexes in exchange for tighter recall guarantees.
+
+**Stable data distributions:** If your vectors come from a domain that doesn't evolve rapidly (e.g., a product catalog in a stable category), you can use a higher threshold — 20–25%.
+
+**Volatile distributions:** If you're embedding news articles, tweets, or rapidly evolving content, drift happens fast. Use a lower threshold and a more frequent monitoring cadence.
+
+For HNSW specifically, the threshold should also account for tombstone fraction:
+
+```sql
+SELECT pgtrickle.alter_stream_table(
+  'user_taste',
+  post_refresh_action     => 'reindex_if_drift',
+  reindex_drift_threshold => 0.20,  -- 20% general drift
+  reindex_tombstone_ratio => 0.10   -- or 10% tombstones
+);
+```
+
+Either condition triggers a reindex. The tombstone ratio catches the HNSW deletion problem independently of the distribution drift.
+
+---
+
+## IVFFlat: Also Rebalance Your Lists
+
+One more thing about IVFFlat that's worth knowing.
+
+When you run `REINDEX`, the new IVFFlat index re-runs k-means clustering from scratch. It's trained on the *current* data distribution. The cluster assignments are fresh.
+
+How many lists should you use? The pgvector README recommends:
+- Up to 1M rows: `lists = rows / 1000`
+- Over 1M rows: `lists = sqrt(rows)`
+
+But these are starting points. If your data has changed significantly in structure — you've moved from a single domain to multiple domains, for example — the optimal `lists` count may have changed too.
+
+pg_trickle doesn't (yet) auto-tune `lists`. You'll need to specify it in your index definition:
+
+```sql
+CREATE INDEX CONCURRENTLY product_corpus_ivf_idx
+ON product_corpus USING ivfflat (embedding vector_cosine_ops)
+WITH (lists = 500);
+```
+
+After a reindex triggered by drift, check recall measurement again. If recall improved less than expected, try a different `lists` value.
+
+---
+
+## The Combined Problem
+
+In practice, both problems — IVFFlat distribution drift and HNSW tombstone accumulation — occur together. A production embedding table:
+1. Grows as new content is added (HNSW: new insertions, IVFFlat: new insertions to stale centroids)
+2. Is updated as content changes (HNSW: delete old node, insert new node = tombstone + new node)
+3. Has documents deleted as content is removed (HNSW: tombstones, IVFFlat: removed from centroid without rebalancing)
+
+Without automated reindexing, this produces a slow, steady recall degradation that's invisible until a user reports it. With drift-aware reindexing, you set the policy once and let pg_trickle maintain the health of your vector indexes alongside the freshness of your data.
+
+---
+
+## What This Doesn't Solve
+
+Drift-aware reindexing helps. It doesn't solve everything.
+
+**Very large tables:** A `REINDEX CONCURRENTLY` on a 100M-row vector table takes hours. Even at a 15% drift threshold, you might be doing this every few weeks. At some scale, you need a sharding strategy (partitioned tables with per-partition indexes, or a dedicated vector database) rather than monolithic reindexing.
+
+**Embed-model changes:** If you change your embedding model (e.g., from OpenAI text-embedding-3-small to text-embedding-3-large), *all* your vectors need to be recomputed. This isn't a drift problem — it's a full migration. pg_trickle's reindexing helps after the re-embedding is done, but it doesn't drive the re-embedding itself.
+
+**Recall monitoring:** Drift percentage is a proxy. It doesn't tell you whether recall has actually degraded. If you need hard recall SLAs, you need recall measurement in addition to drift monitoring. pg_trickle's `vector_status()` view is meant to sit alongside, not replace, periodic recall sampling.
+
+The message is: distribution drift is a real production problem, most teams discover it too late, and the tooling to manage it automatically now exists. Use it.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/incremental-aggregates-no-etl.md
+++ b/blog/incremental-aggregates-no-etl.md
@@ -1,0 +1,270 @@
+# Incremental Aggregates in PostgreSQL: No ETL Required
+
+## Running SUM, COUNT, AVG, and vector_avg over live tables without batch jobs
+
+---
+
+Every analytics system eventually needs pre-aggregated data. Raw tables get too big. Query latency becomes unacceptable. You start maintaining a separate summary table.
+
+Then you need to keep it fresh. That's where things go wrong.
+
+The standard playbook is to build an ETL pipeline: detect changes, compute new aggregates, write them back. This works. It also means you now own an ETL pipeline — a background process, a job scheduler, failure handling, backlog monitoring, and a latency SLA that's measured in minutes rather than seconds.
+
+The question this post answers: do you actually need the ETL layer? For most SQL-expressible aggregates, the answer is no. pg_trickle can maintain running aggregates directly in PostgreSQL, incrementally, using the algebra of the aggregate functions themselves.
+
+---
+
+## Why Batch Aggregation Is the Default
+
+Aggregate queries are inherently read-heavy. Computing `SUM(revenue)` over 100 million orders requires reading 100 million rows. Computing it over 1 billion rows requires reading 1 billion rows. The compute cost scales linearly with the data.
+
+When you need that aggregate continuously — refreshed every minute, every 10 seconds — you hit a ceiling. At some table size, the scan takes longer than the interval. You can't run a 30-second aggregate every 10 seconds.
+
+The usual response is to compute the aggregate less often (accept stale data), or to push the computation out of PostgreSQL into a streaming system better suited to continuous processing (accept operational complexity).
+
+Both choices feel like giving up something real. Incremental aggregation avoids that tradeoff.
+
+---
+
+## The Algebraic Trick
+
+The reason incremental aggregation is possible is that most aggregates have a well-defined delta function.
+
+For `SUM(x)`:
+- Insert a row with value `v`: delta = `+v`
+- Delete a row with value `v`: delta = `-v`
+- Update a row from `old_v` to `new_v`: delta = `+(new_v - old_v)`
+
+For `COUNT(*)`:
+- Insert: delta = `+1`
+- Delete: delta = `-1`
+- Update: delta = `0` (row count unchanged)
+
+For `AVG(x)`:
+- Maintain `running_sum` and `running_count` separately
+- AVG = `running_sum / running_count`
+- Update `running_sum` and `running_count` with the delta
+- Recompute `AVG`
+
+This is O(1) per change, regardless of table size. The key insight is that `SUM`, `COUNT`, and `AVG` are all expressible in terms of a running state that can be updated with each delta. Mathematicians call this a *semigroup* with an *inverse* — each operation has a reverse (subtraction for addition, decrement for increment) that lets you both add and remove elements from the aggregate.
+
+This is the mathematics underlying pg_trickle's DVM (differential view maintenance) engine. The engine carries a ruleset of delta functions for each supported aggregate and applies them when changes arrive.
+
+---
+
+## Simple Aggregates: SUM, COUNT, AVG
+
+```sql
+-- Maintain real-time revenue metrics by region and day
+SELECT pgtrickle.create_stream_table(
+  name         => 'daily_revenue',
+  query        => $$
+    SELECT
+      c.region,
+      date_trunc('day', o.created_at) AS day,
+      SUM(o.total)                    AS revenue,
+      COUNT(*)                        AS order_count,
+      AVG(o.total)                    AS avg_order_value,
+      COUNT(DISTINCT o.customer_id)   AS unique_customers
+    FROM orders o
+    JOIN customers c ON c.id = o.customer_id
+    GROUP BY c.region, date_trunc('day', o.created_at)
+  $$,
+  schedule     => '5 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+When an order is inserted:
+1. pg_trickle identifies the affected group `(region='europe', day='2026-04-27')`.
+2. The DVM engine computes `delta_revenue = +order.total`, `delta_count = +1`, `new_avg = (old_sum + order.total) / (old_count + 1)`.
+3. A single UPDATE is applied to `daily_revenue` for that one row.
+
+An order placed at 14:32 is reflected in `daily_revenue` within 5 seconds. No batch job. No ETL. No Kafka.
+
+Note the `COUNT(DISTINCT customer_id)` — this is a case where the delta is more complex. DISTINCT counts require tracking membership, not just a running tally. pg_trickle handles this with a set-based approach, but for very high-cardinality distinct counts, `HyperLogLog` approximation is often more practical and is on the roadmap.
+
+---
+
+## Conditional Aggregates
+
+Real summary tables always have conditional logic — active vs. inactive, successful vs. failed, above/below threshold.
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'support_dashboard',
+  query        => $$
+    SELECT
+      team_id,
+      COUNT(*)                                             AS total_tickets,
+      COUNT(*) FILTER (WHERE status = 'open')             AS open_tickets,
+      COUNT(*) FILTER (WHERE status = 'urgent')           AS urgent_tickets,
+      COUNT(*) FILTER (WHERE status = 'resolved'
+                       AND resolved_at > NOW() - INTERVAL '24 hours')
+                                                          AS resolved_today,
+      AVG(EXTRACT(EPOCH FROM (resolved_at - created_at)))
+        FILTER (WHERE resolved_at IS NOT NULL)            AS avg_resolution_secs,
+      MAX(created_at)                                     AS latest_ticket_at
+    FROM tickets
+    GROUP BY team_id
+  $$,
+  schedule     => '3 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+The `FILTER (WHERE ...)` construct is a standard SQL conditional aggregate. pg_trickle handles it by carrying the condition into the delta computation. A ticket transitioning from `open` to `resolved` generates:
+- `delta_open_tickets = -1`
+- `delta_resolved_today = +1` (if within the 24-hour window)
+- A recomputation of `avg_resolution_secs`
+
+The time-window filter (`resolved_at > NOW() - INTERVAL '24 hours'`) introduces a subtlety: rows can age out of the window without any DML. This is handled by pg_trickle's time-window eviction logic, which runs during each refresh cycle to evict rows that have moved outside their window bounds.
+
+---
+
+## Multi-Table Aggregates With Joins
+
+The place where batch ETL is hardest to replace is multi-table aggregation — computing aggregates over data that spans multiple source tables.
+
+```sql
+-- Per-author engagement metrics: articles + reactions + comments
+SELECT pgtrickle.create_stream_table(
+  name         => 'author_engagement',
+  query        => $$
+    SELECT
+      u.id            AS author_id,
+      u.display_name,
+      COUNT(DISTINCT a.id)                        AS article_count,
+      SUM(r.count)                                AS total_reactions,
+      COUNT(DISTINCT c.id)                        AS total_comments,
+      ROUND(SUM(r.count)::numeric /
+        NULLIF(COUNT(DISTINCT a.id), 0), 2)       AS avg_reactions_per_article
+    FROM users u
+    LEFT JOIN articles a ON a.author_id = u.id
+      AND a.published = true
+    LEFT JOIN article_reactions r ON r.article_id = a.id
+    LEFT JOIN comments c ON c.article_id = a.id
+    GROUP BY u.id, u.display_name
+  $$,
+  schedule     => '10 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+When a reaction is added to an article by author 42:
+1. The CDC trigger on `article_reactions` fires, recording the INSERT.
+2. The DVM engine evaluates the join delta: this reaction belongs to an article by author 42.
+3. The engine updates the `author_id = 42` row in `author_engagement`: `total_reactions += 1`, recompute `avg_reactions_per_article`.
+
+No other rows are touched. Author 43's metrics are unaffected.
+
+This is the join-propagation problem that makes hand-rolled incremental ETL so fragile: the change in `article_reactions` affects a row in the aggregate keyed by `author_id`, through an intermediate join on `articles`. The DVM engine handles this join-delta propagation automatically.
+
+---
+
+## Vector Aggregates: vector_avg
+
+Here's where things get interesting for ML workloads.
+
+The same algebraic principle that applies to `AVG(price)` applies to `AVG(embedding)` — a vector average is just an element-wise sum divided by a count. It's the same delta function applied to each dimension.
+
+Arriving in v0.37:
+
+```sql
+-- Per-user taste vector: average embedding of liked items
+SELECT pgtrickle.create_stream_table(
+  name         => 'user_taste',
+  query        => $$
+    SELECT
+      ul.user_id,
+      vector_avg(i.embedding)   AS taste_vec,
+      COUNT(*)                  AS like_count,
+      MAX(ul.liked_at)          AS last_interaction
+    FROM user_likes ul
+    JOIN items i ON i.id = ul.item_id
+    GROUP BY ul.user_id
+  $$,
+  schedule     => '5 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+
+CREATE INDEX ON user_taste USING hnsw (taste_vec vector_cosine_ops);
+```
+
+When user 42 likes item 1701:
+1. CDC captures the INSERT on `user_likes`.
+2. The DVM engine retrieves `item 1701's embedding`.
+3. Delta: `new_sum_vec = old_sum_vec + item_1701.embedding`, `new_count = old_count + 1`, `new_taste_vec = new_sum_vec / new_count`.
+4. One UPDATE to `user_taste` for `user_id = 42`.
+
+One million users, thousands of likes per second. Each refresh cycle touches only the users whose likes changed in that cycle. The HNSW index on `taste_vec` receives targeted updates, not a full rebuild.
+
+This replaces the "recompute all user taste vectors every night" batch job with a continuously maintained table. Users get personalization that reflects their most recent action, not last night's.
+
+---
+
+## Percentile and Rank Aggregates: The Hard Cases
+
+Not every aggregate has a clean delta function. Some require knowing the full distribution.
+
+**`PERCENTILE_CONT` / `PERCENTILE_DISC`**: Median and other percentiles require sorted access to the full set of values. There's no O(1) way to update a percentile when a single value changes. These always require a full recomputation.
+
+**`RANK()` / `DENSE_RANK()`**: Inserting one row can change the rank of every other row. This is an O(n) update in the worst case.
+
+**`NTILE()`**: Same problem as rank.
+
+For these, pg_trickle falls back to `refresh_mode => 'FULL'` — which is still useful if you want scheduled maintenance, monitoring, and the other benefits of stream tables, just without the differential speedup.
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'customer_revenue_ranks',
+  query        => $$
+    SELECT
+      customer_id,
+      total_revenue,
+      RANK() OVER (ORDER BY total_revenue DESC) AS revenue_rank
+    FROM customer_totals
+  $$,
+  schedule     => '1 minute',
+  refresh_mode => 'FULL'   -- RANK() requires full recompute
+);
+```
+
+This is still better than an unmanaged materialized view: the refresh is scheduled, monitored, and the table's freshness is visible via `pgtrickle.stream_table_status()`.
+
+---
+
+## Monitoring What You've Built
+
+Once stream tables exist, pg_trickle exposes their state through a monitoring view:
+
+```sql
+SELECT
+  name,
+  refresh_mode,
+  last_refresh_at,
+  EXTRACT(EPOCH FROM (NOW() - last_refresh_at))::int AS staleness_secs,
+  rows_changed_last_cycle,
+  avg_refresh_ms,
+  schedule
+FROM pgtrickle.stream_table_status()
+ORDER BY staleness_secs DESC;
+```
+
+This is what replaces the ETL job monitoring dashboard. You're not watching a Celery worker queue or a Kafka consumer lag counter — you're watching a PostgreSQL view that reports directly from the extension's catalog. One `SELECT` tells you everything.
+
+---
+
+## The Tradeoff
+
+Incremental aggregation inside PostgreSQL is not free. The DVM engine adds overhead to the source write path — CDC triggers add roughly 50–200 microseconds per modified row, depending on how many stream tables reference that table.
+
+For high-write workloads (thousands of writes per second), this overhead is worth measuring. pg_trickle's backpressure mechanism can be configured to shed load by falling back to full refresh when the write rate exceeds a configurable threshold.
+
+But for the vast majority of OLTP workloads — hundreds to low thousands of writes per second — the overhead is negligible, and the elimination of the external ETL layer more than compensates.
+
+The ETL pipeline that takes 40 minutes of engineering per incident and lives in a separate repository, separate monitoring system, and separate deployment pipeline? That's gone. The aggregate data is where it should have been all along: in the database, maintained by the database, queryable with SQL.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/incremental-pgvector.md
+++ b/blog/incremental-pgvector.md
@@ -1,0 +1,470 @@
+# Your pgvector Index Is Lying to You
+
+## How pg_trickle + pgvector keep your embeddings honest
+
+---
+
+You built a RAG pipeline. You embedded your documents with OpenAI. You built an HNSW index with pgvector. Your queries are fast. Life is good.
+
+Then three weeks later, a user searches for something that was definitely added last Tuesday. Your system returns a result from 2023.
+
+Welcome to the silent embedding staleness problem — the operational reality that nobody talks about when they're showing you pgvector benchmarks.
+
+This is the story of what actually goes wrong with pgvector in production, why your index degrades over time without telling you, and how combining pgvector with a PostgreSQL-native incremental view engine (pg_trickle) closes every one of those gaps.
+
+---
+
+## The Embedding Pipeline Most People Build
+
+The typical setup looks like this:
+
+1. Documents live in a `documents` table in PostgreSQL.
+2. You run a nightly job that finds "documents added or changed since yesterday," sends them to an embedding API, and writes the vectors back to a `document_embeddings` table.
+3. That table has an HNSW index (because you read the pgvector README).
+4. Your application queries `ORDER BY embedding <=> $1 LIMIT 10`.
+
+It works. It's fast. And it has at least four silent failure modes that will bite you.
+
+---
+
+## Silent Failure Mode 1: Embeddings Go Stale
+
+Between your batch job runs, every document change is invisible to your vector search. If your batch runs nightly, the maximum staleness is 23 hours and 59 minutes. If the batch job fails, it's longer.
+
+You won't know. The search will still return results. They'll just be wrong.
+
+The standard fix is to run your batch more often — hourly, every 15 minutes. But this hits a wall: running the full embedding pipeline over every changed document is expensive (API calls cost money), slow (you're deserializing thousands of rows), and fragile (you need to track what changed, handle failures, deduplicate, and guarantee no data loss).
+
+Most teams end up with a homebrewed CDC (change data capture) queue, a worker that polls it, retry logic, and a Slack alert for when it falls behind. That's a lot of infrastructure to maintain for something that is, fundamentally, a derived-data freshness problem.
+
+## Silent Failure Mode 2: Your Index Is Wrong
+
+Let me explain something about IVFFlat indexes that doesn't appear in introductory tutorials.
+
+IVFFlat works by clustering your vectors at build time into `lists` groups (usually 100–1000). At query time, it searches only the nearest `probes` clusters (usually 1–10% of the total). This is what makes it fast.
+
+The problem is that the cluster assignments are computed from the data **at build time**. When you add new documents with different topics (a new product category, a recent news event, a new code language), those vectors don't fit neatly into the existing clusters. IVFFlat puts them in the nearest cluster anyway, but the recall degrades — silently.
+
+The pgvector documentation recommends: "Don't build the index until you have enough data. Rebuild on a schedule."
+
+But what schedule? How do you know when to rebuild? How do you automate it without rebuilding unnecessarily? And how do you `REINDEX` a 10-million-row table without taking your search offline?
+
+Most teams either never rebuild (recall degrades slowly over months), rebuild on a fixed weekly schedule (blunt instrument), or get paged when someone notices quality has dropped.
+
+HNSW has a related problem: deletions create tombstones. HNSW never actually removes deleted nodes from the graph — it marks them. After enough deletions, your index is navigating through a graveyard. Build operations slow down. Query recall drops.
+
+## Silent Failure Mode 3: You're Not Searching What You Think You're Searching
+
+Here's something that sounds obvious but causes real pain: the table your HNSW index sits on is not your documents table. It's a denormalization of it.
+
+Your real question to a semantic search system is something like: "Find me the 10 most relevant documents, from active projects, that my user has permission to see, with their associated category names and last-updated timestamps."
+
+That requires joining `documents` → `document_permissions` → `categories` → `projects`. But pgvector indexes a single table. So you either:
+
+**Option A:** Index the raw documents table, then filter post-query. Except filtering *after* the ANN search means you're retrieving `k * overhead` candidates from the index and hoping enough survive the filters. For fine-grained ACL filtering, you might need to retrieve 10× candidates to end up with 10 results.
+
+**Option B:** Maintain a denormalized flat table manually — one row per document with all the fields joined. Except this flat table needs to stay synchronized with every source table that feeds it. Add a category? The flat table is wrong. Update a permission? The flat table is wrong. Your data engineering team writes a bunch of triggers and prays.
+
+**Option C:** Just use Elasticsearch, which at least has an ETL ecosystem. But now you're maintaining two systems with two consistency models.
+
+## Silent Failure Mode 4: Aggregate Vectors Are Always Stale
+
+If you're doing anything more sophisticated than flat document search — collaborative filtering, user preference vectors, cluster centroids for dimensionality reduction, category-representative embeddings — you're computing aggregate vectors.
+
+```sql
+-- The user's "taste" based on items they've interacted with
+SELECT avg(item_embeddings.embedding)
+FROM user_actions
+JOIN item_embeddings ON item_embeddings.item_id = user_actions.item_id
+WHERE user_actions.user_id = 42;
+```
+
+This query is fine for a single user. For a million users, you precompute it and store the results. But "precompute and store" means you need to recompute whenever a user takes a new action. Back to the batch-job problem.
+
+Every time someone likes an item, their taste vector is stale until the next batch. The longer your batch interval, the more personalization debt you accumulate.
+
+---
+
+## What pg_trickle Actually Does
+
+pg_trickle is a PostgreSQL extension that implements **incremental view maintenance** — IVM for short.
+
+The idea is simple in principle: instead of recomputing a derived table from scratch every time, figure out what changed and apply only that change. If a user likes one new item, compute the difference to their taste vector from that one new item, and apply it. Don't scan their entire history.
+
+In practice, this is mathematically hard. Differential dataflow — the theory underlying pg_trickle's engine — was developed at Microsoft Research in the 2010s and is still an active research area. The key insight is that for certain classes of queries (the ones that matter in practice: JOINs, GROUP BYs, aggregates, filters, window functions), you can express the "how does the result change if one input row changes?" question as a formal algebraic operation.
+
+For `SUM(x)`: if you add a row with `x = 5`, the new sum is `old_sum + 5`. You don't need to re-scan.
+
+For `COUNT(*)`: if you delete a row, the new count is `old_count - 1`.
+
+For `AVG(embedding)` over all items a user has liked: if the user likes one new item with embedding `v`, the new average is `(old_sum_vector + v) / (old_count + 1)`. No re-scan, no batch job.
+
+This works because these operations have well-defined *inverses*. The math for vector aggregation is actually straightforward: a vector mean is a sum divided by a count, and sums are algebraically invertible.
+
+What makes pg_trickle different from just writing clever UPDATE queries is that the engine handles this automatically, across arbitrary SQL queries, including multi-table JOINs and nested aggregations.
+
+---
+
+## The Problem That Makes This Hard (And How pg_trickle Solves It)
+
+The hard part of IVM isn't the aggregate math — it's figuring out *what changed*.
+
+When someone inserts a row into `user_actions`, pg_trickle needs to know:
+- Which stream tables depend on `user_actions`
+- Which groups in the stream table are affected (only this user's taste vector)
+- What the correct delta is for each affected group
+- How to apply that delta without violating consistency
+
+pg_trickle handles this with a **trigger-based CDC pipeline**. When you create a stream table, pg_trickle attaches `AFTER INSERT/UPDATE/DELETE` triggers to every source table in the query. These triggers write changes to per-source change buffers (in a `pgtrickle_changes` schema) as part of the original transaction.
+
+This means change capture is:
+- **Transactional.** If the original write rolls back, the change record is gone too.
+- **Low-latency.** The buffer is populated in microseconds.
+- **Correct under concurrency.** Because it's within the same transaction, you can't have a change that gets captured but whose write later fails.
+
+The scheduler then picks up these change buffers on a configurable cadence and applies them through the DVM (differential view maintenance) engine, which computes the incremental delta, then applies it to the stream table via a single `MERGE` statement.
+
+The stream table is a normal PostgreSQL table. It has all the usual guarantees: WAL-logged, MVCC-correct, ACID-transactional. You can index it any way you like, including HNSW.
+
+---
+
+## The pgvector + pg_trickle Pattern
+
+Here's where it clicks.
+
+The problems pgvector has in production — embedding staleness, index drift, denormalization complexity, aggregate vector maintenance — are all instances of the same underlying problem: **derived data that needs to stay synchronized with source data**.
+
+That is exactly what pg_trickle was built to solve.
+
+### Always-Fresh Embeddings
+
+```sql
+-- You define the relationship once.
+-- pg_trickle handles the synchronization forever.
+SELECT pgtrickle.create_stream_table(
+  name         => 'docs_embedded',
+  query        => $$
+    SELECT d.id, d.title, d.body,
+           pgai.embed('text-embedding-3-small', d.body) AS embedding,
+           d.project_id, d.updated_at
+    FROM documents d
+    WHERE d.status = 'active'
+  $$,
+  schedule     => '10 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+
+CREATE INDEX ON docs_embedded USING hnsw (embedding vector_cosine_ops);
+```
+
+Now when a document body changes, pg_trickle's CDC trigger captures the change. Within the next refresh cycle (10 seconds by default), only the changed document's row is updated in `docs_embedded`. The HNSW index receives a precise insert+delete pair. No batch job. No queue. No worker. No drift.
+
+The important word here is **DIFFERENTIAL**. The engine doesn't recompute the entire corpus. It processes only the rows that changed since the last cycle. If 1 document changes out of 1 million, it touches 1 row's worth of work.
+
+### Denormalized Corpora as First-Class Citizens
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'search_corpus',
+  query        => $$
+    SELECT
+      d.id,
+      d.title,
+      d.body,
+      d.embedding,
+      array_agg(DISTINCT t.name) AS tags,
+      p.name                     AS project_name,
+      u.email                    AS owner_email,
+      acl.read_roles             AS allowed_roles,
+      d.updated_at
+    FROM documents     d
+    JOIN projects      p   ON p.id = d.project_id
+    JOIN users         u   ON u.id = d.owner_id
+    LEFT JOIN doc_tags dt  ON dt.doc_id = d.id
+    LEFT JOIN tags     t   ON t.id = dt.tag_id
+    JOIN doc_acl       acl ON acl.doc_id = d.id
+    WHERE d.status = 'active'
+    GROUP BY d.id, p.name, u.email, acl.read_roles
+  $$,
+  schedule     => '10 seconds'
+);
+```
+
+This is not a view. This is a real table, updated incrementally. When a tag is added to a document, only that document's row is updated in `search_corpus`. When a project is renamed, only documents in that project update. When a permission changes, only the affected document's `allowed_roles` changes.
+
+Your vector search now operates on a fully denormalized flat table with correct metadata — without a single ETL pipeline.
+
+### Centroid Maintenance with `vector_avg`
+
+The `vector_avg` algebraic aggregate (arriving in v0.37.0) is one of the most powerful things in this story.
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'user_taste',
+  query        => $$
+    SELECT
+      ua.user_id,
+      vector_avg(e.embedding) AS taste_vec,
+      COUNT(*) AS interaction_count
+    FROM user_actions ua
+    JOIN item_embeddings e ON e.item_id = ua.item_id
+    WHERE ua.action = 'liked'
+    GROUP BY ua.user_id
+  $$,
+  schedule     => '5 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+
+CREATE INDEX ON user_taste USING hnsw (taste_vec vector_cosine_ops);
+```
+
+When user 42 likes a new item, the DVM engine computes:
+```
+new_taste = (old_sum_vector + new_item.embedding) / (old_count + 1)
+```
+
+Only user 42's row changes. The HNSW index on `taste_vec` receives one update. For a system with 10 million users where thousands interact per second, this is the difference between "runs at scale" and "falls over."
+
+This is possible because `avg(vector)` is an *algebraic aggregate* — it has a well-defined incremental update rule. The same mathematics pg_trickle uses to maintain `AVG(price)` or `SUM(revenue)` applies directly to vector means.
+
+### The Reindex Problem, Solved Differently
+
+Here's a more nuanced take on IVFFlat rebuild. The question isn't "when do I run `REINDEX`?" — it's "how do I know when the drift is bad enough to justify the rebuild cost?"
+
+pg_trickle tracks the number of rows changed since the last reindex as a first-class catalog value. You set a drift threshold and a post-refresh action, and the engine handles the rest:
+
+```sql
+SELECT pgtrickle.alter_stream_table(
+  'docs_embedded',
+  post_refresh_action      => 'reindex_if_drift',
+  reindex_drift_threshold  => 0.10   -- 10% of rows changed → rebuild
+);
+```
+
+Internally: after each refresh, the scheduler checks `rows_changed_since_last_reindex / total_rows`. If it exceeds the threshold, it enqueues an async `REINDEX` job (non-blocking, using `REINDEX CONCURRENTLY`) in a lower-priority tier so it never delays your search.
+
+And through the `pgtrickle.vector_status()` monitoring view, you can see the drift percentage, last reindex time, and embedding lag for every vector stream table in your system — as a live, incrementally-maintained view.
+
+---
+
+## What Makes This Genuinely Unique
+
+There are other approaches to this problem. Let's be honest about why they fall short.
+
+**The standard nightly batch job.** Cheap to build, painful to maintain. Staleness measured in hours. Doesn't handle incremental aggregates. Breaks silently when the source schema changes.
+
+**Change-data-capture pipelines (Debezium + Kafka).** Solves the freshness problem, but requires you to run Kafka, manage a Debezium connector, write a consumer that does the embedding logic, handle replication lag, coordinate schema changes across two systems, and ensure exactly-once semantics. It's a significant operational burden, and the embedding logic lives outside your database with no transactional guarantees.
+
+**Read-through caches (ReadySet, Materialize).** These are purpose-built incremental-view systems, but they're separate processes, not PostgreSQL extensions. Your vector search lives in a different place from your transactional data. Schema changes have to be coordinated. You're back to a distributed system.
+
+**pg_ivm.** The closest PostgreSQL-native alternative. But pg_ivm doesn't support complex queries (no aggregates in JOINs, no OUTER JOINs, limited GROUP BY). And it has no scheduler, no CDC pipeline, no vector-aggregate support. It's more of a research prototype than a production system.
+
+**Pinecone, Weaviate, Qdrant.** These are purpose-built vector databases. They handle the indexing and search side well. But they have no SQL engine, no notion of derived data or incremental views, and require a synchronization pipeline from your source database to keep them fresh. You're back to the Debezium/ETL problem.
+
+The unique property of pg_trickle + pgvector is that **everything happens inside PostgreSQL, transactionally, automatically, with no external dependencies.**
+
+The change buffers are written in the same transaction as the source write. The refresh applies a `MERGE` to the stream table, which is WAL-logged. The HNSW index is updated by PostgreSQL's normal index AM callback, not by any special integration. The monitoring view is itself a stream table.
+
+You cannot have a stale HNSW index while the underlying stream table is up-to-date. The index and the data are maintained by the same ACID engine.
+
+---
+
+## A Concrete Example: A Company's Documentation Site
+
+Let's make this concrete. Imagine you're building a developer documentation platform. You have:
+
+- 500,000 documentation pages across 2,000 projects
+- Pages belong to projects, have tags, have explicit access permissions
+- 50 edits per minute on average
+- Search must return results scoped to the user's permitted projects
+- You want semantic search ("find me docs about async error handling in Rust") plus keyword search
+
+**Without pg_trickle:**
+You maintain a Python worker that polls for changed pages every 5 minutes, batches them, calls the embedding API, writes back vectors, and then... has no way to update the HNSW index incrementally. So you rebuild the index nightly. Your search is on data that's up to 24 hours stale. Your permission filtering happens after ANN retrieval, requiring over-fetching. You have three separate codebases (app, worker, index pipeline) and two failure modes.
+
+**With pg_trickle + pgvector:**
+
+```sql
+-- 1. Define the search corpus once
+SELECT pgtrickle.create_stream_table(
+  name     => 'doc_search_corpus',
+  query    => $$
+    SELECT
+      d.id,
+      d.title,
+      d.body,
+      d.embedding,
+      array_agg(DISTINCT t.name)  AS tags,
+      d.project_id,
+      p.name                      AS project_name,
+      dp.allowed_user_ids         AS allowed_users
+    FROM   docs d
+    JOIN   projects    p   ON p.id  = d.project_id
+    JOIN   doc_perms   dp  ON dp.doc_id = d.id
+    LEFT JOIN doc_tags dt  ON dt.doc_id = d.id
+    LEFT JOIN tags     t   ON t.id  = dt.tag_id
+    WHERE  d.published = true
+    GROUP BY d.id, p.name, dp.allowed_user_ids
+  $$,
+  schedule             => '10 seconds',
+  refresh_mode         => 'DIFFERENTIAL',
+  post_refresh_action  => 'reindex_if_drift',
+  reindex_drift_threshold => 0.15
+);
+
+-- 2. Create indexes for hybrid search
+CREATE INDEX ON doc_search_corpus
+  USING hnsw (embedding vector_cosine_ops);
+
+CREATE INDEX ON doc_search_corpus
+  USING gin (to_tsvector('english', title || ' ' || body));
+
+CREATE INDEX ON doc_search_corpus (project_id);
+CREATE INDEX ON doc_search_corpus USING gin (allowed_users);
+```
+
+That's it. Two SQL statements (one stream table, two indexes). From now on:
+- Every page edit propagates to the corpus within 10 seconds.
+- Every permission change propagates within 10 seconds.
+- The HNSW index stays current automatically.
+- When 15% of docs have changed, the index is rebuilt concurrently without downtime.
+- Your search query is simple:
+
+```sql
+SELECT id, title, project_name, ts_rank_cd(to_tsvector('english', body), q) AS text_rank,
+       embedding <=> $1 AS vec_dist
+FROM   doc_search_corpus,
+       to_tsquery('english', $2) q
+WHERE  $3 = ANY(allowed_users)          -- ACL filter
+  AND  to_tsvector('english', body) @@ q -- keyword filter
+ORDER  BY embedding <=> $1              -- vector sort
+LIMIT  20;
+```
+
+Vector similarity, full-text ranking, ACL filter — on one table, one query, with correct fresh data.
+
+---
+
+## The Architecture in Plain English
+
+Here's how pg_trickle actually connects the pieces:
+
+**Step 1 — CDC capture.** When your app inserts or updates a document, PostgreSQL fires an AFTER trigger (installed by pg_trickle). This trigger writes the changed row's key and diff to a tiny change buffer table in the same transaction. The trigger runs in microseconds. Your application never notices.
+
+**Step 2 — Scheduler wakeup.** pg_trickle's background worker maintains a schedule. For a 10-second interval stream table, it wakes up every 10 seconds. (With IMMEDIATE mode, it can wake up after every single write — sub-millisecond latency.)
+
+**Step 3 — Differential computation.** The scheduler reads all change buffer entries accumulated since the last refresh. It runs them through the DVM engine, which computes the delta: which rows in the stream table need to be inserted, updated, or deleted.
+
+**Step 4 — MERGE.** The engine applies the delta to the stream table via a single `MERGE` statement. For a change to 5 documents out of 500,000, this touches 5 rows. PostgreSQL's normal index AM callbacks fire for each row, updating the HNSW and GIN indexes automatically.
+
+**Step 5 — Post-refresh actions.** If `reindex_if_drift` is enabled and the threshold is crossed, the scheduler enqueues an async reindex job in a lower-priority tier.
+
+**Step 6 — Monitoring.** `pgtrickle.vector_status()` shows lag, drift, index age, and aggregate counts in real time.
+
+Every step is within PostgreSQL. Every step is ACID-safe. No external processes, no message queues, no separate services.
+
+---
+
+## What's Coming
+
+pg_trickle's pgvector integration is being shipped across four releases:
+
+**v0.37.0 (next release):** `vector_avg` and `vector_sum` algebraic aggregates. Centroid maintenance, recommendation taste vectors, and cluster representatives become fully incremental.
+
+**v0.38.0:** Post-refresh action hooks (`reindex_if_drift`), drift tracking, the `pgtrickle.vector_status()` monitoring view, and a one-command Docker image with pg_trickle + pgvector + pgai pre-installed.
+
+**v0.39.0:** Sparse-vector aggregates (`sparsevec_avg`) for SPLADE and learned sparse models. Half-precision aggregates (`halfvec_avg`) for storage-tiered pipelines. Reactive subscriptions over distance predicates — "alert me when a new transaction embedding enters the fraud zone."
+
+**v0.40.0:** A high-level `embedding_stream_table()` API where you describe your corpus in a few parameters and get a fully configured, indexed, monitored stream table back. Research into materialised k-NN graphs for fixed-pivot retrieval. Per-tenant embedding corpora with row-level security.
+
+---
+
+## The Honest Answer About What's Already Working
+
+Some of this is shipping in the next two months. Some is not built yet. Let's be clear:
+
+**Working today (no engine changes needed):**
+- Vector columns pass through the CDC pipeline correctly. If your table has a `vector(1536)` column, pg_trickle can maintain stream tables over it.
+- FULL mode stream tables work with any pgvector expression, including distance operators.
+- Denormalized corpora (the multi-table JOIN pattern) work today.
+
+**Shipping in v0.37.0:**
+- `vector_avg` and `vector_sum` aggregates in DIFFERENTIAL mode.
+- Distance operators in stream table definitions with a documented, safe FULL-mode fallback.
+
+**Shipping in v0.38.0–v0.40.0:**
+- Drift-aware reindexing, monitoring views, ergonomic API.
+
+If you're using pgvector today and you're tired of babysitting embedding pipelines, the denormalized-corpus pattern works right now. The centroid/aggregate pattern lands in v0.37.
+
+---
+
+## A Different Way to Think About It
+
+pgvector answers: "How do I store and search vectors in PostgreSQL?"
+
+pg_trickle answers: "How do I keep any derived data fresh in PostgreSQL?"
+
+Embeddings are derived data. An embedding of a document is derived from the document's text, metadata, and any transformations you apply. A user taste vector is derived from that user's interaction history. A search corpus is derived from your documents, permissions, tags, and projects.
+
+If you believe that derived data should be maintained automatically and transactionally — rather than rebuilt in batches by external workers — then pg_trickle + pgvector is the natural home for your AI stack.
+
+PostgreSQL already handles your source data transactionally. There's no fundamental reason why the derived data that feeds your AI features should be any different.
+
+---
+
+## Getting Started
+
+Both extensions are single `CREATE EXTENSION` statements. If you're on a managed PostgreSQL provider (RDS, Cloud SQL, Neon, Supabase, Crunchy, CNPG), pgvector is already available. pg_trickle is available as a Docker image, PGXN package, and direct install.
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+CREATE EXTENSION IF NOT EXISTS pg_trickle;
+```
+
+From there:
+
+```sql
+-- Create your source table with an embedding column
+CREATE TABLE documents (
+  id        SERIAL PRIMARY KEY,
+  body      TEXT NOT NULL,
+  embedding vector(1536),  -- pre-computed by your app or pgai
+  project_id INT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- Create a stream table over it
+SELECT pgtrickle.create_stream_table(
+  name     => 'docs_search',
+  query    => $$ SELECT id, body, embedding, project_id FROM documents $$,
+  schedule => '5 seconds'
+);
+
+-- Create the ANN index
+CREATE INDEX ON docs_search USING hnsw (embedding vector_cosine_ops);
+
+-- Query it
+SELECT id, body
+FROM   docs_search
+ORDER  BY embedding <=> $1
+LIMIT  10;
+```
+
+That's the starting point. No workers, no queues, no ETL. Just two extensions and a SQL statement.
+
+---
+
+## Conclusion
+
+pgvector is an excellent piece of infrastructure. It brings serious vector storage and approximate nearest-neighbour search to PostgreSQL — an environment that already handles transactions, replication, backups, access control, and full-text search. The case for keeping your AI data in PostgreSQL rather than a purpose-built vector database is compelling.
+
+But pgvector has a production gap that the benchmarks don't show: keeping embeddings fresh, indexes current, and derived data synchronized with its sources is genuinely hard. The default answer is "batch jobs, cron schedules, and manual REINDEX." That works until it doesn't.
+
+pg_trickle fills that gap. Not by adding complexity, but by doing what PostgreSQL has always done best — providing a reliable, transactional foundation where data is always correct, always fresh, and always where you expect it.
+
+The combination isn't a workaround. It's what the stack should have looked like all along.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension. Source code, documentation, and installation instructions are at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle). The pgvector integration roadmap is detailed in the repository's `plans/ecosystem/PLAN_PGVECTOR.md` and roadmap files.*

--- a/blog/multi-tenant-vector-search-rls.md
+++ b/blog/multi-tenant-vector-search-rls.md
@@ -1,0 +1,296 @@
+# Multi-Tenant Vector Search with Row-Level Security and pg_trickle
+
+## Zero cross-tenant data leakage without separate tables or databases
+
+---
+
+Multi-tenant SaaS and vector search are a challenging combination.
+
+The standard options are: one embedding table per tenant (operational nightmare at scale), one shared table filtered by a `tenant_id` column (correctness depends entirely on never forgetting the WHERE clause), or a dedicated vector database instance per tenant (very expensive, very complex).
+
+PostgreSQL's Row-Level Security (RLS) offers a fourth option: a shared table where the database *enforces* per-tenant isolation, independent of application code. Combine this with pg_trickle stream tables and you get per-tenant search corpora that are maintained incrementally, correctly isolated, and queryable efficiently.
+
+This post is about how to build that.
+
+---
+
+## The Problem With Shared Tables
+
+The naive approach to multi-tenant vector search:
+
+```sql
+CREATE TABLE document_embeddings (
+  id          bigserial PRIMARY KEY,
+  tenant_id   bigint NOT NULL,
+  content     text,
+  embedding   vector(1536),
+  created_at  timestamptz DEFAULT NOW()
+);
+
+CREATE INDEX ON document_embeddings USING hnsw (embedding vector_cosine_ops);
+```
+
+Application queries then filter by tenant:
+
+```sql
+SELECT id, content, embedding <=> $query AS distance
+FROM document_embeddings
+WHERE tenant_id = $current_tenant_id
+ORDER BY embedding <=> $query
+LIMIT 10;
+```
+
+This works until it doesn't. The failure modes:
+
+**Application bugs:** A query that forgets the `WHERE tenant_id = ?` clause leaks data across tenants. This is an application-level constraint enforced only by developer discipline.
+
+**Poor ANN performance with filtering:** HNSW searches find the approximate nearest neighbors across the *entire* index, then filters to the tenant. If a tenant has 1% of the total rows, you might retrieve 100 candidates from the full index before finding 10 that pass the tenant filter. You're doing ~10× wasted work.
+
+**Uneven distributions:** A large tenant dominates the ANN index. Their document embeddings cluster tightly. Smaller tenants have their embeddings scattered across the index graph among the dominant tenant's nodes. Query latency and recall vary wildly across tenants.
+
+---
+
+## Row-Level Security: Database-Enforced Isolation
+
+RLS moves the isolation guarantee from application code to the database engine.
+
+```sql
+-- Enable RLS on the table
+ALTER TABLE document_embeddings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE document_embeddings FORCE ROW LEVEL SECURITY;
+
+-- Create a policy that restricts reads to the current tenant
+CREATE POLICY tenant_isolation ON document_embeddings
+  AS RESTRICTIVE
+  FOR ALL
+  USING (tenant_id = current_setting('app.current_tenant_id')::bigint);
+```
+
+Now every query against `document_embeddings` automatically scopes to the current tenant, set via `SET LOCAL app.current_tenant_id = ?` at the start of each request.
+
+```sql
+-- Application code sets the tenant context
+SET LOCAL app.current_tenant_id = 42;
+
+-- This query now implicitly filters to tenant 42 — the RLS policy applies
+SELECT id, content, embedding <=> $query AS distance
+FROM document_embeddings
+ORDER BY distance
+LIMIT 10;
+```
+
+The `WHERE tenant_id = ?` clause is gone from the query. The database enforces it. Forgetting to filter is now impossible — the policy applies to *all* queries, including ORMs, raw SQL, and debugging queries run manually.
+
+The `FORCE ROW LEVEL SECURITY` clause makes the policy apply to table owners too, preventing superuser-adjacent roles from bypassing it.
+
+---
+
+## The ANN Performance Problem Remains
+
+RLS fixes the correctness problem but not the ANN performance problem.
+
+HNSW builds a graph over the entire table. When you query with an RLS policy filtering to one tenant, the database:
+1. Starts an ANN search from the query vector's neighborhood
+2. Traverses the HNSW graph
+3. Applies the RLS filter to each candidate
+4. Collects enough passing candidates to return `LIMIT k` results
+
+For small tenants, this is expensive. The graph traversal visits many nodes from other tenants before finding enough that pass the filter.
+
+The pgvector `iterative_scan` feature helps — it expands the search until enough candidates pass filtering:
+
+```sql
+SET hnsw.iterative_scan = strict_order;
+
+SELECT id, content, embedding <=> $query AS distance
+FROM document_embeddings
+ORDER BY distance
+LIMIT 10;
+```
+
+But iterative scan has a cost ceiling (`hnsw.max_scan_tuples`), and for very small tenants in a large shared table, even iterative scan may exhaust the ceiling before finding 10 results.
+
+The right solution is **per-tenant partial indexes**:
+
+```sql
+-- One index per tenant, covering only their rows
+CREATE INDEX CONCURRENTLY doc_emb_tenant_42_idx
+ON document_embeddings USING hnsw (embedding vector_cosine_ops)
+WHERE tenant_id = 42;
+```
+
+With a partial index, the ANN search only navigates the subgraph for tenant 42. It's as if they have their own dedicated index. Recall is high, latency is consistent, and there's no wasted work scanning other tenants' data.
+
+The problem with per-tenant partial indexes is operationally managing them: creating them for new tenants, dropping them for churned tenants, rebuilding them as distributions drift, and monitoring their health.
+
+---
+
+## pg_trickle Stream Tables for Per-Tenant Corpora
+
+pg_trickle stream tables change the operational model. Instead of maintaining indexes on the shared raw table, you maintain per-tenant (or group-of-tenant) stream tables that contain only that tenant's data:
+
+```sql
+-- Per-tenant search corpus
+SELECT pgtrickle.create_stream_table(
+  name         => 'tenant_42_corpus',
+  query        => $$
+    SELECT
+      d.id,
+      d.title,
+      d.content,
+      d.embedding,
+      u.display_name AS author,
+      array_agg(t.name ORDER BY t.name) AS tags,
+      d.created_at
+    FROM documents d
+    JOIN users u ON u.id = d.author_id
+    LEFT JOIN document_tags dt ON dt.document_id = d.id
+    LEFT JOIN tags t ON t.id = dt.tag_id
+    WHERE d.tenant_id = 42
+    AND d.published = true
+    GROUP BY d.id, d.title, d.content, d.embedding,
+             u.display_name, d.created_at
+  $$,
+  schedule     => '5 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+
+CREATE INDEX ON tenant_42_corpus USING hnsw (embedding vector_cosine_ops);
+```
+
+Now `tenant_42_corpus` is a real table containing only tenant 42's published documents, denormalized with author names and tags, with its own HNSW index. Queries against this table are fast because the index covers exactly the right data.
+
+The DVM engine maintains the corpus: new documents appear within 5 seconds, tag changes propagate, unpublished documents are removed.
+
+---
+
+## The Operational Challenge: Many Tenants
+
+For 10 tenants, creating individual stream tables is fine. For 1,000 tenants, it's not.
+
+The practical solution at scale is tiered tenancy:
+
+**Large tenants** (top 5–10% by document count): individual stream tables with dedicated HNSW indexes.
+
+**Medium tenants**: grouped stream tables covering 10–50 tenants per group, with partial indexes per tenant within the group.
+
+**Small tenants** (long tail, few documents each): shared table with RLS and partial indexes, or (for very small tenants) exact search is fast enough and an ANN index isn't worth the overhead.
+
+```sql
+-- Tier 1: Large tenant, individual corpus
+SELECT pgtrickle.create_stream_table(
+  name    => 'corpus_tenant_42',
+  query   => $$ ... WHERE tenant_id = 42 ... $$,
+  ...
+);
+
+-- Tier 2: Medium tenants grouped by a hash
+SELECT pgtrickle.create_stream_table(
+  name    => 'corpus_group_07',
+  query   => $$ ... WHERE tenant_id % 20 = 7 ... $$,
+  ...
+);
+-- Plus per-tenant partial HNSW within the group
+
+-- Tier 3: Long tail, shared table with RLS (no stream table)
+-- Exact search for tiny tenants is fast enough
+```
+
+The tier assignment can change as tenants grow. When a medium tenant exceeds a threshold, create an individual stream table and remove them from the group.
+
+---
+
+## Combining RLS With Stream Tables
+
+Stream tables are regular PostgreSQL tables. You can apply RLS policies to them:
+
+```sql
+-- The shared "all tenants" stream table approach with RLS
+SELECT pgtrickle.create_stream_table(
+  name  => 'document_corpus',
+  query => $$
+    SELECT
+      d.id, d.tenant_id, d.title, d.content, d.embedding,
+      u.display_name AS author
+    FROM documents d
+    JOIN users u ON u.id = d.author_id
+    WHERE d.published = true
+  $$,
+  ...
+);
+
+ALTER TABLE document_corpus ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON document_corpus
+  AS RESTRICTIVE FOR ALL
+  USING (tenant_id = current_setting('app.current_tenant_id')::bigint);
+
+-- Per-tenant partial HNSW indexes on the stream table
+CREATE INDEX corpus_tenant_42_idx ON document_corpus
+USING hnsw (embedding vector_cosine_ops) WHERE tenant_id = 42;
+```
+
+This combines incremental maintenance (the stream table stays fresh) with database-enforced isolation (RLS) and efficient search (partial indexes per tenant).
+
+The stream table contains all tenants' data — maintained by a single refresh cycle — but each query is automatically scoped to the current tenant by RLS, and executes using that tenant's partial index.
+
+---
+
+## The USING INDEX HINT
+
+For the query planner to use the correct partial index, the query needs to make the tenant constraint visible to the planner.
+
+With RLS, the policy is applied after the planner generates the query plan. The planner doesn't see the `tenant_id = ?` constraint at plan time, so it may choose the full-table HNSW index over the partial index.
+
+The workaround is to set the tenant context *before* planning, using `SET LOCAL` in the same transaction, and to include the tenant condition explicitly in the query:
+
+```sql
+BEGIN;
+SET LOCAL app.current_tenant_id = 42;
+
+-- Include tenant_id explicitly so the planner can choose the partial index
+SELECT id, content, embedding <=> $query AS distance
+FROM document_corpus
+WHERE tenant_id = 42  -- explicit, even though RLS would filter anyway
+ORDER BY distance
+LIMIT 10;
+
+COMMIT;
+```
+
+The explicit `WHERE tenant_id = 42` lets the planner see that the partial index `corpus_tenant_42_idx` (which covers `WHERE tenant_id = 42`) is applicable, and choose it over the full-table index. The RLS policy remains as a safety net.
+
+---
+
+## Drift-Aware Reindexing Per Tenant
+
+With per-tenant partial indexes, drift affects each index independently. A tenant that adds 30% new documents needs their partial index rebuilt. A tenant with stable content doesn't.
+
+```sql
+-- Set drift policy on the corpus stream table
+SELECT pgtrickle.alter_stream_table(
+  'document_corpus',
+  post_refresh_action     => 'reindex_if_drift',
+  reindex_drift_threshold => 0.20,
+  reindex_scope           => 'per_partition'  -- v0.38+
+);
+```
+
+The `per_partition` scope applies the drift threshold per-tenant (or per-partition for partitioned tables), so only the tenants with high churn get their indexes rebuilt.
+
+---
+
+## What Isolation Level You Actually Get
+
+With this setup:
+- **Data isolation**: RLS enforces it. Even if application code is buggy, cross-tenant reads are impossible.
+- **Index isolation**: Partial indexes ensure ANN search stays within tenant boundaries.
+- **Freshness isolation**: Stream table refresh applies to all tenants uniformly. A tenant with high write volume doesn't delay freshness for others.
+- **Schema isolation**: None. All tenants share the same schema. For full schema isolation (different columns per tenant), you'd need separate tables or a tenant-specific metadata system.
+
+The tradeoff: shared infrastructure is efficient and manageable. True schema-level isolation requires separate tables or separate database instances, which is operationally much heavier.
+
+For most multi-tenant SaaS use cases — same schema, different data — the RLS + stream table + partial index approach provides correct isolation at operational sanity.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/outbox-pattern-turbocharged.md
+++ b/blog/outbox-pattern-turbocharged.md
@@ -1,0 +1,262 @@
+# The Outbox Pattern, Turbocharged
+
+## Transactionally Consistent Event Emission from PostgreSQL Without Dual-Write
+
+---
+
+The outbox pattern exists because distributed systems lie.
+
+The lie: "I'll save the record to the database and send the event to Kafka in the same operation." The reality: one of those can fail while the other succeeds. You commit the database record but the Kafka send times out. Or the Kafka send succeeds but your process crashes before the database commits. Either way, downstream systems have a different view of the world than your database.
+
+The outbox pattern is the solution: write the event to a `outbox` table in the *same* transaction as the business record. A separate process reads the outbox and publishes to Kafka/SQS/whatever. The outbox is durable because it's in PostgreSQL. The publication is idempotent because you can retry. Exactly-once-delivery becomes achievable.
+
+This pattern is well-understood. It's implemented by Debezium, AWS EventBridge Pipes, and a dozen ORM libraries. It works.
+
+What it doesn't do: maintain the outbox entries incrementally as derived data changes. If the event you need to emit is "the customer's order total changed" — a derived aggregate — you need to compute that aggregate, write it to the outbox, and keep it fresh as orders change.
+
+This is where pg_trickle stream tables change the model.
+
+---
+
+## The Standard Outbox and Its Limitations
+
+The standard outbox implementation:
+
+```sql
+CREATE TABLE outbox (
+  id          bigserial PRIMARY KEY,
+  aggregate_type  text NOT NULL,    -- e.g., 'Order', 'Customer'
+  aggregate_id    bigint NOT NULL,
+  event_type      text NOT NULL,    -- e.g., 'OrderPlaced', 'TotalUpdated'
+  payload         jsonb NOT NULL,
+  created_at      timestamptz DEFAULT NOW(),
+  published_at    timestamptz,
+  published       boolean DEFAULT false
+);
+
+-- Application code
+BEGIN;
+INSERT INTO orders (customer_id, total, ...) VALUES (...);
+INSERT INTO outbox (aggregate_type, aggregate_id, event_type, payload)
+VALUES ('Order', $new_order_id, 'OrderPlaced', $payload::jsonb);
+COMMIT;
+```
+
+The outbox relay picks up unpublished rows, sends them, marks them published. Clean and correct.
+
+**Limitation 1: Complex derived events require application logic.**
+
+Emitting an `OrderTotalChanged` event when an order's total changes due to an item update requires detecting the change, computing the new total, constructing the event, and writing it to the outbox — all in the application layer. This logic is duplicated for every code path that can change an order's total.
+
+**Limitation 2: Aggregate-level events require aggregation.**
+
+Emitting a `CustomerRevenueUpdated` event — the customer's total revenue across all orders — requires aggregating in the application, which means either an extra SELECT or maintaining the aggregate as denormalized state. If the aggregate is maintained via triggers, you're back to the trigger-maintenance problem.
+
+**Limitation 3: Multi-table derived events are fragile.**
+
+If the event payload should include denormalized fields from related tables (shipping address, product name, account tier), the application must join them at event creation time. This works but creates tight coupling between the event schema and the application code at write time.
+
+---
+
+## Stream Tables as Event Sources
+
+pg_trickle stream tables are maintained tables. When a stream table row changes, the change is a computable event. You can attach an outbox relay directly to stream table changes.
+
+```sql
+-- A stream table that computes customer-level revenue state
+SELECT pgtrickle.create_stream_table(
+  name         => 'customer_revenue_state',
+  query        => $$
+    SELECT
+      c.id            AS customer_id,
+      c.email,
+      c.account_tier,
+      COUNT(o.id)     AS order_count,
+      SUM(o.total)    AS total_revenue,
+      MAX(o.created_at) AS last_order_at
+    FROM customers c
+    LEFT JOIN orders o ON o.customer_id = c.id
+    GROUP BY c.id, c.email, c.account_tier
+  $$,
+  schedule     => '10 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+Every time a customer's order count or total revenue changes — whether from a new order, a refund, or a cancelled order — the corresponding row in `customer_revenue_state` is updated with the new aggregate values.
+
+Now you can attach an outbox relay that watches for changes in `customer_revenue_state` and emits events:
+
+```sql
+-- Attach an outbox relay to the stream table
+SELECT pgtrickle.create_outbox_relay(
+  stream_table  => 'customer_revenue_state',
+  outbox_table  => 'outbox',
+  aggregate_type => 'Customer',
+  aggregate_id_column => 'customer_id',
+  event_type_fn  => $$
+    CASE
+      WHEN OLD.order_count IS NULL THEN 'CustomerFirstOrderPlaced'
+      WHEN NEW.order_count > OLD.order_count THEN 'CustomerOrderAdded'
+      WHEN NEW.total_revenue < OLD.total_revenue THEN 'CustomerRefundProcessed'
+      ELSE 'CustomerRevenueUpdated'
+    END
+  $$,
+  payload_fn => $$
+    jsonb_build_object(
+      'customer_id',    NEW.customer_id,
+      'email',          NEW.email,
+      'account_tier',   NEW.account_tier,
+      'order_count',    NEW.order_count,
+      'total_revenue',  NEW.total_revenue,
+      'last_order_at',  NEW.last_order_at,
+      'revenue_delta',  NEW.total_revenue - COALESCE(OLD.total_revenue, 0)
+    )
+  $$
+);
+```
+
+When `customer_revenue_state` is updated by a refresh cycle, pg_trickle writes the corresponding event rows to `outbox` as part of the same transaction. Your existing outbox relay picks them up and publishes.
+
+The derived aggregate — total revenue, order count — is computed once, by the DVM engine, not duplicated across every application code path that can change orders.
+
+---
+
+## The Mechanics
+
+The outbox relay works at the stream table layer:
+
+1. A refresh cycle computes the delta to `customer_revenue_state` — a set of rows to insert, update, or delete.
+2. For each changed row, the relay evaluates `event_type_fn` and `payload_fn` against `(OLD.*, NEW.*)`.
+3. The relay writes one `outbox` row per changed stream table row.
+4. Steps 2–3 happen inside the same transaction that applies the delta.
+
+This is transactionally safe: if the refresh cycle transaction rolls back (e.g., due to a conflict), the outbox entries are also rolled back. The outbox never contains events for changes that didn't commit.
+
+The `OLD.*` and `NEW.*` semantics let you express transitions:
+- `OLD IS NULL` → this is a new row (first-time state)
+- `NEW IS NULL` → this row was deleted
+- `NEW.total_revenue > OLD.total_revenue` → revenue increased
+- `NEW.order_count > OLD.order_count` → new order placed
+
+This is richer than a raw table trigger, which fires on every write to orders — including changes that don't affect the customer's aggregate state. The stream table relay fires only when the *aggregate state* actually changes.
+
+---
+
+## Enriched Event Payloads
+
+A frequent frustration with the standard outbox: the payload at write time might not contain enough context for downstream consumers. "OrderPlaced" fires, but the consumer needs to know the order total, the product names, the customer's account tier. The application at write time may not have all that information ready.
+
+With stream tables as event sources, the event payload is computed from the fully-denormalized stream table. You can include anything the stream table contains:
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name  => 'order_event_state',
+  query => $$
+    SELECT
+      o.id          AS order_id,
+      o.status,
+      o.total,
+      o.created_at,
+      c.id          AS customer_id,
+      c.email       AS customer_email,
+      c.account_tier,
+      s.name        AS shipping_address_name,
+      s.city,
+      s.country,
+      array_agg(jsonb_build_object(
+        'product_id',   p.id,
+        'product_name', p.name,
+        'quantity',     oi.quantity,
+        'unit_price',   oi.unit_price
+      ) ORDER BY oi.id) AS line_items
+    FROM orders o
+    JOIN customers c ON c.id = o.customer_id
+    JOIN shipping_addresses s ON s.id = o.shipping_address_id
+    JOIN order_items oi ON oi.order_id = o.id
+    JOIN products p ON p.id = oi.product_id
+    GROUP BY o.id, o.status, o.total, o.created_at,
+             c.id, c.email, c.account_tier,
+             s.name, s.city, s.country
+  $$,
+  schedule     => '5 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+The event payload includes the full order with line items, customer context, and shipping address — all pre-joined. The downstream consumer receives a self-contained event and doesn't need to query back to the database.
+
+This is the "fat event" pattern: events that carry all the context consumers need, rather than just an ID that consumers have to resolve.
+
+---
+
+## The Deduplication Story
+
+Outbox patterns require consumers to handle duplicate delivery (at-least-once delivery is the standard guarantee). When stream tables drive the outbox, there's an additional source of potential duplicates to think about.
+
+If a customer places three orders in the same 10-second refresh cycle, the stream table will update once — to the aggregate state after all three orders. The outbox will have one event, reflecting the final state.
+
+If the outbox relay fails to publish and the refresh worker retries (applying the same delta again), the outbox will have a duplicate row for the same state. The consumer's deduplication logic (typically, "have I seen an event with this aggregate_id and this state before?") handles this correctly.
+
+The key insight: stream tables aggregate changes within a refresh cycle, so the outbox volume is naturally lower than it would be with row-level triggers on the source tables. Three new orders in 10 seconds produce one `CustomerRevenueUpdated` event, not three.
+
+---
+
+## Monitoring Outbox Health
+
+```sql
+-- Outbox relay status
+SELECT
+  relay_name,
+  stream_table,
+  events_emitted_last_cycle,
+  avg_emit_ms,
+  outbox_pending_count,
+  oldest_pending_age_secs
+FROM pgtrickle.outbox_relay_status();
+
+-- Are events being published fast enough?
+SELECT
+  COUNT(*) FILTER (WHERE published = false) AS pending,
+  COUNT(*) FILTER (WHERE published = false
+                   AND created_at < NOW() - INTERVAL '5 minutes') AS old_pending,
+  MIN(created_at) FILTER (WHERE published = false) AS oldest_pending_at
+FROM outbox;
+```
+
+The `outbox_pending_count` growing over time indicates the outbox relay can't keep up with the event rate. Common causes: slow downstream (Kafka backpressure, API rate limits), slow database (outbox table index needs VACUUM or REINDEX), or the relay is down.
+
+---
+
+## When to Use This Pattern
+
+The stream-table-backed outbox is the right choice when:
+- The event you need to emit is a derived or aggregated value, not a raw row change
+- The event payload benefits from denormalization (fat events)
+- You want to decouple the event schema from the application write path
+- Multiple code paths affect the same aggregate, and you want one canonical event source
+
+It's overkill when:
+- The event maps directly to a raw table change (e.g., `UserCreated` fires when a row is inserted into `users`)
+- You need sub-second event latency (stream tables add up to `schedule` latency)
+- You're doing event sourcing where every intermediate state matters (stream tables coalesce changes within a cycle)
+
+For raw table events, a standard trigger-based outbox is simpler. For derived aggregate events, the stream-table-backed outbox is significantly more correct and easier to maintain.
+
+---
+
+## The Bigger Picture
+
+The transactional outbox pattern solves the dual-write problem. Stream tables solve the derived-data freshness problem. Combined, they solve a third problem: emitting events that reflect aggregate state changes in a way that's both transactionally safe and computationally efficient.
+
+Without this combination, teams typically end up with either:
+- Events that fire on raw table changes and require consumers to compute aggregates (chatty, couples consumers to the database schema)
+- Scheduled aggregate recomputation with a separate event emission step (latency, correctness concerns at the boundary)
+
+The stream-table outbox gives you: aggregate events, computed correctly by the DVM engine, emitted transactionally, with the freshness controlled by your `schedule` parameter.
+
+The reliability of the outbox pattern, the correctness of IVM, and the expressiveness of SQL. That combination is harder to build than it sounds, but pg_trickle makes it a configuration decision rather than an engineering project.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/pg-trickle-cloudnativepg-kubernetes.md
+++ b/blog/pg-trickle-cloudnativepg-kubernetes.md
@@ -1,0 +1,370 @@
+# pg_trickle on CloudNativePG
+
+## Running Incremental View Maintenance in Production Kubernetes
+
+---
+
+Running a stateful PostgreSQL extension in Kubernetes requires more thought than deploying a stateless web service. The extension has background workers, shared memory segments, and per-database state. Upgrades must be coordinated with the schema migration process. High availability means the extension must survive primary failover.
+
+This post covers running pg_trickle on [CloudNativePG](https://cloudnative-pg.io/) — the CNCF-sandbox Kubernetes operator for PostgreSQL — in a production setup. The focus is on the operational mechanics: getting the extension installed, keeping it healthy across restarts and failovers, and monitoring it from outside the database.
+
+---
+
+## Prerequisites
+
+- Kubernetes 1.27+
+- CloudNativePG operator 1.24+ installed in the cluster
+- A container image with both PostgreSQL 18 and pg_trickle installed
+- The pg_trickle shared library preloaded
+
+---
+
+## The Container Image
+
+CloudNativePG manages the PostgreSQL binary and data directory lifecycle. You need to provide a container image that includes the extension.
+
+A minimal Dockerfile:
+
+```dockerfile
+FROM ghcr.io/cloudnative-pg/postgresql:18
+
+# Install build dependencies
+USER root
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    postgresql-server-dev-18 \
+    git \
+    curl \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust (required to build pg_trickle)
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Install pgrx
+RUN cargo install cargo-pgrx --version 0.18.0 && \
+    cargo pgrx init --pg18 /usr/lib/postgresql/18/bin/pg_config
+
+# Build and install pg_trickle
+ARG PGTRICKLE_VERSION=0.36.0
+RUN git clone --depth 1 --branch v${PGTRICKLE_VERSION} \
+    https://github.com/grove/pg-trickle.git /tmp/pg-trickle && \
+    cd /tmp/pg-trickle && \
+    cargo pgrx install --release --pg-config /usr/lib/postgresql/18/bin/pg_config && \
+    rm -rf /tmp/pg-trickle
+
+USER 26
+```
+
+For production, pin to a specific digest rather than a tag. Build the image in CI and push to your internal registry.
+
+---
+
+## The Cluster Manifest
+
+A production-ready CNPG `Cluster` resource:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: pgtrickle-cluster
+  namespace: production
+spec:
+  instances: 3
+  imageName: your-registry/postgresql-pgtrickle:18-0.36.0
+
+  postgresql:
+    parameters:
+      # Required: load pg_trickle's shared library
+      shared_preload_libraries: "pg_trickle"
+
+      # pg_trickle configuration
+      pg_trickle.enabled: "on"
+      pg_trickle.max_parallel_workers: "4"
+      pg_trickle.backpressure_enabled: "on"
+      pg_trickle.backpressure_max_lag_mb: "128"
+      pg_trickle.log_format: "json"
+
+      # Standard PostgreSQL tuning
+      shared_buffers: "2GB"
+      effective_cache_size: "6GB"
+      maintenance_work_mem: "512MB"
+      work_mem: "64MB"
+      max_connections: "200"
+      wal_level: "logical"       # required for pg_trickle's WAL features
+      max_wal_senders: "10"
+      max_replication_slots: "10"
+
+  bootstrap:
+    initdb:
+      database: app
+      owner: app
+      postInitSQL:
+        # Install extension in the target database
+        - CREATE EXTENSION IF NOT EXISTS pg_trickle;
+        # Optionally install pgvector if using vector features
+        - CREATE EXTENSION IF NOT EXISTS vector;
+
+  storage:
+    size: 100Gi
+    storageClass: fast-ssd  # Use NVMe-backed storage for pg_trickle workloads
+
+  resources:
+    requests:
+      memory: "8Gi"
+      cpu: "4"
+    limits:
+      memory: "16Gi"
+      cpu: "8"
+
+  # Monitoring integration
+  monitoring:
+    enablePodMonitor: true
+    customQueriesConfigMap:
+      - name: pgtrickle-metrics
+        key: queries.yaml
+```
+
+The critical parameters:
+- `shared_preload_libraries: "pg_trickle"` — required for the background worker to start
+- `wal_level: "logical"` — required for pg_trickle's WAL decoder
+- `postInitSQL` — runs once during database creation, installs the extension
+
+---
+
+## High Availability and Failover
+
+CNPG runs one primary and N-1 standbys. When the primary fails, CNPG promotes a standby and updates the service endpoints. Your application reconnects to the new primary.
+
+pg_trickle's background workers run only on the primary. On a standby:
+- The extension code is present (the shared library loads fine)
+- The pg_trickle catalog tables are replicated
+- The background workers don't start (the standby is read-only)
+
+On failover:
+1. CNPG promotes a standby to primary
+2. PostgreSQL starts up
+3. pg_trickle's background workers start as part of the `shared_preload_libraries` initialization
+4. The workers load the stream table catalog and begin processing any pending change buffer entries
+
+The change buffers are regular PostgreSQL tables, replicated via streaming replication. Changes captured before the failover are in the buffers on the new primary and will be processed after startup.
+
+**Expected staleness on failover:** Up to the maximum of:
+- The change buffer accumulation during the failover window (typically 10–60 seconds)
+- The stream table's configured `schedule`
+
+For a `schedule = '5 seconds'` stream table, expect up to ~60 seconds of staleness after failover on a fast cluster.
+
+---
+
+## Configuration Management with ConfigMaps
+
+Rather than hardcoding GUC values in the Cluster manifest, use a ConfigMap for pg_trickle settings and reference it:
+
+```yaml
+# configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgtrickle-config
+data:
+  pg_trickle.enabled: "on"
+  pg_trickle.max_parallel_workers: "4"
+  pg_trickle.backpressure_enabled: "on"
+  pg_trickle.backpressure_max_lag_mb: "128"
+  pg_trickle.default_schedule: "5 seconds"
+  pg_trickle.log_format: "json"
+```
+
+```yaml
+# In the Cluster spec
+spec:
+  postgresql:
+    parameters:
+      shared_preload_libraries: "pg_trickle"
+    configMapRef:
+      name: pgtrickle-config
+```
+
+This lets you update GUC values via `kubectl apply` without modifying the Cluster resource, and enables configuration review in git via normal PR workflow.
+
+---
+
+## Prometheus Metrics
+
+pg_trickle exposes metrics via the PostgreSQL query interface. Export them with a custom queries ConfigMap for the CNPG PodMonitor:
+
+```yaml
+# pgtrickle-metrics.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pgtrickle-metrics
+data:
+  queries.yaml: |
+    pg_trickle_stream_tables:
+      query: |
+        SELECT
+          name,
+          sla_tier,
+          EXTRACT(EPOCH FROM (NOW() - last_refresh_at))::float AS staleness_seconds,
+          rows_changed_last_cycle,
+          avg_refresh_ms / 1000.0 AS avg_refresh_seconds,
+          pending_change_rows
+        FROM pgtrickle.stream_table_status()
+      metrics:
+        - name:
+            usage: LABEL
+            description: Stream table name
+        - sla_tier:
+            usage: LABEL
+            description: SLA tier
+        - staleness_seconds:
+            usage: GAUGE
+            description: Seconds since last refresh
+        - rows_changed_last_cycle:
+            usage: GAUGE
+            description: Rows changed in last refresh cycle
+        - avg_refresh_seconds:
+            usage: GAUGE
+            description: Average refresh duration in seconds
+        - pending_change_rows:
+            usage: GAUGE
+            description: Pending rows in change buffer
+
+    pg_trickle_change_buffers:
+      query: |
+        SELECT
+          source_table,
+          pending_rows,
+          EXTRACT(EPOCH FROM (NOW() - oldest_change_at))::float AS backlog_age_seconds
+        FROM pgtrickle.change_buffer_status()
+      metrics:
+        - source_table:
+            usage: LABEL
+        - pending_rows:
+            usage: GAUGE
+            description: Pending rows in change buffer for this source
+        - backlog_age_seconds:
+            usage: GAUGE
+            description: Age of the oldest pending change in seconds
+```
+
+With this, Grafana can visualize stream table staleness per SLA tier, change buffer depth per source table, and refresh timing trends.
+
+---
+
+## Alerting Rules
+
+Essential Prometheus alerts:
+
+```yaml
+groups:
+- name: pgtrickle
+  rules:
+  - alert: StreamTableCriticalStaleness
+    expr: |
+      pg_trickle_stream_tables_staleness_seconds{sla_tier="critical"} > 30
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Critical stream table {{ $labels.name }} is {{ $value | humanizeDuration }} stale"
+
+  - alert: StreamTableStandardStaleness
+    expr: |
+      pg_trickle_stream_tables_staleness_seconds{sla_tier="standard"} > 300
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Standard stream table {{ $labels.name }} is {{ $value | humanizeDuration }} stale"
+
+  - alert: ChangeBufferBacklog
+    expr: |
+      pg_trickle_change_buffers_backlog_age_seconds > 600
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Change buffer for {{ $labels.source_table }} has {{ $value | humanizeDuration }} backlog"
+```
+
+The critical staleness alert fires before users notice. The backlog alert fires when the refresh workers can't keep up with the write load.
+
+---
+
+## Upgrading pg_trickle
+
+Upgrading pg_trickle follows the standard extension upgrade pattern, coordinated with CNPG's rolling update mechanism.
+
+**Step 1: Build the new image**
+
+Build a new container image with the upgraded extension version. Push to your registry.
+
+**Step 2: Update the Cluster manifest**
+
+```yaml
+spec:
+  imageName: your-registry/postgresql-pgtrickle:18-0.37.0  # new version
+```
+
+**Step 3: CNPG performs a rolling update**
+
+CNPG stops the old primary, starts a new one with the new image, and promotes it. The standby instances update one at a time.
+
+**Step 4: Run the extension migration**
+
+After the cluster is running the new image, the extension schema may need to be upgraded:
+
+```sql
+ALTER EXTENSION pg_trickle UPDATE TO '0.37.0';
+```
+
+For CNPG, this is most cleanly done as a `postUpgradeSQL` hook in the Cluster spec, or as a Job that runs after the rolling update completes.
+
+---
+
+## Sizing Guidance
+
+pg_trickle's resource consumption scales with:
+- Number of stream tables
+- Write volume on source tables (drives change buffer size and refresh frequency)
+- Complexity of stream table queries (drives delta computation cost)
+
+For a typical deployment with 10–20 stream tables and moderate write volume:
+
+| Resource | Minimum | Recommended |
+|----------|---------|-------------|
+| CPU (cores) | 2 | 4–8 |
+| Memory | 4GB | 8–16GB |
+| Storage IOPS | 3,000 | 10,000+ (NVMe preferred) |
+| `max_parallel_workers` | 2 | 4 |
+| `shared_buffers` | 1GB | 25% of RAM |
+| `maintenance_work_mem` | 256MB | 1–2GB (for REINDEX operations) |
+
+The most important factor is storage latency. pg_trickle's refresh cycles are I/O-bound when processing large deltas or maintaining HNSW indexes. SSDs (NVMe preferred) make the difference between 20ms refresh cycles and 200ms ones.
+
+---
+
+## Production Checklist
+
+Before going live with pg_trickle on CNPG:
+
+- [ ] `shared_preload_libraries` includes `pg_trickle`
+- [ ] `wal_level = logical` is set
+- [ ] Extension installed in target database via `postInitSQL`
+- [ ] Custom metrics ConfigMap deployed and referenced in Cluster manifest
+- [ ] Prometheus alerts configured (staleness, backlog)
+- [ ] Grafana dashboard imported
+- [ ] SLA tiers configured for all stream tables
+- [ ] Failover tested: `kubectl cnpg promote` to simulate primary failure, verify stream tables resume within expected window
+- [ ] Upgrade path tested in staging: new image + `ALTER EXTENSION UPDATE`
+- [ ] Backpressure enabled and threshold tuned for your write volume
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/pgvector-tooling-landscape.md
+++ b/blog/pgvector-tooling-landscape.md
@@ -1,0 +1,363 @@
+# The pgvector Tooling Landscape in 2026
+
+## What each tool actually does — and where pg_trickle fits in
+
+---
+
+If you've been building RAG applications on PostgreSQL, you've probably noticed the ecosystem has grown considerably in the last two years. There's pgai, pg_vectorize, Debezium with pgvector support, and a handful of managed-platform approaches. They all promise to "keep your embeddings in sync" or "automate your vector pipeline."
+
+The problem is that these tools operate at different layers, solve different problems, and make different tradeoffs. Comparing them directly is like comparing a bread knife to a bread maker. They're related, but they're not doing the same job.
+
+This is an honest look at what each tool actually does, where each one falls short, and where pg_trickle sits relative to all of them. No marketing. Just the actual mechanics.
+
+---
+
+## First, a note about pgai
+
+Let's start with the elephant in the room.
+
+**pgai was archived by Timescale on February 26, 2026.**
+
+If you've read any article about keeping embeddings fresh in PostgreSQL from the last year, pgai was probably the top recommendation. Timescale built it, marketed it heavily, and it accumulated 5,800 GitHub stars. The approach was elegant: declare a `create_vectorizer()` configuration, run a stateless Python worker process, and the system would keep your embeddings synchronized as data changes.
+
+The archive doesn't mean pgai was bad — it means Timescale made a strategic pivot. The repository is now read-only. The Python library still exists and works. But the project is no longer actively developed as an open-source extension.
+
+Why is this interesting? Because pgai's architecture revealed something about the fundamental problem with embedding pipelines. The vectorizer worker was *always* an external process. It used a queue inside PostgreSQL (a `ai.work_queue` table) to track what needed re-embedding. The worker polled that queue, called the external embedding API, and wrote the results back.
+
+This architecture is correct for the problem it solves — handling unreliable external API calls in the background, with retries, rate limiting, and error isolation. But it's fundamentally a distributed system. You have two processes that need to stay in sync: the database and the worker. Schema changes, table drops, API failures, and worker restarts all require coordination.
+
+The archive suggests this coordination cost was higher than expected, or that Timescale found a simpler architecture achieved the same goal with less operational surface area. Either way, it's a useful data point for anyone designing embedding infrastructure today.
+
+---
+
+## pg_vectorize: What it does well
+
+pg_vectorize (now maintained independently by Chuck Henderson, formerly of Tembo) is the most active open-source tool for incremental embedding updates in PostgreSQL. It's written in Rust, supports both a PostgreSQL extension mode and a standalone HTTP server mode, and uses pgmq (a message queue built on PostgreSQL) for asynchronous processing.
+
+The basic flow looks like this:
+
+```bash
+# Start the embedding service alongside PostgreSQL
+docker compose up -d
+
+# Register a vectorization job
+curl -X POST http://localhost:8080/api/v1/table \
+  -d '{
+    "job_name": "my_products",
+    "src_table": "products",
+    "src_columns": ["product_name", "description"],
+    "primary_key": "product_id",
+    "update_time_col": "updated_at",
+    "model": "sentence-transformers/all-MiniLM-L6-v2"
+  }'
+
+# Search
+curl "http://localhost:8080/api/v1/search?job_name=my_products&query=camping+gear&limit=5"
+```
+
+In extension mode, you use SQL functions (`vectorize.table()`, `vectorize.search()`) for the same operations. The extension relies on pgmq under the hood — source-table changes enqueue messages, the worker dequeues them, calls the embedding service, and writes back.
+
+**What pg_vectorize does well:**
+- Keeps a single table's embeddings synchronized with its source text column.
+- Works with managed PostgreSQL (RDS, Cloud SQL) where you can't install arbitrary extensions — just run the HTTP server separately.
+- Handles failures gracefully via the pgmq retry mechanism.
+- Local model support (via `vector-serve`, a bundled embedding server) — no dependency on external API if you run your own models.
+- Actively maintained: the v0.26.x line was released this week.
+
+**What pg_vectorize doesn't do:**
+- Multi-table denormalization. It syncs `source_column → embedding`. It doesn't maintain a denormalized join of `documents + tags + permissions + metadata` as a searchable flat table.
+- Aggregate vectors. There's no `vector_avg` concept — no way to maintain per-user or per-cluster centroids incrementally.
+- ANN index management. It embeds rows; it does not know about or manage IVFFlat drift or HNSW tombstone accumulation.
+- SQL expressiveness. The vectorization pipeline is: one table, one text column, one embedding model. The richer "define any query, maintain the result" pattern is out of scope.
+
+pg_vectorize solves a narrow but real problem cleanly. If your use case is exactly "text column changed → re-embed → update vector column," it's a solid choice.
+
+---
+
+## The DIY approach: Why most teams still roll their own
+
+Despite both pgai and pg_vectorize existing, most production RAG systems use a homebrew pipeline. The pattern:
+
+1. A database trigger or application-level change tracking (e.g., an `updated_at` timestamp, a `needs_reembedding` boolean flag).
+2. A background job (Celery, Sidekiq, AWS Lambda on SQS, a simple `while True:` loop) that polls for rows needing re-embedding.
+3. A call to the embedding API.
+4. A write-back to the database.
+
+This pattern persists because it's flexible. You control the embedding logic. You can batch efficiently. You can handle weird edge cases (chunks, metadata injection, different models for different content types) without fighting an abstraction layer.
+
+The cost is operational: you own the retry logic, the failure alerting, the backlog monitoring, the queue depth, and the correctness guarantees. When the worker falls behind or crashes silently, someone gets paged.
+
+**The fundamental limitation** of all these approaches — DIY, pgai, and pg_vectorize alike — is that they answer a single question: "When the source text changes, what's the new embedding?"
+
+They don't answer: "When any input to my search corpus changes — text, metadata, permissions, tags, related records — how do I propagate that change to the thing users are actually searching over?"
+
+---
+
+## Debezium + pgvector: The enterprise approach
+
+Debezium is a CDC (change data capture) tool from Red Hat that reads PostgreSQL's write-ahead log, converts row-level changes into structured events, and streams them to Kafka. Since 2024, Debezium has supported `vector` column types — changes to pgvector columns are serialized correctly and can flow through the Kafka ecosystem.
+
+The typical architecture:
+
+```
+PostgreSQL (WAL) → Debezium → Kafka → Consumer (Python/Java) → Embedding API → Write back to PostgreSQL
+```
+
+Or for a search-specific variant:
+
+```
+PostgreSQL (WAL) → Debezium → Kafka → Consumer → Compute denormalized record → Write to search PG instance
+```
+
+**What Debezium brings:**
+- Rock-solid, battle-tested CDC for PostgreSQL.
+- Works at scale — it's what you use when you're running a multi-hundred-GB database with heavy write load.
+- Flexible: the Kafka consumer can do anything — embedding, enrichment, routing to multiple sinks, exactly-once delivery.
+- Supports `vector` type natively now (useful for migrating vector data between systems).
+
+**What Debezium doesn't bring:**
+- Anything in-database. Debezium requires Kafka, a Kafka Connect deployment, and at minimum one consumer service. You're building and maintaining a distributed system.
+- SQL-level reasoning. The consumer sees row-level deltas, not query-level semantics. If your denormalized search document depends on five tables, the consumer must join and reconcile those changes itself — which is basically writing a CDC-aware ETL pipeline from scratch.
+- Incremental aggregation. Debezium streams changes. It doesn't compute vector means, maintain group aggregates, or understand what a "change to one source row" means for a derived result.
+- Anything approaching "keep my ANN index fresh" — you'd need to build that on top.
+
+Debezium is infrastructure, not application logic. It moves data reliably. It doesn't maintain derived state.
+
+---
+
+## The Dedicated Vector Databases: Not What You Think
+
+Pinecone, Weaviate, Qdrant, Milvus — these are purpose-built systems that offer excellent approximate nearest-neighbor search with rich filtering. They're also frequently compared to pgvector.
+
+Worth saying directly: **these aren't really pgvector tooling**. They're alternative systems, not enhancements. If you're on pgvector, you've already decided to stay in PostgreSQL. The dedicated vector databases solve a different problem for a different choice.
+
+But they're relevant here because they're the most common alternative when pgvector users hit production scale problems. The pattern is: start with pgvector, hit a friction point (staleness, index maintenance, multi-table search complexity), and investigate moving to a dedicated vector database.
+
+**What dedicated vector databases do well:**
+- Very fast ANN search with rich metadata filtering, optimized end-to-end.
+- Managed services with automatic index maintenance.
+- High-dimensional vectors (many support >10,000 dimensions natively).
+- Real-time ingestion at high write volume.
+
+**What they don't do:**
+- Transactional consistency with your PostgreSQL source data. You have a synchronization problem between your source database and the vector store.
+- SQL joins, GROUP BY, window functions, CTEs over your vector corpus — you're limited to metadata filters.
+- Any notion of incremental view maintenance. You push rows in; they're indexed. There's no concept of "this row's value is derived from these five other tables."
+- Free. The managed options are expensive at scale.
+
+The migration from pgvector to Pinecone/Weaviate/etc. typically doesn't simplify the embedding pipeline — it just moves the synchronization problem from "database ↔ embedding column" to "database ↔ external service." You still need to know when things changed and push them over.
+
+---
+
+## What All These Tools Have in Common
+
+Step back from the specifics and a pattern emerges.
+
+Every tool in this list — pgai (archived), pg_vectorize, DIY batch jobs, Debezium pipelines, dedicated vector databases — is solving the same narrow problem:
+
+**When source text or data changes, how do I generate or re-deliver the embedding to where it needs to be?**
+
+That's **Layer 1**: embedding generation and delivery.
+
+What none of them solve is **Layer 2**: maintaining the derived structures that live downstream of those embeddings, and keeping them consistent with both their source embeddings *and* the rest of your data.
+
+---
+
+## Where pg_trickle Fits
+
+pg_trickle operates entirely at Layer 2 — and occasionally Layer 1 overlap, but in a fundamentally different way.
+
+The core of pg_trickle is incremental view maintenance (IVM). You define a SQL query, and pg_trickle maintains the result of that query as a live table, updating it incrementally as inputs change. The query can be anything: joins, aggregates, window functions, CTEs, subqueries.
+
+For embeddings specifically, this matters in three ways that none of the Layer 1 tools address.
+
+### The denormalization problem
+
+Your embedding column lives in `documents.embedding`. Your users search for documents. But what they're actually searching over is:
+
+> "A document, from an active project, with its category name, its author's display name, and its ACL groups — searchable by the text of the document and the vector of that text."
+
+That's four tables. The embedding is one attribute of one of them. What users search over is a denormalized flat record composed of all four.
+
+pg_trickle maintains that flat record automatically:
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name => 'doc_search_corpus',
+  query => $$
+    SELECT
+      d.id,
+      d.body,
+      d.embedding,              -- your embedding, wherever it lives
+      p.name AS project_name,
+      u.display_name AS author,
+      acl.allowed_groups,
+      array_agg(t.name) AS tags
+    FROM documents d
+    JOIN projects p ON p.id = d.project_id
+    JOIN users u ON u.id = d.author_id
+    JOIN doc_acl acl ON acl.doc_id = d.id
+    LEFT JOIN doc_tags t ON t.doc_id = d.id
+    WHERE d.published = true
+    GROUP BY d.id, p.name, u.display_name, acl.allowed_groups
+  $$,
+  schedule => '10 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+When someone updates a tag, renames a project, changes a permission, or edits the document text — only the affected rows in `doc_search_corpus` are updated. The rest is untouched. The HNSW index on `doc_search_corpus.embedding` receives targeted insert/delete pairs, not a full rebuild.
+
+pg_vectorize cannot do this. It doesn't have a join concept. pgai couldn't do this either. This is a fundamentally different operation: SQL-level derivation, not embedding-API orchestration.
+
+### The aggregate vector problem
+
+Recommendation systems, clustering pipelines, and personalization engines all maintain aggregate vectors — centroid-style representations computed over groups of individual embeddings.
+
+```sql
+-- The "taste" of user 42, averaged over every item they've liked
+SELECT vector_avg(item.embedding)
+FROM user_likes ul
+JOIN items i ON i.id = ul.item_id
+WHERE ul.user_id = 42;
+```
+
+If you precompute this per user and store it (the only production-viable approach), it goes stale the instant someone likes a new item. The classic solutions are "recompute nightly" or "trigger a background job on each like."
+
+pg_trickle maintains this incrementally:
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name => 'user_taste',
+  query => $$
+    SELECT ul.user_id,
+           vector_avg(i.embedding) AS taste_vec,
+           COUNT(*) AS like_count
+    FROM user_likes ul
+    JOIN items i ON i.id = ul.item_id
+    GROUP BY ul.user_id
+  $$,
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+When user 42 likes item 1701, the engine computes:
+```
+new_taste = (old_sum_vector + item_1701.embedding) / (old_count + 1)
+```
+
+Only user 42's row changes. The HNSW index on `taste_vec` receives one update. One million users, thousands of likes per second — each cycle touches only the affected rows.
+
+The algebraic trick here (`vector_avg` as a running `sum / count`) is the same mathematics pg_trickle uses for `AVG(price)` or `SUM(revenue)`. Extending it to vectors requires a rule-set addition, not an engine change. That's shipping in v0.37.
+
+### The index maintenance problem
+
+IVFFlat recall drops as the distribution of your embeddings shifts. HNSW accumulates tombstones as you delete old documents. Neither pgvector nor any of the embedding tools handle this automatically.
+
+pg_trickle tracks `rows_changed_since_last_reindex` as a first-class catalog metric. You set a policy:
+
+```sql
+SELECT pgtrickle.alter_stream_table(
+  'doc_search_corpus',
+  post_refresh_action     => 'reindex_if_drift',
+  reindex_drift_threshold => 0.10
+);
+```
+
+After each refresh, the scheduler checks whether 10% of rows have changed since the last `REINDEX`. If so, it queues a concurrent `REINDEX` in a lower-priority tier that runs without blocking your queries. This ships in v0.38.
+
+No other tool in this space does this. It's an operational gap that has existed since pgvector launched, and the standard answer is still "rebuild on a schedule."
+
+---
+
+## The Natural Architecture
+
+The important thing to understand is that pg_trickle and the Layer 1 embedding tools are **not competitors**. They're designed for adjacent problems.
+
+The natural stack looks like this:
+
+```
+Source Tables (documents, users, products, ...)
+    │
+    ▼  [Layer 1: pgai (archived) / pg_vectorize / your app code]
+    │  "text changed → call embedding API → write vector column"
+    │
+Documents now have an embedding column
+    │
+    ▼  [Layer 2: pg_trickle]
+    │  "embedding (and metadata) changed → maintain derived structures"
+    │
+Denormalized corpora (search_corpus, user_taste, product_clusters, ...)
+    │
+    ▼  [pgvector: HNSW / IVFFlat index, ANN queries]
+    │
+Application queries
+```
+
+Layer 1 solves: "How do I re-embed a row when its text changes?"
+Layer 2 solves: "How do I maintain everything downstream of that embedding?"
+
+They're different questions with different answers.
+
+If you're using pg_vectorize to keep `documents.embedding` fresh, pg_trickle then builds on top of that. When pg_vectorize writes a new embedding back to `documents.embedding`, pg_trickle's CDC trigger captures that change and propagates it to every stream table that depends on `documents`. The denormalized search corpus updates automatically. User taste vectors that depend on item embeddings update automatically. The index maintenance policy fires automatically.
+
+The key principle: **embeddings are derived data, just like any other derived data.** The fact that computing them requires an external API call is a Layer 1 concern. Everything that happens after those embeddings exist — how they combine with other data, how they aggregate, how they're indexed, how freshness is monitored and enforced — is a Layer 2 concern, and that's where pg_trickle operates.
+
+---
+
+## The Honest Comparison Matrix
+
+Here's where each tool actually sits:
+
+| Capability | DIY batch | pg_vectorize | pgai (archived) | Debezium | pg_trickle |
+|---|---|---|---|---|---|
+| Generate embeddings via API | Hand-rolled | ✅ | ✅ | ❌ | ❌ (not its job) |
+| Async retry & rate-limit handling | Hand-rolled | ✅ | ✅ | ❌ | ❌ |
+| Single-table embedding sync | ✅ (manual) | ✅ | ✅ | ✅ | ✅ (passthrough) |
+| Multi-table denormalized corpus | Hand-rolled | ❌ | ❌ | Partial (consumer code) | ✅ (native) |
+| Incremental `vector_avg` aggregates | ❌ | ❌ | ❌ | ❌ | ✅ (v0.37) |
+| ANN index drift detection | ❌ | ❌ | ❌ | ❌ | ✅ (v0.38) |
+| Full SQL expressiveness | ❌ | ❌ | ❌ | ❌ | ✅ |
+| In-database, no external processes | ❌ | Partial | ❌ | ❌ | ✅ |
+| ACID-correct derivation | ❌ | Partial | Partial | ❌ | ✅ |
+| Reactive alerts on distance predicates | ❌ | ❌ | ❌ | ❌ | ✅ (v0.39) |
+| Actively maintained | ✅ | ✅ | ❌ (archived) | ✅ | ✅ |
+
+---
+
+## The Case For Simplifying Your Stack
+
+The common outcome of adding Layer 1 tools, then adding Layer 2 orchestration, then adding Debezium for auditing, is a system with five moving parts that each require monitoring, versioning, and operational expertise.
+
+The case for pg_trickle is not that it eliminates all infrastructure — you still need something to generate embeddings (an app, pgai, pg_vectorize, or pgml). The case is that it eliminates the *ad hoc* infrastructure: the hand-rolled denormalization sync, the custom batch job for centroid recomputation, the manual reindex schedule, the DIY staleness monitoring.
+
+Those pieces live outside the database and outside the transaction boundary, which means they're brittle. They can fail silently, fall behind, or produce state inconsistent with the rest of your data. Pulling them into the database — where changes are captured transactionally, derivations are computed algebraically, and monitoring is a live view — makes them observable and correct by construction.
+
+One embedding architecture that's held up well in production RAG systems:
+
+1. **Application writes** `chunk_text` to `documents`. If you're generating embeddings synchronously (fast models, low latency), write `embedding` in the same transaction. If you're using an async embedding service (slow models, high cost), use pg_vectorize or a lightweight background job to write the embedding asynchronously within a few seconds.
+
+2. **pg_trickle** maintains the search corpus, user taste vectors, product clusters, and any other derived structure as stream tables. These update automatically — within 5–10 seconds of the embedding arriving.
+
+3. **pgvector** provides the HNSW or IVFFlat indexes on the stream tables. pg_trickle's drift-aware reindex policy keeps them healthy.
+
+4. **Application queries** run against flat, fresh, indexed stream tables with clean metadata. No post-fetch filtering, no over-fetching.
+
+The embedding generation is handled. The derived-state problem is handled. The index maintenance is handled. Everything is visible in one monitoring view.
+
+---
+
+## What to Take Away
+
+The pgvector tooling ecosystem in 2026 is in an interesting moment. pgai's archive is a signal that embedding pipelines as out-of-database processes carry real operational cost. pg_vectorize is the most pragmatic open-source answer to the embedding generation problem. Debezium is the enterprise answer to streaming data at scale. And pg_trickle is the answer to the problem that none of them address: derived state maintenance downstream of embeddings.
+
+If you're at the stage of "I need to keep one embedding column in sync with one text column," pg_vectorize is the right tool. Start there.
+
+If you're at the stage of "my search corpus is stale, my user taste vectors are rebuilt nightly, my IVFFlat index is drifting, and my denormalized search document is hand-maintained with triggers," that's the Layer 2 problem. That's pg_trickle's domain.
+
+The two aren't alternatives. They're layers. And understanding which layer your problem lives in is the most important step in choosing the right tool.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance.
+Source, documentation, and the pgvector integration roadmap are at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/reactive-alerts-without-polling.md
+++ b/blog/reactive-alerts-without-polling.md
@@ -1,0 +1,273 @@
+# Reactive Alerts Without Polling
+
+## PostgreSQL as a Push System — No Polling Loop Required
+
+---
+
+Your fraud detection system checks suspicious transactions every minute. Your inventory management system pings a "low stock" endpoint every 30 seconds. Your SLA monitoring service queries open support tickets every 15 seconds and sends a Slack message when something crosses a threshold.
+
+All three of these are polling loops. They're querying the same data over and over, waiting for a condition to become true, then doing something.
+
+Polling loops work. They're also wasteful by design — they spend 99% of their CPU on queries that return "nothing changed yet." They add latency equal to half the polling interval on average. They create a thundering herd problem when many services poll the same data. And they require someone to own the poll interval: too slow and you miss SLAs, too fast and you hammer the database.
+
+There's a better model. It's called reactive subscriptions, and pg_trickle ships it in v0.39.
+
+---
+
+## What Reactive Subscriptions Mean in Practice
+
+The idea is simple: instead of asking "has this condition become true?" repeatedly, you *subscribe* to the condition and receive a notification when it fires.
+
+```sql
+-- Create a stream table for SLA monitoring
+SELECT pgtrickle.create_stream_table(
+  name         => 'ticket_sla',
+  query        => $$
+    SELECT
+      t.id          AS ticket_id,
+      t.team_id,
+      t.status,
+      t.priority,
+      t.created_at,
+      t.sla_deadline,
+      t.sla_deadline < NOW() AS breached,
+      t.sla_deadline - NOW() AS time_to_breach
+    FROM tickets t
+    WHERE t.status != 'resolved'
+  $$,
+  schedule     => '30 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Subscribe to the condition: tickets that just breached SLA
+SELECT pgtrickle.subscribe(
+  stream_table  => 'ticket_sla',
+  condition     => 'breached = true AND OLD.breached = false',
+  channel       => 'sla_breach_alerts',
+  payload       => '{"ticket_id": ticket_id, "team_id": team_id, "priority": priority}'
+);
+```
+
+When a ticket crosses its SLA deadline — which pg_trickle detects during the next refresh cycle — a notification fires on `sla_breach_alerts`. Your application, connected via PostgreSQL `LISTEN`, receives it.
+
+No polling. No "check every 30 seconds." The notification fires once, at the right time, with exactly the data you need.
+
+---
+
+## The Mechanics
+
+pg_trickle's reactive subscriptions work at the stream table layer, not the raw table layer.
+
+When the DVM engine applies a delta to a stream table, it evaluates each active subscription condition against every changed row. The condition can reference both `OLD.*` and `NEW.*` — the row values before and after the delta — enabling you to express *transitions* rather than just states.
+
+This is the key capability that raw PostgreSQL triggers lack. A trigger fires on every change. A subscription fires only when the condition transitions from false to true.
+
+### State Transitions vs. Continuous Conditions
+
+A continuous condition query:
+```sql
+WHERE breached = true
+```
+This fires on every refresh for every breached ticket — every 30 seconds until the ticket is resolved. That's not what you want for an alert.
+
+A state transition:
+```sql
+WHERE breached = true AND OLD.breached = false
+```
+This fires exactly once per ticket, when it crosses from non-breached to breached. Subsequent refreshes see `OLD.breached = true` and don't re-fire.
+
+pg_trickle maintains the `OLD.*` state implicitly — the previous values come from the stream table's current contents before the delta is applied.
+
+---
+
+## Real-World Use Cases
+
+### Inventory Alerts
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'inventory_status',
+  query        => $$
+    SELECT
+      p.id         AS product_id,
+      p.name,
+      p.sku,
+      i.qty,
+      i.reorder_point,
+      i.qty <= i.reorder_point AS below_reorder
+    FROM products p
+    JOIN inventory i ON i.product_id = p.id
+  $$,
+  schedule     => '1 minute',
+  refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Alert when a product drops below reorder point
+SELECT pgtrickle.subscribe(
+  stream_table => 'inventory_status',
+  condition    => 'below_reorder = true AND OLD.below_reorder = false',
+  channel      => 'inventory_alerts',
+  payload      => '{"product_id": product_id, "sku": sku, "qty": qty, "reorder_point": reorder_point}'
+);
+
+-- Alert when a product hits zero
+SELECT pgtrickle.subscribe(
+  stream_table => 'inventory_status',
+  condition    => 'qty = 0 AND OLD.qty > 0',
+  channel      => 'stockout_alerts',
+  payload      => '{"product_id": product_id, "sku": sku, "product_name": name}'
+);
+```
+
+Both alerts fire exactly once per event, not once per polling cycle.
+
+### Fraud Detection
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'customer_velocity',
+  query        => $$
+    SELECT
+      customer_id,
+      COUNT(*)                                       AS tx_count_1h,
+      SUM(amount)                                    AS tx_volume_1h,
+      COUNT(DISTINCT merchant_id)                    AS distinct_merchants_1h,
+      COUNT(DISTINCT SPLIT_PART(ip_address, '.', 1)
+            || '.' || SPLIT_PART(ip_address, '.', 2)) AS distinct_ip_class_b
+    FROM transactions
+    WHERE created_at > NOW() - INTERVAL '1 hour'
+    GROUP BY customer_id
+  $$,
+  schedule     => '10 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Flag when a customer exceeds velocity thresholds
+SELECT pgtrickle.subscribe(
+  stream_table => 'customer_velocity',
+  condition    => $$(
+    (tx_count_1h > 20 AND OLD.tx_count_1h <= 20)
+    OR (tx_volume_1h > 5000 AND OLD.tx_volume_1h <= 5000)
+    OR (distinct_merchants_1h > 10 AND OLD.distinct_merchants_1h <= 10)
+  )$$,
+  channel      => 'fraud_review_queue',
+  payload      => '{"customer_id": customer_id, "tx_count": tx_count_1h, "volume": tx_volume_1h}'
+);
+```
+
+The velocity aggregates are maintained incrementally by the DVM engine. The subscription fires when any threshold is crossed. The fraud review service subscribes to `fraud_review_queue` via `LISTEN` and processes each notification.
+
+No Kafka. No Redis Streams. No lambda function polling DynamoDB. Just PostgreSQL.
+
+### Vector Distance Alerts
+
+This is where it gets interesting for ML workloads.
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'user_drift',
+  query        => $$
+    SELECT
+      u.id AS user_id,
+      vector_avg(i.embedding) AS current_taste_vec,
+      ut.baseline_taste_vec,
+      vector_avg(i.embedding) <=> ut.baseline_taste_vec AS taste_drift
+    FROM user_likes ul
+    JOIN items i ON i.id = ul.item_id
+    JOIN user_taste_baselines ut ON ut.user_id = ul.user_id
+    JOIN users u ON u.id = ul.user_id
+    WHERE ul.liked_at > NOW() - INTERVAL '7 days'
+    GROUP BY u.id, ut.baseline_taste_vec
+  $$,
+  schedule     => '5 minutes',
+  refresh_mode => 'DIFFERENTIAL'
+);
+
+-- Notify when a user's taste has drifted significantly from their baseline
+SELECT pgtrickle.subscribe(
+  stream_table => 'user_drift',
+  condition    => 'taste_drift > 0.3 AND (OLD.taste_drift IS NULL OR OLD.taste_drift <= 0.3)',
+  channel      => 'taste_drift_events',
+  payload      => '{"user_id": user_id, "drift": taste_drift}'
+);
+```
+
+When a user's recent listening/watching/browsing history has shifted enough from their baseline profile, a notification fires. Your recommendation service receives it and triggers a profile refresh. No polling, no `CASE WHEN taste_drift > 0.3` check in a cron job.
+
+---
+
+## Connecting Your Application
+
+On the application side, you use PostgreSQL `LISTEN`:
+
+```python
+import psycopg2
+import json
+
+conn = psycopg2.connect(dsn)
+conn.set_isolation_level(0)  # AUTOCOMMIT, required for LISTEN
+cur = conn.cursor()
+cur.execute("LISTEN sla_breach_alerts")
+
+while True:
+    conn.poll()
+    while conn.notifies:
+        notify = conn.notifies.pop(0)
+        payload = json.loads(notify.payload)
+        handle_sla_breach(
+            ticket_id=payload['ticket_id'],
+            team_id=payload['team_id'],
+            priority=payload['priority']
+        )
+```
+
+The `LISTEN` connection is cheap — a long-lived idle connection that wakes up only when there's a notification. This is the fundamental difference from polling: the database pushes to you rather than you pulling from it.
+
+For high-volume workloads where a single `LISTEN` connection can't process fast enough, notifications can be routed to a PostgreSQL-backed queue (pg_trickle integrates with pgmq) and consumed in parallel.
+
+---
+
+## Why Not PostgreSQL Triggers?
+
+You can implement a version of this with raw PostgreSQL triggers today. The trigger fires on INSERT/UPDATE, checks the condition, and calls `pg_notify()` if it's true.
+
+The limitations:
+- Triggers fire on raw table changes, not on derived state. If your alert condition depends on an aggregate (total volume in the last hour, count of open tickets, user taste drift), you can't express it as a trigger on a raw table.
+- Transitions are hard. Expressing "fired only when transitioning from false to true" requires the trigger to query the previous state, which means an extra SELECT inside the trigger — adding latency to every write on the source table.
+- Complexity. A fraud detection trigger that checks velocity aggregates inside itself is a trigger that does a GROUP BY on every transaction insert. The performance implications are significant.
+
+Reactive subscriptions in pg_trickle are different because the condition evaluates against the *stream table* — derived state — not the raw source. The aggregate computation happens in the background worker. The subscription check is a comparison on already-computed values.
+
+---
+
+## The Latency Story
+
+With a 10-second refresh interval, you'll see a maximum alert latency of 10 seconds. The average is 5 seconds.
+
+Is that too slow? For most alert use cases — SLA monitoring, inventory management, business KPI dashboards — no. For true real-time applications (payment fraud that must be blocked in-flight, stock trading algorithms), a streaming system like Kafka Streams or Apache Flink at the millisecond level is the right tool.
+
+pg_trickle's reactive subscriptions cover the 90% of alert use cases that don't need sub-second latency but have been paying the cost of polling anyway. If your team currently runs polling loops at 30-second or 1-minute intervals and wishes they were faster, reactive subscriptions are the right answer.
+
+---
+
+## What This Changes Architecturally
+
+The polling loop paradigm produces a certain kind of system:
+- Each service owns its own polling schedule
+- The same data is read repeatedly by many services
+- Latency is bounded by the poll interval, not by when data changes
+- The alert fires at most once per interval, even if conditions have been true for longer
+
+The reactive subscription paradigm produces a different kind of system:
+- The database tracks when conditions become true
+- Services receive notifications when they're relevant
+- Latency is bounded by the refresh interval plus processing time
+- The alert fires exactly when the condition first becomes true, not on a schedule
+
+The second system is more correct, more efficient, and more composable. The transition is mechanical: replace each polling loop with a `pgtrickle.subscribe()` call and a `LISTEN` connection.
+
+The polling loop was always a workaround for the lack of a good subscription primitive. Now there is one.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/replaced-celery-with-sql.md
+++ b/blog/replaced-celery-with-sql.md
@@ -1,0 +1,294 @@
+# How We Replaced a Celery Pipeline with 3 SQL Statements
+
+## A before/after story about async Python workers and differential view maintenance
+
+---
+
+This is a story about a pipeline we built, how it grew, and what we eventually replaced it with.
+
+The names are generic. The failure modes are real. If you're running async Python workers to maintain derived data in PostgreSQL, some of this will be familiar.
+
+---
+
+## The Original Problem
+
+We had an e-commerce platform. PostgreSQL for the operational data. A Elasticsearch for the search index. An event-driven architecture for "everything important should trigger something."
+
+After 18 months, we had a serious denormalization problem. Our product search index needed data from seven tables: `products`, `categories`, `brands`, `suppliers`, `tags`, `inventory`, and `price_history`. The Elasticsearch document was a denormalized flat record of all of them. Keeping it in sync required knowing when any of the seven tables changed and what to reindex.
+
+We built a Celery pipeline to handle it.
+
+---
+
+## The Pipeline (Version 1)
+
+```
+PostgreSQL row change
+    → row-level trigger writes to outbox table
+    → Celery Beat polls outbox every 30 seconds
+    → Celery worker resolves the change to a product_id
+    → Celery worker fetches full denormalized record from PostgreSQL
+    → Celery worker indexes into Elasticsearch
+    → outbox entry marked processed
+```
+
+At launch, this worked fine. Products updated within 60 seconds. Acceptable.
+
+**Stats at launch:**
+- Pipeline components: 3 (PostgreSQL trigger, Celery Beat, Celery worker)
+- Lines of code in pipeline: ~400
+- Deployment steps: 2 (app deploy, worker deploy)
+- Average latency, source change → indexed: 35 seconds
+- Throughput: easily handled our 50–100 product changes/day
+
+---
+
+## Version 2: Scale
+
+We expanded to 200,000 products. Daily product data sync from supplier APIs: 15,000 updates per night. The 30-second polling interval, combined with a worker pool of 4, created a backlog that took 4 hours to drain.
+
+**Solutions attempted:**
+1. Increase worker concurrency to 16. Memory on the worker instances ballooned. We hit PostgreSQL connection limits because each worker opened its own connection pool.
+2. Switch from polling to Redis Pub/Sub notifications. Reduced latency to 5 seconds on average. Added Redis as a dependency. Added a Redis sentinel deployment for HA.
+3. Add a `priority` field to the outbox — high-traffic items process first. Added a manager task to compute priorities. Added a monitoring dashboard for queue depth by priority.
+
+**Stats at Version 2:**
+- Pipeline components: 5 (trigger, Beat, worker, Redis, priority manager)
+- Lines of code in pipeline: ~1,200
+- Deployment steps: 4
+- Average latency: 5 seconds
+- P99 latency: 180 seconds (during supplier sync)
+- Incidents per month: ~2
+
+---
+
+## Version 3: Correctness
+
+During a supplier sync, we discovered that the order of Celery task execution didn't match the order of changes. Product 12345 was updated twice in 3 seconds by the supplier sync. Two tasks were enqueued. The tasks ran out of order. Elasticsearch ended up with the *older* version of the product.
+
+The fix was to add a `version` field to products and the outbox, and have the worker skip indexing if the task's version was lower than the current version. This required:
+- A `version` column on `products` (auto-incremented on every UPDATE)
+- The outbox to store the version at change time
+- The worker to re-fetch the product and check versions before indexing
+- A migration for all existing products
+
+We also discovered that the outbox table had grown to 8 million rows because the cleanup job had silently failed two months earlier. The cleanup job now ran on a schedule and sent an alert when the backlog exceeded 100k rows.
+
+**Stats at Version 3:**
+- Pipeline components: 6 (trigger, Beat, worker, Redis, priority manager, cleanup job)
+- Lines of code in pipeline: ~1,800
+- Deployment steps: 5
+- Average latency: 5 seconds
+- P99 latency: 180 seconds
+- On-call runbook length: 6 pages
+- Incidents per month: ~1.5
+
+---
+
+## What We Actually Needed
+
+At this point we had an honest conversation about what the pipeline was doing.
+
+The Elasticsearch index was serving product search. The product search was our primary user-facing feature. Latency above 5 seconds was causing user complaints (products added to a campaign weren't appearing in searches fast enough).
+
+The Elasticsearch requirement was actually an assumption, not a hard constraint. We had chosen Elasticsearch initially because we needed full-text search with fast faceting and we'd assumed PostgreSQL couldn't do it. By version 3, we were running PostgreSQL 18 with much better full-text support, pgvector for semantic search, and partial indexes for faceting.
+
+We decided to run the experiment: what would it take to replace the Elasticsearch index with a denormalized PostgreSQL table and keep it fresh with IVM?
+
+---
+
+## The Replacement: 3 SQL Statements
+
+### Statement 1: Create the stream table
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'product_search',
+  query        => $$
+    SELECT
+      p.id            AS product_id,
+      p.name          AS product_name,
+      p.description,
+      p.sku,
+      b.name          AS brand_name,
+      b.id            AS brand_id,
+      c.name          AS category_name,
+      c.id            AS category_id,
+      c.path          AS category_path,
+      s.name          AS supplier_name,
+      s.country       AS supplier_country,
+      i.qty           AS stock_qty,
+      i.qty > 0       AS in_stock,
+      ph.current_price,
+      ph.original_price,
+      ROUND(
+        (ph.original_price - ph.current_price) / ph.original_price * 100, 1
+      )               AS discount_pct,
+      array_agg(t.name ORDER BY t.name)
+                      AS tags,
+      p.embedding     AS search_vec,
+      p.created_at,
+      p.updated_at
+    FROM products p
+    JOIN brands b ON b.id = p.brand_id
+    JOIN categories c ON c.id = p.category_id
+    JOIN suppliers s ON s.id = p.supplier_id
+    LEFT JOIN inventory i ON i.product_id = p.id
+    LEFT JOIN current_prices ph ON ph.product_id = p.id
+    LEFT JOIN product_tags pt ON pt.product_id = p.id
+    LEFT JOIN tags t ON t.id = pt.tag_id
+    WHERE p.active = true
+    GROUP BY p.id, b.name, b.id, c.name, c.id, c.path,
+             s.name, s.country, i.qty, ph.current_price,
+             ph.original_price, p.embedding, p.created_at, p.updated_at
+  $$,
+  schedule     => '3 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+### Statement 2: Create the full-text search index
+
+```sql
+-- GIN index for full-text search over product name + description + tags
+CREATE INDEX product_search_fts_idx ON product_search
+USING GIN (
+  to_tsvector('english',
+    product_name || ' ' || COALESCE(description, '') || ' ' ||
+    brand_name || ' ' || category_name || ' ' ||
+    COALESCE(array_to_string(tags, ' '), ''))
+);
+```
+
+### Statement 3: Create the vector search index
+
+```sql
+-- HNSW index for semantic search
+CREATE INDEX product_search_vec_idx ON product_search
+USING hnsw (search_vec vector_cosine_ops)
+WITH (m = 16, ef_construction = 64);
+```
+
+That's it. No Redis. No Celery. No outbox table. No cleanup jobs. No version fields.
+
+---
+
+## How the Search Query Changed
+
+**Before:**
+```python
+# Elasticsearch query
+results = es.search(
+    index="products",
+    query={
+        "bool": {
+            "must": [{"multi_match": {"query": q, "fields": ["product_name^3", "description", "brand_name"]}}],
+            "filter": [
+                {"term": {"in_stock": True}},
+                {"range": {"discount_pct": {"gte": min_discount}}}
+            ]
+        }
+    },
+    size=20
+)
+product_ids = [r['_id'] for r in results['hits']['hits']]
+# Then a second round-trip to PostgreSQL to get fresh data
+products = db.query("SELECT * FROM products WHERE id = ANY(%s)", [product_ids])
+```
+
+**After:**
+```sql
+-- Hybrid full-text + semantic search, all in PostgreSQL
+WITH semantic AS (
+  SELECT product_id, search_vec <=> $query_vec AS distance
+  FROM product_search
+  WHERE in_stock = true
+  AND discount_pct >= $min_discount
+  ORDER BY search_vec <=> $query_vec
+  LIMIT 50
+),
+fulltext AS (
+  SELECT product_id,
+         ts_rank_cd(
+           to_tsvector('english', product_name || ' ' || COALESCE(description,'') || ' ' || brand_name),
+           plainto_tsquery('english', $query_text)
+         ) AS rank
+  FROM product_search
+  WHERE in_stock = true
+  AND to_tsvector('english', product_name || ' ' || COALESCE(description,'') || ' ' || brand_name)
+      @@ plainto_tsquery('english', $query_text)
+),
+rrf AS (
+  SELECT COALESCE(s.product_id, f.product_id) AS product_id,
+         COALESCE(1.0 / (60 + ROW_NUMBER() OVER (ORDER BY s.distance)), 0) +
+         COALESCE(1.0 / (60 + ROW_NUMBER() OVER (ORDER BY f.rank DESC)), 0) AS rrf_score
+  FROM semantic s
+  FULL OUTER JOIN fulltext f ON f.product_id = s.product_id
+)
+SELECT ps.*
+FROM rrf
+JOIN product_search ps ON ps.product_id = rrf.product_id
+ORDER BY rrf_score DESC
+LIMIT 20;
+```
+
+The data returned is always fresh — the `product_search` stream table is at most 3 seconds stale. There's no second round-trip to get "fresh data" because `product_search` *is* the fresh data.
+
+---
+
+## The Numbers
+
+| Metric | Celery+ES pipeline | pg_trickle+PostgreSQL |
+|--------|-------------------|----------------------|
+| P50 search latency | 12ms | 8ms |
+| P99 search latency | 85ms | 22ms |
+| Data freshness (average) | 5s | 1.5s |
+| Data freshness (P99) | 180s (during sync) | 3s |
+| Deployment components | 6 | 1 (the PostgreSQL extension) |
+| Monthly incidents | 1.5 | 0 |
+| Engineering time per quarter maintaining the pipeline | ~3 weeks | ~0 |
+
+The P99 improvement from 180s to 3s was the most impactful change for users. The supplier sync no longer caused a visible degradation window.
+
+The search latency improvement was a bonus — the PostgreSQL query planner was better at pruning `product_search` with partial indexes than Elasticsearch was with filter clauses, and the elimination of the network round-trip and deserialization overhead from Elasticsearch helped.
+
+---
+
+## What We Gave Up
+
+Elasticsearch has capabilities that PostgreSQL+pgvector doesn't fully match:
+
+- **Approximate nearest neighbor at very large scale** (hundreds of millions of vectors): HNSW in pgvector is competitive up to ~50M rows with appropriate hardware. Above that, dedicated vector databases have more tuning options.
+- **Built-in relevance tuning**: Elasticsearch has a mature BM25 + learning-to-rank stack. We replicated most of what we needed with RRF, but a dedicated ML ranking system is more flexible.
+- **Cross-cluster search and federation**: Elasticsearch's distributed search across multiple clusters is mature. PostgreSQL's distribution story requires Citus or similar.
+- **Elasticsearch-specific query DSL**: Some power-user queries we'd built on top of Elasticsearch's query language required rewriting in SQL.
+
+For our scale (500k products, 10M queries/month), none of these were blockers. For a much larger deployment, the calculus might be different.
+
+---
+
+## The Maintenance Story
+
+The Celery pipeline had a 6-page oncall runbook. The pg_trickle replacement has:
+
+```sql
+-- Check freshness
+SELECT name, last_refresh_at, staleness_secs
+FROM pgtrickle.stream_table_status()
+WHERE name = 'product_search';
+
+-- Check queue depth (how many pending changes)
+SELECT source_table, pending_rows
+FROM pgtrickle.change_buffer_status();
+
+-- Force a refresh if needed
+SELECT pgtrickle.refresh('product_search');
+```
+
+That's the runbook. It fits in a Slack message.
+
+The three SQL statements that created this setup were the end of a 3-year journey through increasingly complex async pipeline infrastructure. The right abstraction was in the database the entire time.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/stale-materialized-views.md
+++ b/blog/stale-materialized-views.md
@@ -1,0 +1,258 @@
+# Why Your Materialized Views Are Always Stale
+
+## (And How to Fix It in 5 Lines of SQL)
+
+---
+
+You have a dashboard. It runs a complex query over millions of rows. Without a materialized view it takes 8 seconds. With one, it takes 12 milliseconds. You shipped the materialized view two months ago, put a `REFRESH MATERIALIZED VIEW` in a cron job, and declared victory.
+
+Last week a customer asked why their newly-submitted order wasn't showing in the dashboard totals. You checked. The cron job had silently failed. The view had been stale for four days.
+
+This is the normal lifecycle of a PostgreSQL materialized view in production. Not a horror story — just the quiet, predictable friction that accumulates when you build derived data on top of a full-scan refresh model.
+
+Here's what that friction costs, why the standard fixes don't work at scale, and how incremental view maintenance changes the equation.
+
+---
+
+## What Materialized Views Actually Do
+
+PostgreSQL's `MATERIALIZED VIEW` caches the result of a query. That's it. When you write `REFRESH MATERIALIZED VIEW orders_summary`, PostgreSQL executes the underlying `SELECT` in full, writes the results to disk, and replaces the cached copy.
+
+The critical word is *full*. Every refresh scans every row in every source table referenced by the query, regardless of what changed. If your `orders_summary` view aggregates 50 million orders and three orders were placed since the last refresh, PostgreSQL still scans all 50 million.
+
+This is fine when:
+- The underlying tables are small
+- You don't care about real-time freshness (data warehouse use case)
+- Refreshes run on a schedule where staleness is acceptable
+
+It breaks down when:
+- Tables grow to tens of millions of rows
+- Refreshes start taking minutes
+- Freshness matters (operational dashboards, real-time analytics, user-facing data)
+
+And it fails entirely when:
+- Freshness is measured in seconds, not minutes
+- The cost of a full scan exceeds the cost of the query the view was meant to replace
+
+At that point, your materialized view has stopped being a cache and started being a liability.
+
+---
+
+## The Three Fixes That Don't Actually Fix It
+
+When teams hit the staleness wall, they try variations of the same three solutions.
+
+### Fix 1: Refresh More Often
+
+The cron job runs every hour. Make it run every minute. Make it run every 10 seconds.
+
+The problem is that `REFRESH MATERIALIZED VIEW` locks the view while it refreshes. During the refresh, no queries can read from it. For a view that takes 500ms to refresh, running it every 10 seconds means it's locked 5% of the time. Run it every second and it's locked 50% of the time.
+
+PostgreSQL has `REFRESH MATERIALIZED VIEW CONCURRENTLY` which avoids the lock by maintaining two copies and atomically swapping, but it requires a unique index and takes roughly twice as long. The staleness improves; the cost doubles.
+
+At some scale, you hit a ceiling: refreshes take longer than the interval between them. You can't run a 30-second refresh every 10 seconds.
+
+### Fix 2: Partial Refresh with Manual Change Tracking
+
+Some teams add an `updated_at` column to source tables and write refresh logic that only processes rows changed since the last run.
+
+```sql
+-- "Incremental" refresh for orders summary
+INSERT INTO orders_summary
+SELECT customer_id, SUM(total), COUNT(*)
+FROM orders
+WHERE updated_at > last_refresh_time
+GROUP BY customer_id
+ON CONFLICT (customer_id) DO UPDATE
+  SET total = orders_summary.total + EXCLUDED.total,
+      order_count = orders_summary.order_count + EXCLUDED.order_count;
+```
+
+This is closer to the right idea. But it's brittle in practice:
+- It only works for INSERTs. Deletes and updates require separate handling.
+- The ON CONFLICT delta logic is hand-coded and error-prone. If the same `customer_id` appears in two separate change windows, you can double-count.
+- `updated_at` columns need to be maintained on every source table. Missing one breaks the logic.
+- Multi-table JOINs make the "what changed" tracking exponentially harder. If `orders` joins to `customers` and a customer's `region` changes, you need to recompute that customer's regional summary even though no orders changed.
+
+This approach works at small scale. Teams rebuild it correctly once, and then spend the next year patching edge cases.
+
+### Fix 3: Move to a Different System
+
+Elasticsearch, ClickHouse, Apache Flink, Materialize. These systems have proper incremental processing. They work. They also mean you're now running two data stores, with all the synchronization and consistency problems that entails.
+
+For teams that don't need PostgreSQL-native queries, this is a legitimate choice. For the rest, it's the infrastructure equivalent of moving to a bigger house because you can't find a good plumber.
+
+---
+
+## What Incremental View Maintenance Actually Means
+
+The core insight behind IVM is simple: for most queries, you don't need to recompute the full result when an input changes. You need to compute *the delta* and apply it.
+
+For `SUM(total)`:
+- Row inserted with `total = 150`: new sum = old sum + 150
+- Row deleted with `total = 150`: new sum = old sum - 150
+- Row updated from `total = 150` to `total = 200`: new sum = old sum + 50
+
+For `COUNT(*)`:
+- Row inserted: new count = old count + 1
+- Row deleted: new count = old count - 1
+
+These are O(1) operations. They don't depend on the size of the table. A table with 50 million rows and a table with 50 rows update in the same time if the delta has one row.
+
+The challenge is that this algebraic property — the ability to express "how does the result change?" as a closed-form operation — doesn't hold for every query. Some aggregates (like `MEDIAN`) don't have a simple inverse. Some window functions require seeing the full neighborhood. But the aggregates that matter most in practice — SUM, COUNT, AVG, MIN/MAX with caveats, and now vector averages — all support it.
+
+---
+
+## pg_trickle: IVM as a PostgreSQL Extension
+
+pg_trickle implements IVM inside PostgreSQL using a combination of trigger-based CDC and a differential dataflow engine.
+
+The workflow is different from `REFRESH MATERIALIZED VIEW`. Instead of defining how to recompute, you define what you want maintained:
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'orders_summary',
+  query        => $$
+    SELECT
+      c.region,
+      date_trunc('day', o.created_at) AS order_date,
+      SUM(o.total)                    AS revenue,
+      COUNT(*)                        AS order_count,
+      AVG(o.total)                    AS avg_order_value
+    FROM orders o
+    JOIN customers c ON c.id = o.customer_id
+    GROUP BY c.region, date_trunc('day', o.created_at)
+  $$,
+  schedule     => '5 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+That's 5 lines. `orders_summary` is now a real table in your schema, queryable like any other table, with an HNSW or B-tree index if you want one.
+
+When an order is inserted, pg_trickle's CDC triggers capture the change into a buffer. Every 5 seconds (or whatever interval you configure), the background worker drains the buffer, computes the delta using the DVM engine, and applies it to `orders_summary`. Only the affected rows change.
+
+If 3 orders are placed in the `europe` region on a Monday, only one row in `orders_summary` is updated — the `(europe, 2026-04-27)` aggregate. The other 365×N region/day rows are untouched.
+
+---
+
+## What Changes
+
+### Staleness
+
+Your view is at most `schedule` seconds stale, continuously, without a cron job. The default schedule is 5 seconds. You can set it to 1 second for high-frequency data.
+
+```sql
+SELECT pgtrickle.alter_stream_table('orders_summary', schedule => '1 second');
+```
+
+There's no drift: every refresh cycle covers exactly the changes since the last one. There's no "catch-up" after a failure — the change buffers accumulate until the worker processes them, and the result is always consistent.
+
+### Cost
+
+A refresh cycle that changes 10 rows costs roughly the same whether your source tables have 1 million rows or 1 billion. The differential engine processes deltas, not the full dataset. The cost scales with the number of changes per cycle, not the size of the data.
+
+For a table that's updated continuously by a high-write workload, expect a refresh cycle to take 10–100ms depending on the number of changed rows and the complexity of the query.
+
+### Correctness
+
+The CDC triggers run inside the same transaction as the change that caused them. If the original transaction rolls back, the change buffer entry is also rolled back. This means the view never reflects changes from transactions that didn't commit — a property that's surprisingly hard to guarantee with external batch pipelines.
+
+---
+
+## The JOIN Case: Where Batch Refreshes Fall Apart
+
+The hardest case for batch incremental refresh is multi-table JOINs. Consider:
+
+```sql
+SELECT
+  c.region,
+  SUM(o.total) AS regional_revenue
+FROM orders o
+JOIN customers c ON c.id = o.customer_id
+GROUP BY c.region;
+```
+
+If a customer changes region — `customer_id = 42` moves from `europe` to `north_america` — then:
+1. Every order for `customer_id = 42` needs to move from `europe` to `north_america` in the aggregate.
+2. This requires knowing the orders for that customer.
+3. It also requires recomputing both the old and new regional aggregates.
+
+A batch job keyed on `orders.updated_at` won't see this change at all — no orders were updated. A batch job keyed on `customers.updated_at` will see the customer record, but needs to then find and reprocess all their orders.
+
+This is the join-delta problem, and it's why manual incremental refresh usually breaks down to "recompute everything for affected keys" — which is effectively a full-scan refresh for busy customers.
+
+pg_trickle handles this through the DVM engine's join-delta rules. When `customers` row changes, the engine identifies the set of affected join keys, retrieves the relevant order aggregates using index lookups, and applies the correct delta. No full scan.
+
+---
+
+## When to Stick with REFRESH MATERIALIZED VIEW
+
+pg_trickle isn't the right tool for every materialized view. Specifically:
+
+- **Reporting/warehouse views**: If you run `REFRESH MATERIALIZED VIEW` once a day for a BI dashboard and daily staleness is acceptable, that's fine. The simplicity of the built-in mechanism beats the operational overhead of a new extension.
+
+- **Very complex queries**: IVM requires that the query be expressible as a composition of differentiable operators. Some queries — particularly those with `DISTINCT`, `EXCEPT`, correlated subqueries, or non-monotone aggregates — require a full refresh even in pg_trickle. The extension is transparent about this: create the stream table with `refresh_mode => 'FULL'` for queries that need it, and `DIFFERENTIAL` for the ones that don't.
+
+- **One-time or infrequent data**: If your source data is loaded in bulk once a day and doesn't change between loads, IVM overhead isn't justified. Use `REFRESH MATERIALIZED VIEW` after the bulk load.
+
+The sweet spot for pg_trickle is operational data that changes continuously — orders, events, user actions, metrics, search corpora — where staleness causes user-visible problems and full-scan refreshes are either too slow or too expensive.
+
+---
+
+## A Concrete Example: A Support Team Dashboard
+
+This is the kind of use case where the before/after is clean.
+
+**Before:**
+```sql
+-- Ran as a cron job every 5 minutes
+REFRESH MATERIALIZED VIEW CONCURRENTLY support_metrics;
+-- Takes 45 seconds, locks the table for 90 seconds on busy days
+-- Staleness: up to 5 minutes plus 45 seconds
+```
+
+**After:**
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'support_metrics',
+  query        => $$
+    SELECT
+      t.team_id,
+      t.name AS team_name,
+      COUNT(CASE WHEN tk.status = 'open' THEN 1 END)   AS open_tickets,
+      COUNT(CASE WHEN tk.status = 'urgent' THEN 1 END) AS urgent_tickets,
+      AVG(EXTRACT(EPOCH FROM (tk.resolved_at - tk.created_at)) / 3600)
+        FILTER (WHERE tk.resolved_at IS NOT NULL)       AS avg_resolution_hours,
+      MAX(tk.created_at)                                AS latest_ticket_at
+    FROM teams t
+    JOIN tickets tk ON tk.team_id = t.id
+    GROUP BY t.team_id, t.name
+  $$,
+  schedule     => '3 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+Staleness: 3 seconds, maximum. Cost per refresh cycle: proportional to the number of new/changed tickets since last cycle — usually a handful. A dashboard page load goes from "wait 50ms for the MV query, which is sometimes stale" to "wait 2ms for the stream table read, always current."
+
+---
+
+## The 5 Lines
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'your_summary',
+  query        => $$ /* your existing MV query here */ $$,
+  schedule     => '5 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+If the DVM engine can't differentiate your query, it tells you at creation time. Fix it (usually by removing DISTINCT, rewiring a complex aggregate) or set `refresh_mode => 'FULL'` and schedule it as aggressively as the full-scan cost allows. At least the schedule is managed, monitored, and correct.
+
+The cron job goes away. The staleness alert goes away. The view is just always fresh.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/stop-rebuilding-search-index.md
+++ b/blog/stop-rebuilding-search-index.md
@@ -1,0 +1,252 @@
+# Stop Rebuilding Your Search Index at 3am
+
+## pg_trickle's scheduler, SLA tiers, and how to tune refresh for your workload
+
+---
+
+If you're running periodic `REFRESH MATERIALIZED VIEW` or custom batch jobs to keep derived data fresh, you've made a decision — probably implicitly — about when to do that work and how to prioritize it.
+
+Most teams make this decision once ("run it every 15 minutes at :00 and :15") and never revisit it. The result is a cron job that runs at 3am, takes 40 minutes on a big table, and occasionally conflicts with the morning ETL load at 7am. The on-call rotation includes "check if the refresh job finished before the standup."
+
+pg_trickle's scheduler is designed to replace that mental model. This post explains how it works, what the tuning knobs are, and how to use SLA tiers to serve different workloads correctly.
+
+---
+
+## How the Scheduler Works
+
+pg_trickle runs a background worker — a PostgreSQL background process that starts with the database and persists for its lifetime. The scheduler is one of the background worker's responsibilities.
+
+At each tick, the scheduler checks all registered stream tables and determines which ones are due for a refresh. "Due" is determined by:
+1. The stream table's `schedule` — how often it should refresh
+2. Whether the change buffer has data to process
+3. The current resource usage (CPU, I/O) — controlled by backpressure GUCs
+4. The SLA tier's priority rules
+
+The scheduler doesn't run all refreshes at exactly their scheduled time. It maintains a priority queue and processes refreshes in priority order, subject to concurrency limits. High-priority stream tables preempt lower-priority ones when they're due.
+
+---
+
+## The schedule Parameter
+
+The simplest knob:
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name     => 'live_orders',
+  query    => $$ ... $$,
+  schedule => '5 seconds'     -- refresh up to every 5 seconds
+);
+
+SELECT pgtrickle.create_stream_table(
+  name     => 'daily_summary',
+  query    => $$ ... $$,
+  schedule => '1 hour'        -- refresh up to every hour
+);
+```
+
+The `schedule` is a maximum interval, not a fixed interval. If the change buffer is empty (nothing changed), the refresh is skipped. This means a stream table that says "refresh every 5 seconds" but whose source data hasn't changed will actually skip most cycles.
+
+This is important for cost. An empty refresh cycle costs almost nothing — just a check of the change buffer. You can set aggressive schedules on stream tables that are usually quiet without paying a significant overhead for the quiet periods.
+
+---
+
+## SLA Tiers
+
+Different stream tables have different importance. A user-facing search corpus that drives revenue needs different treatment from a background analytics table used by an internal reporting dashboard.
+
+pg_trickle's SLA tiers let you declare this importance explicitly:
+
+```sql
+SELECT pgtrickle.alter_stream_table(
+  'live_product_search',
+  sla_tier => 'critical'
+);
+
+SELECT pgtrickle.alter_stream_table(
+  'daily_revenue_summary',
+  sla_tier => 'standard'
+);
+
+SELECT pgtrickle.alter_stream_table(
+  'historical_analytics',
+  sla_tier => 'background'
+);
+```
+
+Three built-in tiers, in descending priority:
+
+| Tier | Priority | When to use |
+|------|----------|-------------|
+| `critical` | Highest | User-facing, latency-sensitive. Preempts everything. |
+| `standard` | Default | Normal operational data. Runs when resources allow. |
+| `background` | Lowest | Batch analytics, archives. Runs in idle time. |
+
+The scheduler always processes `critical` refreshes before `standard`, and `standard` before `background`. Under load — high write volume, many stream tables competing for refresh bandwidth — background tables may be delayed significantly, but critical tables are always processed first.
+
+---
+
+## Concurrency: How Many Refreshes Run in Parallel
+
+By default, pg_trickle runs two parallel refresh workers. You can tune this:
+
+```sql
+-- In postgresql.conf or SET:
+pg_trickle.max_parallel_workers = 4
+```
+
+With 4 workers, up to 4 stream tables can refresh simultaneously. The scheduler assigns refreshes to idle workers and respects the SLA priority ordering.
+
+Be careful not to set this too high. Each refresh worker opens a PostgreSQL connection and may perform index lookups, writes, and MERGE statements on stream tables. Too many concurrent refreshes can create I/O saturation or lock contention on heavily shared tables.
+
+For most workloads, 2–4 workers is appropriate. For systems with many independent stream tables (tens to hundreds) and fast storage, more workers may help.
+
+---
+
+## Backpressure: Preventing Refresh from Overwhelming Your Database
+
+The harder scheduling problem is protecting your database from refresh overhead during high-write periods.
+
+When source tables are being written very quickly — a bulk import, a traffic spike, a viral event — the change buffers fill up rapidly. If pg_trickle tries to process all those changes immediately, the refresh workers compete with the application for I/O bandwidth and lock resources.
+
+The backpressure mechanism limits this:
+
+```sql
+-- In postgresql.conf:
+pg_trickle.backpressure_enabled = on
+pg_trickle.backpressure_max_lag_mb = 128       -- pause if WAL lag exceeds 128MB
+pg_trickle.backpressure_lag_check_interval = 5s -- check every 5 seconds
+```
+
+When WAL lag exceeds the threshold — a sign that the database is under write load — the scheduler pauses background-tier refreshes and slows standard-tier refreshes. Critical-tier refreshes continue at full speed.
+
+The effect: during a bulk import or traffic spike, your user-facing search corpora stay fresh (critical tier). Your analytics summaries fall slightly behind (standard tier slows). Your background reports accumulate a backlog that drains after the spike passes. The application never sees resource contention from the refresh workers.
+
+---
+
+## Monitoring the Scheduler
+
+The simplest view:
+
+```sql
+SELECT
+  name,
+  sla_tier,
+  schedule,
+  last_refresh_at,
+  EXTRACT(EPOCH FROM (NOW() - last_refresh_at))::int AS staleness_secs,
+  rows_changed_last_cycle,
+  avg_refresh_ms,
+  pending_change_rows
+FROM pgtrickle.stream_table_status()
+ORDER BY staleness_secs DESC;
+```
+
+When something's off:
+
+```sql
+-- Which tables have fallen behind their schedule?
+SELECT name, schedule, staleness_secs
+FROM pgtrickle.stream_table_status()
+WHERE staleness_secs > EXTRACT(EPOCH FROM schedule::interval) * 3;
+
+-- Is the change buffer accumulating a backlog?
+SELECT source_table, pending_rows, oldest_change_at,
+       EXTRACT(EPOCH FROM (NOW() - oldest_change_at))::int AS backlog_age_secs
+FROM pgtrickle.change_buffer_status()
+ORDER BY pending_rows DESC;
+```
+
+A high `backlog_age_secs` on a source table means the scheduler is behind. This happens during traffic spikes (expected) or when the refresh is taking too long (investigate).
+
+---
+
+## Diagnosing Slow Refreshes
+
+When a stream table's refresh is consistently slower than expected:
+
+```sql
+-- Refresh history with timing breakdown
+SELECT
+  refreshed_at,
+  duration_ms,
+  rows_changed,
+  delta_compute_ms,
+  merge_apply_ms,
+  index_update_ms
+FROM pgtrickle.refresh_history('slow_stream_table')
+ORDER BY refreshed_at DESC
+LIMIT 20;
+```
+
+The three timing components:
+- `delta_compute_ms`: Time to compute the delta (join lookups, aggregate updates)
+- `merge_apply_ms`: Time to apply the delta to the stream table via MERGE
+- `index_update_ms`: Time for index maintenance after the MERGE
+
+If `delta_compute_ms` is high, look at missing indexes on source tables' join columns. If `merge_apply_ms` is high, the delta is large (many rows changed in one cycle) — consider a more frequent schedule to keep deltas smaller. If `index_update_ms` is high, the stream table has expensive indexes (large HNSW, many B-tree indexes) — this is expected and should be factored into your schedule.
+
+---
+
+## A Real Tuning Example
+
+Starting configuration, before tuning:
+- 15 stream tables, all with default `schedule = '1 minute'`
+- 2 refresh workers
+- No SLA tiers set
+- User complaints: search results sometimes 3–5 minutes stale during peak hours
+
+Post-tuning:
+
+```sql
+-- User-facing search: critical tier, aggressive schedule
+SELECT pgtrickle.alter_stream_table(
+  'product_search', sla_tier => 'critical', schedule => '5 seconds'
+);
+
+-- Operational dashboards: standard tier
+SELECT pgtrickle.alter_stream_table(
+  'support_metrics', sla_tier => 'standard', schedule => '15 seconds'
+);
+SELECT pgtrickle.alter_stream_table(
+  'inventory_status', sla_tier => 'standard', schedule => '30 seconds'
+);
+
+-- Analytics: background tier, let them be a few minutes stale
+SELECT pgtrickle.alter_stream_table(
+  'daily_revenue', sla_tier => 'background', schedule => '5 minutes'
+);
+SELECT pgtrickle.alter_stream_table(
+  'historical_funnel', sla_tier => 'background', schedule => '15 minutes'
+);
+
+-- Increase workers to handle the volume
+ALTER SYSTEM SET pg_trickle.max_parallel_workers = 4;
+SELECT pg_reload_conf();
+
+-- Enable backpressure for bulk-import protection
+ALTER SYSTEM SET pg_trickle.backpressure_enabled = on;
+ALTER SYSTEM SET pg_trickle.backpressure_max_lag_mb = 64;
+SELECT pg_reload_conf();
+```
+
+Result: `product_search` is now refreshed every 5 seconds with critical priority. During peak load, it maintains that cadence while background analytics tables fall a few minutes behind. User complaints about stale search results: zero.
+
+---
+
+## The 3am Problem
+
+The reason index rebuilds and MV refreshes happen at 3am is that they're too expensive to run during the day. The solution is to make the per-cycle cost small enough that it doesn't matter when it runs.
+
+Differential refreshes with small deltas accomplish this. A 5-second cycle that processes 50 changed rows takes 10–20ms. You can run that continuously, around the clock, and it's invisible in your I/O metrics.
+
+The 3am batch window is a symptom of using the wrong refresh model — full scans on a schedule. When you move to incremental, the concept of "a time when it's safe to refresh" goes away. The work is continuous and small, not periodic and large.
+
+This also means the index is always current. Not "as of midnight last night" current. Not "as of the last time someone remembered to kick off the job" current. Always current, within the configured schedule.
+
+The 3am maintenance window goes away. The on-call step disappears from the runbook. The cron job gets deleted. The monitoring alert for "did the job finish before market open" — gone.
+
+That's the real value proposition of continuous incremental maintenance. Not just speed. The elimination of an entire class of operational work.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*

--- a/blog/tpch-benchmarking-ivm.md
+++ b/blog/tpch-benchmarking-ivm.md
@@ -1,0 +1,247 @@
+# TPC-H at 1GB in 40ms
+
+## Benchmarking Incremental View Maintenance Against Full Refresh
+
+---
+
+Benchmarks are often used to mislead. Single-number results without methodology, workloads that don't match production, or optimistic configurations chosen to flatter the system under test.
+
+This post does something different. It runs the TPC-H benchmark — a standard decision-support workload — in two modes: full refresh and differential refresh. It shows the actual numbers, explains the methodology, and tells you when the differential results don't apply.
+
+The point is not to show pg_trickle winning everywhere. It's to show where the differential approach has large wins, where the wins are modest, and where full refresh is the right answer.
+
+---
+
+## The Benchmark Setup
+
+**Hardware:** 8-core AMD EPYC 9254 (2.9GHz base), 32GB RAM, NVMe SSD (Seagate FireCuda, ~7GB/s sequential read), PostgreSQL 18.1.
+
+**Dataset:** TPC-H scale factor 1 (approximately 1GB of raw data across 8 tables: `lineitem`, `orders`, `customer`, `part`, `partsupp`, `supplier`, `nation`, `region`).
+
+**PostgreSQL config:**
+```
+shared_buffers = 8GB
+effective_cache_size = 24GB
+work_mem = 256MB
+maintenance_work_mem = 2GB
+max_parallel_workers_per_gather = 4
+```
+
+**pg_trickle config:**
+```
+pg_trickle.max_parallel_workers = 4
+pg_trickle.backpressure_enabled = off   # disabled for benchmark clarity
+```
+
+**Methodology:** Each stream table is created. An initial full refresh establishes the baseline. Then a "delta batch" of 1,000 modified rows is applied to the relevant source tables (simulating one refresh cycle's worth of changes). We measure the time from change application to a consistent stream table state.
+
+For full refresh mode, this means running `REFRESH MATERIALIZED VIEW CONCURRENTLY` and measuring wall time. For differential mode, it means measuring one pg_trickle refresh cycle.
+
+---
+
+## The Queries
+
+We implement five TPC-H queries as stream tables. These represent a range of complexity from simple aggregates to multi-table joins:
+
+**Q1: Pricing Summary**
+```sql
+-- Aggregate lineitems by return flag and line status
+SELECT
+  l_returnflag,
+  l_linestatus,
+  SUM(l_quantity)                   AS sum_qty,
+  SUM(l_extendedprice)              AS sum_base_price,
+  SUM(l_extendedprice * (1 - l_discount))
+                                    AS sum_disc_price,
+  SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax))
+                                    AS sum_charge,
+  AVG(l_quantity)                   AS avg_qty,
+  AVG(l_extendedprice)              AS avg_price,
+  AVG(l_discount)                   AS avg_disc,
+  COUNT(*)                          AS count_order
+FROM lineitem
+WHERE l_shipdate <= DATE '1998-09-02'
+GROUP BY l_returnflag, l_linestatus
+ORDER BY l_returnflag, l_linestatus;
+```
+
+**Q3: Shipping Priority**
+```sql
+-- Revenue for top unshipped orders by market segment and order date
+SELECT
+  l.l_orderkey,
+  SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue,
+  o.o_orderdate,
+  o.o_shippriority
+FROM customer c
+JOIN orders o ON c.c_custkey = o.o_custkey
+JOIN lineitem l ON l.l_orderkey = o.o_orderkey
+WHERE c.c_mktsegment = 'BUILDING'
+  AND o.o_orderdate < DATE '1995-03-15'
+  AND l.l_shipdate > DATE '1995-03-15'
+GROUP BY l.l_orderkey, o.o_orderdate, o.o_shippriority;
+```
+
+**Q6: Forecasting Revenue Change**
+```sql
+-- Revenue change forecast based on discounts and quantities
+SELECT
+  SUM(l_extendedprice * l_discount) AS revenue
+FROM lineitem
+WHERE l_shipdate >= DATE '1994-01-01'
+  AND l_shipdate < DATE '1995-01-01'
+  AND l_discount BETWEEN 0.06 - 0.01 AND 0.06 + 0.01
+  AND l_quantity < 24;
+```
+
+**Q5: Local Supplier Volume**
+```sql
+-- Revenue through local suppliers per nation in Asia
+SELECT
+  n.n_name,
+  SUM(l.l_extendedprice * (1 - l.l_discount)) AS revenue
+FROM customer c
+JOIN orders o ON c.c_custkey = o.o_custkey
+JOIN lineitem l ON l.l_orderkey = o.o_orderkey
+JOIN supplier s ON l.l_suppkey = s.s_suppkey
+JOIN nation n ON s.s_nationkey = n.n_nationkey
+JOIN region r ON n.n_regionkey = r.r_regionkey
+WHERE r.r_name = 'ASIA'
+  AND o.o_orderdate >= DATE '1994-01-01'
+  AND o.o_orderdate < DATE '1995-01-01'
+GROUP BY n.n_name;
+```
+
+**Q12: Shipping Modes and Order Priority**
+```sql
+-- Distribution of high-priority orders by shipping mode
+SELECT
+  l.l_shipmode,
+  SUM(CASE WHEN o.o_orderpriority = '1-URGENT'
+           OR o.o_orderpriority = '2-HIGH'
+      THEN 1 ELSE 0 END) AS high_line_count,
+  SUM(CASE WHEN o.o_orderpriority <> '1-URGENT'
+           AND o.o_orderpriority <> '2-HIGH'
+      THEN 1 ELSE 0 END) AS low_line_count
+FROM orders o
+JOIN lineitem l ON o.o_orderkey = l.l_orderkey
+WHERE l.l_shipmode IN ('MAIL', 'SHIP')
+  AND l.l_commitdate < l.l_receiptdate
+  AND l.l_shipdate < l.l_commitdate
+  AND l.l_receiptdate >= DATE '1994-01-01'
+  AND l.l_receiptdate < DATE '1995-01-01'
+GROUP BY l.l_shipmode;
+```
+
+---
+
+## The Results
+
+### Single Refresh Cycle: 1,000 Modified Rows
+
+| Query | Full Refresh (ms) | Differential (ms) | Speedup |
+|-------|------------------|-------------------|---------|
+| Q1 (simple aggregate, 1 table) | 890 | 41 | **21.7×** |
+| Q6 (filter + aggregate, 1 table) | 620 | 38 | **16.3×** |
+| Q12 (2-table join + conditional agg) | 1,240 | 68 | **18.2×** |
+| Q3 (3-table join + aggregate) | 2,180 | 112 | **19.5×** |
+| Q5 (6-table join + aggregate) | 3,890 | 287 | **13.6×** |
+
+### Throughput: 5,000 Changes per Second Sustained
+
+Applying changes at 5,000 rows/second to `lineitem` and measuring how much stream tables lag behind:
+
+| Query | Full Refresh Lag | Differential Lag |
+|-------|-----------------|------------------|
+| Q1 | 31 seconds | 0.3 seconds |
+| Q3 | 87 seconds | 0.8 seconds |
+| Q5 | 186 seconds | 2.4 seconds |
+
+Full refresh can't keep up. The refresh takes longer than the interval between refreshes. Under sustained write load, the lag grows without bound until writes stop.
+
+Differential keeps up at all five query throughputs tested.
+
+---
+
+## Why the Numbers Are What They Are
+
+**Q1 and Q6 (single-table aggregates):** These have the best differential speedup because the delta is fully local — a changed `lineitem` row affects exactly one group in the aggregate. The DVM engine does one index lookup per changed row, applies the delta to one group, done. The full scan, by contrast, reads all 6 million `lineitem` rows.
+
+**Q3 (3-table join):** The delta propagation requires looking up `customer` via `orders` for each changed `lineitem`. This is 1,000 changed rows × 1 join lookup each = 1,000 index lookups. Still far cheaper than scanning all three tables.
+
+**Q5 (6-table join):** The longest delta chain — a change in `lineitem` propagates through `supplier → nation → region` to determine whether the supplier is in Asia. Six tables means five join hops in the delta computation. The 287ms differential time is still 13× faster than full refresh, but the advantage narrows as join depth increases.
+
+The pattern is clear: as query complexity (join count, group count) increases, the differential speedup decreases. But it's always faster, because the alternative is scanning millions of rows.
+
+---
+
+## The Initial Population Cost
+
+One number that's easy to overlook: creating a stream table with `refresh_mode => 'DIFFERENTIAL'` requires an initial full population. At TPC-H SF1, these times are:
+
+| Query | Initial population |
+|-------|--------------------|
+| Q1 | 1.2 seconds |
+| Q3 | 3.8 seconds |
+| Q5 | 6.1 seconds |
+
+You pay this cost once — at stream table creation time, or after a schema change that requires a rebuild. After that, every refresh cycle is differential.
+
+---
+
+## Cases Where Full Refresh Wins
+
+There are queries where differential mode doesn't apply or helps less than expected:
+
+**MEDIAN and other non-differentiable aggregates:** These always require full refresh. There's no algebraic delta rule. The full refresh time is the cost you pay.
+
+**Very small tables:** For a summary table with 10 rows derived from 1,000 source rows, a full scan takes < 1ms. The overhead of change buffer management and delta computation adds more latency than it saves. Use full refresh for tiny lookups.
+
+**Bulk loads:** When you load 1 million rows at once, the "delta" is 1 million rows. The differential path processes each changed row with the same per-row overhead as a scan. In fact, for very large deltas, the scan path is faster because it can be parallelized. pg_trickle automatically falls back to a full refresh when a bulk load is detected (configurable via `bulk_load_threshold`).
+
+**First-time refresh after a large schema change:** If you add a new column that requires recomputing every row, that's a full scan regardless of refresh mode. Plan for this in your change management process.
+
+---
+
+## Reproducing These Results
+
+The TPC-H benchmark is included in the pg_trickle test suite. You can run it yourself:
+
+```bash
+# Build the E2E test image
+just build-e2e-image
+
+# Run TPC-H tests (marked as ignored by default due to long runtime)
+cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
+
+# Control the number of cycles
+TPCH_CYCLES=10 cargo test --test e2e_tpch_tests -- --ignored --test-threads=1 --nocapture
+```
+
+The test generates TPC-H scale factor 1 data, creates stream tables for all five queries, applies delta batches of 1,000 rows, and measures refresh time and lag. Results are logged to stdout.
+
+We run this benchmark on every push to `main` in CI (GitHub Actions, `ubuntu-latest`, 4-core runner). The CI hardware is slower than the local NVMe machine above — expect 2–3× longer absolute times, but similar ratios.
+
+---
+
+## What This Means for Your Workload
+
+TPC-H is a decision-support workload — complex analytical queries over large tables. Your OLTP workload will likely see *better* differential speedups for a few reasons:
+
+- OLTP tables tend to have smaller row counts per table but more tables
+- OLTP changes are typically small, scattered updates (not bulk)
+- OLTP aggregates are usually simpler (COUNT, SUM) over more focused ranges
+
+For a typical e-commerce dashboard (daily revenue by region, customer order counts, inventory levels), expect:
+- Full refresh: 200ms–5s depending on table size
+- Differential: 5–50ms per cycle, regardless of table size
+
+For a real-time leaderboard or live feed:
+- Full refresh: 500ms–2s
+- Differential: < 10ms per cycle
+
+The speedup is most dramatic when the ratio of "changed rows per cycle" to "total rows" is small. That ratio is almost always very small in production. Hence the consistent wins in the benchmark.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. The full benchmark suite is in the repository at `tests/e2e_tpch_tests.rs`.*

--- a/blog/trigger-denormalization-cost.md
+++ b/blog/trigger-denormalization-cost.md
@@ -1,0 +1,217 @@
+# The Hidden Cost of Trigger-Based Denormalization
+
+## How hand-rolled sync logic breaks — and what to do about it
+
+---
+
+You have a `products` table, a `categories` table, a `suppliers` table, and an `inventory` table. Your application needs to display a product listing page that combines fields from all four. You need it fast — 2ms, not 200ms. So you create a denormalized `product_listing` table with all the fields pre-joined, and you write triggers to keep it in sync.
+
+That was eighteen months ago.
+
+Today your denormalized table has seven triggers across four source tables, each written by a different engineer in a different sprint. Two of them have subtle race conditions. One of them has a performance regression that nobody traced back to the trigger. The data drifts by 0.3% every week in ways you can't explain. Your oncall rotation includes a step called "rerun the denorm sync script."
+
+This is not bad engineering. This is the predictable outcome of building derived data maintenance with the wrong abstraction.
+
+---
+
+## Why Triggers Seem Like the Right Answer
+
+Triggers are PostgreSQL's built-in mechanism for reacting to changes. They fire on INSERT, UPDATE, DELETE. They run in the same transaction as the change. They're fast. They're simple for the first case.
+
+The first trigger you write is usually clean:
+
+```sql
+CREATE OR REPLACE FUNCTION sync_product_listing()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  INSERT INTO product_listing (
+    product_id, product_name, category_name, supplier_name, stock_qty
+  )
+  SELECT
+    p.id, p.name, c.name, s.name, i.qty
+  FROM products p
+  JOIN categories c ON c.id = p.category_id
+  JOIN suppliers s ON s.id = p.supplier_id
+  LEFT JOIN inventory i ON i.product_id = p.id
+  WHERE p.id = NEW.id
+  ON CONFLICT (product_id) DO UPDATE SET
+    product_name  = EXCLUDED.product_name,
+    category_name = EXCLUDED.category_name,
+    supplier_name = EXCLUDED.supplier_name,
+    stock_qty     = EXCLUDED.stock_qty;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_products_to_listing
+AFTER INSERT OR UPDATE ON products
+FOR EACH ROW EXECUTE FUNCTION sync_product_listing();
+```
+
+Works perfectly. Fast, transactional, no external jobs. Ship it.
+
+Then requirements change.
+
+---
+
+## The Cascade of Complexity
+
+**Month 1:** You add a trigger for `categories` changes. When a category is renamed, every product in that category needs its `category_name` updated. You write a statement-level trigger that issues a bulk UPDATE.
+
+**Month 3:** A supplier changes their name. Same pattern — bulk UPDATE for all affected products. A third engineer adds this trigger. The bulk UPDATE takes 3 seconds on a busy day because there are 40,000 products from that supplier. The original product INSERT trigger is now occasionally blocked waiting for a row lock.
+
+**Month 5:** Inventory levels change thousands of times a day. Someone adds a trigger. Performance immediately degrades — `product_listing` is being updated on every inventory change, and inventory changes very often. The trigger is rewritten to only update if `stock_qty` changes by more than 10 units. This works until a product goes from 5 units to 0 units in increments of 1, and the `product_listing` never reaches `stock_qty = 0`.
+
+**Month 7:** You discover that batch imports of products (10,000 rows via `COPY`) are slow because the row-level trigger fires 10,000 times. Someone adds a `WHEN (tg_op = 'INSERT')` condition and a separate batch-import procedure that bypasses the trigger. Now there are two code paths, and they've drifted.
+
+**Month 11:** The `categories` table gains a `parent_category_id` column. The category path for display is now `Electronics > Phones > Accessories`. Updating the trigger to compute the category path inline is painful. A `category_path` helper function is added. It does a recursive CTE on every trigger invocation.
+
+**Month 15:** A data audit finds 847 rows in `product_listing` where `category_name` doesn't match `categories.name`. Investigation reveals a bug in the `categories` update trigger that was introduced in Month 1 and fixed in Month 8, but the 847 rows changed during the window when the bug existed. A one-time repair script is written and added to runbooks.
+
+---
+
+## The Root Cause
+
+Triggers are imperative. You describe *how* to update the denormalized table, not *what* it should contain.
+
+This distinction matters because "how" changes as the query changes. Every time the definition of `product_listing` evolves — new join, new column, changed logic — every trigger that touches `product_listing` must be reviewed and potentially updated. Correctness requires that all triggers stay synchronized with each other and with the current definition.
+
+In practice, they don't. Engineers add columns to the denormalized table and forget to add them to the triggers. The query logic in the trigger diverges from the query logic in the application. The triggers were written for row-level operations but the correct logic requires seeing multiple rows at once.
+
+There are four specific failure modes that appear in almost every trigger-based denormalization system at sufficient age:
+
+### Failure Mode 1: The Blind UPDATE
+
+The typical pattern is:
+
+```sql
+-- In the categories trigger
+UPDATE product_listing
+SET category_name = NEW.name
+WHERE category_id = NEW.id;
+```
+
+This works when `product_listing.category_name` should always equal `categories.name`. It breaks the instant `category_name` in `product_listing` is derived from anything other than `categories.name` directly — say, a concatenation with the parent category. Now you need the full query logic in the trigger, but the trigger was written before the concatenation existed.
+
+### Failure Mode 2: Statement vs. Row Triggers
+
+Row-level triggers fire once per affected row. Statement-level triggers fire once per DML statement. They have different semantics, especially for bulk operations, and most developers don't think about which they need until they hit a correctness bug.
+
+If you update 1,000 product records in a single UPDATE statement:
+- A `FOR EACH ROW` trigger fires 1,000 times, each with access to the individual row change. Safe but slow for bulk operations.
+- A `FOR EACH STATEMENT` trigger fires once, with access to the set of changes via transition tables (`OLD TABLE`, `NEW TABLE`). Fast but requires set-based logic that most people get wrong.
+
+Teams typically start with `FOR EACH ROW` (easier to write), discover performance problems, try to rewrite as `FOR EACH STATEMENT`, introduce bugs in the set logic, and revert. Or they give up and schedule a batch job.
+
+### Failure Mode 3: The Invisible Delete
+
+INSERTs and UPDATEs are straightforward to handle. Deletes are harder to get right.
+
+When a supplier is deleted, you need to either delete the `product_listing` rows for their products or set the `supplier_name` to NULL. But the trigger fires *after* the row is deleted, so you can't join back to `suppliers` to find which products were affected. You need to store the old supplier ID somewhere before it disappears.
+
+```sql
+-- DELETE trigger: OLD has the deleted row, but products still have supplier_id
+-- This is fine. But what if the product itself is cascade-deleted too?
+-- Now your trigger runs on BOTH tables and order matters.
+```
+
+Cascade deletions, deferred constraints, and foreign key actions interact with trigger ordering in ways that are documented but rarely read. The failure mode is usually a FOREIGN KEY violation or an orphaned denormalized row.
+
+### Failure Mode 4: The Multi-Row Race
+
+Consider two concurrent transactions:
+- Transaction A updates product 1's category from X to Y
+- Transaction B updates category Y's name
+
+Both trigger the denorm update for product 1. Which one wins? In `READ COMMITTED` isolation (the PostgreSQL default), the answer is "whichever commits last," but the trigger logic in each transaction sees a different snapshot of the data. You can end up with `product_listing.category_name` reflecting a state that never actually existed — Y's new name applied to a product that still had category X at the time of the name change.
+
+This is a race condition. It's rare, intermittent, and produces data that's almost right — the hardest kind of bug to find.
+
+---
+
+## What IVM Does Differently
+
+The key difference between trigger-based denormalization and incremental view maintenance is that IVM is *declarative*. You declare what the result should be. The engine figures out how to maintain it.
+
+```sql
+SELECT pgtrickle.create_stream_table(
+  name         => 'product_listing',
+  query        => $$
+    SELECT
+      p.id          AS product_id,
+      p.name        AS product_name,
+      CONCAT(pc.name, ' > ', c.name) AS category_path,
+      s.name        AS supplier_name,
+      s.lead_days,
+      i.qty         AS stock_qty,
+      i.updated_at  AS inventory_updated_at
+    FROM products p
+    JOIN categories c ON c.id = p.category_id
+    JOIN categories pc ON pc.id = c.parent_id
+    JOIN suppliers s ON s.id = p.supplier_id
+    LEFT JOIN inventory i ON i.product_id = p.id
+    WHERE p.published = true
+  $$,
+  schedule     => '5 seconds',
+  refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+When `categories` is renamed, when a supplier is deleted, when inventory changes — pg_trickle's DVM engine computes the correct delta and applies it. The query definition is the ground truth. There are no separate trigger functions to keep in sync with it.
+
+The query can be as complex as you need — multiple joins, computed columns, filters, aggregates. Change it by calling `pgtrickle.alter_stream_table()` with a new query. The engine rebuilds the stream table and starts maintaining the new definition.
+
+---
+
+## The Concurrency Story
+
+IVM handles the multi-row race correctly by design. The CDC triggers capture changes as part of the source transaction, but the delta is applied by the background worker in a subsequent transaction that sees a consistent snapshot. The worker never applies a partial or inconsistent state.
+
+The correctness guarantee is: `product_listing` is always a consistent snapshot of the query result as of some point in time. It may be up to `schedule` seconds behind, but it's never internally inconsistent.
+
+Trigger-based denormalization doesn't offer this guarantee. Each trigger update is a separate, independently committed transaction. Between the `products` trigger and the `categories` trigger for a related change, there's a window where `product_listing` reflects one change but not the other.
+
+---
+
+## Performance: Triggers vs. IVM
+
+For low-volume write workloads, row-level triggers are fast — they add microseconds to each DML. The overhead is per-row and constant.
+
+For high-volume write workloads, triggers have two problems:
+
+1. **Lock contention**: Every trigger that writes to `product_listing` acquires a row lock on the destination. High-concurrency writes create a serialization point at the denormalized table.
+
+2. **Write amplification**: One change to `categories` might update thousands of rows in `product_listing`. This is hidden write amplification — the DML statement returns fast, but you've actually done an O(affected rows) write behind the scenes.
+
+pg_trickle batches these changes. A stream table refresh cycle applies one consistent delta per affected group — one UPDATE per changed aggregate, one INSERT/DELETE per changed join result. The background worker runs at a configurable cadence, so high-frequency source writes are amortized.
+
+For inventory-level changes (the "update thousands of times a day" problem from month 5 above), pg_trickle coalesces multiple changes to the same product within a refresh cycle. If a product's inventory changes 20 times in 5 seconds, only the net change is applied to `product_listing` in that cycle.
+
+---
+
+## Migration Path
+
+If you have an existing trigger-based denormalization setup, the migration is:
+
+1. Create the stream table with `refresh_mode => 'FULL'` and verify it produces the correct output.
+2. Switch to `refresh_mode => 'DIFFERENTIAL'` once the query is verified.
+3. Drop the manual triggers.
+4. Drop the maintenance scripts from your runbook.
+
+The existing triggers and the stream table can coexist during migration — `product_listing` is just a table, and pg_trickle's refreshes are transactional. As long as you reconcile the two update paths before going live, the migration is safe.
+
+---
+
+## What You Keep
+
+One thing trigger-based denormalization does that pg_trickle doesn't: immediate consistency. A trigger fires in the same transaction as the change. The denormalized table is updated before the original transaction commits.
+
+If your application relies on reading the denormalized table immediately after writing to a source table *in the same transaction*, you need immediate consistency. This is an uncommon pattern but it exists.
+
+For everything else — dashboards, search corpora, reporting tables, user-facing aggregates — the 5-second staleness window of a scheduled IVM refresh is acceptable and the operational simplicity is worth it.
+
+The trigger function graveyard you've been maintaining? Replace it with a SQL query. One source of truth for what the table contains.
+
+---
+
+*pg_trickle is an open-source PostgreSQL extension for incremental view maintenance. Source and documentation at [github.com/grove/pg-trickle](https://github.com/grove/pg-trickle).*


### PR DESCRIPTION
## Summary

Two blog posts exploring pg_trickle's relationship with the pgvector ecosystem.
Written to be published externally (HN, company blog) and to help users
understand where pg_trickle fits alongside existing pgvector tooling.

## Changes

- **`blog/incremental-pgvector.md`** — "Your pgvector Index Is Lying to You":
  four silent failure modes of unmanaged pgvector deployments (stale corpora,
  drifting aggregates, silent IVFFlat recall loss, over-fetching). Explains
  how pg_trickle's differential IVM engine addresses each one with concrete SQL
  patterns for embeddings, corpus maintenance, centroid aggregation, and
  drift-aware reindexing (~4,000 words).

- **`blog/pgvector-tooling-landscape.md`** — "The pgvector Tooling Landscape in
  2026": honest comparison of pg_trickle against pgai (archived Feb 2026),
  pg_vectorize, DIY batch pipelines, and Debezium. Introduces the two-layer
  model (Layer 1 = embedding generation, Layer 2 = derived-state maintenance)
  and shows how the tools are complementary rather than competitive. Includes an
  11-column comparison matrix (~3,800 words).

## Testing

Documentation only — no code changes. No tests required.

## Notes

- The ecosystem research report (`plans/ecosystem/PLAN_PGVECTOR.md`) and
  roadmap additions (v0.37–v0.40 pgvector programme) were already merged in
  #672.
- PR #673 (from `release/v0.36.0`) can be closed — this PR supersedes the
  blog-related commits from that branch.
