### PR TITLE
docs: add overall assessment v8

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,15 +83,18 @@
 | [v0.35.0](roadmap/v0.35.0.md) | EC-01 correctness closeout, Citus chaos hardening, reactive subscriptions, zero-downtime schema changes | Released | Large | [Full details](roadmap/v0.35.0.md-full.md) |
 | [v0.36.0](roadmap/v0.36.0.md) | Structural hardening, L0 cache, WAL backpressure, temporal IVM, columnar storage | ✅ Released | Large | [Full details](roadmap/v0.36.0.md-full.md) |
 | [v0.37.0](roadmap/v0.37.0.md) | Scheduler & merge modularisation, pgVectorMV (vector_avg/sum), OpenTelemetry trace propagation | Released | Medium | [Full details](roadmap/v0.37.0.md-full.md) |
-| [v0.38.0](roadmap/v0.38.0.md) | Embedding pipeline operations: post-refresh hooks, drift-based reindex, vector_status() monitoring, GUC docs overhaul | Planned | Medium | [Full details](roadmap/v0.38.0.md-full.md) |
-| [v0.39.0](roadmap/v0.39.0.md) | Sparse & half-precision vector aggregates, reactive distance subscriptions, hybrid-search benchmarks | Planned | Medium | [Full details](roadmap/v0.39.0.md-full.md) |
-| [v0.40.0](roadmap/v0.40.0.md) | embedding_stream_table() ergonomic API, per-tenant ANN patterns, outbox embedding events, co-marketing | Planned | Large | [Full details](roadmap/v0.40.0.md-full.md) |
+| [v0.38.0](roadmap/v0.38.0.md) | Correctness closeout and operational truthfulness: EC-01, RowIdSchema planning, backpressure wiring, wake/docs fixes | Planned | Large | [Full details](roadmap/v0.38.0.md-full.md) |
+| [v0.39.0](roadmap/v0.39.0.md) | Distributed hardening and performance diagnostics: Citus chaos rig, durable CDC hold, TPC-H explain artifacts, fuzzing | Planned | Large | [Full details](roadmap/v0.39.0.md-full.md) |
+| [v0.40.0](roadmap/v0.40.0.md) | Operator trust and maintainability: generated references, alerting, drain-mode proof, secret hygiene, unsafe gating | Planned | Large | [Full details](roadmap/v0.40.0.md-full.md) |
+| [v0.41.0](roadmap/v0.41.0.md) | Embedding pipeline infrastructure: post-refresh hooks, drift-based reindex, vector monitoring | Planned | Medium | [Full details](roadmap/v0.41.0.md-full.md) |
+| [v0.42.0](roadmap/v0.42.0.md) | Sparse & half-precision vector aggregates, reactive distance subscriptions, hybrid-search benchmarks | Planned | Medium | [Full details](roadmap/v0.42.0.md-full.md) |
+| [v0.43.0](roadmap/v0.43.0.md) | embedding_stream_table() ergonomic API, per-tenant ANN patterns, outbox embedding events | Planned | Large | [Full details](roadmap/v0.43.0.md-full.md) |
 
 ### Beyond v1.0
 
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|------- |---------- |
-| [v1.0.0](roadmap/v1.0.0.md-full.md) | Stable release — PostgreSQL 19, package registries, zero breaking changes | Planned | Large | [Full details](roadmap/v1.0.0.md-full.md) |
+| [v1.0.0](roadmap/v1.0.0.md-full.md) | Stable release — PostgreSQL 19, package registries, signed artifacts, SBOMs, zero breaking changes | Planned | Large | [Full details](roadmap/v1.0.0.md-full.md) |
 | [v1.1.0](roadmap/v1.1.0.md-full.md) | PostgreSQL 17 support | Planned | Medium | [Full details](roadmap/v1.1.0.md-full.md) |
 | [v1.2.0](roadmap/v1.2.0.md-full.md) | PGlite proof of concept | Planned | Medium | [Full details](roadmap/v1.2.0.md-full.md) |
 | [v1.3.0](roadmap/v1.3.0.md-full.md) | Core extraction (`pg_trickle_core`) | Planned | Large | [Full details](roadmap/v1.3.0.md-full.md) |
@@ -132,13 +135,19 @@ v0.36    ─── L0 cache, WAL backpressure, api split, temporal IVM, columnar
     │
 v0.37    ─── Scheduler split, pgVectorMV, OpenTelemetry, pg_partman compat
     │
-v0.38    ─── Embedding pipeline infrastructure: post-refresh actions, drift-based reindex, vector monitoring
+v0.38    ─── Correctness closeout and truthfulness: EC-01, RowIdSchema planning, backpressure, wake/docs repair
     │
-v0.39    ─── Hybrid search & sparse vectors: sparsevec_avg, halfvec_avg, reactive distance alerts
+v0.39    ─── Distributed hardening and diagnostics: Citus chaos, durable CDC hold, TPC-H explain artifacts, fuzzing
     │
-v0.40    ─── Embedding API & advanced RAG: embedding_stream_table(), k-NN graphs, per-tenant ANN
+v0.40    ─── Operator trust and maintainability: generated docs, alerting, drain proof, secret hygiene, unsafe gating
     │
