### PR TITLE
docs(blog): fix technical errors across 3 pgvector blog posts

### DIFF
--- a/blog/deploying-rag-at-scale.md
+++ b/blog/deploying-rag-at-scale.md
@@ -255,7 +255,7 @@ CREATE POLICY tenant_isolation ON search_corpus_shared
 CREATE INDEX ON search_corpus_shared USING hnsw (embedding vector_cosine_ops);
 ```
 
-For small tenants, the over-fetching problem is less severe (they have fewer rows in the index to skip). RLS guarantees data isolation regardless of application bugs. The shared index means less infrastructure per tenant.
+For small tenants, over-fetching is a real trade-off: a tenant with 500 rows in a 50,000-row shared index is 1% of the data, so HNSW may need to visit many non-matching nodes before returning 10 results. In practice this is acceptable because the total shared index is small (small tenants have little data by definition), so even with over-fetching, absolute query latency stays low. RLS guarantees data isolation regardless of application bugs. The shared index means less infrastructure per tenant.
 
 ### Monitoring Per Tenant
 
@@ -478,7 +478,7 @@ SELECT pgtrickle.alter_stream_table(
 ### Monitoring Checklist
 
 1. **Embedding lag** (`pgtrickle_vector_refresh_lag_ms`): Should be below 2× your schedule interval. If consistently above, your refresh is too expensive for the cycle time.
-2. **Drift ratio** (`pgtrickle_vector_drift_ratio`): Steady state should stay below your threshold. If it keeps hitting the threshold, your write rate is high enough to warrant a lower schedule interval.
+2. **Drift ratio** (`pgtrickle_vector_drift_ratio`): Steady state should stay below your threshold. If it keeps hitting the threshold, your write rate is high enough to warrant a shorter schedule interval (more frequent refreshes) to reduce the delta size per cycle.
 3. **Reindex frequency**: Check `last_reindex` in `vector_status()`. If reindexing every day, consider whether the drift threshold is too low or the write volume is genuinely high.
 4. **Refresh duration trend**: If refresh time is trending up, check whether the delta size is growing (more changes per cycle) or the stream table is getting larger (more rows to merge into).
 
@@ -488,7 +488,7 @@ SELECT pgtrickle.alter_stream_table(
 
 **Drift never decreases after reindex.** The write rate is so high that by the time the reindex finishes, enough new changes have accumulated to exceed the threshold again. Solution: increase the threshold, or accept that for very high-write-rate tables, the index will always have some drift.
 
-**REINDEX CONCURRENTLY fails.** PostgreSQL can fail concurrent reindex under certain conditions (e.g., unique constraint violations from concurrent writes to the underlying table). pg_trickle retries once; on second failure, it logs a warning and skips until the next threshold crossing. The old index continues to serve queries — the failure is not catastrophic.
+**REINDEX CONCURRENTLY fails.** PostgreSQL can fail concurrent reindex under certain conditions (e.g., deadlocks with concurrent sessions, or if a conflicting DDL operation runs during the build). pg_trickle retries once; on second failure, it logs a warning and skips until the next threshold crossing. The old index continues to serve queries — the failure is not catastrophic.
 
 ---
 

--- a/blog/incremental-pgvector.md
+++ b/blog/incremental-pgvector.md
@@ -147,7 +147,7 @@ SELECT pgtrickle.create_stream_table(
   name         => 'docs_embedded',
   query        => $$
     SELECT d.id, d.title, d.body,
-           pgai.embed('text-embedding-3-small', d.body) AS embedding,
+           d.embedding,  -- pre-computed by your app or pgai
            d.project_id, d.updated_at
     FROM documents d
     WHERE d.status = 'active'
@@ -159,9 +159,11 @@ SELECT pgtrickle.create_stream_table(
 CREATE INDEX ON docs_embedded USING hnsw (embedding vector_cosine_ops);
 ```
 
-Now when a document body changes, pg_trickle's CDC trigger captures the change. Within the next refresh cycle (10 seconds by default), only the changed document's row is updated in `docs_embedded`. The HNSW index receives a precise insert+delete pair. No batch job. No queue. No worker. No drift.
+Now when a document body changes (and your application writes the new embedding to the source table), pg_trickle's CDC trigger captures the change. Within the next refresh cycle (10 seconds by default), only the changed document's row is updated in `docs_embedded`. The HNSW index receives a precise insert+delete pair. No batch job. No queue. No worker. No drift.
 
 The important word here is **DIFFERENTIAL**. The engine doesn't recompute the entire corpus. It processes only the rows that changed since the last cycle. If 1 document changes out of 1 million, it touches 1 row's worth of work.
+
+> **Note on embedding generation:** The example above assumes your application (or a `pgai` vectorizer worker) writes the embedding to the source `documents` table before commit. pg_trickle's differential refresh reads the already-computed embedding — it doesn't call an embedding API during refresh. Calling a volatile function like `pgai.embed()` inside the stream table query would force a FULL refresh on every cycle, defeating the purpose. Keep embedding generation in your write path; keep corpus maintenance in the stream table.
 
 ### Denormalized Corpora as First-Class Citizens
 
