### PR TITLE
feat(roadmap): EC-01 hard gate — dedicated correctness sprint for v0.38.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -83,8 +83,8 @@
 | [v0.35.0](roadmap/v0.35.0.md) | EC-01 correctness closeout, Citus chaos hardening, reactive subscriptions, zero-downtime schema changes | Released | Large | [Full details](roadmap/v0.35.0.md-full.md) |
 | [v0.36.0](roadmap/v0.36.0.md) | Structural hardening, L0 cache, WAL backpressure, temporal IVM, columnar storage | ✅ Released | Large | [Full details](roadmap/v0.36.0.md-full.md) |
 | [v0.37.0](roadmap/v0.37.0.md) | Scheduler & merge modularisation, pgVectorMV (vector_avg/sum), OpenTelemetry trace propagation | Released | Medium | [Full details](roadmap/v0.37.0.md-full.md) |
-| [v0.38.0](roadmap/v0.38.0.md) | Correctness closeout and operational truthfulness: EC-01, RowIdSchema planning, backpressure wiring, wake/docs fixes | Planned | Large | [Full details](roadmap/v0.38.0.md-full.md) |
-| [v0.39.0](roadmap/v0.39.0.md) | Distributed hardening and performance diagnostics: Citus chaos rig, durable CDC hold, TPC-H explain artifacts, fuzzing | Planned | Large | [Full details](roadmap/v0.39.0.md-full.md) |
+| [v0.38.0](roadmap/v0.38.0.md) | EC-01 Correctness Sprint (Hard Gate): join phantom rows, property-test convergence proof — BLOCKING release gate | Planned | Medium | [Full details](roadmap/v0.38.0.md-full.md) |
+| [v0.39.0](roadmap/v0.39.0.md) | Operational Truthfulness & Distributed Hardening: backpressure/wake fix, generated docs, Citus chaos, SQLSTATE rollout, diagnostics | Planned | Large | [Full details](roadmap/v0.39.0.md-full.md) |
 | [v0.40.0](roadmap/v0.40.0.md) | Operator trust and maintainability: generated references, alerting, drain-mode proof, secret hygiene, unsafe gating | Planned | Large | [Full details](roadmap/v0.40.0.md-full.md) |
 | [v0.41.0](roadmap/v0.41.0.md) | Embedding pipeline infrastructure: post-refresh hooks, drift-based reindex, vector monitoring | Planned | Medium | [Full details](roadmap/v0.41.0.md-full.md) |
 | [v0.42.0](roadmap/v0.42.0.md) | Sparse & half-precision vector aggregates, reactive distance subscriptions, hybrid-search benchmarks | Planned | Medium | [Full details](roadmap/v0.42.0.md-full.md) |
@@ -166,17 +166,28 @@ partially open or insufficiently proven. v0.36.0 and v0.37.0 still delivered
 substantial structural gains: L0 cache construction, temporal IVM,
 `RowIdSchema`, scheduler and merge splits, pgVectorMV, and OpenTelemetry trace
 capture. The next three releases now form a hardening programme rather than an
-immediate feature expansion. v0.38.0 closes the highest-risk correctness and
-truthfulness gaps (EC-01 mitigation, planner-enforced row-id compatibility,
-backpressure wiring or deprecation, wake/docs repair, SQLSTATE rollout, trace
-integration proof, and generated configuration docs). v0.39.0 extends that
-with distributed and diagnostic coverage: Citus chaos testing, durable CDC hold
-semantics, per-query TPC-H explain artifacts, SQLancer light PR mode, targeted
-fuzzing, and inbox/outbox reliability tests. v0.40.0 then focuses on operator
-trust and maintainability: generated SQL/GUC references, drain-mode proof,
-monitoring/alert rules, security-model and secret-handling docs, upgrade-gate
-coverage, unsafe-inventory PR gating, and continued decomposition of the
-largest files. Only after that hardening arc does the roadmap resume the
-embedding programme in v0.41.0-v0.43.0, preserving the pgvector work while
+immediate feature expansion.
+
+**v0.38.0 is a dedicated EC-01 correctness sprint with a hard release gate:**
+This release will NOT ship until join phantom rows are proven closed with a
+comprehensive DIFF-vs-FULL property test suite covering Q07/Q15-style joins.
+EC-01 has been labeled critical since v0.20.0 (6+ releases) and deferred multiple
+times; v0.38.0 breaks that pattern by making EC-01 closure the sole release
+objective. No other features, no operational docs, no SQLSTATE rollout — just the
+join phantom-row fix and its proof.
+
+**v0.39.0 absorbs the operational truthfulness items** that were originally planned
+for v0.38.0: backpressure hysteresis or deprecation, wake-truthfulness repair,
+generated configuration and upgrade docs, OpenTelemetry collector proof, SQLSTATE
+rollout on hot paths, and the full distributed/diagnostic coverage (Citus chaos
+testing, durable CDC hold semantics, per-query TPC-H explain artifacts, SQLancer
+light PR mode, targeted fuzzing, and inbox/outbox reliability tests).
+
+**v0.40.0** then focuses on operator trust and maintainability: generated SQL/GUC
+references, drain-mode proof, monitoring/alert rules, security-model and
+secret-handling docs, upgrade-gate coverage, unsafe-inventory PR gating, and
+continued decomposition of the largest files. Only after that hardening arc does
+the roadmap resume the embedding programme in v0.41.0-v0.43.0, preserving the
+pgvector work while
 aligning the release order with the assessment's conclusion that closing
 correctness and operational gaps matters more than adding new surface area.

--- a/roadmap/v0.38.0.md
+++ b/roadmap/v0.38.0.md
@@ -1,77 +1,84 @@
-# v0.38.0 — Correctness Closeout & Operational Truthfulness
+# v0.38.0 — EC-01 Correctness Sprint (Hard Gate)
 
 > **Full technical details:** [v0.38.0.md-full.md](v0.38.0.md-full.md)
 