-v1.0.0   ─── Stable release, PostgreSQL 19, package registries
+v0.41    ─── Embedding infrastructure: post-refresh actions, drift-based reindex, vector monitoring
+    │
+v0.42    ─── Hybrid search & sparse vectors: sparsevec_avg, halfvec_avg, reactive distance alerts
+    │
+v0.43    ─── Embedding API & advanced RAG: embedding_stream_table(), per-tenant ANN, embedding outbox
+    │
+v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```
 
 v0.1.0 through v0.27.0 build the complete core engine and harden it for
@@ -151,17 +160,23 @@ delivers the full Citus integration immediately after — per-worker slot CDC,
 distributed ST placement, cross-node coordination, and the Citus test suite.
 Pulling v0.33.0 forward means users with Citus topologies (including
 billion-row all-distributed deployments) are unblocked two releases earlier.
-v0.35.0 is the single most important release before v1.0: it closes the EC-01
-phantom-row correctness bug (flagged in three consecutive overall assessments)
-and adds the Citus chaos test rig, on top of reactive subscriptions and
-zero-downtime schema changes. v0.36.0 builds on that foundation with
-performance hardening (L0 cache, WAL backpressure), structural refactoring
-(`src/api/mod.rs` split, `RowIdSchema` type), and temporal IVM / columnar
-storage. v0.37.0 completes the modularisation arc (scheduler and merge splits),
-adds pgVectorMV for AI/RAG workloads, and threads OpenTelemetry traces through
-the refresh pipeline. v0.38–v0.40 form a three-release programme for
-production embedding pipelines: infrastructure (post-refresh hooks, reindex
-scheduling), feature completeness (sparse / half-precision aggregates, reactive
-alerts), and ergonomic API (`embedding_stream_table()`, per-tenant patterns).
-This positions pg_trickle as the default incremental-maintenance layer for
-AI/RAG on PostgreSQL.
+v0.35.0 was intended to be the single most important release before v1.0, but
+the v0.37.0 overall assessment shows several of those closeout items remain
+partially open or insufficiently proven. v0.36.0 and v0.37.0 still delivered
+substantial structural gains: L0 cache construction, temporal IVM,
+`RowIdSchema`, scheduler and merge splits, pgVectorMV, and OpenTelemetry trace
+capture. The next three releases now form a hardening programme rather than an
+immediate feature expansion. v0.38.0 closes the highest-risk correctness and
+truthfulness gaps (EC-01 mitigation, planner-enforced row-id compatibility,
+backpressure wiring or deprecation, wake/docs repair, SQLSTATE rollout, trace
+integration proof, and generated configuration docs). v0.39.0 extends that
+with distributed and diagnostic coverage: Citus chaos testing, durable CDC hold
+semantics, per-query TPC-H explain artifacts, SQLancer light PR mode, targeted
+fuzzing, and inbox/outbox reliability tests. v0.40.0 then focuses on operator
+trust and maintainability: generated SQL/GUC references, drain-mode proof,
+monitoring/alert rules, security-model and secret-handling docs, upgrade-gate
+coverage, unsafe-inventory PR gating, and continued decomposition of the
+largest files. Only after that hardening arc does the roadmap resume the
+embedding programme in v0.41.0-v0.43.0, preserving the pgvector work while
+aligning the release order with the assessment's conclusion that closing
+correctness and operational gaps matters more than adding new surface area.

--- a/plans/PLAN_OVERALL_ASSESSMENT_8.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT_8.md
@@ -1,0 +1,1113 @@
+# pg_trickle - Overall Project Assessment v8
+
+> **Status:** Assessment report
+> **Type:** Repository-wide audit / gap analysis
+> **Date:** 2026-04-28
+> **Scope:** Current `main` branch at `0.37.0` after the v0.35-v0.37 hardening,
+> scheduler split, merge split, pgvector aggregate, trace-propagation, and
+> temporal/columnar feature work.
+> **Requested output path:** `plans/PLAN_OVERALL_ASSESSMENT_8.md`
+> **Method:** Static repository review, prior-assessment comparison, source/test/doc/CI
+> verification, and repo-memory review. No product code changes were made.
+
+---
+
+## 1. Executive Summary
+
+pg_trickle has continued to mature quickly since
+[PLAN_OVERALL_ASSESSMENT_7.md](PLAN_OVERALL_ASSESSMENT_7.md). The current
+tree is now `0.37.0` ([Cargo.toml](../Cargo.toml#L1-L4),
+[META.json](../META.json#L1-L5)), with 78 Rust source files, 118,860 lines of
+extension code, 142 Rust test files, 90,841 lines of tests, 40 non-archive SQL
+install/upgrade scripts, 19 GitHub workflows, 126 GUC definitions, and 132
+`#[pg_extern]` SQL-facing definitions. The project is no longer a small
+extension with a few risky hot files; it is now a full in-database streaming
+platform with CDC, differential view maintenance, a scheduler, distributed
+Citus coordination, relay/TUI/dbt integrations, and substantial operational
+surface area.
+
+The strongest positive movement since v7 is real:
+
+- [src/scheduler](../src/scheduler/) now has focused modules for Citus, cost,
+  worker pool, and tier scheduling instead of a single scheduler file doing
+  everything.
+- [src/refresh/merge](../src/refresh/merge/) now separates column, conflict,
+  delete, insert, and update helpers from the merge entry point.
+- Snapshot/restore atomicity, which older assessments treated as critical, is
+  no longer open: [src/api/snapshot.rs](../src/api/snapshot.rs#L25-L87)
+  contains a `SnapSubTransaction` RAII helper that wraps snapshot and restore
+  work in an internal subtransaction, and restore no longer relies on
+  `SELECT * EXCEPT` ([src/api/snapshot.rs](../src/api/snapshot.rs#L141-L180)).
+- The old inbox/outbox unit-test gap is partially closed: both
+  [src/api/inbox.rs](../src/api/inbox.rs#L1038-L1098) and
+  [src/api/outbox.rs](../src/api/outbox.rs#L1007-L1062) now have unit tests,
+  although the tests cover only helper behavior, not the reliability contract.
+- Q15 is now explicitly in the TPC-H IMMEDIATE skip allowlist
+  ([tests/e2e_tpch_tests.rs](../tests/e2e_tpch_tests.rs#L122-L142)), which
+  turns a previously hidden skip into an acknowledged limitation.
+- Upgrade completeness is in the PR gate
+  ([.github/workflows/ci.yml](../.github/workflows/ci.yml#L275-L313)); full
+  upgrade E2E remains daily/manual because it builds upgrade Docker images
+  ([.github/workflows/ci.yml](../.github/workflows/ci.yml#L314-L377)).
+
+The top risks, however, are still serious and in a few cases sharper than v7:
+
+1. **EC-01 join phantom rows remain the highest correctness risk.** Join deltas
+   still return `is_deduplicated: false` ([src/dvm/operators/join.rs](../src/dvm/operators/join.rs#L650-L668)),
+   PH-D1 cleanup is still documented as conditional
+   ([src/refresh/phd1.rs](../src/refresh/phd1.rs#L18-L33)), and repo memory
+   still records Q07/Q15 phantom-row behavior. This blocks a credible v1.0
+   correctness story for non-trivial joins.
+
+2. **Several hardening features are present but not actually wired.** The
+   SQLSTATE classifier exists, but `PgTrickleError::SpiErrorCode` is not
+   constructed outside display/error-boundary code ([src/error.rs](../src/error.rs#L89-L96),
+   [src/error.rs](../src/error.rs#L227-L245)); SPI errors still usually flow
+   through English message matching ([src/error.rs](../src/error.rs#L276-L346)).
+   WAL backpressure has an implementation function
+   ([src/wal_decoder.rs](../src/wal_decoder.rs#L456-L493)), but no call site
+   in `src/` invokes it. `pg_trickle.history_prune_interval_seconds` is
+   defined, but the scheduler uses a hard-coded daily cleanup interval
+   ([src/scheduler/mod.rs](../src/scheduler/mod.rs#L2394-L2401),
+   [src/scheduler/mod.rs](../src/scheduler/mod.rs#L2768-L2806)).
+
+3. **Event-driven wake is a false-confidence area.** Current code deliberately
+   disables it in the background worker because PostgreSQL does not allow
+   `LISTEN` there ([src/scheduler/mod.rs](../src/scheduler/mod.rs#L2434-L2455)),
+   and the GUC default in code is `false`
+   ([src/config.rs](../src/config.rs#L359-L374)). Documentation still says the
+   default is `true` and promises approximately 15 ms latency
+   ([docs/CONFIGURATION.md](../docs/CONFIGURATION.md#L260-L279),
+   [docs/SCALING.md](../docs/SCALING.md#L160-L176)). The E2E latency test uses
+   a 10-second threshold despite a 5-second poll interval, so poll-only mode can
+   still pass ([tests/e2e_wake_tests.rs](../tests/e2e_wake_tests.rs#L159-L213)).
+
+4. **Citus support is broad but not chaos-tested.** No `tests/**/*citus*.rs`
+   file exists. The codebase has Citus modules and workflows, but no automated
+   multi-node failure rig for worker death, coordinator restart, lease expiry,
+   rebalance churn, or split-brain. This remains the largest distributed
+   correctness gap.
+
+5. **v0.37 documentation has drift.** [docs/CONFIGURATION.md](../docs/CONFIGURATION.md)
+   does not document the v0.37 trace/vector GUCs found in
+   [src/config.rs](../src/config.rs#L1390-L1404) and
+   [CHANGELOG.md](../CHANGELOG.md#L74-L142). [docs/UPGRADING.md](../docs/UPGRADING.md#L760-L846)
+   stops detailed upgrade guidance and its supported path table at `0.34.0`,
+   despite the codebase being `0.37.0`. There is a pgvector tutorial
+   ([docs/tutorials/PGVECTOR_EMBEDDING_PIPELINES.md](../docs/tutorials/PGVECTOR_EMBEDDING_PIPELINES.md)),
+   but no comparable OpenTelemetry/Jaeger/Tempo guide was found.
+
+The project is impressive and unusually well tested for a PostgreSQL
+extension, but it is not yet at the stated "world-class correctness and
+durability" bar. The next hardening wave should focus less on adding surface
+area and more on closing wiring gaps, proving DVM convergence, making
+operational docs truthful, and adding failure-injection coverage for the
+distributed and durability paths.
+
+---
+
+## 2. Method and Scope
+
+This assessment began with the historical baselines requested in the prompt:
+
+- [PLAN_OVERALL_ASSESSMENT.md](PLAN_OVERALL_ASSESSMENT.md) - v0.20.0 baseline.
+- [PLAN_OVERALL_ASSESSMENT_2.md](PLAN_OVERALL_ASSESSMENT_2.md) - v0.23.0 follow-up.
+- [PLAN_OVERALL_ASSESSMENT_3.md](PLAN_OVERALL_ASSESSMENT_3.md) - v0.27.0 follow-up.
+- [PLAN_OVERALL_ASSESSMENT_7.md](PLAN_OVERALL_ASSESSMENT_7.md) - v0.34.0 follow-up.
+- Repo memory:
+  `/memories/repo/df-cdc-buffer-trends-fix.md`,
+  `/memories/repo/join-delta-phantom-rows.md`, and
+  `/memories/repo/tpch-dvm-scaling-analysis.md`.
+
+I then verified current state against primary sources:
+
+- Core Rust under [src](../src/), especially DVM, refresh, CDC/WAL, scheduler,
+  Citus, configuration, error handling, monitor/metrics, snapshot/restore,
+  inbox/outbox, and trace/vector additions.
+- SQL install and upgrade scripts under [sql](../sql/).
+- Tests under [tests](../tests/), including DVM operator tests, E2E, TPC-H,
+  SQLancer, property tests, pgvector, trace, wake, upgrade, and stability files.
+- Fuzz targets under [fuzz/fuzz_targets](../fuzz/fuzz_targets/), benchmarks under
+  [benches](../benches/), and proptest regressions under
+  [proptest-regressions](../proptest-regressions/).
+- Docs under [docs](../docs/), plus [README.md](../README.md),
+  [INSTALL.md](../INSTALL.md), [CHANGELOG.md](../CHANGELOG.md),
+  [ROADMAP.md](../ROADMAP.md), and [ESSENCE.md](../ESSENCE.md).
+- Workflows under [.github/workflows](../.github/workflows/).
+- Supporting integrations: [pgtrickle-relay](../pgtrickle-relay/),
+  [pgtrickle-tui](../pgtrickle-tui/), [dbt-pgtrickle](../dbt-pgtrickle/),
+  [monitoring](../monitoring/), [cnpg](../cnpg/), scripts, Dockerfiles, and
+  release metadata.
+
+No tests or benchmarks were run as part of this assessment. The findings below
+are static-analysis findings, evidence-backed by source and repo structure. If
+something is a plausibility risk rather than proven runtime failure, it is
+labelled as such.
+
+---
+
+## 3. What Has Improved Since Prior Assessments
+
+### 3.1 Fixed or Substantially Mitigated Since v7
+
+| Prior issue | Current state | Evidence |
+|---|---|---|
+| Snapshot/restore atomicity | **Fixed.** Internal subtransaction wrapper with panic-safe rollback now brackets snapshot and restore operations. | [src/api/snapshot.rs](../src/api/snapshot.rs#L25-L87), [src/api/snapshot.rs](../src/api/snapshot.rs#L265-L314), [src/api/snapshot.rs](../src/api/snapshot.rs#L383-L412) |
+| `SELECT * EXCEPT` PG-minor sensitivity in restore | **Fixed.** Restore now builds explicit storage/snapshot column lists from `pg_attribute`. | [src/api/snapshot.rs](../src/api/snapshot.rs#L141-L180), [src/api/snapshot.rs](../src/api/snapshot.rs#L408-L412) |
+| Inbox/outbox no unit tests | **Partially fixed.** Unit-test blocks exist, but only cover partition/name helpers. | [src/api/inbox.rs](../src/api/inbox.rs#L1038-L1098), [src/api/outbox.rs](../src/api/outbox.rs#L1007-L1062) |
+| Q15 IMMEDIATE hidden failure | **Mitigated.** Q15 is now explicitly allowlisted with a comment explaining stale-row behavior. | [tests/e2e_tpch_tests.rs](../tests/e2e_tpch_tests.rs#L122-L142) |
+| `force_full_refresh` missing | **Implemented.** The GUC exists and API mode reporting recognizes it. | [src/config.rs](../src/config.rs#L1240-L1248), [src/api/mod.rs](../src/api/mod.rs#L5265-L5266) |
+| History retention not batched | **Partially fixed.** Daily cleanup deletes 10,000-row batches. | [src/scheduler/mod.rs](../src/scheduler/mod.rs#L2768-L2806) |
+| Scheduler and merge monoliths | **Improved.** Scheduler and merge have submodules, though large files remain. | [src/scheduler](../src/scheduler/), [src/refresh/merge](../src/refresh/merge/) |
+| v0.37 pgvector aggregate support | **Added and tested.** E2E covers insert/update/delete/sum/HNSW cases. | [tests/e2e_pgvector_tests.rs](../tests/e2e_pgvector_tests.rs#L1-L260) |
+| Trace context capture | **Added with integration tests.** Change-buffer column, GUC capture, and refresh success are tested. | [tests/integration_trace_tests.rs](../tests/integration_trace_tests.rs#L1-L190) |
+| Upgrade completeness PR gate | **Present.** PRs run a lightweight version/script completeness check. | [.github/workflows/ci.yml](../.github/workflows/ci.yml#L275-L313) |
+
+### 3.2 Improvements That Are Real but Need Qualification
+
+- **L0 cache:** v0.36 added a process-local L0 map
+  ([src/shmem.rs](../src/shmem.rs#L841-L890)). This is better than an empty
+  signal, but it is not a shared dshash cache; cross-backend sharing still
+  depends on the L2 catalog table ([src/template_cache.rs](../src/template_cache.rs#L4-L16)).
+- **SQLSTATE classifier:** the classifier itself is implemented
+  ([src/error.rs](../src/error.rs#L348-L420)), but no source path constructs
+  `PgTrickleError::SpiErrorCode` for actual SPI failures. This is a partial
+  implementation, not a completed migration.
+- **WAL backpressure:** `is_backpressure_active()` exists
+  ([src/wal_decoder.rs](../src/wal_decoder.rs#L456-L493)), but no call site
+  invokes it. The GUC and docs therefore overstate current protection.
+- **Event-driven wake:** CDC triggers emit `pg_notify('pgtrickle_wake', '')`
+  ([src/cdc.rs](../src/cdc.rs#L1755-L1790)), but scheduler LISTEN is disabled
+  in the background worker ([src/scheduler/mod.rs](../src/scheduler/mod.rs#L2434-L2455)).
+  NOTIFY emission is not the same as event-driven scheduling.
+
+---
+
+## 4. Critical Findings
+
+### Finding C1 - EC-01 join phantom rows remain unresolved
+
+**Severity:** Critical
+
+**Evidence:**
+
+- Join deltas still return `is_deduplicated: false` for all joins
+  ([src/dvm/operators/join.rs](../src/dvm/operators/join.rs#L650-L668)).
+- PH-D1 cleanup is documented as conditional on join shape, prior residuals,
+  and refresh count ([src/refresh/phd1.rs](../src/refresh/phd1.rs#L18-L33)).
+- Repo memory `/memories/repo/join-delta-phantom-rows.md` documents active
+  Q07 and Q15 phantom-row behavior tied to Part 1a/1b row-id divergence and
+  current-delta-only weight aggregation.
+- Q15 is in `IMMEDIATE_SKIP_ALLOWLIST` because it still produces an extra row
+  in IMMEDIATE mode ([tests/e2e_tpch_tests.rs](../tests/e2e_tpch_tests.rs#L136-L142)).
+
+**Why it matters:** pg_trickle's core product promise is that differential
+refresh produces the same result as full refresh. A join-delta phantom is a
+silent wrong-result bug in exactly the class of queries users will expect an
+IVM engine to handle: multi-table joins feeding aggregate or operational
+dashboards.
+
+**User/operator impact:** Incorrect rows can accumulate across cycles, skew
+aggregates, trigger downstream duplicate-key behavior, or force operators to
+fall back to FULL refresh for important join workloads.
+
+**Recommended fix direction:**
+
+- Make PH-D1 cleanup unconditional for non-deduplicated join outputs while the
+  root fix is developed, with a bounded batch size and explicit monitoring.
+- Wire the v0.36 `RowIdSchema` declarations into the DVM planning path so row-id
+  compatibility is verified before execution.
+- Add an EC-01-specific property generator with tens of thousands of random
+  insert/update/delete sequences across left/right co-deletion and scalar
+  subquery cases.
+- Revisit the join row-id formula so Part 1a, Part 1b, and Part 2 converge on
+  the same logical identity across pre/post images.
+
+**Priority/window:** P0, before any v1.0 GA claim. This should be the lead item
+for v0.38.0 or a dedicated correctness sprint.
+
+### Finding C2 - WAL backpressure is advertised but not enforced
+
+**Severity:** High
+
+**Evidence:**
+
+- `pg_trickle.enforce_backpressure` is defined in
+  [src/config.rs](../src/config.rs#L1323-L1331) and documented as suppressing
+  writes when slot lag crosses the critical threshold
+  ([src/config.rs](../src/config.rs#L2915-L2923)).
+- `wal_decoder::is_backpressure_active()` implements a check
+  ([src/wal_decoder.rs](../src/wal_decoder.rs#L456-L493)).
+- A source-wide search finds no call site for `is_backpressure_active()` outside
+  its own definition. CDC trigger generation checks only `pg_trickle.cdc_paused`
+  ([src/cdc.rs](../src/cdc.rs#L1755-L1790)).
+- The function comment says backpressure releases below 50 percent, but the
+  function is stateless and returns `false` for any lag below the critical
+  threshold ([src/wal_decoder.rs](../src/wal_decoder.rs#L475-L493)).
+
+**Why it matters:** WAL slot lag can fill disks. A GUC that appears to protect
+operators from slot-lag explosions but is not wired creates a dangerous false
+sense of safety.
+
+**User/operator impact:** Operators may turn on `pg_trickle.enforce_backpressure`
+under incident pressure and believe source DML is being suppressed, while CDC
+triggers keep writing and WAL retention keeps growing.
+
+**Recommended fix direction:**
+
+- Decide whether suppression belongs in trigger-generated PL/pgSQL, scheduler
+  gating, or a durable pause state. If in triggers, the trigger needs an
+  inexpensive way to know per-source slot lag without running expensive slot
+  queries per row.
+- Add stateful hysteresis, not a one-shot threshold check.
+- Add E2E tests that configure a low `slot_lag_critical_threshold_mb`, simulate
+  lag, and assert writes are paused or explicitly not paused depending on mode.
+- Document the data-loss implications clearly: suppressing CDC writes is not a
+  neutral throttle unless the system also marks the stream table for full
+  reinitialization or holds source writes outside pg_trickle.
+
+**Priority/window:** P0/P1. If the feature cannot be made safe quickly, mark the
+GUC experimental and update docs immediately.
+
+### Finding C3 - Event-driven wake is disabled but documented and tested as if active
+
+**Severity:** High
+
+**Evidence:**
+
+- The scheduler forces `let event_driven = false` even when the GUC is enabled,
+  with a warning that background workers cannot `LISTEN`
+  ([src/scheduler/mod.rs](../src/scheduler/mod.rs#L2434-L2455)).
+- The code default for `PGS_EVENT_DRIVEN_WAKE` is `false`
+  ([src/config.rs](../src/config.rs#L359-L374)).
+- [docs/CONFIGURATION.md](../docs/CONFIGURATION.md#L260-L279),
+  [docs/SCALING.md](../docs/SCALING.md#L160-L176), and
+  [docs/TROUBLESHOOTING.md](../docs/TROUBLESHOOTING.md#L748-L762) describe it
+  as enabled/default or as a low-latency profile knob.
+- The latency test in [tests/e2e_wake_tests.rs](../tests/e2e_wake_tests.rs#L159-L213)
+  configures a 5-second poll interval but accepts completion within 10 seconds,
+  so a poll-only scheduler can pass.
+
+**Why it matters:** Latency is a major product claim. Documentation and tests
+that imply sub-50 ms wake while code is poll-only mislead maintainers and users.
+
+**User/operator impact:** Users tuning for dashboards or operational monitoring
+will set `event_driven_wake = on` and still see poll-bound latency. They may
+then over-tune `scheduler_interval_ms`, increasing scheduler load.
+
+**Recommended fix direction:**
+
+- Update documentation to say the GUC is reserved and currently non-functional
+  in background workers, or implement a background-worker-compatible wake path
+  via latch/shared memory rather than LISTEN.
+- Change the E2E test to assert refresh latency is strictly below the poll
+  interval by a meaningful margin, or skip it while the feature is reserved.
+- Add a regression test for the warning path when users enable the GUC.
+
+**Priority/window:** P0 for docs/test truthfulness; P1/P2 for a real latch-based
+implementation.
+
+### Finding C4 - SQLSTATE classification remains mostly unwired
+
+**Severity:** High
+
+**Evidence:**
+
+- `PgTrickleError::SpiErrorCode(u32, String)` exists
+  ([src/error.rs](../src/error.rs#L89-L96)).
+- `is_retryable()` uses SQLSTATE classification only for that variant
+  ([src/error.rs](../src/error.rs#L227-L245)).
+- The legacy `SpiError(String)` path still matches English message text
+  ([src/error.rs](../src/error.rs#L276-L346)).
+- A source search finds `SpiErrorCode(` only in display/error definitions and
+  boundary formatting, not in actual SPI error construction.
+
+**Why it matters:** Locale-dependent retry classification is fragile. Permanent
+errors can be retried until suspension, and transient errors can be mishandled
+when PostgreSQL message text differs by locale or version.
+
+**User/operator impact:** On non-English PostgreSQL builds or changed message
+wording, scheduler retry decisions become noisy and misleading. Operators see
+retries and fuses rather than direct "permission denied" or "undefined table"
+classification.
+
+**Recommended fix direction:**
+
+- Introduce one conversion helper for pgrx SPI errors that extracts
+  `ErrorData.sqlerrcode` where available and constructs `SpiErrorCode`.
+- Replace ad hoc `PgTrickleError::SpiError(e.to_string())` call sites on
+  scheduler/refresh/catalog hot paths.
+- Add tests that simulate SQLSTATE classes and, if possible, an integration
+  test with localized `lc_messages`.
+
+**Priority/window:** P1, before v1.0.
+
+### Finding C5 - Citus distributed coordination lacks hardening coverage
+
+**Severity:** High
+
+**Evidence:**
+
+- No `tests/**/*citus*.rs` file exists.
+- Citus code is significant: [src/citus.rs](../src/citus.rs) plus
+  [src/scheduler/citus.rs](../src/scheduler/citus.rs).
+- CI has CNPG, dbt, upgrade, TPC-H, SQLancer, and stability jobs, but no Citus
+  topology/chaos workflow ([.github/workflows](../.github/workflows/)).
+
+**Why it matters:** Single-node correctness tests cannot prove distributed CDC
+coordination. Citus failure modes are about leases, workers, topology changes,
+logical slots, timing, and split-brain, not ordinary SQL equivalence.
+
+**User/operator impact:** A production Citus deployment can hit worker death,
+coordinator restart, shard rebalance, or lease expiry paths that have never
+been exercised by CI. The risk is either silent staleness or duplicate/missed
+change processing.
+
+**Recommended fix direction:**
+
+- Add a Citus test rig with coordinator + at least 2 workers.
+- Test worker kill/restart during polling, coordinator restart mid-lease,
+  rebalance churn, stale `pgt_worker_slots` cleanup, and concurrent scheduler
+  lease contention.
+- Expose retry/skipped-worker counters in metrics and assert them in tests.
+
+**Priority/window:** P1 for any serious distributed support claim.
+
+---
+
+## 5. Correctness and Reliability Gaps
+
+### Finding R1 - `RowIdSchema` is documentation unless enforced
+
+**Severity:** High
+
+**Evidence:** [src/dvm/row_id.rs](../src/dvm/row_id.rs#L23-L119) defines
+`RowIdSchema` and `verify_pipeline()`, but source search only finds the verifier
+in its own tests ([src/dvm/row_id.rs](../src/dvm/row_id.rs#L286-L312)).
+
+**Why it matters:** v0.36 correctly names the structural problem behind EC-01,
+but the type does not yet prevent an incompatible operator pipeline from being
+planned. A safety type that is not wired into the planner is a design note, not
+a guardrail.
+
+**Impact:** Future DVM operators can repeat row-id compatibility mistakes
+without a plan-time failure.
+
+**Fix direction:** Require every `DiffResult` or operator node to carry a
+`RowIdSchema`, collect schemas during `diff_node()` traversal, and fail creation
+or force FULL when incompatible schemas are found.
+
+**Priority/window:** P1, in the same sprint as EC-01.
+
+### Finding R2 - CDC pause and backpressure suppression semantics risk data loss
+
+**Severity:** High
+
+**Evidence:** CDC triggers return without recording a change when
+`pg_trickle.cdc_paused = on` ([src/cdc.rs](../src/cdc.rs#L272-L275),
+[src/cdc.rs](../src/cdc.rs#L1763-L1790)). WAL backpressure, if wired the same
+way, would also suppress change capture.
+
+**Why it matters:** A pause knob can mean either "stop refresh but keep durable
+change capture" or "drop changes and require reinitialization". Current trigger
+behavior is the latter unless every affected stream table is later full
+refreshed.
+
+**Impact:** During an incident, operators may pause CDC to reduce pressure and
+later resume expecting no data loss. In reality, source DML that occurred while
+paused was not captured.
+
+**Fix direction:** Split the semantics into two explicit modes: durable hold
+(capture changes but do not refresh) and discarding pause (suppress capture and
+mark affected stream tables for reinit). Document both and add tests.
+
+**Priority/window:** P1 for operational safety.
+
+### Finding R3 - Trace propagation captures context but lacks live export proof
+
+**Severity:** Medium
+
+**Evidence:** Integration tests verify `__pgt_trace_context` capture and refresh
+success ([tests/integration_trace_tests.rs](../tests/integration_trace_tests.rs#L1-L190)),
+and unit-style checks validate payload shape. The file explicitly notes live
+OTLP/Jaeger export needs an ignored/local setup
+([tests/integration_trace_tests.rs](../tests/integration_trace_tests.rs#L8-L13)).
+
+**Why it matters:** The feature claim is distributed trace propagation through
+CDC -> DVM -> MERGE. Capturing the traceparent in a buffer is necessary but not
+the same as verifying export to an OTLP collector, retry behavior, timeout
+behavior, or endpoint failures.
+
+**Impact:** Operators may enable trace propagation and discover only in
+production that collector outages block, spam logs, or silently drop spans.
+
+**Fix direction:** Add a dockerized OTEL Collector/Jaeger E2E test, endpoint
+failure tests, timeout tests, and docs for collector configuration.
+
+**Priority/window:** P2, before advertising tracing as production-grade.
+
+### Finding R4 - TRUNCATE behavior remains a user-facing semantic edge
+
+**Severity:** Medium
+
+**Evidence:** TRUNCATE trigger functions exist and write an action-only record
+([src/cdc.rs](../src/cdc.rs#L250-L285)), but user docs still warn that row-level
+triggers do not fire on TRUNCATE and recommend manual/full refresh in some
+places ([docs/GETTING_STARTED.md](../docs/GETTING_STARTED.md#L339-L339)).
+
+**Why it matters:** TRUNCATE is a common operational action during reloads.
+Conflicting docs and implementation details make it unclear whether all
+refresh modes handle it incrementally, as a full invalidation, or via manual
+operator intervention.
+
+**Impact:** Users may over-trust or under-use TRUNCATE support depending on
+which doc they read.
+
+**Fix direction:** Consolidate TRUNCATE semantics in SQL_REFERENCE and tutorials:
+what is captured, which refresh modes are valid, whether FULL is forced, and
+what happens to downstream DAG nodes.
+
+**Priority/window:** P2.
+
+---
+
+## 6. Performance and Scalability Gaps
+
+### Finding P1 - TPC-H DVM scaling is not yet world-class
+
+**Severity:** High
+
+**Evidence:** Repo memory `/memories/repo/tpch-dvm-scaling-analysis.md` records
+SF=0.01, SF=0.1, and SF=1.0 runs with threshold-collapse patterns for Q05,
+Q07, Q08, Q09, Q22, early collapse for Q04, and structural slowness for Q20.
+The current join operator still contains a deep-join L0 threshold
+([src/dvm/operators/join.rs](../src/dvm/operators/join.rs#L104-L104)), which is
+itself evidence that deep join SQL generation remains a spill-risk area.
+
+**Why it matters:** A best-in-class DVM engine should make common analytic
+joins cheaper than full refresh, not fall into multi-minute or temp-file-limit
+paths at moderate scale.
+
+**Impact:** Users with TPC-H-like schemas may find DIFF mode slower or less
+reliable than FULL for the very queries that motivate pg_trickle adoption.
+
+**Fix direction:** Capture generated delta SQL and `EXPLAIN (ANALYZE, BUFFERS)`
+for Q04/Q05/Q07/Q08/Q09/Q20/Q22 at SF=0.1 and SF=1.0. Measure with larger
+`work_mem` to distinguish PostgreSQL spill from DVM SQL shape. Add per-query
+benchmark artifacts to CI for trend analysis.
+
+**Priority/window:** P1/P2, depending on v1.0 performance claims.
+
+### Finding P2 - Process-local L0 cache is useful but not the shared cache the name implies
+
+**Severity:** Medium
+
+**Evidence:** [src/shmem.rs](../src/shmem.rs#L820-L832) explains that L0 is a
+process-local `RwLock<HashMap>` and that L2 catalog entries provide
+cross-backend sharing. The actual map is a `OnceLock<RwLock<HashMap<...>>>`
+([src/shmem.rs](../src/shmem.rs#L841-L890)).
+
+**Why it matters:** Connection-pooler and short-lived backend workloads still
+pay per-backend warmup. The design is better than v7's empty signal, but it is
+not a shared-memory template cache.
+
+**Impact:** Operators may size latency expectations based on a fully shared L0
+cache and still see first-touch catalog lookup overhead per backend.
+
+**Fix direction:** Either rename/document the cache as process-local, or build
+the originally described shared dshash/dynamic shared-memory cache with bounded
+memory and invalidation semantics.
+
+**Priority/window:** P2.
+
+### Finding P3 - History pruning interval GUC is unused
+
+**Severity:** Medium
+
+**Evidence:** `pg_trickle.history_prune_interval_seconds` is defined and exposed
+([src/config.rs](../src/config.rs#L1271-L1277),
+[src/config.rs](../src/config.rs#L2902-L2906)), but the scheduler uses
+`const HISTORY_CLEANUP_INTERVAL_MS: u64 = 24 * 60 * 60 * 1000`
+([src/scheduler/mod.rs](../src/scheduler/mod.rs#L2394-L2401)). A source search
+finds `pg_trickle_history_prune_interval_seconds()` only in
+[src/config.rs](../src/config.rs#L3090-L3091).
+
+**Why it matters:** Operators tuning history table growth will reasonably
+expect the interval GUC to control cleanup cadence.
+
+**Impact:** Large deployments can accumulate far more history than expected
+between daily runs even if they set the interval to 60 seconds.
+
+**Fix direction:** Use the GUC in scheduler cleanup cadence, or remove it and
+document daily cleanup. Prefer a dedicated pruner or a bounded per-tick budget.
+
+**Priority/window:** P2.
+
+### Finding P4 - Benchmark gates are broad but still miss per-query p99 and generated-SQL diagnosis
+
+**Severity:** Medium
+
+**Evidence:** The repo has Criterion benches ([benches](../benches/)), E2E
+benchmarks ([.github/workflows/e2e-benchmarks.yml](../.github/workflows/e2e-benchmarks.yml)),
+and TPC-H nightly ([.github/workflows/tpch-nightly.yml](../.github/workflows/tpch-nightly.yml#L42-L84)).
+The benchmark workflow extracts TPC-H benchmark text artifacts
+([.github/workflows/e2e-benchmarks.yml](../.github/workflows/e2e-benchmarks.yml#L319-L350)),
+but there is no first-class artifact containing generated delta SQL plus
+`EXPLAIN` plans for regressions.
+
+**Why it matters:** Pass/fail correctness and coarse timing do not explain why
+a differential query crosses a spill threshold.
+
+**Impact:** Performance regressions can be found late and require manual
+reproduction rather than being diagnosable from CI artifacts.
+
+**Fix direction:** Emit structured JSON/CSV per query, refresh mode, phase,
+delta row count, temp blocks, work_mem, and generated SQL hash. Archive EXPLAIN
+for query families known to collapse.
+
+**Priority/window:** P2.
+
+---
+
+## 7. Code Quality and Maintainability Gaps
+
+### Finding M1 - Large-file risk remains despite improved modularity
+
+**Severity:** Medium
+
+**Evidence:** Largest source files as of this audit:
+
+| File | Lines |
+|---|---:|
+| [src/scheduler/mod.rs](../src/scheduler/mod.rs) | 7,428 |
+| [src/api/mod.rs](../src/api/mod.rs) | 7,026 |
+| [src/dvm/parser/sublinks.rs](../src/dvm/parser/sublinks.rs) | 6,559 |
+| [src/dvm/parser/rewrites.rs](../src/dvm/parser/rewrites.rs) | 6,112 |
+| [src/dvm/parser/mod.rs](../src/dvm/parser/mod.rs) | 5,526 |
+| [src/dvm/operators/aggregate.rs](../src/dvm/operators/aggregate.rs) | 5,400 |
+| [src/config.rs](../src/config.rs) | 4,405 |
+| [src/dag.rs](../src/dag.rs) | 4,295 |
+| [src/cdc.rs](../src/cdc.rs) | 4,107 |
+
+**Why it matters:** The scheduler split and merge split reduced some change
+risk, but critical paths still concentrate large amounts of logic in files
+that are hard to review completely.
+
+**Impact:** Future correctness fixes, especially around scheduler/Citus/DVM,
+will be slower and riskier than necessary.
+
+**Fix direction:** Continue extracting `api/mod.rs` into lifecycle, refresh,
+status, fuse, bulk, and temporal/vector APIs. Split parser rewrites by rewrite
+family. Move scheduler loop state machines into smaller testable units.
+
+**Priority/window:** P2.
+
+### Finding M2 - Unsafe surface remains large and hard to audit mechanically
+
+**Severity:** Medium
+
+**Evidence:** Approximate static count found 364 non-comment `unsafe` keyword
+lines in [src](../src/). Parser files dominate the unsafe surface. The project
+does have safety comments and an unsafe-inventory workflow
+([.github/workflows/unsafe-inventory.yml](../.github/workflows/unsafe-inventory.yml)),
+but that workflow is manual-only.
+
+**Why it matters:** pgrx parser FFI needs unsafe code, but unsafe drift should
+be visible on every PR that touches parser/FFI code.
+
+**Impact:** New unsafe blocks can be introduced without a mandatory inventory
+diff in the PR gate.
+
+**Fix direction:** Run unsafe inventory on PRs touching `src/dvm/parser/**`,
+`src/shmem.rs`, `src/api/helpers.rs`, `src/wal_decoder.rs`, and `src/lib.rs`.
+Fail if a new unsafe block lacks a `SAFETY:` comment.
+
+**Priority/window:** P2.
+
+### Finding M3 - Thin helper tests can mask reliability-contract gaps
+
+**Severity:** Medium
+
+**Evidence:** Inbox unit tests cover partition hashing
+([src/api/inbox.rs](../src/api/inbox.rs#L1038-L1098)); outbox unit tests cover
+table-name generation ([src/api/outbox.rs](../src/api/outbox.rs#L1007-L1062)).
+The actual inbox/outbox reliability surface includes dedup keys, envelope
+versions, consumer offsets, leases, replay behavior, NULL payloads, and
+concurrency.
+
+**Why it matters:** v7's "no unit tests" item is technically fixed, but the
+risk that motivated it is not fully addressed.
+
+**Impact:** At-least-once/dedup promises rely on slow E2E coverage and manual
+reasoning rather than fast deterministic unit/property tests.
+
+**Fix direction:** Add pure helper functions around envelope encoding/decoding,
+dedup-key validation, lease arithmetic, and offset transitions, then test them
+without PostgreSQL. Keep E2E for transactional integration.
+
+**Priority/window:** P2.
+
+---
+
+## 8. Testing and CI Coverage Gaps
+
+### Finding T1 - Event-driven wake test does not prove event-driven wake
+
+**Severity:** High
+
+**Evidence:** [tests/e2e_wake_tests.rs](../tests/e2e_wake_tests.rs#L159-L213)
+claims a scheduler with `scheduler_interval_ms = 5000` should complete via
+NOTIFY much faster than the poll interval, but it waits up to 10 seconds and
+asserts only `elapsed < 10s`.
+
+**Why it matters:** This is a classic false-confidence test. It can pass while
+the code path under test is disabled.
+
+**Impact:** Maintainers may believe event-driven latency is protected by CI.
+
+**Fix direction:** Until event-driven wake works, rewrite the test to assert the
+warning/poll-only behavior. Once implemented, assert a bound below the poll
+interval, for example `< 2s` with a 5s interval and enough margin for CI.
+
+**Priority/window:** P0 for test truthfulness.
+
+### Finding T2 - No Citus E2E/chaos test tier
+
+**Severity:** High
+
+**Evidence:** No `tests/**/*citus*.rs` file exists. Citus behavior is too
+specific to be covered by ordinary PostgreSQL/Testcontainers tests.
+
+**Why it matters:** Distributed source CDC is among the highest-risk areas and
+cannot be validated by static checks or single-node tests.
+
+**Impact:** Release confidence for v0.32-v0.34 Citus claims is lower than the
+roadmap suggests.
+
+**Fix direction:** Create `tests/e2e_citus_tests.rs` plus a workflow that can
+run daily/manual. Start with topology setup and lease acquisition; then add
+chaos scenarios.
+
+**Priority/window:** P1.
+
+### Finding T3 - Fuzzing is still concentrated in pure parsing/config helpers
+
+**Severity:** Medium
+
+**Evidence:** Current fuzz targets are
+[cdc_fuzz.rs](../fuzz/fuzz_targets/cdc_fuzz.rs),
+[cron_fuzz.rs](../fuzz/fuzz_targets/cron_fuzz.rs),
+[guc_fuzz.rs](../fuzz/fuzz_targets/guc_fuzz.rs), and
+[parser_fuzz.rs](../fuzz/fuzz_targets/parser_fuzz.rs). There is no fuzz target
+for WAL decoder parsing, merge SQL template generation, DAG SCC/topology, or
+snapshot column-list generation.
+
+**Why it matters:** The highest-impact correctness failures are often in state
+machines and code generation, not only user input parsers.
+
+**Impact:** Core paths with unsafe/parser/SQL-generation complexity rely on
+unit/E2E tests but not randomized adversarial coverage.
+
+**Fix direction:** Add fuzz targets for WAL change payloads, merge template
+inputs, DAG graph mutations, and snapshot/restore identifier/column shapes.
+
+**Priority/window:** P2.
+
+### Finding T4 - Full upgrade E2E is daily/manual only
+
+**Severity:** Medium
+
+**Evidence:** Upgrade completeness runs on PRs
+([.github/workflows/ci.yml](../.github/workflows/ci.yml#L275-L313)), but true
+upgrade E2E jobs run only on schedule/workflow dispatch
+([.github/workflows/ci.yml](../.github/workflows/ci.yml#L314-L377)).
+
+**Why it matters:** This is a reasonable cost trade-off, but SQL-facing changes
+can merge before full upgrade behavior is tested.
+
+**Impact:** Upgrade regressions may be discovered after merge rather than before.
+
+**Fix direction:** Add a PR path filter: run a small upgrade E2E matrix when
+`sql/**`, `src/lib.rs`, `src/config.rs`, `src/cdc.rs`, or SQL-exposed API files
+change. Keep full all-pairs matrix daily/manual.
+
+**Priority/window:** P2.
+
+---
+
+## 9. SQL/API/UX and Documentation Gaps
+
+### Finding U1 - CONFIGURATION.md is out of sync with code
+
+**Severity:** High
+
+**Evidence:**
+
+- Code default for `pg_trickle.event_driven_wake` is `false`
+  ([src/config.rs](../src/config.rs#L359-L374)), but
+  [docs/CONFIGURATION.md](../docs/CONFIGURATION.md#L260-L279) says default
+  `true` and describes active LISTEN/NOTIFY wake.
+- `pg_trickle.enable_trace_propagation`, `pg_trickle.otel_endpoint`,
+  `pg_trickle.trace_id`, and `pg_trickle.enable_vector_agg` are in
+  [CHANGELOG.md](../CHANGELOG.md#L74-L142) and [src/config.rs](../src/config.rs),
+  but searches of [docs/CONFIGURATION.md](../docs/CONFIGURATION.md) did not
+  find their configuration sections.
+
+**Why it matters:** Configuration docs are operational controls. Stale values
+cause wrong tuning and incident-response mistakes.
+
+**Impact:** Operators may enable knobs that do not work, miss new v0.37 knobs,
+or apply inappropriate latency profiles.
+
+**Fix direction:** Generate CONFIGURATION.md from `GucRegistry` metadata or add
+a CI check comparing `src/config.rs` GUC names against docs.
+
+**Priority/window:** P0/P1 for event-driven/backpressure truth; P2 for full
+generation.
+
+### Finding U2 - UPGRADING.md stops at 0.34.0 while current is 0.37.0
+
+**Severity:** Medium
+
+**Evidence:** Detailed guidance ends at `0.33.0 -> 0.34.0`, and the supported
+path table ends at `0.33.0 -> 0.34.0`
+([docs/UPGRADING.md](../docs/UPGRADING.md#L760-L846)). Current release metadata
+is `0.37.0`.
+
+**Why it matters:** Upgrade documentation is part of production readiness,
+especially for an extension with 40 non-archive SQL scripts.
+
+**Impact:** Operators upgrading through v0.35-v0.37 lack a single human-readable
+summary of schema changes, restart needs, GUC changes, trace-context column
+addition, and pgvector enablement.
+
+**Fix direction:** Add v0.34 -> v0.35, v0.35 -> v0.36, and v0.36 -> v0.37
+sections and update the supported path table. Add a docs check that latest
+upgrade target matches `Cargo.toml`.
+
+**Priority/window:** P1.
+
+### Finding U3 - OpenTelemetry documentation is missing compared with feature surface
+
+**Severity:** Medium
+
+**Evidence:** Trace code and tests exist ([src/otel.rs](../src/otel.rs),
+[tests/integration_trace_tests.rs](../tests/integration_trace_tests.rs)), but no
+dedicated docs page for OpenTelemetry/OTLP/Jaeger/Tempo setup was found under
+[docs](../docs/).
+
+**Why it matters:** Trace propagation is operationally useful only if operators
+can wire it into their collector stack safely.
+
+**Impact:** Users must infer endpoint format, timeout behavior, and failure
+mode from code.
+
+**Fix direction:** Add `docs/integrations/opentelemetry.md` or similar with
+collector config, Jaeger/Tempo examples, GUCs, expected spans, security notes,
+and troubleshooting.
+
+**Priority/window:** P2.
+
+### Finding U4 - Need a generated SQL/API surface inventory
+
+**Severity:** Medium
+
+**Evidence:** Current static count found 132 `#[pg_extern]` definitions and 126
+GUC definitions. Docs are extensive, but manually maintained references lag new
+surface area.
+
+**Why it matters:** With this many SQL functions and GUCs, manual docs will
+continue to drift.
+
+**Impact:** Users discover important functions through source or changelog
+rather than the reference docs.
+
+**Fix direction:** Generate API and GUC inventories from source metadata and
+fail CI when public entries are absent from SQL_REFERENCE/CONFIGURATION.
+
+**Priority/window:** P2.
+
+---
+
+## 10. Security and Safety Findings
+
+### Finding S1 - SECURITY DEFINER search_path discipline looks good, but docs should state the contract
+
+**Severity:** Low/Medium
+
+**Evidence:** CDC trigger functions use `SECURITY DEFINER` with explicit
+`SET search_path = pgtrickle_changes, pgtrickle, pg_catalog, pg_temp`
+([src/cdc.rs](../src/cdc.rs#L250-L285), [src/cdc.rs](../src/cdc.rs#L1755-L1790)).
+
+**Why it matters:** This is good hardening, but the privilege model should be
+obvious to security reviewers: who can create stream tables, who owns source
+tables, and what RLS/security-definer behavior is intentional.
+
+**Impact:** Adoption reviews may stall if privilege boundaries require source
+reading.
+
+**Fix direction:** Add a dedicated security model section covering invoker vs
+definer functions, search_path, CDC buffer schema access, RLS behavior, and
+required grants.
+
+**Priority/window:** P2.
+
+### Finding S2 - Supply-chain trust lacks signing/SBOM/provenance
+
+**Severity:** Medium
+
+**Evidence:** No workflow references to `cosign`, `cyclonedx`, `cargo-sbom`,
+`slsa`, or provenance attestation were found in [.github/workflows](../.github/workflows/).
+Release workflows build PGXN/Docker artifacts, but signing/attestation is not
+visible.
+
+**Why it matters:** A PostgreSQL extension loaded into the database process has
+a high trust bar. Production operators increasingly require SBOMs and signed
+artifacts.
+
+**Impact:** Enterprise or regulated deployments may block adoption even if the
+code is technically strong.
+
+**Fix direction:** Publish CycloneDX/SPDX SBOMs, sign Docker images with cosign,
+attach SLSA provenance, and document verification.
+
+**Priority/window:** P2 before v1.0.
+
+### Finding S3 - TUI/relay secret handling needs explicit operator guidance
+
+**Severity:** Medium
+
+**Evidence:** Relay has environment-variable interpolation tests and config
+support; TUI connection strings can still include credentials depending on how
+users invoke it. The exact risk is usage-dependent, but secrets in command-line
+arguments and config files are common operational hazards.
+
+**Why it matters:** Tooling around a database extension should not train users
+to put passwords in shell history, process lists, or world-readable config.
+
+**Impact:** Credential exposure in operational tooling.
+
+**Fix direction:** Prefer `.pgpass`, libpq service files, env-only secrets, or
+secret-manager integration in docs. Add a secret-scanning workflow such as
+truffleHog or detect-secrets.
+
+**Priority/window:** P2.
+
+---
+
+## 11. Ecosystem and Operational Readiness Gaps
+
+### Finding O1 - No drain-mode end-to-end operational proof was found
+
+**Severity:** Medium
+
+**Evidence:** v0.36 changelog claims drain mode, and the repo has many
+operational tests, but this audit did not find a focused E2E test that proves
+maintenance drain semantics across pause, in-flight refresh completion, CDC
+drain, and resume.
+
+**Why it matters:** Drain mode is an operator-facing safety feature. Its value
+depends on precise behavior under load.
+
+**Impact:** Maintenance windows can still rely on manual sequencing.
+
+**Fix direction:** Add a runbook plus E2E test: start long refresh, begin drain,
+assert no new refresh dispatch, wait for active job completion, verify buffers,
+resume, and verify catch-up.
+
+**Priority/window:** P2.
+
+### Finding O2 - Monitoring stack lacks enough alert-rule-as-code coverage
+
+**Severity:** Medium
+
+**Evidence:** [monitoring](../monitoring/) contains operational artifacts, and
+the code emits many alert events via [src/monitor.rs](../src/monitor.rs), but
+this audit did not find a complete, versioned alert rule set for freshness,
+slot lag, Citus worker failures, EC-01 residual cleanup, history growth, and
+trace export failures.
+
+**Why it matters:** Production readiness is not only metrics existence; it is
+also default actionable alerts.
+
+**Impact:** Operators must compose their own alerting story from docs and SQL.
+
+**Fix direction:** Ship Prometheus alert rules and Grafana panels for the core
+SLOs: freshness, p99 refresh latency, CDC buffer depth, WAL slot lag, scheduler
+worker saturation, Citus lease health, and failed refresh/error budget burn.
+
+**Priority/window:** P2.
+
+### Finding O3 - dbt, relay, and TUI should track new v0.36/v0.37 surface faster
+
+**Severity:** Low/Medium
+
+**Evidence:** The repo includes strong integration projects, but new core
+features such as temporal IVM, vector aggregates, trace propagation, drain mode,
+and force-full override need parallel UX in docs, dbt macros, relay/TUI status,
+and examples.
+
+**Why it matters:** Ecosystem value falls behind core capability if the extra
+tools cannot observe or configure new states.
+
+**Impact:** Users can create advanced stream tables but may not manage them well
+through dbt or TUI workflows.
+
+**Fix direction:** Add a release checklist item: every new SQL/GUC feature gets
+SQL reference, configuration docs, TUI visibility if operational, dbt support
+if modeling-related, and relay docs if event-related.
+
+**Priority/window:** P3.
+
+---
+
+## 12. Missing Feature Opportunities
+
+These are not defects, but they materially affect the "world-class" bar.
+
+| Opportunity | Why it matters | Suggested release |
+|---|---|---|
+| `EXPLAIN STREAM TABLE` plan visualizer | Users need to know whether their query is DIFF-safe, FULL-fallback, join-heavy, or using vector/temporal operators. | v0.38/v0.39 |
+| DVM generated-SQL artifact API | Debugging performance and correctness requires inspecting generated delta SQL without enabling broad logs. | v0.38 |
+| Citus chaos harness | Distributed correctness cannot be inferred from single-node tests. | v0.38 |
+| Durable CDC hold mode | Operators need to stop refresh pressure without dropping change capture. | v0.38 |
+| Complete GUC/API generated catalog | 126 GUCs and 132 SQL definitions are too many for manual docs. | v0.38 |
+| OpenTelemetry integration guide and collector test | Trace propagation needs operational proof. | v0.38 |
+| SBOM and signed artifacts | Required for serious production adoption. | v1.0 prep |
+| Per-query p99 and temp-spill regression gate | DVM performance must be tracked by query shape, not aggregate averages. | v0.39 |
+| Row-id schema verifier in planner | Turns row-id design into a guardrail. | v0.38 |
+| SQLancer light PR mode | A small oracle run on PRs could catch obvious DVM/FULL regressions before weekly runs. | v0.39 |
+
+---
+
+## 13. Prioritized Action Plan
+
+| ID | Area | Action | Severity | Effort | Window |
+|---|---|---|---|---|---|
+| A01 | Correctness | Close EC-01 with unconditional PH-D1 mitigation plus principled row-id convergence fix. | Critical | L | v0.38 |
+| A02 | Correctness | Wire `RowIdSchema::verify_pipeline()` into DVM planning. | High | M | v0.38 |
+| A03 | CDC/WAL | Wire or deprecate `pg_trickle.enforce_backpressure`; add safe semantics and tests. | High | M | v0.38 |
+| A04 | Scheduler | Fix event-driven wake docs/tests now; design latch-based wake separately. | High | S/M | v0.38 |
+| A05 | Error handling | Construct `SpiErrorCode` from SPI errors on refresh/scheduler/catalog paths. | High | M | v0.38 |
+| A06 | Citus | Add Citus E2E/chaos rig and workflow. | High | L | v0.38/v0.39 |
+| A07 | Docs | Regenerate/update CONFIGURATION.md for all GUCs and correct event-driven wake. | High | S/M | v0.38 |
+| A08 | Docs | Update UPGRADING.md through 0.37.0. | Medium | S | v0.38 |
+| A09 | Ops | Split CDC pause into durable hold vs discard/reinit semantics. | High | M | v0.39 |
+| A10 | Tests | Fix wake latency test so poll-only cannot pass event-driven assertions. | High | XS | v0.38 |
+| A11 | Performance | Add TPC-H generated SQL + EXPLAIN artifacts for known collapse queries. | Medium | M | v0.39 |
+| A12 | Config | Use or remove `history_prune_interval_seconds`. | Medium | XS | v0.38 |
+| A13 | Security | Add SBOM, cosign signing, and provenance. | Medium | M | v1.0 prep |
+| A14 | Fuzz | Add WAL decoder, merge codegen, DAG, and snapshot fuzz targets. | Medium | M/L | v0.39 |
+| A15 | Inbox/outbox | Expand unit/property tests to envelope, dedup, leases, offsets. | Medium | M | v0.39 |
+| A16 | Observability | Add OpenTelemetry guide and live collector E2E. | Medium | S/M | v0.38 |
+| A17 | Maintainability | Continue splitting `api/mod.rs`, parser rewrites, and scheduler loop state. | Medium | L | ongoing |
+
+---
+
+## 14. Risk Register
+
+| Risk | Severity | Likelihood | Current control | Residual concern |
+|---|---|---:|---|---|
+| Join delta phantom rows | Critical | Medium | Q15 allowlist, DVM tests, PH-D1 helper | Still not proven convergent; silent wrong results possible. |
+| WAL slot lag fills disk | High | Medium | Lag metrics/warnings, inactive backpressure helper | Enforcement GUC not wired; operators may trust it. |
+| Event-driven latency claim false | High | High | Warning at scheduler startup | Docs/tests still imply active low-latency wake. |
+| SQLSTATE retry misclassification | High | Medium | SQLSTATE classifier exists | Real SPI errors still use text path. |
+| Citus coordination failure | High | Medium | Unit-level/static code only | No chaos/topology E2E. |
+| CDC pause drops changes | High | Low/Medium | Superuser-only GUC | Semantics can surprise incident responders. |
+| History table growth | Medium | Medium | Daily batched prune | Interval GUC unused; daily may be too slow at high refresh rates. |
+| Configuration doc drift | High | High | Manual docs | 126 GUCs make drift recurring. |
+| Trace export failure | Medium | Medium | Integration tests for capture | No live collector or failure-mode tests. |
+| Supply-chain trust gap | Medium | Medium | cargo-deny/security workflows | No SBOM/signing/provenance. |
+
+---
+
+## 15. Appendices
+
+### Appendix A - Current Repository Metrics
+
+| Metric | Value |
+|---|---:|
+| Current version | 0.37.0 |
+| Rust files in `src/` | 78 |
+| Rust LOC in `src/` | 118,860 |
+| Rust files in `tests/` | 142 |
+| Rust LOC in `tests/` | 90,841 |
+| `GucRegistry::define*` calls | 126 |
+| `#[pg_extern]` definitions | 132 |
+| Non-archive SQL scripts | 40 |
+| Archive SQL scripts | 80 |
+| Workflow YAML files | 19 |
+| Fuzz targets | 4 |
+| Criterion benches | 3 |
+| TODO/FIXME/HACK in `src/` | 0 |
+| Approx. non-comment unsafe keyword lines | 364 |
+
+### Appendix B - Test and CI Inventory
+
+- Unit and pure Rust tests: `src/**` tests and [tests/property_tests.rs](../tests/property_tests.rs).
+- Integration/Testcontainers tests: non-E2E files under [tests](../tests/), including
+  [tests/integration_trace_tests.rs](../tests/integration_trace_tests.rs).
+- E2E tests: 100+ `tests/e2e_*_tests.rs` files, including DVM, CDC, WAL, DAG,
+  upgrade, pgvector, TPC-H, SQLancer, wake, schema evolution, and stability.
+- Fuzz targets: [fuzz/fuzz_targets/cdc_fuzz.rs](../fuzz/fuzz_targets/cdc_fuzz.rs),
+  [fuzz/fuzz_targets/cron_fuzz.rs](../fuzz/fuzz_targets/cron_fuzz.rs),
+  [fuzz/fuzz_targets/guc_fuzz.rs](../fuzz/fuzz_targets/guc_fuzz.rs),
+  [fuzz/fuzz_targets/parser_fuzz.rs](../fuzz/fuzz_targets/parser_fuzz.rs).
+- Benchmark files: [benches/diff_operators.rs](../benches/diff_operators.rs),
+  [benches/refresh_bench.rs](../benches/refresh_bench.rs),
+  [benches/scheduler_bench.rs](../benches/scheduler_bench.rs).
+- Primary CI: [.github/workflows/ci.yml](../.github/workflows/ci.yml).
+- Long-running correctness/performance workflows:
+  [.github/workflows/tpch-nightly.yml](../.github/workflows/tpch-nightly.yml),
+  [.github/workflows/sqlancer.yml](../.github/workflows/sqlancer.yml),
+  [.github/workflows/e2e-benchmarks.yml](../.github/workflows/e2e-benchmarks.yml),
+  [.github/workflows/stability-tests.yml](../.github/workflows/stability-tests.yml).
+
+### Appendix C - Prior-Assessment Status Summary
+
+| Prior finding | Status in v8 |
+|---|---|
+| EC-01 join phantom rows | Still open, still critical. |
+| Snapshot/restore atomicity | Fixed by `SnapSubTransaction` and explicit column lists. |
+| SQLSTATE classifier | Partially fixed; classifier exists but is not wired into actual SPI error construction. |
+| Citus chaos gap | Still open. |
+| Inbox/outbox no unit tests | Partially fixed; helper tests exist but reliability contract needs tests. |
+| L0 cache empty signal | Improved; process-local map exists, but not shared dshash. |
+| History pruning | Improved; daily batched prune exists, but interval GUC is unused. |
+| Force-full override | Fixed/implemented. |
+| Scheduler/merge monoliths | Improved, not eliminated. |
+| GUC documentation gap | Still open and larger due to v0.37 docs drift. |
+
+### Appendix D - High-Value Verification Tasks
+
+These are the fastest ways to turn the highest-risk hypotheses into hard facts:
+
+1. Run EC-01 property stress with random co-deletes and scalar-subquery joins,
+   comparing DIFF vs FULL after every cycle.
+2. Enable `pg_trickle.enforce_backpressure`, create artificial slot lag, and
+   prove whether source DML is paused or captured.
+3. Run the wake test with `scheduler_interval_ms = 10000` and assert completion
+   under 2 seconds; it should fail today because event-driven wake is disabled.
+4. Search/replace SPI error construction through a single helper and run retry
+   classifier tests by SQLSTATE class.
+5. Build the smallest Citus topology test that verifies lease acquisition and
+   worker-slot polling, then add worker kill/restart.
+6. Generate a complete GUC list from [src/config.rs](../src/config.rs) and diff
+   against [docs/CONFIGURATION.md](../docs/CONFIGURATION.md).
+
+---
+
+## Closing Assessment
+
+pg_trickle is in a strong but delicate position. The codebase has the ambition,
+test investment, and operational scope of a serious database subsystem. The
+remaining gaps are not cosmetic: they are exactly the gaps that separate a
+feature-rich extension from a platform operators can trust under failure,
+locale variance, large joins, distributed topology changes, and incident
+response.
+
+The highest-leverage next step is a focused hardening milestone: close EC-01,
+make the advertised safety GUCs truthful, correct the event-driven wake story,
+add Citus chaos coverage, and regenerate public docs from source metadata. That
+would move the project much closer to its stated world-class bar than another
+round of new feature surface.

--- a/roadmap/v0.38.0.md
+++ b/roadmap/v0.38.0.md
@@ -1,77 +1,79 @@
-# v0.38.0 — Embedding Pipeline Infrastructure & ANN Maintenance
+# v0.38.0 — Correctness Closeout & Operational Truthfulness
 
 > **Full technical details:** [v0.38.0.md-full.md](v0.38.0.md-full.md)
 
-**Status: Planned** | **Scope: Medium**
+**Status: Planned** | **Scope: Large**
 
-> Embedding pipeline hardening via post-refresh hooks, automatic IVFFlat
-> re-clustering on drift, vector-aggregate status monitoring, AI/RAG
-> Docker image, and pgvector + pgai ecosystem integration.
+> Close the highest-risk gaps from the v0.37.0 overall assessment before more
+> feature surface is added: EC-01 join phantoms, planner-enforced row-id
+> safety, backpressure truthfulness, wake/docs repair, SQLSTATE-based retry
+> classification, and source-driven configuration and upgrade docs.
 
 ---
 
 ## What is this?
 
-Following on from pgVectorMV in v0.37.0, v0.38.0 adds operational primitives
-for production embedding pipelines: post-refresh actions (ANALYZE, REINDEX,
-drift-based re-clustering), vector-aware monitoring views, and a one-command
-Docker image with pg_trickle + pgvector + pgai pre-installed for RAG
-developers.
+v0.36.0 and v0.37.0 delivered important structural work, but the assessment
+showed too many partially wired or poorly documented behaviors still sitting
+between users and a trustworthy 1.0. v0.38.0 is the first release in a
+hardening programme. It makes existing guarantees correct, documented, and
+measurable before the roadmap resumes the deferred embedding-focused work.
 
 ---
 
-## Embedding pipeline operational hardening
+## Silent wrong-result and durability hardening
 
-When a stream table refreshes, it is often necessary to run housekeeping tasks:
-analyzing statistics, rebuilding indexes, or re-clustering ANN structures that
-have drifted. v0.38.0 adds explicit scheduling primitives:
+The lead item is EC-01: non-deduplicated join outputs must stop silently
+accumulating phantom rows. v0.38.0 makes PH-D1 cleanup unconditional where
+needed, wires `RowIdSchema` verification into the DVM planner, and proves
+DIFF-vs-FULL convergence with targeted property tests over Q07/Q15-style
+co-delete and scalar-subquery cases.
 
-- `post_refresh_action` — per-stream-table option: `none`, `analyze`, `reindex`,
-  or `reindex_if_drift`. Runs asynchronously in a lower-priority tier after the
-  refresh commits.
-- `reindex_drift_threshold` — fraction (0.0–1.0, default 0.10) of rows that
-  must change since last reindex to trigger `reindex_if_drift`. The scheduler
-  tracks "rows changed since last reindex" in the catalog.
-- `pgtrickle.vector_status()` — new monitoring view: per-vector stream table,
-  shows last refresh time, embedding lag, ANN index age, approximate drift %,
-  and segment count (for HNSW). Integrated with the v0.20+ self-monitoring
-  system.
+The same release also resolves the most dangerous control-plane truth gap in
+the current tree: `pg_trickle.enforce_backpressure` and related pause behavior
+must either be wired with explicit hysteresis and documented semantics or be
+demoted so operators are not misled into believing source writes are protected
+when they are not.
 
 ---
 
-## pgvector + pgai integration
+## Operational truthfulness and documentation repair
 
-- **Always-Fresh RAG cookbook:** `docs/tutorials/PGVECTOR_RAG_COOKBOOK.md` —
-  end-to-end pattern: pgai embeddings → stream table maintaining denormalised
-  corpus (documents + tags + permissions joined) → BM25 + HNSW indexes on the
-  flat table → application hybrid search.
-- **Docker image:** `pg_trickle + pgvector + pgai + pgml` Dockerfile variant
-  for one-command RAG deployment.
+`event_driven_wake` is currently documented and tested as if the background
+worker can `LISTEN`, but the code forces poll-only mode. v0.38.0 corrects the
+docs, rewrites the wake test so poll-only mode cannot masquerade as event
+delivery, and tracks a latch-based wake path separately instead of promising
+what PostgreSQL cannot do in a background worker.
+
+This release also regenerates `docs/CONFIGURATION.md` from source metadata,
+updates `docs/UPGRADING.md` through v0.37.0, documents trace/vector GUCs and
+TRUNCATE/CDC pause semantics, and adds a live OpenTelemetry collector test plus
+operator guide so trace propagation is proven, not just partially wired.
 
 ---
 
 ## Also in v0.38.0
 
-- Any deferred items from v0.37.0 that did not meet the exit criteria
-- Citus integration tests for vector aggregates (shard-additive centroid
-  aggregation) — required exit criterion; defer with tracked issue if Citus
-  infra is unavailable, but do not silently skip
-- `docs/CONFIGURATION.md` overhaul: auto-generated GUC reference covering
-  all 111+ GUCs, plus the new per-table stream-table options
+- SQLSTATE-first SPI retry classification rollout on scheduler, refresh, and
+  catalog paths
+- `history_prune_interval_seconds` wired into scheduler cleanup or removed from
+  the public surface
+- Deferred pg_partman / TimescaleDB integration coverage from v0.37.0 if still
+  outstanding
 
 ---
 
 ## Scope
 
-v0.38.0 is a medium release. The post-refresh-action primitives are scheduler
-options (no engine change); the monitoring view is purely observational;
-ecosystem integration (cookbook, Docker image) is additive. The CONFIGURATION
-docs overhaul is new but tractable.
+v0.38.0 is a large release because it touches the DVM core, error handling,
+scheduler documentation, test strategy, and public operator docs. The work is
+deliberately biased toward correctness and truthfulness rather than new product
+surface, matching the conclusion of `PLAN_OVERALL_ASSESSMENT_8.md`.
 
-> **Hard prerequisite:** v0.38.0 development must not start until F4
-> (v0.37.0 `vector_avg`) has landed with `tests/e2e_pgvector_tests.rs` green.
+> **Release-order note:** The old embedding-pipeline v0.38.0 plan is not being
+> dropped. It moves to v0.41.0 after the hardening arc in v0.38.0-v0.40.0.
 
 ---
 
 *Previous: [v0.37.0 — Scheduler Modularisation, pgVectorMV & OpenTelemetry](v0.37.0.md)*
-*Next: [v0.39.0 — Hybrid Search & Sparse Vector Aggregates](v0.39.0.md)*
+*Next: [v0.39.0 — Distributed Hardening & Diagnostic Depth](v0.39.0.md)*

--- a/roadmap/v0.38.0.md-full.md
+++ b/roadmap/v0.38.0.md-full.md
@@ -1,19 +1,16 @@
 > **Plain-language companion:** [v0.38.0.md](v0.38.0.md)
 
-## v0.38.0 — Embedding Pipeline Infrastructure & ANN Maintenance
+## v0.38.0 — Correctness Closeout & Operational Truthfulness
 
-**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](plans/ecosystem/PLAN_PGVECTOR.md) §6.2 (VP-1 through VP-5).
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md) §4-§13; action items A01-A08, A10, A12, and A16.
 
 > **Release Theme**
-> v0.38.0 completes the embedding-pipeline feature set by adding post-refresh
-> action hooks (REINDEX, ANALYZE, drift-based re-clustering), vector-aggregate
-> monitoring and diagnostics, full pgai integration tutorial, and a Docker
-> image combining pg_trickle + pgvector + pgai for AI/RAG deployments.
-
-> **Hard prerequisite:** v0.38.0 development must not start until F4 (v0.37.0
-> `vector_avg` / `vector_sum`) has landed with `tests/e2e_pgvector_tests.rs`
-> green and pgvector present in `tests/Dockerfile.e2e`. All VP items depend
-> on the pgvector CI infrastructure established in v0.37.0.
+> v0.38.0 is the first release in a hardening programme triggered by the
+> overall assessment. It closes the highest-risk correctness and truthfulness
+> gaps before more feature surface is added: EC-01 join convergence,
+> planner-enforced `RowIdSchema`, truthful backpressure and wake behavior,
+> SQLSTATE-based retry classification, generated configuration and upgrade
+> docs, and live OpenTelemetry collector proof.
 
 ---
 
@@ -21,167 +18,143 @@
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| VP-1 | `post_refresh_action` ST option (`none`/`analyze`/`reindex`/`reindex_if_drift`) | M | P1 |
-| VP-2 | `reindex_drift_threshold` ST option + drift counter in catalog | M | P1 |
-| VP-3 | `pgtrickle.vector_status()` view: embedding lag, ANN age, drift % | S | P1 |
-| VP-4 | Cookbook: "Always-fresh RAG with pg_trickle + pgvector + pgai" | S | P2 |
-| VP-5 | Docker image variant: `pg_trickle + pgvector + pgai` for one-command RAG | S | P2 |
-| VP-6 | `docs/CONFIGURATION.md` overhaul: enumerate all GUCs with defaults | M | P1 |
+| H38-1 | Unconditional PH-D1 cleanup plus join row-id convergence | L | P0 |
+| H38-2 | Plan-time `RowIdSchema` verification in DVM planner | M | P0 |
+| H38-3 | Truthful backpressure semantics with hysteresis or explicit deprecation | M | P0 |
+| H38-4 | SQLSTATE-first SPI retry classification rollout | M | P1 |
+| H38-5 | Wake truthfulness: docs, warnings, and test repair | S | P0 |
+| H38-6 | Generated `CONFIGURATION.md` plus corrected v0.37 operator docs | M | P0 |
+| H38-7 | `UPGRADING.md` through v0.37 and explicit TRUNCATE/CDC semantics | S | P1 |
+| H38-8 | OpenTelemetry operator guide and live collector proof | M | P1 |
+| H38-9 | `history_prune_interval_seconds` wired or removed | XS | P1 |
+| H38-10 | Deferred pg_partman / TimescaleDB ecosystem coverage from v0.37 | M | P2 |
 
-**VP-1 — Post-refresh actions.**
-Add a `post_refresh_action` option to `pgtrickle.create_stream_table()`:
+**H38-1 — Unconditional PH-D1 cleanup plus join row-id convergence.**
+The assessment confirmed that join deltas still return `is_deduplicated: false`
+and that Q07/Q15-style workloads can accumulate phantom rows. v0.38.0 makes
+PH-D1 cleanup unconditional for non-deduplicated join outputs while the root
+fix lands, then reworks the join row-id formula so Part 1a, Part 1b, and Part 2
+converge on the same logical identity across pre/post images. Verification is
+DIFF-vs-FULL equivalence, not just absence of obvious duplicates.
 
-```sql
-SELECT pgtrickle.create_stream_table(
-  name => 'embeddings_st',
-  query => $$SELECT id, embedding FROM docs$$,
-  post_refresh_action => 'reindex_if_drift'
-);
-```
+**H38-2 — Plan-time `RowIdSchema` verification in DVM planner.**
+`RowIdSchema` exists in v0.36.0, but the verifier is effectively dormant unless
+tests call it. Carry the schema through `DiffResult` and enforce compatibility
+at plan time so incompatible pipelines either fail creation or explicitly force
+FULL refresh. This turns row-id design into a guardrail rather than a comment.
 
-Valid values: `none` (default), `analyze`, `reindex`, `reindex_if_drift`.
-- `none`: no post-action.
-- `analyze`: run `ANALYZE` on the stream table after refresh commits.
-- `reindex`: run `REINDEX` on all indexes for the stream table.
-- `reindex_if_drift`: conditional reindex based on VP-2 threshold (see below).
+**H38-3 — Truthful backpressure semantics with hysteresis or explicit deprecation.**
+`pg_trickle.enforce_backpressure` currently looks operator-ready without an
+actual control path that suppresses or redirects writes safely. v0.38.0 either
+wires it into a real stateful path with hysteresis and observable status, or it
+demotes the GUC as experimental until the durable hold mode lands in v0.39.0.
+The release must also document the current `cdc_paused` discard semantics so
+operators know whether changes are captured, deferred, or dropped.
 
-Runs in a separate transaction *after* the refresh commits (not in the refresh
-transaction itself), so it does not lengthen the refresh window. Goes into the
-lower-priority tier of the SLA scheduler (v0.22) so it never blocks
-refresh-cadence SLAs.
+**H38-4 — SQLSTATE-first SPI retry classification rollout.**
+The SQLSTATE classifier exists, but hot paths still classify retryability from
+English message text. Introduce a single helper that constructs
+`PgTrickleError::SpiErrorCode` from SPI failures on scheduler, refresh, and
+catalog paths so retry behavior is locale-independent and stable across message
+wording changes.
 
-**VP-2 — Drift detection.**
-Catalog extension: add `reindex_drift_threshold FLOAT` and
-`rows_changed_since_last_reindex INT8` columns to `pgtrickle.pgt_stream_tables`.
+**H38-5 — Wake truthfulness: docs, warnings, and test repair.**
+`event_driven_wake` cannot rely on `LISTEN` in a PostgreSQL background worker,
+yet docs and tests still imply low-latency event delivery. v0.38.0 makes the
+warning path explicit, rewrites the wake test so poll-only behavior cannot pass
+as event-driven, and documents a future latch-based wake path as separate work
+rather than as an implied current guarantee.
 
-After each refresh, increment `rows_changed_since_last_reindex` by the delta row
-count. When `post_refresh_action = 'reindex_if_drift'`, check if
-`rows_changed_since_last_reindex >= table_size * reindex_drift_threshold`.
-If so, queue an `REINDEX` action and reset the counter to 0.
+**H38-6 — Generated `CONFIGURATION.md` plus corrected v0.37 operator docs.**
+Configuration docs must be generated from source metadata so defaults and new
+GUCs stop drifting. The generated reference covers all known GUCs, corrects the
+`event_driven_wake` default and behavior, includes the v0.37 vector/trace GUCs,
+and aligns `docs/SCALING.md` and `docs/TROUBLESHOOTING.md` with the real code.
 
-Default threshold: 0.10 (reindex after 10% of rows have changed since last
-reindex). Users can tune per-table with `ALTER STREAM TABLE … SET
-(reindex_drift_threshold = 0.05)`.
+**H38-7 — `UPGRADING.md` through v0.37 and explicit TRUNCATE/CDC semantics.**
+`docs/UPGRADING.md` stops at v0.34 even though the codebase is at v0.37. Add
+v0.34 -> v0.35, v0.35 -> v0.36, and v0.36 -> v0.37 guidance, then document how
+TRUNCATE, CDC pause, and FULL invalidation behave so operators are not left to
+infer semantics from trigger code.
 
-**VP-3 — Vector status view.**
-Add a monitoring view `pgtrickle.vector_status()` that shows:
+**H38-8 — OpenTelemetry operator guide and live collector proof.**
+Trace context capture exists, but the roadmap must include proof that spans can
+be exported to a live collector without surprising failure behavior. Add an
+operator guide for OTLP/Jaeger/Tempo configuration plus a dockerized collector
+test that verifies success, timeout, and endpoint-failure handling.
 
-```
-stream_table | last_refresh_at | embedding_lag_s | agg_count | last_reindex_at | rows_since_reindex | drift_pct | vector_agg_type
-```
+**H38-9 — `history_prune_interval_seconds` wired or removed.**
+The GUC exists but the scheduler still uses a hard-coded 24-hour cleanup loop.
+v0.38.0 either makes the scheduler honor the GUC or removes the public setting
+and documents daily cleanup as the intentional behavior.
 
-Columns:
-- `stream_table` — ST name
-- `last_refresh_at` — timestamp of last refresh (from `pgt_stream_tables.last_refresh_lsn` timestamp)
-- `embedding_lag_s` — seconds since last refresh (for SLA monitoring)
-- `agg_count` — number of groups if the ST uses a vector aggregate
-- `last_reindex_at` — timestamp of last successful REINDEX
-- `rows_since_reindex` — count since last reindex (absolute)
-- `drift_pct` — `(rows_since_reindex / table_size) * 100`
-- `vector_agg_type` — `vector_avg`, `vector_sum`, or `null` if no vector aggregate
-
-Used with the v0.20+ self-monitoring system to detect and alert on:
-- Embedding staleness (lag > SLA)
-- Excessive drift (drift_pct approaching threshold)
-- Reindex overhead (frequency vs. drift_pct trade-off)
-
-> **Known limitation (document proactively):** `vector_status()` joins across
-> multiple catalog tables with per-ST cost. It is not designed for deployments
-> with more than ~100k stream tables; use the Prometheus scrape endpoint for
-> fleet-scale monitoring. This must be documented in the view's SQL comment
-> and in `docs/CONFIGURATION.md`.
-
-**VP-6 — `docs/CONFIGURATION.md` overhaul.**
-The extension has grown to 111+ GUC definitions across `src/config.rs` (as of
-v0.34.0 assessment). `docs/CONFIGURATION.md` does not enumerate all of them;
-operators cannot tune without reading source. v0.37.0 adds 3 new GUCs
-(`enable_vector_agg`, `otel_endpoint`, `enable_trace_propagation`); v0.38.0
-adds per-table options (`post_refresh_action`, `reindex_drift_threshold`).
-
-This overhaul:
-- Adds an auto-generated GUC reference table to `docs/CONFIGURATION.md`
-  (driven by a script that greps `GucRegistry::define_*_guc` call sites).
-- Adds a per-table stream-table options reference alongside.
-- Marks each GUC/option with: default value, valid range, scope
-  (per-session / per-table / server), and which release added it.
-
-This addresses the operational ergonomics gap identified in OA7 §5 before it
-compounds further.
-
-**VP-4 — pgai cookbook.**
-`docs/tutorials/PGVECTOR_RAG_COOKBOOK.md`:
-
-- Pattern 1: Pre-compute embeddings into a column with pgai, then stream table
-  maintains denormalised corpus
-- Pattern 2: Always-fresh document corpus with metadata (docs + tags + ACL joins)
-  indexed with HNSW for similarity search
-- Pattern 3: Embedding refresh on source change (using pgai or external service)
-- Pattern 4: Hybrid search (BM25 + vector + metadata-filter on a single flat
-  stream table)
-- Appendix: resource sizing (memory, disk, `max_parallel_workers_per_gather`)
-
-Copy-paste examples for all patterns.
-
-**VP-5 — Docker image.**
-Add `Dockerfile.pgai-bundle` that extends `postgres:18-bookworm` with:
-- pg_trickle (built from current release)
-- pgvector (0.8+)
-- pgai (Timescale's pgai extension)
-- pgml (if license allows)
-- dbt-postgres (for dbt projects)
-
-Published to Docker Hub as `grove/pg-trickle:0.38.0-pgai`.
+**H38-10 — Deferred pg_partman / TimescaleDB ecosystem coverage from v0.37.**
+The v0.37 roadmap already allowed pg_partman and TimescaleDB integration tests
+to slip if the structural work consumed capacity. If they are still open when
+v0.38.0 begins, land them here rather than carrying silent gaps into the next
+cycle.
 
 ### Test Coverage
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| T-VP1 | Integration test: drift-based reindex on HNSW stream table | M | P1 |
-| T-VP2 | Citus integration: `vector_avg` shard-additive property verified | M | P2 |
+| T-H38-1 | EC-01 DIFF-vs-FULL property generator for joins | L | P0 |
+| T-H38-2 | Backpressure and wake truthfulness E2E coverage | M | P0 |
+| T-H38-3 | Live OpenTelemetry collector integration test | M | P1 |
+| T-H38-4 | Docs drift and upgrade-reference CI checks | S | P1 |
+| T-H38-5 | Deferred pg_partman / TimescaleDB ecosystem tests | M | P2 |
 
-**T-VP1.**
-Test in `tests/e2e_pgvector_tests.rs`:
+**T-H38-1.**
+Add a dedicated property generator that runs thousands of random insert/update/
+delete sequences over join-heavy workloads, including left/right co-deletes,
+scalar-subquery joins, and Q07/Q15-inspired shapes. After every cycle, compare
+DIFF against FULL and fail on any row-set divergence.
 
-1. Create embedding stream table with 1000 rows, `post_refresh_action = 'reindex_if_drift'`, `reindex_drift_threshold = 0.05`.
-2. Create HNSW index on the embedding column.
-3. Insert 100 new rows (10% change), trigger refresh.
-4. Assert REINDEX was queued and completed (observable from v0.20+ self-monitoring).
-5. Query `pgtrickle.vector_status()` and verify `drift_pct < 1%` (reset after reindex).
+**T-H38-2.**
+The wake test must assert a bound below the poll interval or explicitly assert
+poll-only warning behavior until latch-based wake exists. Backpressure tests
+must create synthetic slot-lag conditions, validate hysteresis, and verify the
+operator-visible state matches whether writes are captured, held, or discarded.
 
-**T-VP2.**
-For distributed Citus deployments, verify that `vector_avg` is shard-additive:
-- Compute `vector_avg` per shard on a partitioned stream table.
-- Verify final result == `avg(vector)` computed across all shards.
+**T-H38-3.**
+Run an integration test against a dockerized OTEL Collector or Jaeger instance.
+Verify that a refresh span is exported when enabled, that timeouts do not wedge
+the refresh path, and that collector failures degrade predictably.
 
-> **Assessment note (2026-04-27):** The exit criteria below listed T-VP2 with
-> a soft "if v0.33+ Citus support available" gate. This has been hardened:
-> T-VP2 is a **required** exit criterion. If the Citus test infrastructure is
-> not available at the time of the release, explicitly defer T-VP2 to v0.39.0
-> with a tracked issue — do not silently skip it.
+**T-H38-4.**
+Add CI checks that diff source-discovered GUC metadata against
+`docs/CONFIGURATION.md` and ensure `docs/UPGRADING.md`'s latest documented
+target matches the extension version. This is the cheapest way to prevent the
+same docs drift from recurring.
+
+**T-H38-5.**
+If the deferred v0.37 ecosystem coverage is still open, add explicit daily or
+manual workflows proving pg_partman and TimescaleDB compatibility rather than
+leaving the support story implied.
 
 ### Conflicts & Risks
 
-- **VP-1/VP-2** (post-refresh actions) require careful queuing to avoid
-  scheduler queue overflow. Approach: store action in catalog and check queue
-  depth before enqueueing; drop with warning if queue full. Document backlog
-  visibility in `pgtrickle.vector_status()`.
-- **VP-3** (vector_status view) joins across multiple catalogs; performance
-  with millions of STs not yet characterized. Add a note: "Not for queries
-  over 100k STs; use Prometheus scrape if needed."
-- **VP-5** (Docker image) must pin specific versions of pgvector, pgai, pgml to
-  avoid breakage on minor updates. Add version documentation.
+- **H38-1/H38-2** touch the DVM core and therefore carry high regression risk.
+  They require property tests and DIFF-vs-FULL comparison before the release is
+  considered complete.
+- **H38-3** must not promise more safety than the implementation provides. If
+  durable hold semantics are not ready, deprecate or narrow the surface instead
+  of shipping ambiguous pause behavior.
+- **H38-6/H38-7** must be source-driven wherever possible. Hand-edited docs are
+  exactly what created the current drift.
 
 ### Exit Criteria
 
-- [ ] **Prerequisite:** F4 (v0.37.0 `vector_avg`) merged and `tests/e2e_pgvector_tests.rs` green
-- [ ] VP-1: `post_refresh_action` option stored in catalog, scheduler correctly dequeues actions
-- [ ] VP-2: `rows_changed_since_last_reindex` counter incremented per refresh; drift threshold comparison logic tested over 1000 refresh cycles
-- [ ] VP-3: `pgtrickle.vector_status()` view returns correct lag, drift_pct for all vector ST types; query plan optimized; scale limitation documented in SQL comment and `docs/CONFIGURATION.md`
-- [ ] VP-4: Cookbook published with 4+ worked examples; copy-paste code tested
-- [ ] VP-5: Docker image builds and passes smoke test (pg_trickle + pgvector + pgai extensions load, `pg_extension_info()` lists all three)
-- [ ] VP-6: `docs/CONFIGURATION.md` overhaul complete; auto-generated GUC table covers all 111+ GUCs; per-table options reference added
-- [ ] T-VP1: `tests/e2e_pgvector_tests.rs::test_drift_reindex_e2e` passes
-- [ ] T-VP2: Citus `vector_avg` shard-additive integration tests pass (or deferred with tracked issue if Citus infra unavailable)
+- [ ] H38-1: Non-deduplicated join outputs no longer accumulate phantom rows in Q07/Q15-style and random property workloads
+- [ ] H38-2: Incompatible `RowIdSchema` pipelines fail planning or explicitly force FULL refresh with a clear reason
+- [ ] H38-3: `pg_trickle.enforce_backpressure` is either fully wired with hysteresis and tests or clearly marked experimental/off with truthful docs
+- [ ] H38-4: SQLSTATE drives retry classification on scheduler, refresh, and catalog hot paths
+- [ ] H38-5: Wake docs, warnings, and tests no longer imply background-worker `LISTEN` support
+- [ ] H38-6: `docs/CONFIGURATION.md`, `docs/SCALING.md`, and `docs/TROUBLESHOOTING.md` are source-aligned and include v0.37 trace/vector GUCs
+- [ ] H38-7: `docs/UPGRADING.md` is updated through v0.37 and TRUNCATE/CDC semantics are explicitly documented
+- [ ] H38-8: OTEL operator guide is published and collector integration tests pass
+- [ ] H38-9: `history_prune_interval_seconds` is wired into scheduler cadence or removed from the public surface
+- [ ] H38-10: Deferred pg_partman / TimescaleDB coverage is either complete or explicitly carried with a tracked issue
 - [ ] Extension upgrade path tested (`0.37.0 → 0.38.0`)
 - [ ] `just check-version-sync` passes
 

--- a/roadmap/v0.39.0.md
+++ b/roadmap/v0.39.0.md
@@ -1,135 +1,81 @@
-# v0.39.0 — Hybrid Search & Sparse Vector Aggregates
+# v0.39.0 — Distributed Hardening & Diagnostic Depth
 
 > **Full technical details:** [v0.39.0.md-full.md](v0.39.0.md-full.md)
 
-**Status: Planned** | **Scope: Medium**
+**Status: Planned** | **Scope: Large**
 
-> Sparse and half-precision vector aggregates for storage-tiered embedding
-> pipelines, reactive neighbour-alert subscriptions, hybrid-search corpus
-> patterns, and differential-refresh performance benchmarks for vector
-> workloads.
+> Extend the v0.38 hardening sprint into distributed proof and deep
+> diagnostics: Citus chaos coverage, durable CDC hold semantics, generated SQL
+> and explain artifacts, SQLancer light PR mode, targeted fuzzing, and
+> inbox/outbox reliability tests.
 
 ---
 
 ## What is this?
 
-v0.38.0 completed embedding pipeline infrastructure; v0.39.0 completes the
-feature set for production AI/RAG workloads by adding sparse and half-precision
-vector aggregation (for tiered storage), reactive vector-similarity alerts, and
-hybrid-search cookbook patterns with performance benchmarks.
+v0.38.0 makes the single-node correctness story honest. v0.39.0 makes the
+distributed and operational story believable. It adds the failure injection,
+artifacts, and fast gates needed to explain why DIFFERENTIAL refresh succeeds,
+falls back, or collapses under scale instead of forcing maintainers to debug
+those cases manually after merge.
 
 ---
 
-## Sparse and half-precision vector aggregates
+## Distributed correctness and safe operator controls
 
-pgvector 0.7+ ships `halfvec` and `sparsevec` types for storage-efficient
-embeddings. v0.39.0 adds:
+The biggest unresolved distributed risk after v0.38.0 is still Citus: the code
+has coordinator and worker logic, but the assessment found no real chaos rig.
+v0.39.0 adds a coordinator-plus-workers topology, exercises lease acquisition,
+worker kill and restart, coordinator restarts, rebalance churn, and stale slot
+cleanup, and treats that coverage as a release gate rather than a best-effort
+nice-to-have.
 
-- `sparsevec_avg` — element-wise mean over the union of sparse dimensions,
-  treating absent entries as 0. Returns `sparsevec`.
-- `halfvec_avg` — element-wise mean with running state upcast to `vector(d)`;
-  returns `halfvec(d)` on read.
-- `sparsevec_sum` and `halfvec_sum` — for pre-aggregation workflows.
-
-These are algebraically identical to `vector_avg` / `vector_sum` but respect
-the native type on output. A stream table can maintain tiered storage: raw
-`vector(1536)` → `halfvec(1536)` → `sparsevec(1536)` (for binary-quantised
-re-ranking), each layer incrementally maintained and independently indexed.
-
----
-
-## Reactive vector-similarity subscriptions
-
-Extending reactive subscriptions (v0.35), add support for reactive queries
-over distance predicates:
-
-```sql
-LISTEN fraud_alert;
-
-SELECT pgtrickle.create_reactive_subscription(
-  'fraud_alert',
-  $$
-    SELECT new_txn.id
-    FROM transactions_embedded new_txn
-    JOIN known_fraud_vectors k ON new_txn.embedding <=> k.embedding < 0.05
-  $$
-);
-```
-
-The subscription fires whenever a *new* transaction embedding lands within ε
-of a known-fraud cluster, emitting the transaction ID via `NOTIFY`. Unlike a
-plain SELECT, the subscription is differential: only *newly matched* rows fire,
-no spurious re-emits on every refresh.
+This release also replaces the ambiguous single pause knob with explicit,
+operator-visible semantics: one mode that captures changes and holds refreshes,
+and a separate discard-and-reinitialize mode for emergency use only. The same
+milestone broadens inbox/outbox reliability coverage from helper tests to the
+actual delivery contract: envelopes, dedup keys, leases, offsets, replay, and
+NULL payload edge cases.
 
 ---
 
-## Hybrid-search corpus pattern
+## Diagnostic depth for TPC-H and generated SQL
 
-Combine vector similarity with BM25 full-text search and metadata filters on a
-single flat stream table:
+The assessment showed that TPC-H scaling problems are still hard to diagnose
+from current CI artifacts. v0.39.0 adds generated-SQL artifact export, a richer
+`explain_stream_table()` visualizer for DIFF vs FULL reasoning, per-query
+`EXPLAIN (ANALYZE, BUFFERS)` artifacts for collapse-prone queries, and a
+measured p99/temp-spill regression gate instead of coarse aggregate timings.
 
-```sql
--- One-statement denormalised corpus maintenance
-SELECT pgtrickle.create_stream_table(
-  'hybrid_search_corpus',
-  $$
-    SELECT doc.id, doc.title, doc.body, doc.embedding,
-           array_agg(tag.name) AS tags,
-           perm.tenant_id, perm.read_groups
-    FROM documents doc
-    JOIN doc_tags tag ON tag.doc_id = doc.id
-    JOIN doc_permissions perm ON perm.doc_id = doc.id
-    WHERE doc.active
-    GROUP BY doc.id, perm.tenant_id, perm.read_groups
-  $$,
-  refresh_mode => 'DIFFERENTIAL',
-  schedule => '10 seconds'
-);
-
-CREATE INDEX ON hybrid_search_corpus USING hnsw (embedding vector_cosine_ops);
-CREATE INDEX ON hybrid_search_corpus USING gin  (to_tsvector('english', body));
-CREATE INDEX ON hybrid_search_corpus            (tenant_id);
-```
-
-Cookbook: `docs/tutorials/HYBRID_SEARCH_PATTERNS.md`.
-
----
-
-## Performance benchmarks
-
-Add benchmark suite `benches/pgvector_bench.rs`:
-
-- **Differential refresh + HNSW insert throughput:** measure rows/sec for
-  incremental embedding corpus updates vs. bulk REINDEX.
-- **Vector aggregate reducer cost:** microseconds per element for `vector_avg`
-  vs. plain `sum` reducer.
-- **Drift detection overhead:** per-refresh cost of tracking `rows_changed_since_last_reindex`.
-
-CI integration: publish results to the benchmark dashboard alongside refresh
-latency benchmarks (v0.31).
+To catch silent regressions earlier, the release also adds a SQLancer light PR
+mode and fuzz targets for WAL decoding, merge SQL generation, DAG mutations,
+and snapshot column-list generation. The goal is simple: make failures cheaper
+to catch and much easier to explain.
 
 ---
 
 ## Also in v0.39.0
 
-- Any deferred items from v0.38.0 that did not meet the exit criteria
-- Integration tests for hybrid-search corpus under write load (Nexmark-style)
-  with latency baseline established before the 50 ms assertion is written
+- PR-scoped upgrade E2E slice for SQL-facing changes instead of waiting for
+  daily/manual upgrade jobs
+- Structured benchmark artifacts for Q04/Q05/Q07/Q08/Q09/Q20/Q22 and similar
+  collapse-prone workloads
 
 ---
 
 ## Scope
 
-v0.39.0 is a medium release — but sits at the upper end. The three new test
-files (tiered storage, reactive distance, Nexmark hybrid) are each substantive
-integration tests; VH-4 (benchmarks) adds CI infrastructure. If capacity is
-tight, VH-3 (cookbook) and VH-4 (benchmarks) may slip to v0.40.0; the VH-1
-and VH-2 feature work must land in v0.39.0.
+v0.39.0 is a large release because it combines new distributed test
+infrastructure, control-plane semantics, CI gates, and artifact-heavy
+diagnostics. This is still hardening work, not feature sprawl: it is the
+minimum foundation needed before the roadmap resumes the deferred embedding
+programme in v0.41.0.
 
-> **Note:** VH-2 (reactive distance subscriptions) requires v0.35.0 reactive
-> subscription correctness to be fully confirmed before implementation begins.
+> **Release-order note:** The old sparse-vector and hybrid-search v0.39.0 plan
+> is not dropped. It moves to v0.42.0 after distributed proof and diagnostics
+> are in place.
 
 ---
 
-*Previous: [v0.38.0 — Embedding Pipeline Infrastructure & ANN Maintenance](v0.38.0.md)*
-*Next: [v0.40.0 — Embedding API & Advanced RAG Patterns (Research)](v0.40.0.md)*
+*Previous: [v0.38.0 — Correctness Closeout & Operational Truthfulness](v0.38.0.md)*
+*Next: [v0.40.0 — Operator Trust, Maintainability & Release Confidence](v0.40.0.md)*

--- a/roadmap/v0.39.0.md-full.md
+++ b/roadmap/v0.39.0.md-full.md
@@ -1,15 +1,15 @@
 > **Plain-language companion:** [v0.39.0.md](v0.39.0.md)
 
-## v0.39.0 — Hybrid Search & Sparse Vector Aggregates
+## v0.39.0 — Distributed Hardening & Diagnostic Depth
 
-**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](plans/ecosystem/PLAN_PGVECTOR.md) §6.3 (VH-1 through VH-4).
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md) §4-§13; action items A06, A09, A11, A14, and A15, plus the diagnostic opportunities in §12.
 
 > **Release Theme**
-> v0.39.0 completes the vector-aggregate feature set with sparse and
-> half-precision types, adds reactive vector-similarity subscriptions for
-> real-time anomaly detection, patterns for hybrid-search (BM25 + vector +
-> metadata) STs, and comprehensive performance benchmarks for differential
-> vector workloads.
+> v0.39.0 takes the hardening work from local correctness into distributed
+> proof and deep diagnostics. It adds the missing Citus chaos rig, explicit
+> durable hold semantics for CDC pressure events, richer generated-SQL and
+> explain artifacts, SQLancer light gating on pull requests, targeted fuzzing,
+> and true reliability-contract coverage for inbox/outbox flows.
 
 ---
 
@@ -17,188 +17,125 @@
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| VH-1 | `sparsevec_avg`, `sparsevec_sum`, `halfvec_avg`, `halfvec_sum` aggregates | M | P1 |
-| VH-2 | Reactive subscriptions over distance predicates (`embedding <=> q < ε`) | M | P1 |
-| VH-3 | Hybrid-search corpus cookbook: BM25 + vector + metadata on one ST | S | P2 |
-| VH-4 | Benchmark suite: differential refresh + HNSW throughput, aggregate cost | M | P2 |
+| D39-1 | Citus coordinator/worker E2E and chaos harness | L | P0 |
+| D39-2 | Durable capture-and-hold vs discard-and-reinit semantics | M | P0 |
+| D39-3 | Generated-SQL artifact API and richer `explain_stream_table()` visualizer | M | P1 |
+| D39-4 | TPC-H per-query `EXPLAIN` artifacts and p99/temp-spill regression gate | M | P1 |
+| D39-5 | SQLancer light PR mode for DIFF-vs-FULL oracle coverage | M | P1 |
+| D39-6 | WAL decoder, merge SQL, DAG, and snapshot fuzz expansion | M/L | P1 |
+| D39-7 | Inbox/outbox reliability helpers plus property-test coverage | M | P1 |
+| D39-8 | PR-scoped upgrade E2E slice for SQL-facing changes | M | P2 |
 
-**VH-1 — Sparse and half-precision aggregates.**
-Extend the algebraic-aggregate framework to support pgvector 0.7+ type variants:
+**D39-1 — Citus coordinator/worker E2E and chaos harness.**
+The assessment found a significant Citus surface with no real topology or
+chaos coverage. v0.39.0 adds a coordinator-plus-workers rig that verifies lease
+acquisition, worker death and restart, coordinator restart mid-lease, shard
+rebalance churn, and stale `pgt_worker_slots` cleanup. Distributed correctness
+stops being an assumption and becomes a tested contract.
 
-- `sparsevec_avg(sparsevec) → sparsevec`: element-wise mean over the union of
-  sparse dimensions, treating missing entries as 0.
-- `sparsevec_sum(sparsevec) → sparsevec`: element-wise sum.
-- `halfvec_avg(halfvec) → halfvec`: upcast running state to `vector(d)` for
-  numerical stability, return as `halfvec` on read.
-- `halfvec_sum(halfvec) → halfvec`: upcast to vector, sum, return as halfvec.
+**D39-2 — Durable capture-and-hold vs discard-and-reinit semantics.**
+The current `cdc_paused` behavior is too easy to misread as a harmless throttle
+when it can actually drop change capture. Split the operator surface into an
+explicit capture-and-hold mode that keeps durable CDC while pausing refreshes,
+and a separate discard-and-reinitialize mode for emergencies. The active mode
+must be visible in status output so operators know which stream tables require
+catch-up or reinit.
 
-State representation:
-- `sparsevec_avg`: `(sum_sparsevec, count)` — store as JSON or binary tuple in
-  aggregate buffer.
-- `halfvec_avg`: `(sum_vector, count)` — upcast for stability.
+**D39-3 — Generated-SQL artifact API and richer `explain_stream_table()` visualizer.**
+Maintainers need to see why a stream table is DIFF-safe, why it fell back to
+FULL, which operators are row-id sensitive, and which generated SQL fragments
+exist for the current definition. Extend `explain_stream_table()` or add a
+dedicated generated-SQL artifact API that exposes operator-tree summary, SQL
+hashes, fallback reasons, and phase-level SQL snippets without turning on broad
+debug logging.
 
-All variants are differential and work in stream tables at any layer of a
-multi-level materialization pipeline (raw embedding → halfvec → sparsevec
-for progressive quantisation).
+**D39-4 — TPC-H per-query `EXPLAIN` artifacts and p99/temp-spill regression gate.**
+Aggregate benchmark dashboards are not enough for Q04/Q05/Q07/Q08/Q09/Q20/Q22
+style collapse queries. v0.39.0 records generated SQL hashes, `EXPLAIN
+ANALYZE BUFFERS`, temp blocks, phase timings, and measured p50/p99 so CI can
+track query-shape regressions instead of only overall throughput. The gate must
+be baseline-driven, not hard-coded from wishful numbers.
 
-**VH-2 — Reactive distance subscriptions.**
-Extend reactive subscriptions (v0.35) to support distance-predicate queries:
+**D39-5 — SQLancer light PR mode for DIFF-vs-FULL oracle coverage.**
+Weekly SQLancer runs are valuable but too slow to protect every PR. Add a small
+oracle mode to PR CI that exercises a measured subset of SQLancer-generated
+workloads and compares DIFF against FULL so obvious query-engine regressions are
+caught before merge.
 
-> **Prerequisite:** VH-2 depends on the v0.35.0 reactive subscription
-> implementation being fully signed off (exit criteria passed, no open
-> correctness issues). Confirm reactive subscription stability before building
-> the distance-predicate extension on top.
+**D39-6 — WAL decoder, merge SQL, DAG, and snapshot fuzz expansion.**
+Current fuzzing is concentrated in parser/config helpers. Expand it into the
+state machines and code generators most likely to fail under adversarial input:
+logical decoding payloads, merge-template inputs, DAG graph mutations, and
+snapshot/restore identifier and column-list generation.
 
-```sql
-LISTEN new_anomaly;
+**D39-7 — Inbox/outbox reliability helpers plus property-test coverage.**
+Inbox/outbox helper tests exist, but they do not prove the actual delivery
+contract. Extract pure helpers for envelope encoding/decoding, dedup-key
+validation, lease math, offset transitions, replay behavior, and NULL payload
+handling, then cover them with property tests in addition to end-to-end flows.
 
-SELECT pgtrickle.create_reactive_subscription(
-  'new_anomaly',
-  $$
-    SELECT t.id, t.embedding <=> $1::vector AS distance
-    FROM transactions_embedded t
-    WHERE t.embedding <=> $1::vector < 0.05
-  $$,
-  params => '{"1": "[0.1, 0.2, ...]"}'::jsonb
-);
-```
-
-Implementation notes:
-- The `$1` parameter is bound at subscription-creation time (not per-query).
-- The subscription fires on INSERT/UPDATE/DELETE only if the new/old row
-  satisfies the distance predicate.
-- Useful for real-time alerts: "alert me when a new embedding enters this
-  anomaly cluster."
-
-**VH-3 — Hybrid-search cookbook.**
-`docs/tutorials/HYBRID_SEARCH_PATTERNS.md`:
-
-- Pattern 1: Flat denormalised corpus (documents + tags + metadata) with vector
-  + BM25 + tag-facet indexes.
-- Pattern 2: RLS-scoped corpus (per-tenant or per-org hybrid search).
-- Pattern 3: Tiered search (broad vector → narrow BM25 → re-rank by cross-
-  encoder).
-- Pattern 4: Combining search results from multiple stream tables (e.g., docs
-  + comments + metadata, each with their own vector corpus).
-- Appendix: performance tuning (index hints, `work_mem`, parallel worker count).
-
-Copy-paste examples for all patterns. Worked example: e-commerce product
-search (products × categories × brands × reviews, hybrid corpus with 1M rows,
-< 10 ms query latency target).
-
-**VH-4 — Vector benchmark suite.**
-Add `benches/pgvector_bench.rs` using the Criterion framework (matching the
-TPC-H refresh benchmarks in v0.31):
-
-- **Throughput: differential refresh + HNSW insert.** Measure rows/sec for
-  incremental embedding corpus vs. bulk REINDEX over 10k rows.
-- **Aggregate reducer cost.** Microseconds per vector for `vector_avg` vs. plain
-  numeric `sum`.
-- **Drift detection overhead.** Cost of tracking `rows_changed_since_last_reindex`
-  per refresh (should be negligible).
-- **Storage savings.** Compare table size under `vector` vs. `halfvec` vs.
-  `sparsevec` for typical embeddings (1536-dim, 10M rows).
-
-Integrate with the benchmark dashboard (v0.31) — publish results alongside
-refresh latency and TPC-H metrics.
+**D39-8 — PR-scoped upgrade E2E slice for SQL-facing changes.**
+Full upgrade E2E is currently daily/manual only. Add a smaller PR matrix that
+triggers when SQL scripts, `src/config.rs`, `src/cdc.rs`, or SQL-facing API
+files change so upgrade regressions are more likely to fail before merge.
 
 ### Test Coverage
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| T-VH1 | Integration test: tiered storage (vector → halfvec → sparsevec) | M | P1 |
-| T-VH2 | Reactive distance subscriptions: new anomaly alerts | M | P1 |
-| T-VH3 | Hybrid-search corpus under Nexmark-style write load | M | P2 |
+| T-D39-1 | Citus chaos suite with worker and coordinator failure injection | L | P0 |
+| T-D39-2 | Durable hold vs discard semantics E2E | M | P0 |
+| T-D39-3 | SQLancer light PR gate | M | P1 |
+| T-D39-4 | TPC-H artifact and p99/temp-spill regression workflow | M | P1 |
+| T-D39-5 | Inbox/outbox reliability property suite | M | P1 |
 
-**T-VH1.**
-`tests/e2e_pgvector_tiered_tests.rs`:
+**T-D39-1.**
+Create a topology-aware test harness with at least one coordinator and two
+workers. Kill workers mid-refresh, restart the coordinator during lease
+ownership, trigger rebalance churn, and verify the system neither loses change
+capture nor duplicates refresh ownership.
 
-1. Create embedding stream table on source documents.
-2. Create halfvec stream table on the embedding table (cast to halfvec).
-3. Create sparsevec stream table on the halfvec table (binary quantise).
-4. Insert new rows at source; verify all three layers refresh correctly.
-5. Query `pgtrickle.vector_status()` and verify appropriate aggregates on each
-   layer.
-6. Assert tiered indexes (HNSW on each) return consistent results (same nearest
-   neighbours up to quantisation loss).
+**T-D39-2.**
+Exercise both control-plane modes introduced by D39-2. In capture-and-hold
+mode, writes continue to be captured while refreshes stop; in discard mode,
+status output and docs must clearly mark the need for reinitialization.
 
-**T-VH2.**
-`tests/e2e_reactive_distance_tests.rs`:
+**T-D39-3.**
+Run a bounded SQLancer subset on PRs and compare DIFF vs FULL outputs. Keep the
+runtime small enough for PR CI, but publish seed values and failing queries so
+maintainers can reproduce any divergence quickly.
 
-1. Create embedding stream table (e.g., fraud transactions).
-2. Create reactive subscription with distance predicate:
-   `embedding <=> known_fraud_vec < 0.05`.
-3. Insert new transaction; verify NOTIFY fires.
-4. Update the same transaction (move further away from fraud centroid);
-   verify NOTIFY does not fire (no change in predicate truth).
-5. Insert 1000 new transactions, half within ε; verify 500 NOTIFYs.
+**T-D39-4.**
+Publish per-query TPC-H artifacts for collapse-prone workloads, including SQL
+hash, `EXPLAIN`, temp blocks, and measured p99. Use baselines captured from the
+target CI hardware instead of invented thresholds.
 
-**T-VH3.**
-`tests/e2e_hybrid_search_nexmark_tests.rs`:
-
-Run Nexmark Stream using a hybrid-search corpus definition:
-
-```sql
-SELECT pgtrickle.create_stream_table(
-  'nexmark_auction_corpus',
-  $$
-    SELECT a.id, a.title, a.description, a.embedding,
-           array_agg(b.name) AS category_names,
-           c.seller_name, c.seller_rating
-    FROM nexmark_auctions a
-    JOIN nexmark_categories b ON b.id = a.category
-    JOIN nexmark_sellers c ON c.id = a.seller
-    GROUP BY a.id, c.seller_name, c.seller_rating
-  $$,
-  refresh_mode => 'DIFFERENTIAL'
-);
-```
-
-Monitor: refresh latency, corpus row count, drift %, HNSW index size.
-Assert: corpus stays < 1s behind Nexmark event time; hybrid queries (BM25 +
-vector) < 50 ms on 100k rows.
-
-> **Latency target note:** The < 50 ms target must be validated against a
-> baseline measurement on the CI hardware before the test is written.
-> Establish this baseline in the first pass of T-VH3 and adjust the assertion
-> if the CI hardware cannot sustain the target — do not hard-code an
-> unmeasured number.
+**T-D39-5.**
+Property tests verify envelope round-trips, dedup semantics, lease arithmetic,
+offset transitions, and replay rules. Keep end-to-end tests for transactional
+integration, but move the contract itself into fast deterministic coverage.
 
 ### Conflicts & Risks
 
-- **VH-1** (sparse/halfvec aggregates) requires careful handling of dimension
-  mismatches. `sparsevec_avg` may aggregate over vectors with different sparse
-  dimension sets — define the result as the union. Test extensively over
-  heterogeneous sparse patterns (all-zero sparse vectors, dimension-set
-  cardinality mismatches between old and new rows, state serialization
-  round-trips).
-- **VH-1** (halfvec precision): the running state is upcast to `vector(d)` for
-  numerical stability. Verify that the upcast does not introduce significant
-  precision loss vs. full `vector_avg` on the same data. Add an explicit
-  proptest that compares `halfvec_avg(cast(v as halfvec))` against
-  `vector_avg(v)` and asserts relative error < 1e-3.
-- **VH-2** (reactive distance) requires binding the query vector at
-  subscription-creation time, not query-time. This is a trade-off: slightly
-  less flexible than parameterised queries, but vastly more efficient for
-  real-time alerts (no per-query distance recomputation).
-- **VH-3** (hybrid-search patterns) may surface indexing challenges (GIN on
-  array columns, HNSW on vector, B-tree on foreign keys). Document index
-  creation order and maintenance.
+- **D39-1** requires substantial test infrastructure, but the assessment makes
+  it clear this is no longer optional if Citus support is to remain a roadmap
+  claim.
+- **D39-2** can increase retained change-buffer volume if operators hold for
+  too long. The feature needs clear status visibility, limits, and runbook
+  guidance rather than a hidden background state.
+- **D39-3/D39-4/D39-5** must use measured budgets. Diagnostic gates help only if
+  they are reliable enough not to be immediately disabled.
 
 ### Exit Criteria
 
-- [ ] VH-1: `sparsevec_avg`, `sparsevec_sum`, `halfvec_avg`, `halfvec_sum` aggregates implemented and tested
-- [ ] VH-1: All four aggregates pass proptest equivalence check vs. non-incremental computation
-- [ ] VH-1: `halfvec_avg` precision contract verified: relative error vs. `vector_avg` on same data < 1e-3
-- [ ] VH-1: `sparsevec_avg` edge cases tested: all-zero sparse vectors, heterogeneous dimension sets, round-trip serialization
-- [ ] VH-2: v0.35.0 reactive subscription correctness confirmed (no open issues) before VH-2 implementation begins
-- [ ] VH-2: Reactive subscriptions accept distance predicates; firing logic verified over 10k inserts
-- [ ] VH-2: No spurious re-fires on rows that do not change predicate truth
-- [ ] VH-3: Hybrid-search cookbook published with 4+ worked examples
-- [ ] VH-4: Benchmark suite runs in CI, results published to dashboard
-- [ ] T-VH1: `tests/e2e_pgvector_tiered_tests.rs` passes (multi-layer tiered storage)
-- [ ] T-VH2: `tests/e2e_reactive_distance_tests.rs` passes (reactive anomaly alerts)
-- [ ] T-VH3: `tests/e2e_hybrid_search_nexmark_tests.rs` passes (hybrid-search corpus under write load)
+- [ ] D39-1: Citus topology and chaos tests pass for lease acquisition, worker death/restart, coordinator restart, and rebalance churn
+- [ ] D39-2: Capture-and-hold and discard-and-reinit semantics are both implemented, documented, and visible through status APIs
+- [ ] D39-3: Generated-SQL artifact export and explain visualizer expose DIFF/FULL reasoning without broad debug logging
+- [ ] D39-4: TPC-H artifact workflow records SQL hash, `EXPLAIN`, temp blocks, and measured p99 for collapse-prone queries
+- [ ] D39-5: SQLancer light PR mode runs on pull requests and publishes reproducible seeds for failures
+- [ ] D39-6: New fuzz targets exist for WAL decoding, merge SQL, DAG mutation, and snapshot column-list generation
+- [ ] D39-7: Inbox/outbox reliability contract is covered by property tests in addition to end-to-end scenarios
+- [ ] D39-8: SQL-facing PRs trigger a smaller upgrade E2E matrix instead of relying only on daily/manual jobs
 - [ ] Extension upgrade path tested (`0.38.0 → 0.39.0`)
 - [ ] `just check-version-sync` passes
 

--- a/roadmap/v0.40.0.md
+++ b/roadmap/v0.40.0.md
@@ -1,136 +1,83 @@
-# v0.40.0 — Embedding API & Advanced RAG Patterns
+# v0.40.0 — Operator Trust, Maintainability & Release Confidence
 
 > **Full technical details:** [v0.40.0.md-full.md](v0.40.0.md-full.md)
 
 **Status: Planned** | **Scope: Large**
 
-> Ergonomic `embedding_stream_table()` API for one-statement RAG corpus setup,
-> materialised k-NN graph research for fixed-pivot retrieval, per-tenant ANN
-> indexing patterns, joint case studies with pgvector team, and strategic
-> ecosystem positioning for the v1.0 release.
+> Finish the post-v0.37 hardening arc with generated references and runbooks,
+> drain-mode proof, alert rules, secret hygiene, unsafe-surface gating,
+> large-file decomposition, L0-cache truthfulness, and a clear event-wake
+> direction before the roadmap resumes embedding-focused feature work.
 
 ---
 
 ## What is this?
 
-v0.37–v0.39 build comprehensive pgvector support in pg_trickle. v0.40.0
-consolidates and elevates that work into strategic, long-term patterns:
-an ergonomic API so RAG developers can set up denormalised, indexed embedding
-corpora in one function call; research into materialised k-NN graphs for
-efficient approximate retrieval; production patterns for multi-tenant RAG; and
-co-marketing with the pgvector and pgai teams to position pg_trickle as the
-default incremental-view solution for AI on PostgreSQL.
+v0.38.0 and v0.39.0 make correctness claims and distributed behavior credible.
+v0.40.0 makes the operator experience and engineering process credible too.
+This is the release that turns a large, fast-moving extension into a platform
+with generated references, explicit runbooks, actionable alerts, safer tooling,
+and a smaller maintenance surface.
 
 ---
 
-## `embedding_stream_table()` ergonomic API
+## Generated operator surface and runbooks
 
-Today: `create_stream_table('name', $$SELECT ...$$)` — users must write the
-full denormalization query. For RAG, we can offer a higher-level primitive:
-
-```sql
-SELECT pgtrickle.embedding_stream_table(
-  name              => 'docs_embedded',
-  source_table      => 'documents',
-  embedding_columns => ARRAY['embedding'],
-  denormalize_from  => ARRAY[
-    ('doc_tags', 'JOIN doc_tags ON doc_tags.doc_id = documents.id', 'tags'),
-    ('doc_metadata', 'LEFT JOIN doc_metadata ...', 'metadata')
-  ],
-  schedule          => '10 seconds',
-  index_type        => 'hnsw',
-  post_refresh_action => 'reindex_if_drift'
-);
-```
-
-The function auto-generates the denormalization query, creates the stream table,
-creates the indexes, sets up vector monitoring, and returns a summary. For 80%
-of users, this eliminates boilerplate.
-
-Key design requirements: `dry_run => true` returns the generated SQL without
-executing it (essential for expert users); index-type inference defaults to
-HNSW for `vector`/`halfvec` columns with explicit documentation of the
-heuristic.
+The assessment found too much public surface area being tracked manually:
+hundreds of GUCs and SQL-facing definitions, security assumptions that live in
+code rather than docs, and semantics such as TRUNCATE or `cdc_paused` that are
+easy to misunderstand. v0.40.0 adds generated GUC and SQL API inventories,
+security-model documentation, secret-handling guidance for relay and TUI users,
+and explicit runbooks for drain mode and incident response.
 
 ---
 
-## Materialised k-NN graph (parallel research spike)
+## Observability, drain mode, and ecosystem parity
 
-> **Reclassified (assessment 2026-04-27):** This is now a parallel research
-> spike — not a v0.40.0 release gate. A dedicated tracking issue drives the
-> investigation; findings may graduate to v0.41.0 or later.
+Metrics alone are not enough if operators still have to design their own alert
+rules from scratch. This release ships alert rules and dashboard coverage for
+freshness, WAL slot lag, worker saturation, Citus lease health, and trace export
+failures, and it proves drain mode end to end under load rather than treating it
+as a nominal API.
 
-For fixed retrieval pivots (e.g., a set of 100 centroids), pre-computing the
-k-NN graph can accelerate approximate retrieval. Research direction:
-
-- Define a set of pivot vectors (e.g., centroids of embedding clusters).
-- Maintain a stream table of `(pivot_id, neighbor_id, distance)` tuples for
-  each embedding's k nearest pivots.
-- Application queries: `SELECT * FROM pivot_neighbours WHERE pivot_id = p LIMIT k`.
-
-This trades storage (O(k·N) rows) for query latency. Feasible but requires
-careful handling of clustering lifecycle. Likely a v0.40–v0.41 research task,
-not production-ready in v0.40.0.
+The surrounding tools must also catch up with the core surface added in v0.35-
+v0.39: dbt, relay, and TUI views need to understand temporal/vector states,
+drain mode, force-full overrides, and safer credential handling.
 
 ---
 
-## Per-tenant ANN indexing patterns
+## Maintainability and remaining platform decisions
 
-For multi-tenant RAG (e.g., SaaS with per-org embeddings), use row-level
-security (v0.5) to create tenant-scoped stream tables:
-
-```sql
-SELECT pgtrickle.create_stream_table(
-  'tenant_embeddings',
-  $$
-    SELECT e.id, e.embedding, e.tenant_id
-    FROM embeddings e
-    WHERE e.tenant_id = current_setting('app.current_tenant_id')::int
-  $$
-);
-```
-
-Pattern documentation + security audit checklist.
-
----
-
-## Joint case studies with pgvector / pgai *(best-effort)*
-
-> **Best-effort (assessment 2026-04-27):** Co-marketing depends on third-party
-> availability and timing. It must not block the release. If outreach has not
-> resulted in commitments by feature-freeze, ship with a pg_trickle-solo blog
-> post and the public `pg-trickle-rag-starter` example repo.
-
-- Co-authored blog post: "PostgreSQL as a Vector Database" with pgvector and
-  pgai maintainers.
-- Case study: real production RAG system (anonymized if needed) using pg_trickle
-  + pgvector + pgai for embedding pipeline, corpus maintenance, and search.
-- Shared benchmark: TPC-H with hybrid search (vector similarity + SQL filters)
-  on pg_trickle stream tables.
-
-Strategic impact: positions pg_trickle as the infrastructure layer for
-incremental AI/RAG on PostgreSQL, raising the profile of the entire PostgreSQL
-ecosystem in the AI niche. Begin pgvector/pgai outreach during v0.38 timeframe.
+The assessment still found very large core files, a large unsafe surface with a
+manual-only inventory workflow, and ambiguity around whether the so-called L0
+cache is merely process-local or should become shared. v0.40.0 continues the
+decomposition of `api/mod.rs`, parser rewrites, and scheduler loop state,
+makes unsafe inventory a real PR gate, and either implements or explicitly
+documents the long-term direction for the L0 cache and event-driven wake.
 
 ---
 
 ## Also in v0.40.0
 
-- Citus multi-database vector aggregation patterns (if v0.34 Citus support available)
-- Research: LLM-generated stream-table definitions (e.g., "create a ST for
-  customer churn prediction from my schema")
+- Secret-scanning workflow coverage for relay/TUI examples and docs
+- Decision records for L0-cache direction and latch-backed wake versus formal
+  deprecation
 
 ---
 
 ## Scope
 
-v0.40.0 is a large release. The `embedding_stream_table()` API is primarily
-syntactic sugar over existing primitives, but the query-generation logic and
-index inference require careful implementation. The k-NN graph work is a
-parallel research spike and does not gate the release. The per-tenant
-patterns are documentation + examples. Co-marketing is best-effort.
+v0.40.0 is a large release because it spans documentation generation,
+monitoring, ecosystem parity, maintainability, and release-confidence tooling.
+It is still part of the hardening programme, not a detour from it: the goal is
+to remove the last major trust and process gaps before the deferred embedding
+programme restarts in v0.41.0.
+
+> **Release-order note:** The old `embedding_stream_table()` and advanced RAG
+> plan is not dropped. It moves to v0.43.0 after the hardening arc in
+> v0.38.0-v0.40.0.
 
 ---
 
-*Previous: [v0.39.0 — Hybrid Search & Sparse Vector Aggregates](v0.39.0.md)*
-*Next: [v1.0.0 — Stable Release](v1.0.0.md-full.md)*
+*Previous: [v0.39.0 — Distributed Hardening & Diagnostic Depth](v0.39.0.md)*
+*Next: [v0.41.0 — Embedding Pipeline Infrastructure & ANN Maintenance](v0.41.0.md)*

--- a/roadmap/v0.40.0.md-full.md
+++ b/roadmap/v0.40.0.md-full.md
@@ -1,17 +1,15 @@
 > **Plain-language companion:** [v0.40.0.md](v0.40.0.md)
 
-## v0.40.0 — Embedding API & Advanced RAG Patterns
+## v0.40.0 — Operator Trust, Maintainability & Release Confidence
 
-**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](plans/ecosystem/PLAN_PGVECTOR.md) §6.4 (VA-1 through VA-5).
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md) §7-§13, plus v1.0-prep security and release-confidence items.
 
 > **Release Theme**
-> v0.40.0 consolidates the pgvector integration programme (v0.37–v0.39) into
-> a production-ready, ergonomic surface layer. The `embedding_stream_table()`
-> API enables one-function RAG corpus setup; materialised k-NN graph research
-> explores fixed-pivot retrieval patterns; per-tenant ANN indexing is
-> documented as a production pattern; and co-marketing with pgvector/pgai
-> positions pg_trickle as the default incremental-view solution for AI on
-> PostgreSQL.
+> v0.40.0 completes the assessment-driven hardening arc by turning operator
+> knowledge into generated references, runbooks, alerts, and CI gates. It also
+> shrinks long-term maintenance risk through unsafe-surface enforcement,
+> continued large-file decomposition, explicit L0-cache truthfulness, and a
+> clear decision on the remaining event-wake direction.
 
 ---
 
@@ -19,256 +17,128 @@
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| VA-1 | `embedding_stream_table()` ergonomic API: one-call RAG corpus setup | L | P1 |
-| VA-2 | Materialised k-NN graph research: explore fixed-pivot retrieval *(parallel research spike — not a release gate)* | L | P3 |
-| VA-3 | Per-tenant ANN indexing patterns: RLS-scoped embedding corpora | M | P2 |
-| VA-4 | Outbox-emitted embedding events for downstream consumption | M | P2 |
-| VA-5 | Joint case study / co-marketing with pgvector and pgai teams *(best-effort, not a release gate)* | — | P1 |
+| O40-1 | Generated GUC and SQL API catalogs plus docs-drift CI | M | P0 |
+| O40-2 | Security model, TRUNCATE semantics, and secret-handling guide | M | P1 |
+| O40-3 | Drain-mode runbook and end-to-end proof | M | P1 |
+| O40-4 | Alert rules, dashboards, and trace-export monitoring pack | M | P1 |
+| O40-5 | TUI, dbt, and relay parity for recent operational surface | M | P2 |
+| O40-6 | Unsafe-inventory PR gate and continued large-file decomposition | L | P1 |
+| O40-7 | L0-cache truthfulness: rename/document or shared-cache implementation decision | M | P2 |
+| O40-8 | Latch-backed wake implementation or formal deprecation path | M | P2 |
+| O40-9 | Secret scanning and v1.0 supply-chain prep | S/M | P2 |
 
-**VA-1 — `embedding_stream_table()` ergonomic API.**
-Add a high-level function that auto-generates the full denormalization query,
-creates the stream table, indexes, and monitoring:
+**O40-1 — Generated GUC and SQL API catalogs plus docs-drift CI.**
+The assessment counted 126 GUC definitions and 132 SQL-facing definitions,
+which is too much public surface for hand-maintained reference docs. Generate
+GUC and SQL API catalogs from source metadata, publish them into the docs, and
+make CI fail if the reference lags the code. This closes the loop opened by the
+v0.38 configuration-doc generation work.
 
-```sql
-SELECT pgtrickle.embedding_stream_table(
-  name                => 'product_search_corpus',
-  source_table        => 'products',
-  embedding_column    => 'embedding',     -- single column name or ARRAY[...]
-  joins               => ARRAY[
-    ('product_tags', 'product_id', 'tag', 'name'),  -- auto-JOIN syntax
-    ('product_metadata', 'product_id', 'metadata')
-  ],
-  aggregates          => ARRAY['category', 'price_bin'],  -- GROUP BY cols
-  filters             => 'active = true AND seller_rating > 4',
-  schedule            => '10 seconds',
-  refresh_mode        => 'DIFFERENTIAL',
-  index_type          => 'hnsw',  -- or 'ivfflat'
-  post_refresh_action => 'reindex_if_drift',
-  reindex_drift_threshold => 0.15,
-  vector_agg          => 'vector_avg',  -- if aggregating over embeddings
-  retention           => '90 days'       -- optional PITR window
-);
-```
+**O40-2 — Security model, TRUNCATE semantics, and secret-handling guide.**
+Document the security contract explicitly: `SECURITY DEFINER` usage,
+`search_path`, RLS expectations, CDC buffer access, and who is expected to own
+or invoke each surface. Add an operator guide for relay/TUI credentials that
+prefers `.pgpass`, libpq service files, or environment-based secrets over shell
+history and world-readable config. Keep TRUNCATE semantics and pause-related
+behavior in the same guide so incident response has a single source of truth.
 
-Under the hood, this constructs:
-```sql
-SELECT
-  p.id, p.name, p.description, p.embedding,
-  array_agg(pt.tag) AS tags,
-  pm.metadata,
-  p.category, p.price_bin
-FROM products p
-LEFT JOIN product_tags pt ON pt.product_id = p.id
-LEFT JOIN product_metadata pm ON pm.product_id = p.id
-WHERE p.active AND p.seller_rating > 4
-GROUP BY p.id, p.category, p.price_bin, pm.metadata
-```
+**O40-3 — Drain-mode runbook and end-to-end proof.**
+Drain mode exists, but the assessment found no focused end-to-end proof of its
+behavior under load. Add a runbook plus tests that start a long refresh, enter
+drain, prove no new cycles are dispatched, wait for in-flight work to finish,
+verify buffer state, and then resume cleanly.
 
-And then:
-1. Creates the stream table with the inferred schema.
-2. Creates an HNSW index on the embedding column.
-3. Creates B-tree or GIN indexes on join-result columns as needed.
-4. Configures post-refresh actions, monitoring, and retention.
-5. Returns a summary JSON: `{created_at, st_name, embedding_dim, approx_rows, index_size_mb}`.
+**O40-4 — Alert rules, dashboards, and trace-export monitoring pack.**
+Metrics are useful only if operators know which thresholds matter. Ship alert
+rules and dashboard coverage for freshness lag, refresh p99, CDC buffer depth,
+slot lag, worker saturation, Citus lease health, and trace export failures.
+Treat these as versioned artifacts rather than as examples hidden in blog posts.
 
-Benefits:
-- 80% of RAG users don't need to write SQL — this covers their use case.
-- Maintains SQL-first flexibility for power users (they use `create_stream_table`
-  directly).
-- Lowers the barrier to entry for AI/ML engineers unfamiliar with PostgreSQL
-  query authoring.
+**O40-5 — TUI, dbt, and relay parity for recent operational surface.**
+Core features added in v0.35-v0.39 need to be visible in the surrounding tools:
+temporal/vector state, drain mode, force-full overrides, backpressure status,
+and safer credential handling. Add release-checklist coverage so new operational
+features do not ship without matching ecosystem visibility.
 
-Required design constraints:
-- **Show generated SQL (P1):** The function must accept a `dry_run => true`
-  parameter that returns the generated `CREATE STREAM TABLE` + `CREATE INDEX`
-  SQL without executing it. This is essential for expert users who want to
-  audit or customise the output.
-- **Index-inference heuristics (P1):** When `index_type` is omitted, document
-  the inference rule explicitly: HNSW is chosen for `vector` and `halfvec`
-  columns; IVFFlat is chosen only when explicitly requested. The heuristic and
-  its rationale must be documented in the function's SQL comment and in
-  `docs/SQL_REFERENCE.md`.
+**O40-6 — Unsafe-inventory PR gate and continued large-file decomposition.**
+Parser and FFI code still carry a large unsafe footprint, and several files are
+still large enough to slow reviews materially. Promote unsafe inventory from a
+manual workflow to a real PR gate for touched paths, and continue extracting
+`api/mod.rs`, parser rewrites, and scheduler loop state into smaller testable
+units.
 
-**VA-2 — Materialised k-NN graph (research spike).**
+**O40-7 — L0-cache truthfulness: rename/document or shared-cache implementation decision.**
+The v0.36 L0 cache is process-local, which is useful but not what many readers
+infer from the name. v0.40.0 either documents and renames the current design so
+pooler users know exactly what they get, or it makes an explicit move toward a
+shared cache design with bounded memory and invalidation semantics.
 
-> **Scope change (assessment 2026-04-27):** VA-2 has been reclassified from a
-> v0.40.0 release item to a **parallel research spike**. The roadmap itself
-> acknowledged it is "likely not production-ready in v0.40.0." Keeping it as
-> a release gate on a Large release with uncertain scope creates risk. Open a
-> dedicated research tracking issue; VA-2 findings may graduate to v0.41.0 or
-> later. T-VA2 is optional/informational in v0.40.0.
+**O40-8 — Latch-backed wake implementation or formal deprecation path.**
+After v0.38 fixed the docs and tests, the remaining question is whether
+event-driven wake should actually exist in background-worker form. v0.40.0 must
+either land a latch-backed implementation with tests and docs or formally
+deprecate the old surface so users stop planning around a feature that will not
+arrive in that shape.
 
-Explore whether pre-computing a k-NN graph can accelerate approximate retrieval
-for fixed query pivots:
-
-- Given a set of N embedding vectors and a set of P pivot vectors, maintain a
-  stream table of `(pivot_id, embedding_id, distance)` tuples representing the
-  k-nearest embeddings to each pivot.
-- Application queries: `SELECT * FROM knn_graph WHERE pivot_id = 42 ORDER BY
-  distance LIMIT 10`.
-
-Research questions:
-- Storage/compute trade-off: is maintaining k·N rows cheaper than an HNSW
-  index scan?
-- Clustering lifecycle: when pivots change, how do we efficiently rebuild the
-  graph?
-- Heterogeneous k: can we keep the k-NN graph up-to-date when k varies per
-  pivot?
-
-Outcome: a research document (`docs/research/MATERIALISED_KNN.md`) and
-optionally a proof-of-concept implementation if the trade-off is favorable.
-Likely not production-ready in v0.40.0; may be promoted to v0.41.0 or later.
-
-**VA-3 — Per-tenant ANN indexing patterns.**
-Document and exemplify the pattern for multi-tenant RAG:
-
-```sql
--- Create a tenant-scoped embedding stream table using RLS (v0.5)
-SELECT pgtrickle.create_stream_table(
-  'tenant_embeddings_scoped',
-  $$
-    SELECT e.id, e.embedding, e.tenant_id, e.chunk_text
-    FROM embeddings e
-    WHERE e.tenant_id = current_setting('app.current_tenant_id')::int
-  $$,
-  rls_context => 'app.current_tenant_id',
-  schedule    => '5 seconds'
-);
-
-CREATE INDEX ON tenant_embeddings_scoped USING hnsw (embedding vector_cosine_ops);
-
--- Application queries automatically filtered by RLS:
-SELECT id FROM tenant_embeddings_scoped
-WHERE embedding <=> $1 < 0.1
-LIMIT 20;
-```
-
-Pattern documentation: `docs/tutorials/MULTI_TENANT_RAG.md`.
-Security audit checklist: verify that RLS policies are correctly applied to
-stream tables, that cross-tenant data never leaks, and that the ST inherits
-permissions from the source table.
-
-**VA-4 — Outbox-emitted embedding events.**
-Extend the outbox (v0.28) to emit embedding-change events:
-
-```sql
-SELECT pgtrickle.create_stream_table(
-  'embedding_changes_outbox',
-  $$
-    SELECT doc_id, old_embedding, new_embedding,
-           'EMBEDDING_UPDATED' AS event_type
-    FROM docs_embedded_audit
-  $$,
-  outbox_name => 'embedding_outbox'
-);
-```
-
-Downstream systems (AI agents, re-rankers, external embedding services) can
-subscribe to the outbox and react to embedding changes. Enables
-event-driven architecture for RAG applications.
-
-**VA-5 — Joint case studies and co-marketing.**
-
-> **Best-effort only (assessment 2026-04-27):** VA-5 depends on third-party
-> coordination (pgvector and pgai team willingness, timing, publishing
-> schedules). It must not be a blocking exit criterion for the v0.40.0 release.
-> If outreach has not resulted in a commitment by feature-freeze, ship with
-> an internal cookbook and a public solo blog post instead.
-
-Partner with pgvector and pgai teams:
-
-- **Blog post:** "PostgreSQL as a Vector Database: pg_trickle + pgvector +
-  pgai" (cross-published on blogs).
-- **Case study:** Real production system (anonymized as needed) maintaining a
-  document-embedding corpus with pg_trickle + pgvector + pgai, serving
-  semantic search + LLM context retrieval.
-- **Benchmark:** TPC-H with hybrid-search queries (vector similarity + SQL
-  filters + BM25 if using pg_search) on pg_trickle stream tables. Measure
-  latency, throughput, and resource consumption.
-- **Repository:** Create a public example repo (`pg-trickle-rag-starter`)
-  with Docker Compose, sample data, and working RAG application code (Python +
-  LangChain / LlamaIndex).
-
-Strategic positioning: pg_trickle is the incremental-maintenance layer for
-AI/RAG on PostgreSQL. Combined with pgvector (indexing) and pgai (embedding
-generation), users get a complete, open-source, self-hosted RAG stack with
-no external vector database.
+**O40-9 — Secret scanning and v1.0 supply-chain prep.**
+SBOMs, signed artifacts, and provenance belong to v1.0, but v0.40.0 can still
+prepare the ground. Add secret-scanning workflows for examples and config, and
+capture the concrete work needed so the v1.0 supply-chain milestone is an
+execution task rather than a discovery task.
 
 ### Test Coverage
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| T-VA1 | Integration test: `embedding_stream_table()` auto-generates correct ST | M | P1 |
-| T-VA2 | k-NN graph proof of concept: verify throughput trade-off | L | P2 |
-| T-VA3 | Multi-tenant security test: RLS policies applied to embedding STs | M | P1 |
-| T-VA4 | Outbox event emission for embedding changes | M | P2 |
+| T-O40-1 | Drain-mode end-to-end workload test | M | P1 |
+| T-O40-2 | Generated reference and docs-drift CI | S | P0 |
+| T-O40-3 | Alert-rule and dashboard smoke coverage | M | P1 |
+| T-O40-4 | Ecosystem parity tests for TUI, dbt, and relay | M | P2 |
+| T-O40-5 | Unsafe-inventory and secret-scanning PR gates | S | P1 |
 
-**T-VA1.**
-`tests/e2e_embedding_api_tests.rs`:
+**T-O40-1.**
+Exercise drain mode under an active workload. The test should show that new
+cycles stop dispatching, in-flight work completes, status output reflects the
+drained state, and resume restores normal scheduling.
 
-1. Call `embedding_stream_table()` with a realistic joins + aggregates spec.
-2. Verify the generated stream table exists with the expected schema.
-3. Verify indexes are created correctly.
-4. Insert new source rows; verify stream table refreshes correctly.
-5. Query the stream table and assert results match the manually-written
-   equivalent `create_stream_table()` with identical query.
+**T-O40-2.**
+Use CI to compare source-discovered GUC and SQL metadata against the generated
+reference docs. This is the cheapest durable control against future drift.
 
-**T-VA2.**
-`tests/e2e_knn_graph_research_tests.rs` (may be optional / research-only):
+**T-O40-3.**
+Smoke-test the shipped alert rules and dashboards against a seeded monitoring
+environment so metric renames or label-contract changes fail loudly.
 
-1. Create embedding stream table with 100k rows.
-2. Define a set of 10 pivot vectors (e.g., cluster centroids).
-3. Maintain a k-NN graph ST listing the 50 nearest embeddings to each pivot.
-4. Measure: row count, index size, refresh latency vs. direct HNSW index.
-5. Benchmark: single-pivot query via k-NN graph vs. direct `LIMIT 50` on HNSW
-   index.
+**T-O40-4.**
+Add lightweight checks that relay, TUI, and dbt examples can surface recent
+operational states such as drain, force-full, and temporal/vector context.
 
-**T-VA3.**
-`tests/e2e_multi_tenant_embedding_tests.rs`:
-
-1. Create two tenant contexts (tenant_id 1 and 2) with separate embedding data.
-2. Create an embedding stream table with RLS policy: `WHERE tenant_id =
-   current_setting('app.current_tenant_id')::int`.
-3. Connect as tenant 1; query stream table; verify only tenant 1's embeddings
-   returned.
-4. Connect as tenant 2; query stream table; verify only tenant 2's embeddings
-   returned.
-5. Verify that an admin can see the full table (or is restricted appropriately
-   per policy).
-
-**T-VA4.**
-`tests/e2e_embedding_outbox_tests.rs`:
-
-1. Create an embedding stream table with `outbox_name` configured.
-2. Insert source rows; verify outbox contains the corresponding embedding
-   records.
-3. Verify downstream subscriber receives the outbox events.
+**T-O40-5.**
+Unsafe-inventory diffs and secret scanning run automatically on pull requests
+that touch sensitive paths or operator-facing examples. The goal is not perfect
+detection; it is to make drift visible before release time.
 
 ### Conflicts & Risks
 
-- **VA-1** (embedding_stream_table API) is syntactic sugar; it hides complexity
-  and may lead to suboptimal queries if users don't understand the generated
-  SQL. Mitigation: `dry_run => true` shows the generated SQL (P1 requirement);
-  index-inference heuristics are documented explicitly.
-- **VA-2** (k-NN graph) is a parallel research spike; it does not block the
-  release. See the scope-change note above.
-- **VA-3** (multi-tenant RLS) must be audited carefully. RLS can be bypassed
-  by a careless admin. Include security best practices in the documentation.
-- **VA-5** (co-marketing) depends on willingness from pgvector/pgai teams.
-  Outreach should begin during v0.38 timeframe. See the best-effort note above.
+- **O40-1/O40-2** must stay source-driven. Manually curating large public
+  inventories is what created the current drift.
+- **O40-4** depends on the surrounding projects staying in sync with core
+  metadata. The release checklist should make this explicit instead of relying
+  on memory.
+- **O40-6/O40-7/O40-8** can all touch sensitive internal surfaces. Treat them
+  as staged refactors or ADR-backed decisions, not as casual cleanup.
 
 ### Exit Criteria
 
-- [ ] VA-1: `embedding_stream_table()` function implemented, generates correct SQL, creates indexes and monitoring
-- [ ] VA-1: `dry_run => true` parameter returns generated SQL without executing it
-- [ ] VA-1: Index-inference heuristic (HNSW default for vector/halfvec; IVFFlat only if explicit) documented in SQL comment and `docs/SQL_REFERENCE.md`
-- [ ] VA-1: Function auto-generates query for 80%+ of common RAG patterns (single source + 2–3 joins + GROUP BY)
-- [ ] VA-1: Calling `embedding_stream_table()` produces identical results to manually-written equivalent
-- [ ] VA-2: Research spike tracking issue opened; `docs/research/MATERIALISED_KNN.md` published with trade-off analysis *(optional: T-VA2 PoC if favorable)*
-- [ ] VA-3: `docs/tutorials/MULTI_TENANT_RAG.md` published with security checklist
-- [ ] VA-3: `tests/e2e_multi_tenant_embedding_tests.rs` passes (RLS policies enforced)
-- [ ] VA-4: Outbox events emitted correctly on embedding stream table inserts
-- [ ] VA-5: *(best-effort)* Blog post published (co-published or pg_trickle solo); `pg-trickle-rag-starter` repo available on GitHub
+- [ ] O40-1: Generated GUC and SQL API catalogs are published and CI fails on docs drift
+- [ ] O40-2: Security model, TRUNCATE semantics, and secret-handling guidance are published and reviewed
+- [ ] O40-3: Drain-mode runbook is published and end-to-end tests prove behavior under load
+- [ ] O40-4: Alert rules and dashboards cover freshness, slot lag, worker saturation, Citus lease health, and trace export failures
+- [ ] O40-5: TUI, dbt, and relay expose the operational surface added in recent releases
+- [ ] O40-6: Unsafe inventory is enforced on relevant PRs and major hot files continue to shrink
+- [ ] O40-7: L0-cache direction is made explicit through implementation or source-of-truth documentation
+- [ ] O40-8: Event wake has either a tested latch-backed implementation or a documented deprecation path
+- [ ] O40-9: Secret scanning runs in CI and the v1.0 supply-chain work is explicitly staged
 - [ ] Extension upgrade path tested (`0.39.0 → 0.40.0`)
 - [ ] `just check-version-sync` passes
 

--- a/roadmap/v0.41.0.md
+++ b/roadmap/v0.41.0.md
@@ -1,0 +1,63 @@
+# v0.41.0 — Embedding Pipeline Infrastructure & ANN Maintenance
+
+> **Full technical details:** [v0.41.0.md-full.md](v0.41.0.md-full.md)
+
+**Status: Planned** | **Scope: Medium**
+
+> After the v0.38.0-v0.40.0 hardening arc, the roadmap resumes the deferred
+> embedding programme with post-refresh actions, drift-based ANN maintenance,
+> vector-aware monitoring, AI/RAG cookbooks, and a bundled `pg_trickle` +
+> `pgvector` + `pgai` developer image.
+
+---
+
+## What is this?
+
+v0.37.0 introduced pgVectorMV. v0.38.0-v0.40.0 then deliberately prioritized
+correctness, operational truthfulness, diagnostics, and platform trust before
+new AI surface area. v0.41.0 picks the embedding roadmap back up once those
+foundations are in place.
+
+---
+
+## Embedding pipeline operational hardening
+
+When a vector stream table refreshes, it often needs follow-up housekeeping:
+statistics refresh, ANN maintenance, or drift-aware reindexing. v0.41.0 adds
+explicit post-refresh actions, per-table drift thresholds, and a
+`pgtrickle.vector_status()` view so operators can see embedding lag, index age,
+and reindex pressure instead of inferring those signals indirectly.
+
+---
+
+## pgvector + pgai integration
+
+This release also adds the documentation and packaging needed for a serious
+self-hosted RAG workflow: a full cookbook for always-fresh embedding pipelines
+and a Docker image variant that bundles `pg_trickle`, `pgvector`, and `pgai`
+for fast experimentation and demos.
+
+---
+
+## Also in v0.41.0
+
+- Citus vector-aggregate cases integrated into the v0.39 distributed test rig
+- Vector-specific options and monitoring integrated into the generated reference
+  docs added during the hardening arc
+
+---
+
+## Scope
+
+v0.41.0 is a medium release. The work is primarily scheduler options,
+monitoring, cookbook material, and packaging, rather than DVM-core changes.
+That is exactly why it belongs after the hardening arc, not before it.
+
+> **Hard prerequisite:** v0.38.0-v0.40.0 must complete their correctness,
+> diagnostics, and operator-trust exit criteria before this embedding work
+> starts.
+
+---
+
+*Previous: [v0.40.0 — Operator Trust, Maintainability & Release Confidence](v0.40.0.md)*
+*Next: [v0.42.0 — Hybrid Search & Sparse Vector Aggregates](v0.42.0.md)*

--- a/roadmap/v0.41.0.md-full.md
+++ b/roadmap/v0.41.0.md-full.md
@@ -1,0 +1,111 @@
+> **Plain-language companion:** [v0.41.0.md](v0.41.0.md)
+
+## v0.41.0 — Embedding Pipeline Infrastructure & ANN Maintenance
+
+**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](plans/ecosystem/PLAN_PGVECTOR.md) §6.2, rescheduled after the assessment-driven hardening arc in [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md).
+
+> **Release Theme**
+> v0.41.0 resumes the deferred embedding programme once the roadmap has closed
+> the immediate correctness and operational gaps. It adds post-refresh action
+> hooks (ANALYZE, REINDEX, drift-based re-clustering), vector-aware monitoring,
+> pgai integration material, and a bundled development image for production
+> embedding pipelines on PostgreSQL.
+
+> **Hard prerequisite:** v0.38.0-v0.40.0 must complete their hardening exit
+> criteria first. The embedding programme is intentionally sequenced after the
+> correctness and operator-trust work, not in parallel with it.
+
+---
+
+### Features
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| VP-1 | `post_refresh_action` ST option (`none` / `analyze` / `reindex` / `reindex_if_drift`) | M | P1 |
+| VP-2 | `reindex_drift_threshold` ST option plus drift counter in catalog | M | P1 |
+| VP-3 | `pgtrickle.vector_status()` view: embedding lag, ANN age, drift % | S | P1 |
+| VP-4 | Cookbook: always-fresh RAG with pg_trickle + pgvector + pgai | S | P2 |
+| VP-5 | Docker image variant: `pg_trickle + pgvector + pgai` | S | P2 |
+| VP-6 | Citus vector-aggregate cases folded into distributed coverage | M | P2 |
+
+**VP-1 — Post-refresh actions.**
+Add a `post_refresh_action` option to vector-heavy stream tables so operators can
+run `ANALYZE`, `REINDEX`, or `reindex_if_drift` after a refresh commits. The
+work runs in a lower-priority queue after the refresh transaction, so it does
+not lengthen the critical refresh window or turn ANN maintenance into hidden
+refresh latency.
+
+**VP-2 — Drift detection.**
+Catalog state tracks `rows_changed_since_last_reindex` and a
+`reindex_drift_threshold`. When a vector table changes enough since its last
+index rebuild, the post-refresh action can queue a targeted REINDEX instead of
+forcing operators to guess when ANN quality has drifted too far.
+
+**VP-3 — Vector status view.**
+Add `pgtrickle.vector_status()` to expose embedding lag, last refresh, last
+reindex time, rows changed since reindex, drift percentage, and vector-aggregate
+usage. This view plugs into the monitoring foundation built in the hardening
+arc and gives RAG operators a first-class place to look for ANN maintenance
+pressure.
+
+**VP-4 — pgai cookbook.**
+Publish `docs/tutorials/PGVECTOR_RAG_COOKBOOK.md` with copy-paste workflows for
+pre-computed embeddings, denormalized corpora, hybrid search, and operational
+sizing guidance. The key outcome is that AI engineers can start with a working
+pattern instead of reverse-engineering examples from tests.
+
+**VP-5 — Docker image.**
+Ship a bundled development image containing `pg_trickle`, `pgvector`, and
+`pgai` so the cookbook and demo workflows run with one command. Keep version
+pinning explicit to avoid silent breakage from upstream minor releases.
+
+**VP-6 — Citus vector-aggregate cases folded into distributed coverage.**
+The v0.39 Citus rig becomes the place where shard-additive vector-aggregate
+behavior is verified. This keeps vector work honest in distributed deployments
+without treating Citus as an afterthought.
+
+### Test Coverage
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| T-VP1 | Drift-based reindex integration test on HNSW stream table | M | P1 |
+| T-VP2 | `vector_status()` accuracy and reset behavior | S | P1 |
+| T-VP3 | Citus shard-additive vector aggregate verification | M | P2 |
+
+**T-VP1.**
+Create a vector stream table with `post_refresh_action = 'reindex_if_drift'`,
+change more than the configured threshold, and verify that REINDEX is queued and
+completed outside the refresh transaction.
+
+**T-VP2.**
+Verify that `pgtrickle.vector_status()` reports lag, drift, and last-reindex
+metadata correctly before and after a drift-triggered REINDEX.
+
+**T-VP3.**
+Run vector-aggregate cases inside the v0.39 Citus rig so shard-local partial
+results still converge to the same answer as a global `avg(vector)` or
+`sum(vector)` computation.
+
+### Conflicts & Risks
+
+- **VP-1/VP-2** add queueable post-refresh work. Backlog visibility must be
+  clear so operators can see if ANN maintenance is lagging behind the refresh
+  pipeline.
+- **VP-3** is observational, but large fleets still need scrape-friendly
+  monitoring rather than expensive ad hoc queries across huge numbers of stream
+  tables.
+- **VP-5** depends on careful dependency pinning; the image should be treated as
+  a reproducible bundle, not a floating latest tag.
+
+### Exit Criteria
+
+- [ ] VP-1: `post_refresh_action` is stored in the catalog and dequeued correctly after refresh commit
+- [ ] VP-2: drift threshold logic increments and resets correctly over repeated refresh cycles
+- [ ] VP-3: `pgtrickle.vector_status()` reports correct lag and drift for vector stream tables
+- [ ] VP-4: RAG cookbook published with multiple worked examples
+- [ ] VP-5: bundled image builds and passes extension smoke tests
+- [ ] VP-6: vector-aggregate cases pass inside the Citus distributed test rig
+- [ ] Extension upgrade path tested (`0.40.0 → 0.41.0`)
+- [ ] `just check-version-sync` passes
+
+---

--- a/roadmap/v0.42.0.md
+++ b/roadmap/v0.42.0.md
@@ -1,0 +1,136 @@
+# v0.42.0 — Hybrid Search & Sparse Vector Aggregates
+
+> **Full technical details:** [v0.42.0.md-full.md](v0.42.0.md-full.md)
+
+**Status: Planned** | **Scope: Medium**
+
+> Sparse and half-precision vector aggregates for storage-tiered embedding
+> pipelines, reactive neighbour-alert subscriptions, hybrid-search corpus
+> patterns, and differential-refresh performance benchmarks for vector
+> workloads.
+
+---
+
+## What is this?
+
+v0.41.0 completes embedding pipeline infrastructure; v0.42.0 completes the
+feature set for production AI/RAG workloads by adding sparse and half-precision
+vector aggregation (for tiered storage), reactive vector-similarity alerts, and
+hybrid-search cookbook patterns with performance benchmarks.
+
+---
+
+## Sparse and half-precision vector aggregates
+
+pgvector 0.7+ ships `halfvec` and `sparsevec` types for storage-efficient
+embeddings. v0.42.0 adds:
+
+- `sparsevec_avg` — element-wise mean over the union of sparse dimensions,
+  treating absent entries as 0. Returns `sparsevec`.
+- `halfvec_avg` — element-wise mean with running state upcast to `vector(d)`;
+  returns `halfvec(d)` on read.
+- `sparsevec_sum` and `halfvec_sum` — for pre-aggregation workflows.
+
+These are algebraically identical to `vector_avg` / `vector_sum` but respect
+the native type on output. A stream table can maintain tiered storage: raw
+`vector(1536)` → `halfvec(1536)` → `sparsevec(1536)` (for binary-quantised
+re-ranking), each layer incrementally maintained and independently indexed.
+
+---
+
+## Reactive vector-similarity subscriptions
+
+Extending reactive subscriptions (v0.35), add support for reactive queries
+over distance predicates:
+
+```sql
+LISTEN fraud_alert;
+
+SELECT pgtrickle.create_reactive_subscription(
+  'fraud_alert',
+  $$
+    SELECT new_txn.id
+    FROM transactions_embedded new_txn
+    JOIN known_fraud_vectors k ON new_txn.embedding <=> k.embedding < 0.05
+  $$
+);
+```
+
+The subscription fires whenever a *new* transaction embedding lands within ε
+of a known-fraud cluster, emitting the transaction ID via `NOTIFY`. Unlike a
+plain SELECT, the subscription is differential: only *newly matched* rows fire,
+no spurious re-emits on every refresh.
+
+---
+
+## Hybrid-search corpus pattern
+
+Combine vector similarity with BM25 full-text search and metadata filters on a
+single flat stream table:
+
+```sql
+-- One-statement denormalised corpus maintenance
+SELECT pgtrickle.create_stream_table(
+  'hybrid_search_corpus',
+  $$
+    SELECT doc.id, doc.title, doc.body, doc.embedding,
+           array_agg(tag.name) AS tags,
+           perm.tenant_id, perm.read_groups
+    FROM documents doc
+    JOIN doc_tags tag ON tag.doc_id = doc.id
+    JOIN doc_permissions perm ON perm.doc_id = doc.id
+    WHERE doc.active
+    GROUP BY doc.id, perm.tenant_id, perm.read_groups
+  $$,
+  refresh_mode => 'DIFFERENTIAL',
+  schedule => '10 seconds'
+);
+
+CREATE INDEX ON hybrid_search_corpus USING hnsw (embedding vector_cosine_ops);
+CREATE INDEX ON hybrid_search_corpus USING gin  (to_tsvector('english', body));
+CREATE INDEX ON hybrid_search_corpus            (tenant_id);
+```
+
+Cookbook: `docs/tutorials/HYBRID_SEARCH_PATTERNS.md`.
+
+---
+
+## Performance benchmarks
+
+Add benchmark suite `benches/pgvector_bench.rs`:
+
+- **Differential refresh + HNSW insert throughput:** measure rows/sec for
+  incremental embedding corpus updates vs. bulk REINDEX.
+- **Vector aggregate reducer cost:** microseconds per element for `vector_avg`
+  vs. plain `sum` reducer.
+- **Drift detection overhead:** per-refresh cost of tracking `rows_changed_since_last_reindex`.
+
+CI integration: publish results to the benchmark dashboard alongside refresh
+latency benchmarks.
+
+---
+
+## Also in v0.42.0
+
+- Any deferred items from v0.41.0 that did not meet the exit criteria
+- Integration tests for hybrid-search corpus under write load (Nexmark-style)
+  with latency baseline established before the 50 ms assertion is written
+
+---
+
+## Scope
+
+v0.42.0 is a medium release at the upper end. The new test files (tiered
+storage, reactive distance, Nexmark hybrid) are substantive integration work,
+and the benchmark suite adds CI infrastructure. If capacity is tight, cookbook
+polish and dashboard integration may slip; the aggregate and reactive-subscribe
+feature work should not.
+
+> **Note:** Reactive distance subscriptions require the underlying v0.35.0
+> reactive subscription implementation to remain fully signed off before this
+> extension work begins.
+
+---
+
+*Previous: [v0.41.0 — Embedding Pipeline Infrastructure & ANN Maintenance](v0.41.0.md)*
+*Next: [v0.43.0 — Embedding API & Advanced RAG Patterns](v0.43.0.md)*

--- a/roadmap/v0.42.0.md-full.md
+++ b/roadmap/v0.42.0.md-full.md
@@ -1,0 +1,93 @@
+> **Plain-language companion:** [v0.42.0.md](v0.42.0.md)
+
+## v0.42.0 — Hybrid Search & Sparse Vector Aggregates
+
+**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](plans/ecosystem/PLAN_PGVECTOR.md) §6.3.
+
+> **Release Theme**
+> v0.42.0 completes the vector-aggregate feature set with sparse and
+> half-precision types, adds reactive vector-similarity subscriptions for
+> real-time anomaly detection, patterns for hybrid-search (BM25 + vector +
+> metadata) stream tables, and comprehensive performance benchmarks for
+> differential vector workloads.
+
+---
+
+### Features
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| VH-1 | `sparsevec_avg`, `sparsevec_sum`, `halfvec_avg`, `halfvec_sum` aggregates | M | P1 |
+| VH-2 | Reactive subscriptions over distance predicates (`embedding <=> q < ε`) | M | P1 |
+| VH-3 | Hybrid-search corpus cookbook: BM25 + vector + metadata on one ST | S | P2 |
+| VH-4 | Benchmark suite: differential refresh + HNSW throughput, aggregate cost | M | P2 |
+
+**VH-1 — Sparse and half-precision aggregates.**
+Extend the algebraic-aggregate framework to support pgvector type variants:
+`sparsevec_avg`, `sparsevec_sum`, `halfvec_avg`, and `halfvec_sum`. The running
+state for `halfvec_avg` is upcast to `vector(d)` for numerical stability; sparse
+variants aggregate over the union of dimensions while treating absent entries as
+zero.
+
+**VH-2 — Reactive distance subscriptions.**
+Extend reactive subscriptions to support distance-predicate queries where the
+query vector is bound at subscription-creation time. The subscription fires only
+when rows newly satisfy or cease to satisfy the predicate, avoiding spurious
+re-emits on every refresh.
+
+**VH-3 — Hybrid-search cookbook.**
+Publish `docs/tutorials/HYBRID_SEARCH_PATTERNS.md` with flat denormalised
+corpora, RLS-scoped corpora, tiered search patterns, and performance-tuning
+notes. The goal is a copy-paste path to BM25 + vector + metadata retrieval on
+incrementally maintained tables.
+
+**VH-4 — Vector benchmark suite.**
+Add `benches/pgvector_bench.rs` to measure differential refresh plus ANN insert
+throughput, vector aggregate reducer cost, drift-detection overhead, and storage
+savings across `vector`, `halfvec`, and `sparsevec` representations.
+
+### Test Coverage
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| T-VH1 | Integration test: tiered storage (`vector` → `halfvec` → `sparsevec`) | M | P1 |
+| T-VH2 | Reactive distance subscriptions: new anomaly alerts | M | P1 |
+| T-VH3 | Hybrid-search corpus under write load | M | P2 |
+
+**T-VH1.**
+Build a multi-layer stream-table stack and verify all layers refresh correctly
+when the source changes. Check both aggregate correctness and ANN query
+consistency up to expected quantisation loss.
+
+**T-VH2.**
+Create a reactive distance subscription, insert and update rows around a chosen
+similarity threshold, and assert that notifications fire only when predicate
+truth changes.
+
+**T-VH3.**
+Run a hybrid-search corpus under sustained write load, record refresh lag and
+query latency, and only write hard latency assertions once the CI baseline is
+measured on the actual runner hardware.
+
+### Conflicts & Risks
+
+- **VH-1** needs careful handling of dimension mismatches and all-zero sparse
+  vectors. The result definition must be explicit and heavily tested.
+- **VH-2** depends on reactive subscription correctness remaining solid after
+  the hardening arc; do not layer distance semantics on top of a shaky base.
+- **VH-4** should publish measured baselines, not aspirational numbers.
+
+### Exit Criteria
+
+- [ ] VH-1: sparse and half-precision aggregates are implemented and pass equivalence tests against non-incremental computation
+- [ ] VH-1: `halfvec_avg` precision is characterized and kept within an explicit error contract
+- [ ] VH-2: reactive distance subscriptions fire only on predicate-truth changes
+- [ ] VH-3: hybrid-search cookbook published with worked examples
+- [ ] VH-4: benchmark suite runs in CI and publishes results alongside other performance data
+- [ ] T-VH1: tiered-storage integration tests pass
+- [ ] T-VH2: reactive distance tests pass
+- [ ] T-VH3: hybrid-search corpus tests pass with baseline-derived assertions
+- [ ] Extension upgrade path tested (`0.41.0 → 0.42.0`)
+- [ ] `just check-version-sync` passes
+
+---

--- a/roadmap/v0.43.0.md
+++ b/roadmap/v0.43.0.md
@@ -1,0 +1,58 @@
+# v0.43.0 — Embedding API & Advanced RAG Patterns
+
+> **Full technical details:** [v0.43.0.md-full.md](v0.43.0.md-full.md)
+
+**Status: Planned** | **Scope: Large**
+
+> Ergonomic `embedding_stream_table()` API for one-statement RAG corpus setup,
+> materialised k-NN graph research for fixed-pivot retrieval, per-tenant ANN
+> indexing patterns, outbox-emitted embedding events, and ecosystem positioning
+> for the post-hardening AI stack.
+
+---
+
+## What is this?
+
+v0.41.0-v0.42.0 build the production embedding primitives and hybrid-search
+coverage. v0.43.0 consolidates that work into a higher-level ergonomic surface:
+an API that sets up common RAG corpus patterns in one call, documentation for
+multi-tenant ANN deployments, downstream embedding events, and a research spike
+for materialised k-NN graphs.
+
+---
+
+## `embedding_stream_table()` ergonomic API
+
+Today, users still write the full denormalization query by hand. v0.43.0 adds a
+higher-level helper that can generate the query, create the stream table,
+provision indexes, configure post-refresh actions, and return a dry-run preview
+for expert users who want to inspect the generated SQL first.
+
+---
+
+## Advanced RAG patterns
+
+This release also documents multi-tenant ANN patterns, explores materialised
+k-NN graphs as a parallel research spike, and extends the outbox so embedding
+changes can feed downstream agents, rerankers, or external services.
+
+---
+
+## Also in v0.43.0
+
+- Public starter repository and examples for the post-hardening AI stack
+- Best-effort ecosystem positioning with pgvector / pgai partners, but never as
+  a release gate
+
+---
+
+## Scope
+
+v0.43.0 is a large release because the ergonomic API hides real query-shape and
+indexing complexity. The k-NN graph work remains research unless the trade-off
+looks decisively favorable; the release should not block on speculative work.
+
+---
+
+*Previous: [v0.42.0 — Hybrid Search & Sparse Vector Aggregates](v0.42.0.md)*
+*Next: [v1.0.0 — Stable Release](v1.0.0.md-full.md)*

--- a/roadmap/v0.43.0.md-full.md
+++ b/roadmap/v0.43.0.md-full.md
@@ -1,0 +1,101 @@
+> **Plain-language companion:** [v0.43.0.md](v0.43.0.md)
+
+## v0.43.0 — Embedding API & Advanced RAG Patterns
+
+**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](plans/ecosystem/PLAN_PGVECTOR.md) §6.4, rescheduled after the assessment-driven hardening arc.
+
+> **Release Theme**
+> v0.43.0 turns the embedding infrastructure built in v0.41.0-v0.42.0 into a
+> higher-level ergonomic surface. The `embedding_stream_table()` API enables
+> one-call RAG corpus setup; materialised k-NN graph work remains a parallel
+> research spike; per-tenant ANN patterns and outbox-emitted embedding events
+> complete the application-facing story.
+
+---
+
+### Features
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| VA-1 | `embedding_stream_table()` ergonomic API: one-call RAG corpus setup | L | P1 |
+| VA-2 | Materialised k-NN graph research spike for fixed-pivot retrieval | L | P3 |
+| VA-3 | Per-tenant ANN indexing patterns: RLS-scoped embedding corpora | M | P2 |
+| VA-4 | Outbox-emitted embedding events for downstream consumption | M | P2 |
+| VA-5 | Starter repo and ecosystem positioning *(best-effort, not a release gate)* | S | P2 |
+
+**VA-1 — `embedding_stream_table()` ergonomic API.**
+Add a high-level function that auto-generates the denormalization query,
+creates the stream table, provisions indexes, configures post-refresh actions,
+and returns a dry-run preview when requested. The API should cover the common
+single-source-plus-joins RAG patterns without taking SQL control away from
+power users.
+
+**VA-2 — Materialised k-NN graph research spike.**
+Explore whether pre-computing neighbour relationships for fixed pivot vectors is
+worth the storage and maintenance overhead relative to ANN index scans. This is
+research, not a release gate: the deliverable is a real trade-off analysis and,
+optionally, a proof of concept if the numbers look promising.
+
+**VA-3 — Per-tenant ANN indexing patterns.**
+Document and example the production pattern for multi-tenant RAG using RLS and
+tenant-scoped vector corpora. The emphasis is on safe defaults and explicit
+security review, not just on query examples.
+
+**VA-4 — Outbox-emitted embedding events.**
+Extend the outbox surface so embedding changes can be emitted as downstream
+application events. This lets external agents or search services react to
+embedding churn without polling.
+
+**VA-5 — Starter repo and ecosystem positioning.**
+Provide a public starter repository and best-effort ecosystem material that show
+how pg_trickle fits alongside pgvector and pgai after the hardening arc. This is
+useful, but it must never block the release.
+
+### Test Coverage
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| T-VA1 | Integration test: `embedding_stream_table()` generates correct stream tables | M | P1 |
+| T-VA2 | Research benchmark: k-NN graph trade-off measurement | L | P2 |
+| T-VA3 | Multi-tenant security test for ANN stream tables | M | P1 |
+| T-VA4 | Outbox event emission for embedding changes | M | P2 |
+
+**T-VA1.**
+Call `embedding_stream_table()` with a realistic joins-and-aggregates spec,
+verify the generated stream table and indexes, and compare results with the
+manually written equivalent definition.
+
+**T-VA2.**
+If the k-NN research spike includes code, benchmark pivot-neighbour queries
+against direct ANN index scans so the trade-off is evidence-based.
+
+**T-VA3.**
+Verify that tenant-scoped ANN stream tables respect RLS policies and do not leak
+cross-tenant embeddings.
+
+**T-VA4.**
+Create an embedding-aware outbox stream and verify downstream subscribers see
+correctly structured events when embeddings change.
+
+### Conflicts & Risks
+
+- **VA-1** hides real query complexity. `dry_run => true` and explicit index
+  heuristics are essential so expert users can audit the generated surface.
+- **VA-2** is intentionally non-blocking research. Keep it from turning into an
+  unbounded scope sink for a release that already includes a large ergonomic API.
+- **VA-3** must be reviewed with the security model documented in the hardening
+  arc; RLS examples are only useful if their trust boundaries are explicit.
+
+### Exit Criteria
+
+- [ ] VA-1: `embedding_stream_table()` generates correct SQL, indexes, and monitoring configuration
+- [ ] VA-1: `dry_run => true` returns the generated SQL without side effects
+- [ ] VA-1: documented index-inference heuristics exist for vector and halfvec cases
+- [ ] VA-2: research findings for materialised k-NN graphs are published; implementation remains optional
+- [ ] VA-3: multi-tenant ANN documentation and security tests are complete
+- [ ] VA-4: embedding outbox events emit and validate correctly
+- [ ] VA-5: starter repo or equivalent public examples are available
+- [ ] Extension upgrade path tested (`0.42.0 → 0.43.0`)
+- [ ] `just check-version-sync` passes
+
+---

--- a/roadmap/v1.0.0.md-full.md
+++ b/roadmap/v1.0.0.md-full.md
@@ -4,7 +4,8 @@
 
 **Goal:** First officially supported release. Semantic versioning locks in.
 API, catalog schema, and GUC names are considered stable. Focus is
-distribution — getting pg_trickle onto package registries — and PostgreSQL 19
+distribution and trust: getting pg_trickle onto package registries, shipping
+signed artifacts and SBOMs with provenance, and proving PostgreSQL 19
 forward-compatibility.
 
 ### PostgreSQL 19 Forward-Compatibility (A3)
@@ -47,9 +48,11 @@ forward-compatibility.
 | SAST-SEMGREP | **Elevate Semgrep to blocking in CI.** CodeQL and cargo-deny already block; Semgrep is advisory-only. Flip to blocking for consistent safety gating. Before flipping, verify zero findings across all current rules. | 1–2h | [PLAN_SAST.md](plans/testing/PLAN_SAST.md) |
 | OTL-1 | **OpenTelemetry tracing spans.** Add `pgtrickle.refresh`, `pgtrickle.cdc_capture`, and `pgtrickle.snapshot` spans via the OTel SDK so every pg_trickle operation is visible to OTel collectors. Minimum viable: trace_id propagation through the refresh pipeline; attribute set = `stream_table`, `refresh_mode`, `rows_processed`. | 4–8h | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.6 |
 | SIGN-1 | **Cosign-sign GHCR release images.** Add `cosign sign` step to the GitHub Actions release workflow for `grove/pg-trickle`, `grove/pgtrickle-relay`, and `pg_trickle-ext` GHCR images. Attach Rekor transparency log entry. Document `cosign verify` command in `SECURITY.md`. | 2–4h | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.11 |
+| SIGN-2 | **Publish SBOMs for extension and release artifacts.** Generate CycloneDX or SPDX SBOMs for the extension tarball, relay binary, and release images; attach them to GitHub releases and document how operators verify them. | 2–4h | [PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md) §10 |
+| SIGN-3 | **Attach provenance attestations to release workflows.** Emit SLSA-style provenance or equivalent signed attestations for published binaries and images so operators can verify how each artifact was built. | 2–4h | [PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md) §10 |
 | MDB-1 | **Promote G17-MDB multi-database soak test to `ci.yml`.** The `stability-tests.yml` G17-MDB job runs multi-database scenarios in isolation. Move it to `ci.yml` under the "Push to main" trigger alongside the existing soak test. Gate it on a 30-min wall-clock budget for PR CI; use the full 2-hour run on schedule. | 2–3h | [PLAN_OVERALL_ASSESSMENT_3.md](plans/PLAN_OVERALL_ASSESSMENT_3.md) §9.10 |
 
-> **v1.0.0 total: ~42–78 hours** (incl. PG 19 compat ~18–36h + release engineering ~18–30h + OTel/cosign/MDB ~8–12h)
+> **v1.0.0 total: ~46–86 hours** (incl. PG 19 compat ~18–36h + release engineering ~18–30h + OTel/signing/SBOM/provenance/MDB ~12–20h)
 
 **Exit criteria:**
 - [ ] A3: PG 19 builds and passes full E2E suite
@@ -62,6 +65,8 @@ forward-compatibility.
 - [ ] SAST-SEMGREP: Semgrep elevated to blocking in CI; zero findings verified
 - [ ] OTL-1: OTel refresh/CDC/snapshot spans emitted; visible in Jaeger test run
 - [ ] SIGN-1: All GHCR release images cosign-signed; `cosign verify grove/pg-trickle:1.0.0` passes
+- [ ] SIGN-2: SBOMs are published for release tarballs, relay, and release images
+- [ ] SIGN-3: Provenance attestations are published and verification is documented
 - [ ] MDB-1: G17-MDB soak test runs in `ci.yml` on push to main; green
 - [ ] Upgrade path from v0.30.0 tested
 - [ ] Semantic versioning policy in effect


### PR DESCRIPTION
## Summary

Adds `plans/PLAN_OVERALL_ASSESSMENT_8.md`, a repository-wide v0.37.0 assessment that compares the current tree against the prior overall assessments and repo memory. The report focuses on correctness, durability, performance, testing, docs, security, and operational readiness, with special attention to fixed-vs-open-vs-new findings.

## Changes

- Documents improvements since v7, including snapshot subtransactions, scheduler/merge modularization, Q15 allowlisting, inbox/outbox helper tests, upgrade completeness gating, pgvector tests, and trace context integration tests.
- Calls out high-priority remaining gaps such as EC-01 join phantom rows, unwired SQLSTATE classification, advertised-but-unwired WAL backpressure, event-driven wake false confidence, and missing Citus chaos coverage.
- Adds prioritized action plan, risk register, current repo metrics, CI/test inventory, and verification tasks for maintainers.

## Testing

- `git diff --cached --check` - passed before commit.
- No build or runtime test suite run; this is a documentation-only assessment report.

## Notes

- Only `plans/PLAN_OVERALL_ASSESSMENT_8.md` is included in the commit.
- Existing untracked local log files were left untouched.