@@ -325,7 +327,7 @@ CREATE INDEX ON doc_search_corpus (project_id);
 CREATE INDEX ON doc_search_corpus USING gin (allowed_users);
 ```
 
-That's it. Two SQL statements (one stream table, two indexes). From now on:
+That's it. Five SQL statements (one stream table, four indexes). From now on:
 - Every page edit propagates to the corpus within 10 seconds.
 - Every permission change propagates within 10 seconds.
 - The HNSW index stays current automatically.

--- a/blog/incremental-vector-aggregates.md
+++ b/blog/incremental-vector-aggregates.md
@@ -176,16 +176,13 @@ SELECT pgtrickle.create_stream_table(
     SELECT
       dc.cluster_id,
       vector_avg(d.embedding) AS centroid,
-      count(*)                AS doc_count,
-      array_agg(d.id ORDER BY d.created_at DESC)
-        FILTER (WHERE row_number() OVER (
-          PARTITION BY dc.cluster_id ORDER BY d.created_at DESC
-        ) <= 5)               AS recent_doc_ids
+      count(*)                AS doc_count
     FROM document_clusters dc
     JOIN documents d ON d.id = dc.doc_id
     GROUP BY dc.cluster_id
   $$,
-  schedule     => '15 seconds'
+  schedule     => '15 seconds',
+  refresh_mode => 'DIFFERENTIAL'
 );
 ```
 
@@ -216,7 +213,7 @@ SELECT pgtrickle.create_stream_table(
 -- taste_vec = weighted_sum / total_weight
 ```
 
-The weight can be anything: a recency decay, an action-type multiplier (purchase = 3, like = 2, view = 1), or a learned user-specific weight. The DVM engine doesn't care — it maintains `vector_sum` and `scalar_sum` as independent algebraic aggregates.
+The weight can be anything: a recency decay, an action-type multiplier (purchase = 3, like = 2, view = 1), or a learned user-specific weight. The DVM engine doesn't care — it maintains `vector_sum` and `sum` as independent algebraic aggregates.
 
 ---
 
@@ -276,18 +273,15 @@ The real power of maintaining taste vectors as a stream table is that you can in
 
 ```sql
 -- Find users with similar taste to user 42
-SELECT user_id, taste_vec <=> (
-  SELECT taste_vec FROM user_taste WHERE user_id = 42
-) AS similarity
+SELECT user_id,
+       taste_vec <=> (SELECT taste_vec FROM user_taste WHERE user_id = 42) AS distance
 FROM user_taste
 WHERE user_id != 42
-ORDER BY taste_vec <=> (
-  SELECT taste_vec FROM user_taste WHERE user_id = 42
-)
+ORDER BY distance
 LIMIT 20;
 ```
 
-This returns the 20 users whose taste vectors are closest to user 42's — a user similarity search over HNSW. The index makes it fast. The stream table makes it fresh.
+This returns the 20 users whose taste vectors are closest to user 42's (lowest cosine distance) — a user-similarity search over HNSW. The index makes it fast. The stream table makes it fresh.
 
 **"Items for me" queries:**
 


### PR DESCRIPTION
## Summary

Technical review and error fixes across the three pgvector blog posts (`incremental-pgvector.md`, `incremental-vector-aggregates.md`, `deploying-rag-at-scale.md`).

## Changes

### Post 1: `incremental-pgvector.md`
- **Fix statement count** — "Two SQL statements (one stream table, two indexes)" → "Five SQL statements (one stream table, four indexes)" to match the actual code block
- **Fix volatile function in DIFFERENTIAL example** — The "Always-Fresh Embeddings" example called `pgai.embed()` inside the stream table query with `refresh_mode => 'DIFFERENTIAL'`, but `pgai.embed()` is volatile and would force a FULL refresh on every cycle. Replaced with a pre-computed `d.embedding` column and added a blockquote note explaining why embedding generation belongs in the write path, not the refresh path

### Post 2: `incremental-vector-aggregates.md`
- **Fix invalid SQL** — The `cluster_centroids` example used `row_number() OVER (...)` inside an aggregate `FILTER (WHERE ...)` clause, which is not valid PostgreSQL. Removed the invalid subexpression; simplified to just the centroid + count
- **Fix misleading column name** — Renamed `similarity` to `distance` in the "Users like me" query, since `<=>` returns cosine distance (lower = more similar), and simplified the duplicate subquery
- **Fix terminology** — Changed `scalar_sum` (not a real function) to `sum` (PostgreSQL built-in)

### Post 3: `deploying-rag-at-scale.md`
- **Fix ambiguous wording** — "a lower schedule interval" → "a shorter schedule interval (more frequent refreshes)" to clarify the tuning direction
- **Fix REINDEX failure reason** — Changed "unique constraint violations" to "deadlocks with concurrent sessions, or if a conflicting DDL operation runs during the build" — HNSW/IVFFlat indexes don't enforce uniqueness
- **Fix over-fetching claim** — "For small tenants, the over-fetching problem is less severe" was backwards. Replaced with an honest description of the trade-off: small tenants are a tiny fraction of the shared index so over-fetching is real, but absolute latency stays low because the total shared index is small

## Testing

Documentation only — no code changes. All SQL examples reviewed for PostgreSQL correctness.