-**Status: Planned** | **Scope: Large**
+**Status: Planned** | **Scope: Medium** | **Release Gate: EC-01 property convergence proof (BLOCKING)**
 
-> Close the highest-risk gaps from the v0.37.0 overall assessment before more
-> feature surface is added: EC-01 join phantoms, planner-enforced row-id
-> safety, backpressure truthfulness, wake/docs repair, SQLSTATE-based retry
-> classification, and source-driven configuration and upgrade docs.
+> **v0.38.0 will NOT ship until EC-01 (join phantom rows) is proven closed** with
+> a comprehensive DIFF-vs-FULL property test suite covering Q07/Q15-style joins.
+> This is a dedicated correctness sprint with a single focus: make join deltas
+> always-deduplicated and prove convergence.
 
 ---
 
 ## What is this?
 
-v0.36.0 and v0.37.0 delivered important structural work, but the assessment
-showed too many partially wired or poorly documented behaviors still sitting
-between users and a trustworthy 1.0. v0.38.0 is the first release in a
-hardening programme. It makes existing guarantees correct, documented, and
-measurable before the roadmap resumes the deferred embedding-focused work.
+EC-01 has been labeled "critical" since v0.20.0 (6+ releases) but keeps sliding.
+**v0.38.0 stops the deferral pattern.** This release is explicitly scoped to
+close EC-01 and nothing else. There are no other features, no operational docs,
+no SQLSTATE rollout — just the join phantom rows fix and its proof.
+
+The release is gated: v0.38.0 will be tagged only when:
+1. Join deltas unconditionally return `is_deduplicated: true` (or are cleaned
+   by unconditional PH-D1) for all join shapes
+2. A property generator runs thousands of random insert/update/delete sequences
+   and proves DIFF result set == FULL result set for every cycle
+3. Q07 and Q15 no longer need to be in the skip allowlist
+4. All prior phantom-row accumulation is resolved
 
 ---
 
-## Silent wrong-result and durability hardening
+## EC-01 Correctness: The Lead (and Only) Item
 
-The lead item is EC-01: non-deduplicated join outputs must stop silently
-accumulating phantom rows. v0.38.0 makes PH-D1 cleanup unconditional where
-needed, wires `RowIdSchema` verification into the DVM planner, and proves
-DIFF-vs-FULL convergence with targeted property tests over Q07/Q15-style
-co-delete and scalar-subquery cases.
+**H38-1 — Unconditional PH-D1 cleanup plus join row-id convergence (P0, L effort).**
 
-The same release also resolves the most dangerous control-plane truth gap in
-the current tree: `pg_trickle.enforce_backpressure` and related pause behavior
-must either be wired with explicit hysteresis and documented semantics or be
-demoted so operators are not misled into believing source writes are protected
-when they are not.
+Join deltas still return `is_deduplicated: false`, allowing phantom rows to
+accumulate across cycles. v0.38.0 fixes this by:
 
----
+1. Making PH-D1 cleanup unconditional for all non-deduplicated join outputs
+2. Reworking the join row-id formula so Part 1a, Part 1b, and Part 2 converge
+   on the same logical identity across pre/post images
+3. Wiring `RowIdSchema` verification into the DVM planner so incompatible
+   pipelines fail at plan time, not at result time
 
-## Operational truthfulness and documentation repair
-
-`event_driven_wake` is currently documented and tested as if the background
-worker can `LISTEN`, but the code forces poll-only mode. v0.38.0 corrects the
-docs, rewrites the wake test so poll-only mode cannot masquerade as event
-delivery, and tracks a latch-based wake path separately instead of promising
-what PostgreSQL cannot do in a background worker.
-
-This release also regenerates `docs/CONFIGURATION.md` from source metadata,
-updates `docs/UPGRADING.md` through v0.37.0, documents trace/vector GUCs and
-TRUNCATE/CDC pause semantics, and adds a live OpenTelemetry collector test plus
-operator guide so trace propagation is proven, not just partially wired.
+**Verification:** DIFF-vs-FULL equivalence test, not just absence of obvious
+duplicates. After every refresh cycle, the result set must be byte-identical to
+a full refresh.
 
 ---
 
-## Also in v0.38.0
+## Test Coverage: EC-01 Property Generator (Blocking Gate)
 
-- SQLSTATE-first SPI retry classification rollout on scheduler, refresh, and
-  catalog paths
-- `history_prune_interval_seconds` wired into scheduler cleanup or removed from
-  the public surface
-- Deferred pg_partman / TimescaleDB integration coverage from v0.37.0 if still
-  outstanding
+**T-H38-1 — EC-01 DIFF-vs-FULL property generator for joins (P0, L effort).**
+
+Add a dedicated property generator that:
+- Runs thousands of random insert/update/delete sequences
+- Covers left/right co-deletes, scalar-subquery joins, Q07/Q15-inspired shapes
+- After every cycle, compares DIFF result set against FULL result set
+- Fails the release if any row-set divergence is detected
+
+This test must pass with 100% success rate before v0.38.0 is tagged.
 
 ---
 
-## Scope
+## What's NOT in v0.38.0
 
-v0.38.0 is a large release because it touches the DVM core, error handling,
-scheduler documentation, test strategy, and public operator docs. The work is
-deliberately biased toward correctness and truthfulness rather than new product
-surface, matching the conclusion of `PLAN_OVERALL_ASSESSMENT_8.md`.
+Operational truthfulness, backpressure semantics, wake docs, SQLSTATE rollout,
+generated configuration, and all other items from the previous v0.38.0 plan have
+moved to **v0.39.0** so this release can maintain singular focus on EC-01.
+
+**Why?** Correctness is the foundation. Operational polish without correctness
+is just prettier wrong answers.
+
+---
+
+## Release Confidence
 
 > **Release-order note:** The old embedding-pipeline v0.38.0 plan is not being
-> dropped. It moves to v0.41.0 after the hardening arc in v0.38.0-v0.40.0.
+> dropped. It moves to v0.41.0+ after the hardening arc in v0.38.0-v0.40.0.
+>
+> **Deferral protection:** If EC-01 is not closed when v0.38.0 window closes,
+> the release is postponed, not the feature. No more "EC-01 will ship next time".
 
 ---
 

