### PR TITLE
docs: add back-link to blog index on all blog posts

### DIFF
--- a/blog/append-only-fast-path.md
+++ b/blog/append-only-fast-path.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # The Append-Only Fast Path
 
 ## Why event logs get special treatment in the differential engine

--- a/blog/backup-and-restore.md
+++ b/blog/backup-and-restore.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Backup and Restore for Stream Tables
 
 ## pg_dump, PITR, and what happens when you restore a database with active stream tables

--- a/blog/cost-model-auto-mode.md
+++ b/blog/cost-model-auto-mode.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # The Cost Model: How pg_trickle Decides Whether to Refresh Differentially
 
 ## Inside the AUTO mode decision engine

--- a/blog/cqrs-without-second-database.md
+++ b/blog/cqrs-without-second-database.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # CQRS Without a Second Database
 
 ## Command Query Responsibility Segregation using stream tables instead of a separate read store

--- a/blog/dbt-analytics-stack.md
+++ b/blog/dbt-analytics-stack.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # dbt + pg_trickle: The Analytics Engineer's Stack
 
 ## Using dbt to manage stream tables that actually stay fresh

--- a/blog/diamond-dependencies.md
+++ b/blog/diamond-dependencies.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # How pg_trickle Handles Diamond Dependencies
 
 ## The refresh ordering problem that nobody talks about until it causes double-counting

--- a/blog/differential-dataflow-explained.md
+++ b/blog/differential-dataflow-explained.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Differential Dataflow for the Rest of Us
 
 ## The mathematics behind incremental view maintenance, explained without a PhD

--- a/blog/distributed-ivm-citus.md
+++ b/blog/distributed-ivm-citus.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Distributed IVM with Citus
 
 ## Incremental view maintenance across sharded PostgreSQL

--- a/blog/hnsw-recall-distribution-drift.md
+++ b/blog/hnsw-recall-distribution-drift.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # HNSW Recall Is a Lie
 
 ## How Distribution Drift Silently Breaks Similarity Search (and What to Do About It)

--- a/blog/immediate-mode-zero-lag.md
+++ b/blog/immediate-mode-zero-lag.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # IMMEDIATE Mode: When "Good Enough Freshness" Isn't Good Enough
 
 ## Synchronous IVM inside your transaction

--- a/blog/inbox-pattern-kafka.md
+++ b/blog/inbox-pattern-kafka.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # The Inbox Pattern: Receiving Events from Kafka into PostgreSQL
 
 ## Idempotent, ordered, exactly-once event ingestion without writing a consumer

--- a/blog/incremental-aggregates-no-etl.md
+++ b/blog/incremental-aggregates-no-etl.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Incremental Aggregates in PostgreSQL: No ETL Required
 
 ## Running SUM, COUNT, AVG, and vector_avg over live tables without batch jobs

--- a/blog/incremental-pgvector.md
+++ b/blog/incremental-pgvector.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Your pgvector Index Is Lying to You
 
 ## How pg_trickle + pgvector keep your embeddings honest

--- a/blog/medallion-architecture-postgresql.md
+++ b/blog/medallion-architecture-postgresql.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # The Medallion Architecture Lives Inside PostgreSQL
 
 ## Bronze, Silver, Gold — without Spark, without Airflow, without leaving your database

--- a/blog/migrating-from-pg-ivm.md
+++ b/blog/migrating-from-pg-ivm.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Migrating from pg_ivm to pg_trickle
 
 ## Feature gap, SQL differences, and a step-by-step migration procedure

--- a/blog/multi-tenant-vector-search-rls.md
+++ b/blog/multi-tenant-vector-search-rls.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Multi-Tenant Vector Search with Row-Level Security and pg_trickle
 
 ## Zero cross-tenant data leakage without separate tables or databases

--- a/blog/nexmark-benchmark.md
+++ b/blog/nexmark-benchmark.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # From Nexmark to Production: Benchmarking Stream Processing in PostgreSQL
 
 ## How pg_trickle performs on the standard streaming benchmark suite

--- a/blog/online-schema-evolution.md
+++ b/blog/online-schema-evolution.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # How to Change a Stream Table Query Without Taking It Offline
 
 ## Online schema evolution for incremental views

