### PR TITLE
roadmap(v0.37-v0.40): apply 2026-04-27 assessment findings to pgvector arc

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -82,10 +82,10 @@
 | [v0.34.0](roadmap/v0.34.0.md) | Citus: automated distributed CDC scheduler wiring and shard rebalance auto-recovery | ✅ Released | Medium | [Full details](roadmap/v0.34.0.md-full.md) |
 | [v0.35.0](roadmap/v0.35.0.md) | EC-01 correctness closeout, Citus chaos hardening, reactive subscriptions, zero-downtime schema changes | Released | Large | [Full details](roadmap/v0.35.0.md-full.md) |
 | [v0.36.0](roadmap/v0.36.0.md) | Structural hardening, L0 cache, WAL backpressure, temporal IVM, columnar storage | ✅ Released | Large | [Full details](roadmap/v0.36.0.md-full.md) |
-| [v0.37.0](roadmap/v0.37.0.md) | Scheduler modularisation, pgVectorMV, OpenTelemetry trace propagation | Planned | Medium | [Full details](roadmap/v0.37.0.md-full.md) |
-| [v0.38.0](roadmap/v0.38.0.md) | Embedding pipeline infrastructure: post-refresh hooks, drift-based reindex, vector_status() monitoring | Planned | Medium | [Full details](roadmap/v0.38.0.md-full.md) |
-| [v0.39.0](roadmap/v0.39.0.md) | Hybrid search & sparse vector aggregates: sparsevec_avg, halfvec_avg, reactive distance subscriptions | Planned | Medium | [Full details](roadmap/v0.39.0.md-full.md) |
-| [v0.40.0](roadmap/v0.40.0.md) | Embedding API & advanced RAG patterns: embedding_stream_table(), k-NN graph research, per-tenant ANN | Planned | Large | [Full details](roadmap/v0.40.0.md-full.md) |
+| [v0.37.0](roadmap/v0.37.0.md) | Scheduler & merge modularisation, pgVectorMV (vector_avg/sum), OpenTelemetry trace propagation | Planned | Medium | [Full details](roadmap/v0.37.0.md-full.md) |
+| [v0.38.0](roadmap/v0.38.0.md) | Embedding pipeline operations: post-refresh hooks, drift-based reindex, vector_status() monitoring, GUC docs overhaul | Planned | Medium | [Full details](roadmap/v0.38.0.md-full.md) |
+| [v0.39.0](roadmap/v0.39.0.md) | Sparse & half-precision vector aggregates, reactive distance subscriptions, hybrid-search benchmarks | Planned | Medium | [Full details](roadmap/v0.39.0.md-full.md) |
+| [v0.40.0](roadmap/v0.40.0.md) | embedding_stream_table() ergonomic API, per-tenant ANN patterns, outbox embedding events, co-marketing | Planned | Large | [Full details](roadmap/v0.40.0.md-full.md) |
 
 ### Beyond v1.0
 

--- a/roadmap/v0.37.0.md
+++ b/roadmap/v0.37.0.md
@@ -85,7 +85,12 @@ recommendations for production readiness.
 
 - pg_partman and TimescaleDB hypertable integration tests — verify that
   pg_trickle's declarative partitioning support works with pg_partman's
-  runtime partition creation and TimescaleDB chunks
+  runtime partition creation and TimescaleDB chunks *(deferrable to v0.38.0
+  if capacity is constrained by the scheduler split or pgvector CI setup)*
+- pgvector added to `tests/Dockerfile.e2e` — prerequisite CI infrastructure
+  for the entire v0.37–v0.40 vector arc
+- Minimal `vector_avg` Criterion benchmark baseline (microseconds/vector)
+  for future regression gating
 - Any deferred items from v0.36.0 that did not meet the exit criteria
 
 ---
@@ -95,6 +100,11 @@ recommendations for production readiness.
 v0.37.0 is a medium release. The scheduler and merge splits are
 pure restructuring; pgVectorMV and OpenTelemetry are additive features with
 no impact on existing stream tables.
