### PR TITLE
fix(docs): find first # heading for blog SUMMARY.md entries

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,9 +55,14 @@ jobs:
                          if f.endswith('.md') and f not in ('README.md', 'SUMMARY.md'))
           lines = ['# Summary\n', '\n', '[Blog Index](README.md)\n', '\n']
           for f in files:
+              title = f  # fallback to filename
               with open(os.path.join(src, f)) as fp:
-                  first = fp.readline().strip().lstrip('# ').strip()
-              lines.append(f'- [{first}]({f})\n')
+                  for line in fp:
+                      stripped = line.strip()
+                      if stripped.startswith('# '):
+                          title = stripped.lstrip('# ').strip()
+                          break
+              lines.append(f'- [{title}]({f})\n')
           with open(os.path.join(src, 'SUMMARY.md'), 'w') as fp:
               fp.writelines(lines)
           PYEOF


### PR DESCRIPTION
## Summary

Fixes the docs CI build failure (run #25021139087, exit code 101). The "Build blog posts as standalone pages" workflow step was failing because the Python script extracted blog post titles incorrectly, generating malformed nested links in SUMMARY.md that mdBook could not parse.

## Changes

- Modified the Python script in the "Build blog posts as standalone pages" step to scan each blog post file for the first `# ` heading, rather than using the raw first line
- Blog posts all start with `[← Back to Blog Index](README.md)` as their first line; using that directly created invalid nested links like `[[← Back to Blog Index](README.md)](file.md)`
- Now correctly extracts actual heading titles (e.g., "The Append-Only Fast Path") for the sub-book SUMMARY.md
- Falls back to filename if no `# ` heading is found

## Testing

- Verified locally that the fixed Python script generates a correct SUMMARY.md with proper heading titles
- Confirmed mdbook builds the blog sub-book successfully with the updated SUMMARY.md

## Notes

This fixes the CI failure introduced by PR #687 (commit 71a6a3c), which added blog post building as a new workflow step.
