### PR TITLE
test(outbox): fix IMMEDIATE-mode test to verify rejection

### DIFF
--- a/tests/e2e_outbox_tests.rs
+++ b/tests/e2e_outbox_tests.rs
@@ -676,16 +676,15 @@ async fn test_outbox_written_after_manual_full_refresh() {
     );
 }
 
-/// Gap-1 regression: outbox must be written after a manual IMMEDIATE-mode refresh.
-/// IMMEDIATE mode delegates to `execute_manual_full_refresh`, so the same fix
-/// must reach it.
+/// OUTBOX-1e: `enable_outbox()` on an IMMEDIATE-mode stream table must return
+/// `OutboxRequiresNotImmediateMode`.  IMMEDIATE refreshes fire inside every
+/// source transaction; the design explicitly rejects the outbox for this mode
+/// to avoid adding an INSERT on every application write.
 #[tokio::test]
-async fn test_outbox_written_after_manual_immediate_refresh() {
+async fn test_enable_outbox_rejected_for_immediate_mode() {
     let db = E2eDb::new().await.with_extension().await;
 
     db.execute("CREATE TABLE gap1_imm_src (id INT PRIMARY KEY, val TEXT)")
-        .await;
-    db.execute("INSERT INTO gap1_imm_src VALUES (1, 'x'), (2, 'y')")
         .await;
     db.create_st(
         "gap1_imm_st",
@@ -694,26 +693,19 @@ async fn test_outbox_written_after_manual_immediate_refresh() {
         "IMMEDIATE",
     )
     .await;
-    db.execute("SELECT pgtrickle.enable_outbox('gap1_imm_st')")
-        .await;
 
-    let outbox_name: String = db
-        .query_scalar(
-            "SELECT outbox_table_name FROM pgtrickle.pgt_outbox_config \
-             WHERE stream_table_name = 'gap1_imm_st'",
-        )
-        .await;
-
-    db.execute("INSERT INTO gap1_imm_src VALUES (3, 'z')").await;
-    db.refresh_st("gap1_imm_st").await;
-
-    let count: i64 = db
-        .query_scalar(&format!("SELECT count(*) FROM pgtrickle.\"{outbox_name}\""))
+    let result = db
+        .try_execute("SELECT pgtrickle.enable_outbox('gap1_imm_st')")
         .await;
     assert!(
-        count >= 1,
-        "outbox must contain at least one row after a manual IMMEDIATE refresh \
-         (Gap-1 regression test)"
+        result.is_err(),
+        "enable_outbox on an IMMEDIATE-mode stream table should fail"
+    );
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("outbox requires deferred refresh mode"),
+        "expected OutboxRequiresNotImmediateMode error, got: {}",
+        err
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes the E2E test failure in CI run [#1961](https://github.com/grove/pg-trickle/actions/runs/25039017739).

`test_outbox_written_after_manual_immediate_refresh` (added in commit 683a074) called `enable_outbox()` on an `IMMEDIATE`-mode stream table and then asserted that the outbox had been written. This can never succeed: `enable_outbox_impl` explicitly returns `OutboxRequiresNotImmediateMode` for any `IMMEDIATE`-mode table — a documented design decision (adding an outbox INSERT on every source-transaction write is unacceptable overhead for IMMEDIATE mode).

The test is renamed and rewritten as `test_enable_outbox_rejected_for_immediate_mode`, which verifies the correct rejection behaviour by:
1. Creating an `IMMEDIATE`-mode stream table.
2. Calling `enable_outbox()` via `try_execute` (returns `Result` instead of panicking).
3. Asserting the call returns an error whose message contains `"outbox requires deferred refresh mode"`.

## Changes

- `tests/e2e_outbox_tests.rs`: replace `test_outbox_written_after_manual_immediate_refresh` with `test_enable_outbox_rejected_for_immediate_mode`.

## Testing

- `just fmt && just lint` — passes with zero warnings.
- The renamed test will pass in both Light E2E and Full E2E (it only needs the extension loaded, no special docker image).

## Notes

The underlying code path that the old test tried to reach (`execute_manual_full_refresh` writing to the outbox) is already covered by the adjacent `test_outbox_written_after_manual_full_refresh` test. No production code changes are needed.