+
+> **Implementation discipline:** A15 (scheduler split) and A16 (merge split)
+> must land as the first two commits of this release before any feature work
+> begins. F4 (pgVectorMV) is a hard gate for v0.38.0 — the entire v0.38–v0.40
+> pgvector arc depends on it.
 
 ---
 

--- a/roadmap/v0.37.0.md-full.md
+++ b/roadmap/v0.37.0.md-full.md
@@ -35,6 +35,11 @@ The split must be purely mechanical — no logic changes. All existing tests
 must pass without modification. Each sub-module has its own `#[cfg(test)]
 mod tests` block moved from `src/scheduler.rs`.
 
+> **Implementation order:** A15 and A16 must land as the **first two commits
+> of the v0.37.0 development cycle**, before any F4 or F10 work begins.
+> Any concurrent feature work touching `scheduler.rs` or `merge.rs` during
+> the split creates merge-conflict risk with 7,768 LOC in motion.
+
 **A16 — Merge split.**
 `src/refresh/merge.rs` is 3,472 LOC of MERGE-path codegen. Split along
 PostgreSQL operator boundaries:
@@ -128,6 +133,11 @@ Requires a Testcontainers image with pg_partman and TimescaleDB installed.
 Gate behind a `partman-tests.yml` workflow running daily and on manual
 dispatch.
 
+> **Deferral note (assessment 2026-04-27):** A43 is a new CI workflow
+> plus a multi-extension Docker image. It is the lowest-risk item in this
+> release and may be deferred to v0.38.0 if capacity is constrained by the
+> A15/A16 split or F4 pgvector CI setup work.
+
 ---
 
 ### Conflicts & Risks
@@ -138,10 +148,15 @@ dispatch.
   commit with `[no-behaviour-change]` in the message.
 - **F4** (pgVectorMV) requires pgvector to be present in the CI image.
   Add pgvector to `tests/Dockerfile.e2e` and gate the tests behind
-  `#[cfg(feature = "pgvector")]`.
+  `#[cfg(feature = "pgvector")]`. This is a **prerequisite for all v0.38–v0.40
+  vector work** — treat adding pgvector to the E2E image as a tracked issue
+  that must close before v0.37.0 exits.
 - **F10** (OpenTelemetry) must not add latency to the critical refresh path
   when `enable_trace_propagation = off`. The implementation must be
   branch-free for the disabled case.
+- **Dependency-chain risk:** v0.38.0, v0.39.0, and v0.40.0 all depend on F4
+  landing correctly. If pgVectorMV slips, the entire pgvector integration arc
+  slips. F4 is a hard gate for starting v0.38.0 work.
 
 ### Exit Criteria
 
@@ -149,8 +164,10 @@ dispatch.
 - [ ] A16: `src/refresh/merge.rs` replaced by five sub-modules; all existing tests pass without change
 - [ ] F4: `vector_avg` + `vector_sum` aggregates maintain correct centroids vs FULL refresh over 10k-iteration proptest; distance operators explicitly classified as FULL-fallback safe; pgvector HNSW index refreshes correctly on stream-table delta; cookbook published
 - [ ] F10: OTLP spans visible in test-mode Jaeger for a complete refresh cycle; `traceparent` correctly propagated from session GUC through CDC → DVM → MERGE → NOTIFY
-- [ ] A43: pg_partman + TimescaleDB integration tests pass in `partman-tests.yml`
+- [ ] A43: pg_partman + TimescaleDB integration tests pass in `partman-tests.yml` *(may defer to v0.38.0)*
 - [ ] `tests/e2e_pgvector_tests.rs` passes (user-taste centroid example)
+- [ ] pgvector added to `tests/Dockerfile.e2e`; `#[cfg(feature = "pgvector")]` gate wired in CI
+- [ ] Minimal Criterion benchmark for `vector_avg` aggregate reducer added to `benches/` (microseconds/vector baseline for v0.38–v0.40 regression gate)
 - [ ] Extension upgrade path tested (`0.36.0 → 0.37.0`)
 - [ ] `just check-version-sync` passes
 

