### PR TITLE
fix(security): resolve all 10 open semgrep code-scanning alerts

### DIFF
--- a/sql/archive/pg_trickle--0.37.0.sql
+++ b/sql/archive/pg_trickle--0.37.0.sql
@@ -503,7 +503,8 @@ COMMENT ON TABLE pgtrickle.relay_consumer_offsets IS
 CREATE OR REPLACE FUNCTION pgtrickle.relay_config_notify()
 RETURNS TRIGGER
 LANGUAGE plpgsql
-SECURITY DEFINER
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+SET search_path = pgtrickle, pg_catalog, pg_temp
 AS $$
 BEGIN
     PERFORM pg_notify(
@@ -539,7 +540,8 @@ CREATE OR REPLACE FUNCTION pgtrickle.set_relay_outbox(
     p_enabled         BOOLEAN DEFAULT true
 ) RETURNS void
 LANGUAGE plpgsql
-SECURITY DEFINER
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+SET search_path = pgtrickle, pg_catalog, pg_temp
 AS $$
 DECLARE
     v_sink_type TEXT;
@@ -578,7 +580,8 @@ CREATE OR REPLACE FUNCTION pgtrickle.set_relay_inbox(
     p_enabled          BOOLEAN DEFAULT true
 ) RETURNS void
 LANGUAGE plpgsql
-SECURITY DEFINER
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+SET search_path = pgtrickle, pg_catalog, pg_temp
 AS $$
 DECLARE
     v_source_type TEXT;
@@ -609,7 +612,10 @@ $$;
 
 -- RELAY-CAT (v0.29.0): enable_relay — enable a named pipeline.
 CREATE OR REPLACE FUNCTION pgtrickle.enable_relay(p_name TEXT) RETURNS void
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+SET search_path = pgtrickle, pg_catalog, pg_temp
+AS $$
 DECLARE v_o INT; v_i INT;
 BEGIN
     UPDATE pgtrickle.relay_outbox_config SET enabled = true WHERE name = p_name;
@@ -624,7 +630,10 @@ $$;
 
 -- RELAY-CAT (v0.29.0): disable_relay — disable a named pipeline.
 CREATE OR REPLACE FUNCTION pgtrickle.disable_relay(p_name TEXT) RETURNS void
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+SET search_path = pgtrickle, pg_catalog, pg_temp
+AS $$
 DECLARE v_o INT; v_i INT;
 BEGIN
     UPDATE pgtrickle.relay_outbox_config SET enabled = false WHERE name = p_name;
@@ -639,7 +648,10 @@ $$;
 
 -- RELAY-CAT (v0.29.0): delete_relay — delete a named pipeline.
 CREATE OR REPLACE FUNCTION pgtrickle.delete_relay(p_name TEXT) RETURNS void
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+SET search_path = pgtrickle, pg_catalog, pg_temp
+AS $$
 DECLARE v_o INT; v_i INT;
 BEGIN
     DELETE FROM pgtrickle.relay_outbox_config WHERE name = p_name;
@@ -655,7 +667,10 @@ $$;
 -- RELAY-CAT (v0.29.0): get_relay_config — fetch config for a single pipeline.
 CREATE OR REPLACE FUNCTION pgtrickle.get_relay_config(p_name TEXT)
 RETURNS TABLE (name TEXT, direction TEXT, enabled BOOLEAN, config JSONB)
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+SET search_path = pgtrickle, pg_catalog, pg_temp
+AS $$
 BEGIN
     RETURN QUERY
         SELECT r.name, 'forward'::TEXT, r.enabled, r.config
@@ -672,7 +687,10 @@ $$;
 -- RELAY-CAT (v0.29.0): list_relay_configs — list all pipelines.
 CREATE OR REPLACE FUNCTION pgtrickle.list_relay_configs()
 RETURNS TABLE (name TEXT, direction TEXT, enabled BOOLEAN, config JSONB)
-LANGUAGE plpgsql SECURITY DEFINER AS $$
+LANGUAGE plpgsql
+SECURITY DEFINER -- nosemgrep: sql.security-definer.present
+SET search_path = pgtrickle, pg_catalog, pg_temp
+AS $$
 BEGIN
     RETURN QUERY
         SELECT r.name, 'forward'::TEXT, r.enabled, r.config

--- a/sql/pg_trickle--0.28.0--0.29.0.sql
+++ b/sql/pg_trickle--0.28.0--0.29.0.sql
@@ -417,7 +417,7 @@ END;
 $$;
 
 -- Revoke direct table access from the relay role; all mutations go through
--- the SECURITY DEFINER API functions.
+-- the SECURITY DEFINER API functions. -- nosemgrep: sql.security-definer.present
 REVOKE ALL ON pgtrickle.relay_outbox_config    FROM pgtrickle_relay;
 REVOKE ALL ON pgtrickle.relay_inbox_config     FROM pgtrickle_relay;
 REVOKE ALL ON pgtrickle.relay_consumer_offsets FROM pgtrickle_relay;

--- a/src/api/snapshot.rs
+++ b/src/api/snapshot.rs
@@ -382,8 +382,8 @@ fn restore_from_snapshot_impl(name: &str, source: &str) -> Result<(), PgTrickleE
     // storage table is left on crash and concurrent refreshes are blocked.
     let subtxn = SnapSubTransaction::begin();
 
+    // nosemgrep: rust.spi.run.dynamic-format — DDL cannot be parameterized; storage_fqn is a double-quoted and escaped catalog identifier.
     let lock_result = Spi::run(&format!(
-        // nosemgrep: rust.spi.run.dynamic-format — DDL cannot be parameterized; storage_fqn is a double-quoted and escaped catalog identifier.
         "LOCK TABLE {} IN ACCESS EXCLUSIVE MODE",
         storage_fqn
     ))


### PR DESCRIPTION
## Summary

Resolves all 10 open semgrep code-scanning alerts (alerts #613, #708–#716)
raised against the GitHub Actions security scanner. Two categories of findings
are addressed: misplaced `nosemgrep` suppression in Rust, and missing
`SET search_path` / suppression annotations on `SECURITY DEFINER` SQL functions.

## Changes

- **`src/api/snapshot.rs`** — Move the `// nosemgrep: rust.spi.run.dynamic-format`
  comment from inside the `format!` macro to the line immediately preceding the
  `Spi::run` call. `cargo fmt` relocates inline comments inside macro arguments,
  which prevented semgrep from recognising the suppression (alert #716). The SQL
  is DDL (`LOCK TABLE … IN ACCESS EXCLUSIVE MODE`) and cannot be parameterised;
  `storage_fqn` is already double-quoted and escape-sanitised.

- **`sql/archive/pg_trickle--0.37.0.sql`** — Add
  `SET search_path = pgtrickle, pg_catalog, pg_temp` as a function option and
  a `-- nosemgrep: sql.security-definer.present` annotation to all 8 `SECURITY
  DEFINER` relay functions that were missing both (alerts #708–#715):
  `relay_config_notify`, `set_relay_outbox`, `set_relay_inbox`, `enable_relay`,
  `disable_relay`, `delete_relay`, `get_relay_config`, `list_relay_configs`.
  Pinning the search path prevents a search-path-injection attack where an
  unprivileged user pre-creates objects in a schema earlier on the path.

- **`sql/pg_trickle--0.28.0--0.29.0.sql`** — Add `-- nosemgrep: sql.security-definer.present`
  to the prose comment `-- the SECURITY DEFINER API functions.` that triggered a
  false-positive (alert #613). The other 8 `SECURITY DEFINER` function
  definitions in this file already carry the correct annotation and pinned
  search path.

## Testing

- `just fmt` — passes (nosemgrep placement survives `cargo fmt`)
- `just lint` — passes with zero warnings

## Notes

The archive file (`pg_trickle--0.37.0.sql`) is used for clean installs from
that version onwards. Adding `SET search_path` as a function option is safe and
idempotent — it only affects the function's execution context, not its
signature or the data it operates on. The migration file change is suppression-
only (the functions were already patched with the correct search-path pinning in
the `0.28.0→0.29.0` migration).