--- a/roadmap/v0.38.0.md-full.md
+++ b/roadmap/v0.38.0.md-full.md
@@ -1,123 +1,124 @@
 > **Plain-language companion:** [v0.38.0.md](v0.38.0.md)
 
-## v0.38.0 — Correctness Closeout & Operational Truthfulness
+## v0.38.0 — EC-01 Correctness Sprint (Hard Gate)
 
-**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md) §4-§13; action items A01-A08, A10, A12, and A16.
+**Status: Planned.** This is a focused release with a single objective: close EC-01 (join phantom rows) with a hard release gate. Derived from [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md) §4.1 (Finding C1).
 
 > **Release Theme**
-> v0.38.0 is the first release in a hardening programme triggered by the
-> overall assessment. It closes the highest-risk correctness and truthfulness
-> gaps before more feature surface is added: EC-01 join convergence,
-> planner-enforced `RowIdSchema`, truthful backpressure and wake behavior,
-> SQLSTATE-based retry classification, generated configuration and upgrade
-> docs, and live OpenTelemetry collector proof.
+> v0.38.0 will NOT be tagged until EC-01 is proven closed. This release breaks
+> the deferral pattern that has carried EC-01 through 6+ releases (v0.20–v0.37).
+> The only feature in v0.38.0 is unconditional PH-D1 cleanup plus join row-id
+> convergence, verified by a comprehensive DIFF-vs-FULL property test. All
+> operational truthfulness, docs, and ecosystem work moves to v0.39.0.
+>
+> **Release Gate:** EC-01 property convergence test must pass with 100% success
+> before v0.38.0 is tagged. If EC-01 is not closed when the v0.38.0 window
+> closes, the release is postponed—not the feature.
 
 ---
 
-### Features
+### Features (EC-01 Only)
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| H38-1 | Unconditional PH-D1 cleanup plus join row-id convergence | L | P0 |
-| H38-2 | Plan-time `RowIdSchema` verification in DVM planner | M | P0 |
-| H38-3 | Truthful backpressure semantics with hysteresis or explicit deprecation | M | P0 |
-| H38-4 | SQLSTATE-first SPI retry classification rollout | M | P1 |
-| H38-5 | Wake truthfulness: docs, warnings, and test repair | S | P0 |
-| H38-6 | Generated `CONFIGURATION.md` plus corrected v0.37 operator docs | M | P0 |
-| H38-7 | `UPGRADING.md` through v0.37 and explicit TRUNCATE/CDC semantics | S | P1 |
-| H38-8 | OpenTelemetry operator guide and live collector proof | M | P1 |
-| H38-9 | `history_prune_interval_seconds` wired or removed | XS | P1 |
-| H38-10 | Deferred pg_partman / TimescaleDB ecosystem coverage from v0.37 | M | P2 |
+| C38-1 | Unconditional PH-D1 cleanup plus join row-id convergence | L | P0 |
+| C38-2 | Plan-time `RowIdSchema` verification in DVM planner | M | P0 |
 
-**H38-1 — Unconditional PH-D1 cleanup plus join row-id convergence.**
-The assessment confirmed that join deltas still return `is_deduplicated: false`
-and that Q07/Q15-style workloads can accumulate phantom rows. v0.38.0 makes
-PH-D1 cleanup unconditional for non-deduplicated join outputs while the root
-fix lands, then reworks the join row-id formula so Part 1a, Part 1b, and Part 2
-converge on the same logical identity across pre/post images. Verification is
-DIFF-vs-FULL equivalence, not just absence of obvious duplicates.
+**C38-1 — Unconditional PH-D1 cleanup plus join row-id convergence.**
 
-**H38-2 — Plan-time `RowIdSchema` verification in DVM planner.**
-`RowIdSchema` exists in v0.36.0, but the verifier is effectively dormant unless
-tests call it. Carry the schema through `DiffResult` and enforce compatibility
-at plan time so incompatible pipelines either fail creation or explicitly force
-FULL refresh. This turns row-id design into a guardrail rather than a comment.
+Join deltas currently return `is_deduplicated: false` for all joins, allowing
+phantom rows to accumulate silently across refresh cycles. This fix has two
+parts:
 
-**H38-3 — Truthful backpressure semantics with hysteresis or explicit deprecation.**
-`pg_trickle.enforce_backpressure` currently looks operator-ready without an
-actual control path that suppresses or redirects writes safely. v0.38.0 either
-wires it into a real stateful path with hysteresis and observable status, or it
-demotes the GUC as experimental until the durable hold mode lands in v0.39.0.
-The release must also document the current `cdc_paused` discard semantics so
-operators know whether changes are captured, deferred, or dropped.
+1. **Make PH-D1 cleanup unconditional.** For all non-deduplicated join outputs,
+   apply phantom-row cleanup after each refresh without condition checks on
+   join shape, prior residuals, or refresh count. This stops new phantoms from
+   accumulating while the root fix lands.
 
-**H38-4 — SQLSTATE-first SPI retry classification rollout.**
-The SQLSTATE classifier exists, but hot paths still classify retryability from
-English message text. Introduce a single helper that constructs
-`PgTrickleError::SpiErrorCode` from SPI failures on scheduler, refresh, and
-catalog paths so retry behavior is locale-independent and stable across message
-wording changes.
+2. **Rework the join row-id formula.** The current formula diverges between:
+   - **Part 1a** (left INSERT new, join with current right): uses right row-id
+     from R₁
+   - **Part 1b** (left DELETE old, join with pre-change right): uses right row-id
+     from R₀
+   - **Part 2** (pre-change left, join with RIGHT delta): mixed semantics
 