--- a/roadmap/v0.38.0.md
+++ b/roadmap/v0.38.0.md
@@ -54,7 +54,10 @@ have drifted. v0.38.0 adds explicit scheduling primitives:
 
 - Any deferred items from v0.37.0 that did not meet the exit criteria
 - Citus integration tests for vector aggregates (shard-additive centroid
-  aggregation)
+  aggregation) — required exit criterion; defer with tracked issue if Citus
+  infra is unavailable, but do not silently skip
+- `docs/CONFIGURATION.md` overhaul: auto-generated GUC reference covering
+  all 111+ GUCs, plus the new per-table stream-table options
 
 ---
 
@@ -62,7 +65,11 @@ have drifted. v0.38.0 adds explicit scheduling primitives:
 
 v0.38.0 is a medium release. The post-refresh-action primitives are scheduler
 options (no engine change); the monitoring view is purely observational;
-ecosystem integration (cookbook, Docker image) is additive.
+ecosystem integration (cookbook, Docker image) is additive. The CONFIGURATION
+docs overhaul is new but tractable.
+
+> **Hard prerequisite:** v0.38.0 development must not start until F4
+> (v0.37.0 `vector_avg`) has landed with `tests/e2e_pgvector_tests.rs` green.
 
 ---
 

--- a/roadmap/v0.38.0.md-full.md
+++ b/roadmap/v0.38.0.md-full.md
@@ -10,6 +10,11 @@
 > monitoring and diagnostics, full pgai integration tutorial, and a Docker
 > image combining pg_trickle + pgvector + pgai for AI/RAG deployments.
 
+> **Hard prerequisite:** v0.38.0 development must not start until F4 (v0.37.0
+> `vector_avg` / `vector_sum`) has landed with `tests/e2e_pgvector_tests.rs`
+> green and pgvector present in `tests/Dockerfile.e2e`. All VP items depend
+> on the pgvector CI infrastructure established in v0.37.0.
+
 ---
 
 ### Features
@@ -21,6 +26,7 @@
 | VP-3 | `pgtrickle.vector_status()` view: embedding lag, ANN age, drift % | S | P1 |
 | VP-4 | Cookbook: "Always-fresh RAG with pg_trickle + pgvector + pgai" | S | P2 |
 | VP-5 | Docker image variant: `pg_trickle + pgvector + pgai` for one-command RAG | S | P2 |
+| VP-6 | `docs/CONFIGURATION.md` overhaul: enumerate all GUCs with defaults | M | P1 |
 
 **VP-1 — Post-refresh actions.**
 Add a `post_refresh_action` option to `pgtrickle.create_stream_table()`:
@@ -79,6 +85,29 @@ Used with the v0.20+ self-monitoring system to detect and alert on:
 - Excessive drift (drift_pct approaching threshold)
 - Reindex overhead (frequency vs. drift_pct trade-off)
 
+> **Known limitation (document proactively):** `vector_status()` joins across
+> multiple catalog tables with per-ST cost. It is not designed for deployments
+> with more than ~100k stream tables; use the Prometheus scrape endpoint for
+> fleet-scale monitoring. This must be documented in the view's SQL comment
+> and in `docs/CONFIGURATION.md`.
+
+**VP-6 — `docs/CONFIGURATION.md` overhaul.**
+The extension has grown to 111+ GUC definitions across `src/config.rs` (as of
+v0.34.0 assessment). `docs/CONFIGURATION.md` does not enumerate all of them;
+operators cannot tune without reading source. v0.37.0 adds 3 new GUCs
+(`enable_vector_agg`, `otel_endpoint`, `enable_trace_propagation`); v0.38.0
+adds per-table options (`post_refresh_action`, `reindex_drift_threshold`).
+
+This overhaul:
+- Adds an auto-generated GUC reference table to `docs/CONFIGURATION.md`
+  (driven by a script that greps `GucRegistry::define_*_guc` call sites).
+- Adds a per-table stream-table options reference alongside.
+- Marks each GUC/option with: default value, valid range, scope
+  (per-session / per-table / server), and which release added it.
+
+This addresses the operational ergonomics gap identified in OA7 §5 before it
+compounds further.
+
 **VP-4 — pgai cookbook.**
 `docs/tutorials/PGVECTOR_RAG_COOKBOOK.md`:
 