--- a/blog/outbox-pattern-turbocharged.md
+++ b/blog/outbox-pattern-turbocharged.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # The Outbox Pattern, Turbocharged
 
 ## Transactionally Consistent Event Emission from PostgreSQL Without Dual-Write

--- a/blog/pg-trickle-cloudnativepg-kubernetes.md
+++ b/blog/pg-trickle-cloudnativepg-kubernetes.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # pg_trickle on CloudNativePG
 
 ## Running Incremental View Maintenance in Production Kubernetes

--- a/blog/pgbouncer-compatibility.md
+++ b/blog/pgbouncer-compatibility.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Making pg_trickle Work Through PgBouncer
 
 ## Connection pooling, session state, and the gotchas nobody warns you about

--- a/blog/pgvector-tooling-landscape.md
+++ b/blog/pgvector-tooling-landscape.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # The pgvector Tooling Landscape in 2026
 
 ## What each tool actually does — and where pg_trickle fits in

--- a/blog/reactive-alerts-without-polling.md
+++ b/blog/reactive-alerts-without-polling.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Reactive Alerts Without Polling
 
 ## PostgreSQL as a Push System — No Polling Loop Required

--- a/blog/real-time-leaderboards.md
+++ b/blog/real-time-leaderboards.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Real-Time Leaderboards That Don't Lie
 
 ## Maintaining ranked lists incrementally — no full recomputation, no stale scores

--- a/blog/replaced-celery-with-sql.md
+++ b/blog/replaced-celery-with-sql.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # How We Replaced a Celery Pipeline with 3 SQL Statements
 
 ## A before/after story about async Python workers and differential view maintenance

--- a/blog/self-monitoring.md
+++ b/blog/self-monitoring.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # pg_trickle Monitors Itself
 
 ## How the extension eats its own cooking

--- a/blog/shadow-mode-correctness-fuzzing.md
+++ b/blog/shadow-mode-correctness-fuzzing.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Testing Stream Tables: Shadow Mode and Correctness Fuzzing
 
 ## How pg_trickle validates that differential refresh matches full refresh

--- a/blog/slowly-changing-dimensions.md
+++ b/blog/slowly-changing-dimensions.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Slowly Changing Dimensions in Real Time
 
 ## SCD Type 2 without nightly ETL, without Airflow, without leaving PostgreSQL

--- a/blog/stop-rebuilding-search-index.md
+++ b/blog/stop-rebuilding-search-index.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Stop Rebuilding Your Search Index at 3am
 
 ## pg_trickle's scheduler, SLA tiers, and how to tune refresh for your workload

--- a/blog/streaming-to-kafka-without-kafka.md
+++ b/blog/streaming-to-kafka-without-kafka.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Streaming to Kafka Without Kafka Expertise
 
 ## How pgtrickle-relay bridges stream table deltas to external systems

--- a/blog/temporal-stream-tables.md
+++ b/blog/temporal-stream-tables.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # Temporal Stream Tables: Time-Windowed Views That Update Themselves
 
 ## Handling the "last 7 days" problem without cron

--- a/blog/tpch-benchmarking-ivm.md
+++ b/blog/tpch-benchmarking-ivm.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # TPC-H at 1GB in 40ms
 
 ## Benchmarking Incremental View Maintenance Against Full Refresh

--- a/blog/trigger-denormalization-cost.md
+++ b/blog/trigger-denormalization-cost.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # The Hidden Cost of Trigger-Based Denormalization
 
 ## How hand-rolled sync logic breaks — and what to do about it

--- a/blog/z-set-data-structure.md
+++ b/blog/z-set-data-structure.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](README.md)
+
 # The Z-Set: The Data Structure That Makes IVM Correct
 
 ## A short tour of the data structure under pg_trickle's differential engine


### PR DESCRIPTION
## Summary

Added navigation back-links to the blog frontpage from each blog post. Every post now has a `[← Back to Blog Index](README.md)` header at the top for improved navigation and user experience across the 35-post blog collection.

## Changes

- Added header link `[← Back to Blog Index](README.md)` to all 34 blog posts in `blog/`
- Link appears as the first line of content in each post
- Maintains consistent navigation across all posts and enables easy return to the index

## Testing

- Documentation-only change, no code tests needed
- Visual verification: all blog posts now have back-link header

## Notes

This improves the blog browsing experience by making navigation between posts and the index seamless. Readers can now easily return to the blog index without using browser back button.