-**H38-5 — Wake truthfulness: docs, warnings, and test repair.**
-`event_driven_wake` cannot rely on `LISTEN` in a PostgreSQL background worker,
-yet docs and tests still imply low-latency event delivery. v0.38.0 makes the
-warning path explicit, rewrites the wake test so poll-only behavior cannot pass
-as event-driven, and documents a future latch-based wake path as separate work
-rather than as an implied current guarantee.
+   When the right side has deleted rows, Part 1a and Part 1b produce different
+   row_ids for the same logical join result, breaking weight aggregation.
+   v0.38.0 redesigns the formula so all three parts converge on the same logical
+   identity, making join outputs truly deduplicated or ensuring PH-D1 cleanup
+   catches all phantoms.
 
-**H38-6 — Generated `CONFIGURATION.md` plus corrected v0.37 operator docs.**
-Configuration docs must be generated from source metadata so defaults and new
-GUCs stop drifting. The generated reference covers all known GUCs, corrects the
-`event_driven_wake` default and behavior, includes the v0.37 vector/trace GUCs,
-and aligns `docs/SCALING.md` and `docs/TROUBLESHOOTING.md` with the real code.
+3. **Wire `RowIdSchema` verification.** The schema exists in v0.36.0 but is
+   mostly dormant. Carry it through `DiffResult`, check compatibility at plan
+   time, and either prove join is safe or explicitly force FULL refresh. This
+   turns row-id design into a guardrail.
 
-**H38-7 — `UPGRADING.md` through v0.37 and explicit TRUNCATE/CDC semantics.**
-`docs/UPGRADING.md` stops at v0.34 even though the codebase is at v0.37. Add
-v0.34 -> v0.35, v0.35 -> v0.36, and v0.36 -> v0.37 guidance, then document how
-TRUNCATE, CDC pause, and FULL invalidation behave so operators are not left to
-infer semantics from trigger code.
+**Acceptance criteria:**
+- Join deltas either return `is_deduplicated: true` or are unconditionally cleaned
+  by PH-D1
+- Q07 and Q15 are no longer in `IMMEDIATE_SKIP_ALLOWLIST`
+- No phantom accumulation across 100 random-mutation cycles
 
-**H38-8 — OpenTelemetry operator guide and live collector proof.**
-Trace context capture exists, but the roadmap must include proof that spans can
-be exported to a live collector without surprising failure behavior. Add an
-operator guide for OTLP/Jaeger/Tempo configuration plus a dockerized collector
-test that verifies success, timeout, and endpoint-failure handling.
+**C38-2 — Plan-time `RowIdSchema` verification in DVM planner.**
 
-**H38-9 — `history_prune_interval_seconds` wired or removed.**
-The GUC exists but the scheduler still uses a hard-coded 24-hour cleanup loop.
-v0.38.0 either makes the scheduler honor the GUC or removes the public setting
-and documents daily cleanup as the intentional behavior.
+`RowIdSchema` exists as a type but the verifier is mostly dormant. This task
+enforces schema compatibility at plan time so incompatible joins either fail
+creation with a clear error or explicitly route to FULL refresh. The check must
+be inexpensive and clear so users understand why a join requires FULL mode if it
+does.
 
-**H38-10 — Deferred pg_partman / TimescaleDB ecosystem coverage from v0.37.**
-The v0.37 roadmap already allowed pg_partman and TimescaleDB integration tests
-to slip if the structural work consumed capacity. If they are still open when
-v0.38.0 begins, land them here rather than carrying silent gaps into the next
-cycle.
-
-### Test Coverage
+### Test Coverage (EC-01 Only)
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| T-H38-1 | EC-01 DIFF-vs-FULL property generator for joins | L | P0 |
-| T-H38-2 | Backpressure and wake truthfulness E2E coverage | M | P0 |
-| T-H38-3 | Live OpenTelemetry collector integration test | M | P1 |
-| T-H38-4 | Docs drift and upgrade-reference CI checks | S | P1 |
-| T-H38-5 | Deferred pg_partman / TimescaleDB ecosystem tests | M | P2 |
+| T-C38-1 | EC-01 DIFF-vs-FULL property generator for joins | L | P0 |
 
-**T-H38-1.**
-Add a dedicated property generator that runs thousands of random insert/update/
-delete sequences over join-heavy workloads, including left/right co-deletes,
-scalar-subquery joins, and Q07/Q15-inspired shapes. After every cycle, compare
-DIFF against FULL and fail on any row-set divergence.
+**T-C38-1 — EC-01 DIFF-vs-FULL property generator (Release Gate).**
 
-**T-H38-2.**
-The wake test must assert a bound below the poll interval or explicitly assert
-poll-only warning behavior until latch-based wake exists. Backpressure tests
-must create synthetic slot-lag conditions, validate hysteresis, and verify the
-operator-visible state matches whether writes are captured, held, or discarded.
+Create a dedicated test harness that:
 
-**T-H38-3.**
-Run an integration test against a dockerized OTEL Collector or Jaeger instance.
+1. **Generates random DML sequences**: insert/update/delete in random order and
+   timing over tables participating in multi-table joins.
+
+2. **Covers EC-01 failure modes:**
+   - Left/right co-deletes (the case where R₀ ≠ R₁)
+   - Scalar-subquery joins (where the subquery result can shift)
+   - Q07-style 5-table joins
+   - Q15-style derived-table + subquery-in-WHERE shapes
+
+3. **After every refresh cycle:** Compare DIFF result set byte-for-byte against
+   FULL result set. If any divergence is found, the test FAILS and the release
+   is blocked.
+
+4. **Scale to confidence:** Run at least 1000–10,000 cycles per join shape,
+   randomizing left/right table order, join key types (int/uuid/composite),
+   and DML timing.
+
+5. **Report clearly:** If divergence is found, output the exact row_id values,
+   action counts (INSERT/DELETE), aggregated weights, and the FULL-vs-DIFF
+   row_id/value pairs that differ.
+
+**This test must pass 100% before v0.38.0 is tagged.**
+
+### What's NOT in v0.38.0
+
+- Operational truthfulness (backpressure, wake, docs) — moves to v0.39.0
+- SQLSTATE-first retry classification rollout — moves to v0.39.0
+- Generated `CONFIGURATION.md` — moves to v0.39.0
+- `UPGRADING.md` through v0.37 — moves to v0.39.0
+- OpenTelemetry operator guide — moves to v0.39.0
+- pg_partman / TimescaleDB ecosystem coverage — moves to v0.40.0 or later
+- `history_prune_interval_seconds` wiring — moves to v0.40.0
+
+### Release Confidence & Deferral Protection
+
+> **Why no other features?** Correctness is the foundation. Adding operational
+> polish or new features without first closing EC-01 repeats the last 6 releases
+> of deferral.
+>
+> **Deferral Protection:** If EC-01 is still not closed when the v0.38.0 window
+> approaches completion, the release is POSTPONED. No more "EC-01 will ship next
+> time." The release date is flexible; EC-01 closure is not.
 Verify that a refresh span is exported when enabled, that timeouts do not wedge
 the refresh path, and that collector failures degrade predictably.
 