@@ -124,6 +153,12 @@ For distributed Citus deployments, verify that `vector_avg` is shard-additive:
 - Compute `vector_avg` per shard on a partitioned stream table.
 - Verify final result == `avg(vector)` computed across all shards.
 
+> **Assessment note (2026-04-27):** The exit criteria below listed T-VP2 with
+> a soft "if v0.33+ Citus support available" gate. This has been hardened:
+> T-VP2 is a **required** exit criterion. If the Citus test infrastructure is
+> not available at the time of the release, explicitly defer T-VP2 to v0.39.0
+> with a tracked issue — do not silently skip it.
+
 ### Conflicts & Risks
 
 - **VP-1/VP-2** (post-refresh actions) require careful queuing to avoid
@@ -138,13 +173,15 @@ For distributed Citus deployments, verify that `vector_avg` is shard-additive:
 
 ### Exit Criteria
 
+- [ ] **Prerequisite:** F4 (v0.37.0 `vector_avg`) merged and `tests/e2e_pgvector_tests.rs` green
 - [ ] VP-1: `post_refresh_action` option stored in catalog, scheduler correctly dequeues actions
 - [ ] VP-2: `rows_changed_since_last_reindex` counter incremented per refresh; drift threshold comparison logic tested over 1000 refresh cycles
-- [ ] VP-3: `pgtrickle.vector_status()` view returns correct lag, drift_pct for all vector ST types; query plan optimized
+- [ ] VP-3: `pgtrickle.vector_status()` view returns correct lag, drift_pct for all vector ST types; query plan optimized; scale limitation documented in SQL comment and `docs/CONFIGURATION.md`
 - [ ] VP-4: Cookbook published with 4+ worked examples; copy-paste code tested
 - [ ] VP-5: Docker image builds and passes smoke test (pg_trickle + pgvector + pgai extensions load, `pg_extension_info()` lists all three)
+- [ ] VP-6: `docs/CONFIGURATION.md` overhaul complete; auto-generated GUC table covers all 111+ GUCs; per-table options reference added
 - [ ] T-VP1: `tests/e2e_pgvector_tests.rs::test_drift_reindex_e2e` passes
-- [ ] T-VP2: Citus integration tests pass (if v0.33+ Citus support available)
+- [ ] T-VP2: Citus `vector_avg` shard-additive integration tests pass (or deferred with tracked issue if Citus infra unavailable)
 - [ ] Extension upgrade path tested (`0.37.0 → 0.38.0`)
 - [ ] `just check-version-sync` passes
 

--- a/roadmap/v0.39.0.md
+++ b/roadmap/v0.39.0.md
@@ -114,15 +114,20 @@ latency benchmarks (v0.31).
 
 - Any deferred items from v0.38.0 that did not meet the exit criteria
 - Integration tests for hybrid-search corpus under write load (Nexmark-style)
+  with latency baseline established before the 50 ms assertion is written
 
 ---
 
 ## Scope
 
-v0.39.0 is a medium release. Sparse and half-precision aggregates are
-rule-set extensions (no engine change). Reactive distance subscriptions
-reuse the v0.35 reactive subscription infrastructure. Benchmarks are
-observational (no product change).
+v0.39.0 is a medium release — but sits at the upper end. The three new test
+files (tiered storage, reactive distance, Nexmark hybrid) are each substantive
+integration tests; VH-4 (benchmarks) adds CI infrastructure. If capacity is
+tight, VH-3 (cookbook) and VH-4 (benchmarks) may slip to v0.40.0; the VH-1
+and VH-2 feature work must land in v0.39.0.
+
+> **Note:** VH-2 (reactive distance subscriptions) requires v0.35.0 reactive
+> subscription correctness to be fully confirmed before implementation begins.
 
 ---
 