--- a/roadmap/v0.39.0.md
+++ b/roadmap/v0.39.0.md
@@ -1,23 +1,25 @@
-# v0.39.0 — Distributed Hardening & Diagnostic Depth
+# v0.39.0 — Operational Truthfulness & Distributed Hardening
 
 > **Full technical details:** [v0.39.0.md-full.md](v0.39.0.md-full.md)
 
 **Status: Planned** | **Scope: Large**
 
-> Extend the v0.38 hardening sprint into distributed proof and deep
-> diagnostics: Citus chaos coverage, durable CDC hold semantics, generated SQL
-> and explain artifacts, SQLancer light PR mode, targeted fuzzing, and
-> inbox/outbox reliability tests.
+> Fix the operational lies in the current tree (backpressure, wake, docs) and
+> prove distributed behavior under chaos: backpressure hysteresis, wake
+> truthfulness, generated configuration, explicit CDC hold semantics, Citus
+> chaos coverage, upgrade docs through v0.37, SQLSTATE-first retry logic,
+> generated SQL/explain artifacts, and deep diagnostic depth.
 
 ---
 
 ## What is this?
 
-v0.38.0 makes the single-node correctness story honest. v0.39.0 makes the
-distributed and operational story believable. It adds the failure injection,
-artifacts, and fast gates needed to explain why DIFFERENTIAL refresh succeeds,
-falls back, or collapses under scale instead of forcing maintainers to debug
-those cases manually after merge.
+v0.38.0 closes EC-01 and proves join correctness. v0.39.0 makes the operational
+and distributed story honest. It fixes misleading docs and partially-wired
+features (`event_driven_wake`, `enforce_backpressure`), proves behavior under
+failure injection and scale, and adds the diagnostics needed to explain why
+DIFFERENTIAL refresh succeeds, falls back, or collapses instead of leaving
+maintainers to debug those cases manually after merge.
 
 ---
 

--- a/roadmap/v0.39.0.md-full.md
+++ b/roadmap/v0.39.0.md-full.md
@@ -1,15 +1,17 @@
 > **Plain-language companion:** [v0.39.0.md](v0.39.0.md)
 
-## v0.39.0 — Distributed Hardening & Diagnostic Depth
+## v0.39.0 — Operational Truthfulness & Distributed Hardening
 
-**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md) §4-§13; action items A06, A09, A11, A14, and A15, plus the diagnostic opportunities in §12.
+**Status: Planned.** Derived from [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md) §4-§13; action items A02-A08, A10, A12-A15.
 
 > **Release Theme**
-> v0.39.0 takes the hardening work from local correctness into distributed
-> proof and deep diagnostics. It adds the missing Citus chaos rig, explicit
-> durable hold semantics for CDC pressure events, richer generated-SQL and
-> explain artifacts, SQLancer light gating on pull requests, targeted fuzzing,
-> and true reliability-contract coverage for inbox/outbox flows.
+> v0.38.0 closes EC-01 and proves join correctness. v0.39.0 makes the operational
+> and distributed story honest. It fixes misleading docs (backpressure, wake),
+> wires partially-implemented features (`enforce_backpressure`, `event_driven_wake`),
+> adds generated configuration and upgrade docs, proves behavior under failure
+> injection and scale (Citus chaos, CDC hold semantics), and adds richer
+> diagnostics to explain why DIFFERENTIAL refresh succeeds, falls back, or
+> collapses instead of leaving maintainers to debug manually after merge.
 
 ---
 
@@ -17,23 +19,79 @@
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| D39-1 | Citus coordinator/worker E2E and chaos harness | L | P0 |
-| D39-2 | Durable capture-and-hold vs discard-and-reinit semantics | M | P0 |
-| D39-3 | Generated-SQL artifact API and richer `explain_stream_table()` visualizer | M | P1 |
-| D39-4 | TPC-H per-query `EXPLAIN` artifacts and p99/temp-spill regression gate | M | P1 |
-| D39-5 | SQLancer light PR mode for DIFF-vs-FULL oracle coverage | M | P1 |
-| D39-6 | WAL decoder, merge SQL, DAG, and snapshot fuzz expansion | M/L | P1 |
-| D39-7 | Inbox/outbox reliability helpers plus property-test coverage | M | P1 |
-| D39-8 | PR-scoped upgrade E2E slice for SQL-facing changes | M | P2 |
+| O39-1 | Truthful backpressure semantics with hysteresis or explicit deprecation | M | P0 |
+| O39-2 | Wake truthfulness: docs, warnings, and test repair | S | P0 |
+| O39-3 | Generated `CONFIGURATION.md` plus corrected operator docs | M | P0 |
+| O39-4 | `UPGRADING.md` through v0.37 and explicit TRUNCATE/CDC semantics | S | P0 |
+| O39-5 | OpenTelemetry operator guide and live collector proof | M | P1 |
+| O39-6 | SQLSTATE-first SPI retry classification rollout | M | P1 |
+| O39-7 | Citus coordinator/worker E2E and chaos harness | L | P1 |
+| O39-8 | Durable capture-and-hold vs discard-and-reinit semantics | M | P1 |
+| O39-9 | Generated-SQL artifact API and richer `explain_stream_table()` visualizer | M | P1 |
+| O39-10 | TPC-H per-query `EXPLAIN` artifacts and p99/temp-spill regression gate | M | P1 |
+| O39-11 | SQLancer light PR mode for DIFF-vs-FULL oracle coverage | M | P2 |
+| O39-12 | WAL decoder, merge SQL, DAG, and snapshot fuzz expansion | M/L | P2 |
+| O39-13 | Inbox/outbox reliability helpers plus property-test coverage | M | P2 |
+| O39-14 | PR-scoped upgrade E2E slice for SQL-facing changes | M | P2 |
 
-**D39-1 — Citus coordinator/worker E2E and chaos harness.**
-The assessment found a significant Citus surface with no real topology or
-chaos coverage. v0.39.0 adds a coordinator-plus-workers rig that verifies lease
+**O39-1 — Truthful backpressure semantics with hysteresis or explicit deprecation.**
+
+`pg_trickle.enforce_backpressure` currently looks operator-ready without an
+actual control path that suppresses or redirects writes safely. v0.39.0 either
+wires it into a real stateful path with explicit hysteresis and observable
+status (capture-and-hold mode keeps durable CDC while pausing refreshes), or
+demotes the GUC as experimental/reserved until the durable hold mode is
+properly designed. Either way, document the current `cdc_paused` discard
+semantics so operators know whether changes are captured, deferred, or dropped,
+and make the active mode visible in status output.
+
+**O39-2 — Wake truthfulness: docs, warnings, and test repair.**
+
+`event_driven_wake` cannot rely on `LISTEN` in a PostgreSQL background worker,
+yet docs and tests still imply low-latency event delivery. v0.39.0 makes the
+warning path explicit, rewrites the wake test so poll-only behavior cannot pass
+as event-driven, and documents a future latch-based wake path as separate work
+rather than as an implied current guarantee.
+
+**O39-3 — Generated `CONFIGURATION.md` plus corrected operator docs.**
+
+Configuration docs must be generated from source metadata so defaults and new
+GUCs stop drifting. The generated reference covers all known GUCs, corrects the
+`event_driven_wake` default and behavior, includes the v0.37 vector/trace GUCs,
+and aligns `docs/SCALING.md` and `docs/TROUBLESHOOTING.md` with the real code.
+
+**O39-4 — `UPGRADING.md` through v0.37 and explicit TRUNCATE/CDC semantics.**
+
+`docs/UPGRADING.md` stops at v0.34 even though the codebase is at v0.37. Add
+v0.34 → v0.35, v0.35 → v0.36, and v0.36 → v0.37 guidance, then document how
+TRUNCATE, CDC pause, and FULL invalidation behave so operators are not left to
+infer semantics from trigger code.
+
+**O39-5 — OpenTelemetry operator guide and live collector proof.**
+
+Trace context capture exists, but the roadmap must include proof that spans can
+be exported to a live collector without surprising failure behavior. Add an
+operator guide for OTLP/Jaeger/Tempo configuration plus a dockerized collector
+test that verifies success, timeout, and endpoint-failure handling.
+
+**O39-6 — SQLSTATE-first SPI retry classification rollout.**
+
+The SQLSTATE classifier exists, but hot paths still classify retryability from
+English message text. Introduce a single helper that constructs
+`PgTrickleError::SpiErrorCode` from SPI failures on scheduler, refresh, and
+catalog paths so retry behavior is locale-independent and stable across message
+wording changes.
+
+**O39-7 — Citus coordinator/worker E2E and chaos harness.**
+
+The assessment found a significant Citus surface with no real topology or chaos
+coverage. v0.39.0 adds a coordinator-plus-workers rig that verifies lease
 acquisition, worker death and restart, coordinator restart mid-lease, shard
 rebalance churn, and stale `pgt_worker_slots` cleanup. Distributed correctness
 stops being an assumption and becomes a tested contract.
 
-**D39-2 — Durable capture-and-hold vs discard-and-reinit semantics.**
+**O39-8 — Durable capture-and-hold vs discard-and-reinit semantics.**
+
 The current `cdc_paused` behavior is too easy to misread as a harmless throttle
 when it can actually drop change capture. Split the operator surface into an
 explicit capture-and-hold mode that keeps durable CDC while pausing refreshes,
@@ -41,7 +99,8 @@ and a separate discard-and-reinitialize mode for emergencies. The active mode
 must be visible in status output so operators know which stream tables require
 catch-up or reinit.
 
-**D39-3 — Generated-SQL artifact API and richer `explain_stream_table()` visualizer.**
+**O39-9 — Generated-SQL artifact API and richer `explain_stream_table()` visualizer.**
+
 Maintainers need to see why a stream table is DIFF-safe, why it fell back to
 FULL, which operators are row-id sensitive, and which generated SQL fragments
 exist for the current definition. Extend `explain_stream_table()` or add a
@@ -49,32 +108,37 @@ dedicated generated-SQL artifact API that exposes operator-tree summary, SQL
 hashes, fallback reasons, and phase-level SQL snippets without turning on broad
 debug logging.
 
-**D39-4 — TPC-H per-query `EXPLAIN` artifacts and p99/temp-spill regression gate.**
+**O39-10 — TPC-H per-query `EXPLAIN` artifacts and p99/temp-spill regression gate.**
+
 Aggregate benchmark dashboards are not enough for Q04/Q05/Q07/Q08/Q09/Q20/Q22
 style collapse queries. v0.39.0 records generated SQL hashes, `EXPLAIN
 ANALYZE BUFFERS`, temp blocks, phase timings, and measured p50/p99 so CI can
 track query-shape regressions instead of only overall throughput. The gate must
 be baseline-driven, not hard-coded from wishful numbers.
 