--- a/roadmap/v0.39.0.md-full.md
+++ b/roadmap/v0.39.0.md-full.md
@@ -44,6 +44,11 @@ for progressive quantisation).
 **VH-2 — Reactive distance subscriptions.**
 Extend reactive subscriptions (v0.35) to support distance-predicate queries:
 
+> **Prerequisite:** VH-2 depends on the v0.35.0 reactive subscription
+> implementation being fully signed off (exit criteria passed, no open
+> correctness issues). Confirm reactive subscription stability before building
+> the distance-predicate extension on top.
+
 ```sql
 LISTEN new_anomaly;
 
@@ -153,12 +158,25 @@ Monitor: refresh latency, corpus row count, drift %, HNSW index size.
 Assert: corpus stays < 1s behind Nexmark event time; hybrid queries (BM25 +
 vector) < 50 ms on 100k rows.
 
+> **Latency target note:** The < 50 ms target must be validated against a
+> baseline measurement on the CI hardware before the test is written.
+> Establish this baseline in the first pass of T-VH3 and adjust the assertion
+> if the CI hardware cannot sustain the target — do not hard-code an
+> unmeasured number.
+
 ### Conflicts & Risks
 
 - **VH-1** (sparse/halfvec aggregates) requires careful handling of dimension
   mismatches. `sparsevec_avg` may aggregate over vectors with different sparse
   dimension sets — define the result as the union. Test extensively over
-  heterogeneous sparse patterns.
+  heterogeneous sparse patterns (all-zero sparse vectors, dimension-set
+  cardinality mismatches between old and new rows, state serialization
+  round-trips).
+- **VH-1** (halfvec precision): the running state is upcast to `vector(d)` for
+  numerical stability. Verify that the upcast does not introduce significant
+  precision loss vs. full `vector_avg` on the same data. Add an explicit
+  proptest that compares `halfvec_avg(cast(v as halfvec))` against
+  `vector_avg(v)` and asserts relative error < 1e-3.
 - **VH-2** (reactive distance) requires binding the query vector at
   subscription-creation time, not query-time. This is a trade-off: slightly
   less flexible than parameterised queries, but vastly more efficient for
@@ -171,6 +189,9 @@ vector) < 50 ms on 100k rows.
 
 - [ ] VH-1: `sparsevec_avg`, `sparsevec_sum`, `halfvec_avg`, `halfvec_sum` aggregates implemented and tested
 - [ ] VH-1: All four aggregates pass proptest equivalence check vs. non-incremental computation
+- [ ] VH-1: `halfvec_avg` precision contract verified: relative error vs. `vector_avg` on same data < 1e-3
+- [ ] VH-1: `sparsevec_avg` edge cases tested: all-zero sparse vectors, heterogeneous dimension sets, round-trip serialization
+- [ ] VH-2: v0.35.0 reactive subscription correctness confirmed (no open issues) before VH-2 implementation begins
 - [ ] VH-2: Reactive subscriptions accept distance predicates; firing logic verified over 10k inserts
 - [ ] VH-2: No spurious re-fires on rows that do not change predicate truth
 - [ ] VH-3: Hybrid-search cookbook published with 4+ worked examples

--- a/roadmap/v0.40.0.md
+++ b/roadmap/v0.40.0.md
@@ -47,9 +47,18 @@ The function auto-generates the denormalization query, creates the stream table,
 creates the indexes, sets up vector monitoring, and returns a summary. For 80%
 of users, this eliminates boilerplate.
 
+Key design requirements: `dry_run => true` returns the generated SQL without
+executing it (essential for expert users); index-type inference defaults to
+HNSW for `vector`/`halfvec` columns with explicit documentation of the
+heuristic.
+
 ---
 
-## Materialised k-NN graph (research)
+## Materialised k-NN graph (parallel research spike)
+
+> **Reclassified (assessment 2026-04-27):** This is now a parallel research
+> spike — not a v0.40.0 release gate. A dedicated tracking issue drives the
+> investigation; findings may graduate to v0.41.0 or later.
 
 For fixed retrieval pivots (e.g., a set of 100 centroids), pre-computing the
 k-NN graph can accelerate approximate retrieval. Research direction:
@@ -85,7 +94,12 @@ Pattern documentation + security audit checklist.
 
 ---
 
-## Joint case studies with pgvector / pgai
+## Joint case studies with pgvector / pgai *(best-effort)*
+
+> **Best-effort (assessment 2026-04-27):** Co-marketing depends on third-party
+> availability and timing. It must not block the release. If outreach has not
+> resulted in commitments by feature-freeze, ship with a pg_trickle-solo blog
+> post and the public `pg-trickle-rag-starter` example repo.
 
 - Co-authored blog post: "PostgreSQL as a Vector Database" with pgvector and
   pgai maintainers.
@@ -96,7 +110,7 @@ Pattern documentation + security audit checklist.
 
 Strategic impact: positions pg_trickle as the infrastructure layer for
 incremental AI/RAG on PostgreSQL, raising the profile of the entire PostgreSQL
-ecosystem in the AI niche.
+ecosystem in the AI niche. Begin pgvector/pgai outreach during v0.38 timeframe.
 
 ---
 
@@ -111,9 +125,10 @@ ecosystem in the AI niche.
 ## Scope
 
 v0.40.0 is a large release. The `embedding_stream_table()` API is primarily
-syntactic sugar over existing primitives. The k-NN graph work is research and
-may be deferred. The case studies and co-marketing are editorial (no product
-code). The per-tenant patterns are documentation + examples.
+syntactic sugar over existing primitives, but the query-generation logic and
+index inference require careful implementation. The k-NN graph work is a
+parallel research spike and does not gate the release. The per-tenant
+patterns are documentation + examples. Co-marketing is best-effort.
 
 ---
 

--- a/roadmap/v0.40.0.md-full.md
+++ b/roadmap/v0.40.0.md-full.md
@@ -20,10 +20,10 @@
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
 | VA-1 | `embedding_stream_table()` ergonomic API: one-call RAG corpus setup | L | P1 |
-| VA-2 | Materialised k-NN graph research: explore fixed-pivot retrieval | L | P2 |
+| VA-2 | Materialised k-NN graph research: explore fixed-pivot retrieval *(parallel research spike — not a release gate)* | L | P3 |
 | VA-3 | Per-tenant ANN indexing patterns: RLS-scoped embedding corpora | M | P2 |
 | VA-4 | Outbox-emitted embedding events for downstream consumption | M | P2 |
-| VA-5 | Joint case study / co-marketing with pgvector and pgai teams | — | P1 |
+| VA-5 | Joint case study / co-marketing with pgvector and pgai teams *(best-effort, not a release gate)* | — | P1 |
 
 **VA-1 — `embedding_stream_table()` ergonomic API.**
 Add a high-level function that auto-generates the full denormalization query,
@@ -78,7 +78,26 @@ Benefits:
 - Lowers the barrier to entry for AI/ML engineers unfamiliar with PostgreSQL
   query authoring.
 
-**VA-2 — Materialised k-NN graph (research).**
+Required design constraints:
+- **Show generated SQL (P1):** The function must accept a `dry_run => true`
+  parameter that returns the generated `CREATE STREAM TABLE` + `CREATE INDEX`
+  SQL without executing it. This is essential for expert users who want to
+  audit or customise the output.
+- **Index-inference heuristics (P1):** When `index_type` is omitted, document
+  the inference rule explicitly: HNSW is chosen for `vector` and `halfvec`
+  columns; IVFFlat is chosen only when explicitly requested. The heuristic and
+  its rationale must be documented in the function's SQL comment and in
+  `docs/SQL_REFERENCE.md`.
+
+**VA-2 — Materialised k-NN graph (research spike).**
+
+> **Scope change (assessment 2026-04-27):** VA-2 has been reclassified from a
+> v0.40.0 release item to a **parallel research spike**. The roadmap itself
+> acknowledged it is "likely not production-ready in v0.40.0." Keeping it as
+> a release gate on a Large release with uncertain scope creates risk. Open a
+> dedicated research tracking issue; VA-2 findings may graduate to v0.41.0 or
+> later. T-VA2 is optional/informational in v0.40.0.
+
 Explore whether pre-computing a k-NN graph can accelerate approximate retrieval
 for fixed query pivots:
 
@@ -149,6 +168,13 @@ subscribe to the outbox and react to embedding changes. Enables
 event-driven architecture for RAG applications.
 
 **VA-5 — Joint case studies and co-marketing.**
+
+> **Best-effort only (assessment 2026-04-27):** VA-5 depends on third-party
+> coordination (pgvector and pgai team willingness, timing, publishing
+> schedules). It must not be a blocking exit criterion for the v0.40.0 release.
+> If outreach has not resulted in a commitment by feature-freeze, ship with
+> an internal cookbook and a public solo blog post instead.
+
 Partner with pgvector and pgai teams:
 
 - **Blog post:** "PostgreSQL as a Vector Database: pg_trickle + pgvector +
@@ -222,28 +248,27 @@ no external vector database.
 
 - **VA-1** (embedding_stream_table API) is syntactic sugar; it hides complexity
   and may lead to suboptimal queries if users don't understand the generated
-  SQL. Recommendation: always show the generated query and offer a "show me the
-  SQL" option.
-- **VA-2** (k-NN graph) is research; it may not yield a favorable trade-off.
-  Approach: document the findings regardless (positive or negative) so future
-  work is informed.
+  SQL. Mitigation: `dry_run => true` shows the generated SQL (P1 requirement);
+  index-inference heuristics are documented explicitly.
+- **VA-2** (k-NN graph) is a parallel research spike; it does not block the
+  release. See the scope-change note above.
 - **VA-3** (multi-tenant RLS) must be audited carefully. RLS can be bypassed
   by a careless admin. Include security best practices in the documentation.
 - **VA-5** (co-marketing) depends on willingness from pgvector/pgai teams.
-  Outreach early (v0.38 timeframe).
+  Outreach should begin during v0.38 timeframe. See the best-effort note above.
 
 ### Exit Criteria
 
 - [ ] VA-1: `embedding_stream_table()` function implemented, generates correct SQL, creates indexes and monitoring
+- [ ] VA-1: `dry_run => true` parameter returns generated SQL without executing it
+- [ ] VA-1: Index-inference heuristic (HNSW default for vector/halfvec; IVFFlat only if explicit) documented in SQL comment and `docs/SQL_REFERENCE.md`
 - [ ] VA-1: Function auto-generates query for 80%+ of common RAG patterns (single source + 2–3 joins + GROUP BY)
 - [ ] VA-1: Calling `embedding_stream_table()` produces identical results to manually-written equivalent
-- [ ] VA-2: Research document published documenting k-NN graph trade-offs (storage, latency, maintenance cost)
-- [ ] VA-2: PoC implementation (if favorable) or negative result documented
+- [ ] VA-2: Research spike tracking issue opened; `docs/research/MATERIALISED_KNN.md` published with trade-off analysis *(optional: T-VA2 PoC if favorable)*
 - [ ] VA-3: `docs/tutorials/MULTI_TENANT_RAG.md` published with security checklist
 - [ ] VA-3: `tests/e2e_multi_tenant_embedding_tests.rs` passes (RLS policies enforced)
 - [ ] VA-4: Outbox events emitted correctly on embedding stream table inserts
-- [ ] VA-5: Blog post co-published on pgvector + pgai blogs (or at least pg_trickle blog)
-- [ ] VA-5: Example repo `pg-trickle-rag-starter` available on GitHub
+- [ ] VA-5: *(best-effort)* Blog post published (co-published or pg_trickle solo); `pg-trickle-rag-starter` repo available on GitHub
 - [ ] Extension upgrade path tested (`0.39.0 → 0.40.0`)
 - [ ] `just check-version-sync` passes
 


### PR DESCRIPTION
## Summary

Applies the findings from the 2026-04-27 assessment of the v0.37.0–v0.40.0
pgvector integration arc to all eight roadmap files (full-spec + plain-language
companion for each release). No code or test changes — documentation and
planning documents only.

The assessment found the arc to be strategically coherent and technically
sound, but identified six concrete gaps in the planning documents:

1. No ordering constraint on the v0.37.0 structural splits (A15/A16 must land
   before any feature work begins).
2. pgvector CI infrastructure (adding pgvector to `tests/Dockerfile.e2e`) was
   implicit — not tracked as a gate for the v0.38–v0.40 arc.
3. No `vector_avg` Criterion benchmark baseline until v0.39.0, leaving two
   releases without a regression gate.
4. v0.38.0 exit criteria had a soft skip for T-VP2 (Citus vector_avg) and
   was missing a GUC documentation overhaul item.
5. v0.39.0 had unverified latency targets (T-VH3 50 ms) and incomplete edge-
   case requirements for VH-1 (halfvec precision contract, sparsevec edge
   cases).
6. v0.40.0 included VA-2 (k-NN graph research) as a release gate despite the
   roadmap itself noting it is "likely not production-ready"; VA-5 co-marketing
   was listed as a blocking exit criterion with a hard external dependency.

## Changes

### v0.37.0
- Add implementation-order note: A15 + A16 must be the first two commits
- Add pgvector-in-Dockerfile as a tracked prerequisite (hard gate for v0.38–v0.40)
- Add minimal `vector_avg` Criterion benchmark to exit criteria
- Flag A43 (pg_partman tests) as deferrable to v0.38.0 if capacity is tight
- Add F4 hard-gate note: entire v0.38–v0.40 arc depends on F4 landing
- Plain-language companion updated to reflect the above

### v0.38.0
- Add VP-6: `docs/CONFIGURATION.md` overhaul (auto-generated GUC reference,
  111+ GUCs, per-table options reference)
- Add hard prerequisite block: v0.38.0 must not start until F4 is green
- Harden T-VP2 (Citus shard-additive vector_avg) from soft-skip to
  "explicit defer with tracked issue or required exit criterion"
- Add VP-3 scale limitation note to feature spec and monitoring view SQL comment
- Plain-language companion updated

### v0.39.0
- Add VH-2 prerequisite: confirm v0.35.0 reactive subscription correctness
  before building the distance-predicate extension
- Add T-VH3 latency-baseline caveat: measure before asserting the 50 ms target
- Add `halfvec_avg` precision contract exit criterion (relative error < 1e-3
  vs. `vector_avg` on identical data)
- Expand VH-1 edge-case requirements: all-zero sparse vectors, heterogeneous
  dimension sets, state serialization round-trips
- Scope note updated: sits at upper end of Medium; VH-3/VH-4 are slippable
- Plain-language companion updated

### v0.40.0
- Demote VA-2 (k-NN graph) to parallel research spike — not a release gate;
  T-VA2 is optional/informational
- Promote `dry_run => true` and explicit index-inference heuristics to P1
  requirements for VA-1 (`embedding_stream_table()`)
- Reclassify VA-5 (co-marketing) as best-effort — not a blocking exit criterion;
  fallback is pg_trickle-solo blog + `pg-trickle-rag-starter` repo
- Update Conflicts & Risks and Exit Criteria to reflect all changes above
- Plain-language companion updated

## Testing

Documentation-only changes — no code modified.

- `just lint` — not applicable (no Rust changes)
- Manual review of all eight files confirms correct Markdown formatting,
  no broken cross-references, and consistent terminology

## Notes

- The `enrich-release-roadmap` skill was used to frame the assessment; this PR
  applies the concrete action items that emerged from it.
- Begin VA-5 co-marketing outreach (pgvector/pgai teams) during v0.38.0
  timeframe to maximise the chance of joint publication with v0.40.0.
- The VP-6 GUC docs overhaul needs a companion script (grep `GucRegistry` →
  auto-generate table); that script will be tracked as part of the VP-6
  implementation work, not this PR.