-**D39-5 — SQLancer light PR mode for DIFF-vs-FULL oracle coverage.**
+**O39-11 — SQLancer light PR mode for DIFF-vs-FULL oracle coverage.**
+
 Weekly SQLancer runs are valuable but too slow to protect every PR. Add a small
 oracle mode to PR CI that exercises a measured subset of SQLancer-generated
 workloads and compares DIFF against FULL so obvious query-engine regressions are
 caught before merge.
 
-**D39-6 — WAL decoder, merge SQL, DAG, and snapshot fuzz expansion.**
+**O39-12 — WAL decoder, merge SQL, DAG, and snapshot fuzz expansion.**
+
 Current fuzzing is concentrated in parser/config helpers. Expand it into the
 state machines and code generators most likely to fail under adversarial input:
 logical decoding payloads, merge-template inputs, DAG graph mutations, and
 snapshot/restore identifier and column-list generation.
 
-**D39-7 — Inbox/outbox reliability helpers plus property-test coverage.**
+**O39-13 — Inbox/outbox reliability helpers plus property-test coverage.**
+
 Inbox/outbox helper tests exist, but they do not prove the actual delivery
 contract. Extract pure helpers for envelope encoding/decoding, dedup-key
 validation, lease math, offset transitions, replay behavior, and NULL payload
 handling, then cover them with property tests in addition to end-to-end flows.
 
-**D39-8 — PR-scoped upgrade E2E slice for SQL-facing changes.**
+**O39-14 — PR-scoped upgrade E2E slice for SQL-facing changes.**
+
 Full upgrade E2E is currently daily/manual only. Add a smaller PR matrix that
 triggers when SQL scripts, `src/config.rs`, `src/cdc.rs`, or SQL-facing API
 files change so upgrade regressions are more likely to fail before merge.
@@ -83,60 +147,82 @@ files change so upgrade regressions are more likely to fail before merge.
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| T-D39-1 | Citus chaos suite with worker and coordinator failure injection | L | P0 |
-| T-D39-2 | Durable hold vs discard semantics E2E | M | P0 |
-| T-D39-3 | SQLancer light PR gate | M | P1 |
-| T-D39-4 | TPC-H artifact and p99/temp-spill regression workflow | M | P1 |
-| T-D39-5 | Inbox/outbox reliability property suite | M | P1 |
+| T-O39-1 | Citus chaos suite with worker and coordinator failure injection | L | P0 |
+| T-O39-2 | Durable hold vs discard semantics E2E | M | P0 |
+| T-O39-3 | Backpressure and wake truthfulness E2E coverage | M | P0 |
+| T-O39-4 | SQLancer light PR gate | M | P1 |
+| T-O39-5 | TPC-H artifact and p99/temp-spill regression workflow | M | P1 |
+| T-O39-6 | Inbox/outbox reliability property suite | M | P1 |
+| T-O39-7 | Live OpenTelemetry collector integration test | M | P1 |
+| T-O39-8 | Docs drift and upgrade-reference CI checks | S | P1 |
 
-**T-D39-1.**
+**T-O39-1.**
 Create a topology-aware test harness with at least one coordinator and two
 workers. Kill workers mid-refresh, restart the coordinator during lease
 ownership, trigger rebalance churn, and verify the system neither loses change
 capture nor duplicates refresh ownership.
 
-**T-D39-2.**
-Exercise both control-plane modes introduced by D39-2. In capture-and-hold
-mode, writes continue to be captured while refreshes stop; in discard mode,
-status output and docs must clearly mark the need for reinitialization.
+**T-O39-2.**
+Exercise both control-plane modes (capture-and-hold vs discard). In
+capture-and-hold mode, writes continue to be captured while refreshes stop; in
+discard mode, status output and docs must clearly mark the need for
+reinitialization.
 
-**T-D39-3.**
+**T-O39-3.**
+The wake test must assert a bound below the poll interval or explicitly assert
+poll-only warning behavior. Backpressure tests must create synthetic slot-lag
+conditions, validate hysteresis, and verify the operator-visible state matches
+whether writes are captured, held, or discarded.
+
+**T-O39-4.**
 Run a bounded SQLancer subset on PRs and compare DIFF vs FULL outputs. Keep the
 runtime small enough for PR CI, but publish seed values and failing queries so
 maintainers can reproduce any divergence quickly.
 
-**T-D39-4.**
+**T-O39-5.**
 Publish per-query TPC-H artifacts for collapse-prone workloads, including SQL
 hash, `EXPLAIN`, temp blocks, and measured p99. Use baselines captured from the
 target CI hardware instead of invented thresholds.
 
-**T-D39-5.**
+**T-O39-6.**
 Property tests verify envelope round-trips, dedup semantics, lease arithmetic,
 offset transitions, and replay rules. Keep end-to-end tests for transactional
 integration, but move the contract itself into fast deterministic coverage.
 
+**T-O39-7.**
+Run an integration test against a dockerized OTEL Collector or Jaeger instance.
+
+**T-O39-8.**
+Check for docs drift and confirm upgrade references are current for all versions
+since v0.34.
+
 ### Conflicts & Risks
 
-- **D39-1** requires substantial test infrastructure, but the assessment makes
-  it clear this is no longer optional if Citus support is to remain a roadmap
-  claim.
-- **D39-2** can increase retained change-buffer volume if operators hold for
-  too long. The feature needs clear status visibility, limits, and runbook
-  guidance rather than a hidden background state.
-- **D39-3/D39-4/D39-5** must use measured budgets. Diagnostic gates help only if
-  they are reliable enough not to be immediately disabled.
+- **O39-1** and **O39-7** require substantial test infrastructure, but the
+  assessment makes it clear this is no longer optional if Citus and distributed
+  support are to remain roadmap claims.
+- **O39-2** and **O39-8** can increase retained change-buffer volume if operators
+  hold for too long. The feature needs clear status visibility, limits, and
+  runbook guidance rather than a hidden background state.
+- **O39-3/O39-4/O39-5** must use measured budgets. Operational docs only help if
+  they match the actual code, and diagnostic gates only help if they are reliable
+  enough not to be immediately disabled.
 
 ### Exit Criteria
 
-- [ ] D39-1: Citus topology and chaos tests pass for lease acquisition, worker death/restart, coordinator restart, and rebalance churn
-- [ ] D39-2: Capture-and-hold and discard-and-reinit semantics are both implemented, documented, and visible through status APIs
-- [ ] D39-3: Generated-SQL artifact export and explain visualizer expose DIFF/FULL reasoning without broad debug logging
-- [ ] D39-4: TPC-H artifact workflow records SQL hash, `EXPLAIN`, temp blocks, and measured p99 for collapse-prone queries
-- [ ] D39-5: SQLancer light PR mode runs on pull requests and publishes reproducible seeds for failures
-- [ ] D39-6: New fuzz targets exist for WAL decoding, merge SQL, DAG mutation, and snapshot column-list generation
-- [ ] D39-7: Inbox/outbox reliability contract is covered by property tests in addition to end-to-end scenarios
-- [ ] D39-8: SQL-facing PRs trigger a smaller upgrade E2E matrix instead of relying only on daily/manual jobs
+- [ ] O39-1: Truthful backpressure semantics or explicit deprecation; `cdc_paused` semantics documented
+- [ ] O39-2: Wake truthfulness corrected; test updated; poll-only warning present
+- [ ] O39-3: `CONFIGURATION.md` is auto-generated from source; includes all GUCs; defaults correct
+- [ ] O39-4: `UPGRADING.md` covers v0.34–v0.37; TRUNCATE/CDC semantics explicit
+- [ ] O39-5: OpenTelemetry operator guide and live collector test; propagation proven
+- [ ] O39-6: SQLSTATE-first retry classification on scheduler, refresh, and catalog paths
+- [ ] O39-7: Citus topology and chaos tests pass for lease acquisition, worker death/restart, coordinator restart, and rebalance churn
+- [ ] O39-8: Capture-and-hold and discard-and-reinit semantics are implemented and visible through status APIs
+- [ ] O39-9: Generated-SQL artifact export and explain visualizer expose DIFF/FULL reasoning without broad debug logging
+- [ ] O39-10: TPC-H artifact workflow records SQL hash, `EXPLAIN`, temp blocks, and measured p99 for collapse-prone queries
+- [ ] O39-11: SQLancer light PR mode runs on pull requests and publishes reproducible seeds for failures
+- [ ] O39-12: New fuzz targets exist for WAL decoding, merge SQL, DAG mutation, and snapshot column-list generation
+- [ ] O39-13: Inbox/outbox reliability contract covered by property tests
+- [ ] O39-14: SQL-facing PRs trigger a smaller upgrade E2E matrix
 - [ ] Extension upgrade path tested (`0.38.0 → 0.39.0`)
 - [ ] `just check-version-sync` passes
-
----


### PR DESCRIPTION
## Summary

Restructure v0.38.0 and v0.39.0 roadmaps to implement **Option A: Hard Gate** for EC-01 (join phantom rows). EC-01 has been labeled "critical" since v0.20.0 (6+ releases) but deferred multiple times. v0.38.0 now becomes a dedicated correctness sprint with a release-blocking gate: **v0.38.0 will NOT ship until EC-01 is proven closed** by a comprehensive DIFF-vs-FULL property test suite.

All operational truthfulness work (backpressure, wake, docs, SQLSTATE) moves to v0.39.0 so v0.38 can maintain singular focus.

## Changes

- **v0.38.0** — EC-01 Correctness Sprint (Hard Gate)
  - Singular objective: close join phantom rows + property-test convergence proof
  - 2 features: unconditional PH-D1 cleanup + row-id convergence, plan-time RowIdSchema verification
  - 1 test: EC-01 DIFF-vs-FULL property generator (1000s random cycles, multiple join shapes)
  - Release blocker: property test must pass 100% before tag
  - Scope reduced from Large to Medium

- **v0.39.0** — Operational Truthfulness & Distributed Hardening  
  - Absorbs all operational items from old v0.38.0 plan
  - 14 features: backpressure hysteresis/deprecation, wake truthfulness, generated CONFIGURATION.md, upgrade docs, OpenTelemetry, SQLSTATE rollout, Citus chaos, CDC hold semantics, TPC-H explain artifacts, SQLancer light, fuzzing expansion, inbox/outbox reliability, PR-scoped upgrade E2E
  - 8 test suites covering chaos, semantics, docs drift, diagnostics
  - Scope maintained at Large

- **Deferral Protection Language**
  > If EC-01 is still not closed when the v0.38.0 window approaches completion, the release is POSTPONED. No more "EC-01 will ship next time." The release date is flexible; EC-01 closure is not.

## Files Modified

- `ROADMAP.md` — updated narrative and v0.38/v0.39 table entries
- `roadmap/v0.38.0.md` — rewritten as hard-gate EC-01 sprint
- `roadmap/v0.38.0.md-full.md` — detailed spec with release-gate criteria
- `roadmap/v0.39.0.md` — retitled and expanded scope
- `roadmap/v0.39.0.md-full.md` — merged 14 features + 8 tests + exit criteria

## Testing

- No new code or tests affected; documentation-only changes
- Validated markdown formatting and internal links via `git diff --check`
- Commits staged and pushed to `feat/roadmap-restructuring-v0.38-v0.39`

## Notes

**Why Option A (Hard Gate)?**
- Credibility: "Critical" now has teeth. If EC-01 doesn't close, v0.38.0 doesn't ship.
- Focus: v0.38.0 stays singular; no feature creep or scope drift.
- Protection: Explicit deferral rule prevents EC-01 from sliding again.

**Timeline Impact:**
- v0.38.0 ships when EC-01 is done, not on a calendar date.
- Calendar dates are flexible; correctness closure is not.

**Related Issues:**
- Assessment finding C1 (plans/PLAN_OVERALL_ASSESSMENT_8.md §4.1): EC-01 join phantom rows remain critical
- Repository memory: /memories/repo/join-delta-phantom-rows.md documents Q07/Q15 phantom behavior, row-id divergence, and current code state
