### PR TITLE
fix(pgvector): CDC trigger vector type compatibility and HNSW dimension fix

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1818,6 +1818,45 @@ fn validate_and_parse_query(
     })
 }
 
+/// F4: Post-fix vector aggregate output column types to include explicit
+/// dimensions (e.g. `vector` → `vector(3)`).
+///
+/// `avg(embedding)` where `embedding` is `vector(3)` returns type `vector`
+/// (undimensioned) at the PostgreSQL query-analysis level. HNSW / IVFFlat
+/// indexes require the column to have an explicit dimension. This function
+/// looks up each VectorAvg/VectorSum output column's source column typmod and
+/// runs `ALTER TABLE … ALTER COLUMN … TYPE vector(N)` when the dimension is
+/// known.
+fn fix_vector_aggregate_column_types(
+    schema: &str,
+    table_name: &str,
+    tree: &crate::dvm::parser::OpTree,
+) -> Result<(), PgTrickleError> {
+    let dims = crate::dvm::extract_vector_agg_output_dims(tree);
+    for (col_alias, typmod) in dims {
+        if typmod <= 0 {
+            continue;
+        }
+        // Look up the pgvector type name to build the correct type expression.
+        // We need the base type name (vector / halfvec / sparsevec) as well as
+        // the dimension. `format_type(oid, typmod)` handles this canonically.
+        let alter_sql = format!(
+            "ALTER TABLE {}.{} ALTER COLUMN {} TYPE vector({})",
+            quote_identifier(schema),
+            quote_identifier(table_name),
+            quote_identifier(&col_alias),
+            typmod,
+        );
+        Spi::run(&alter_sql).map_err(|e| {
+            PgTrickleError::SpiError(format!(
+                "F4: failed to set vector dimension for column '{}': {}",
+                col_alias, e
+            ))
+        })?;
+    }
+    Ok(())
+}
+
 /// Set up the storage table: CREATE TABLE, row_id index, DML guard trigger,
 /// and optional GROUP BY composite index.
 #[allow(clippy::too_many_arguments)]
@@ -3361,6 +3400,17 @@ fn create_stream_table_impl(
         &vq.nonnull_aux_columns,
         partition_by,
     )?;
+
+    // F4: Fix vector aggregate column dimensions (VectorAvg/VectorSum output
+    // columns need vector(N) type with explicit dimension for HNSW / IVFFlat
+    // index support). avg(vector(3)) returns undimensioned `vector` at the
+    // SQL type-inference level; we post-fix via ALTER COLUMN using the source
+    // column's atttypmod.
+    if crate::config::pg_trickle_enable_vector_agg()
+        && let Some(ref pr) = vq.parsed_tree
+    {
+        fix_vector_aggregate_column_types(&schema, &table_name, &pr.tree)?;
+    }
 
     // CITUS-7: Distribute the output storage table when requested and Citus is available.
     if let Some(dist_col) = output_distribution_column {

--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -407,12 +407,24 @@ pub fn build_changed_cols_bitmask_expr(
     }
     let parts: Vec<String> = columns
         .iter()
-        .map(|(col_name, _)| {
+        .map(|(col_name, type_name)| {
             let qcol = col_name.replace('"', "\"\"");
-            format!(
-                "(CASE WHEN NEW.\"{qcol}\" IS DISTINCT FROM OLD.\"{qcol}\" \
-                 THEN B'1' ELSE B'0' END)::varbit"
-            )
+            // pgvector types (vector, halfvec, sparsevec) do not define an '='
+            // operator, so IS DISTINCT FROM (which uses '=') would fail.
+            // Cast to text for comparison — text always supports equality.
+            let base_type = type_name.split('(').next().unwrap_or("").trim();
+            let is_pgvector = matches!(base_type, "vector" | "halfvec" | "sparsevec");
+            if is_pgvector {
+                format!(
+                    "(CASE WHEN NEW.\"{qcol}\"::text IS DISTINCT FROM OLD.\"{qcol}\"::text \
+                     THEN B'1' ELSE B'0' END)::varbit"
+                )
+            } else {
+                format!(
+                    "(CASE WHEN NEW.\"{qcol}\" IS DISTINCT FROM OLD.\"{qcol}\" \
+                     THEN B'1' ELSE B'0' END)::varbit"
+                )
+            }
         })
         .collect();
     Some(parts.join(" ||\n        "))
@@ -2032,12 +2044,24 @@ fn build_changed_cols_bitmask_stmt_expr(
     }
     let parts: Vec<String> = columns
         .iter()
-        .map(|(col_name, _)| {
+        .map(|(col_name, type_name)| {
             let qcol = col_name.replace('"', "\"\"");
-            format!(
-                "(CASE WHEN n.\"{qcol}\" IS DISTINCT FROM o.\"{qcol}\" \
-                 THEN B'1' ELSE B'0' END)::varbit"
-            )
+            // pgvector types (vector, halfvec, sparsevec) do not define an '='
+            // operator, so IS DISTINCT FROM (which uses '=') would fail.
+            // Cast to text for comparison — text always supports equality.
+            let base_type = type_name.split('(').next().unwrap_or("").trim();
+            let is_pgvector = matches!(base_type, "vector" | "halfvec" | "sparsevec");
+            if is_pgvector {
+                format!(
+                    "(CASE WHEN n.\"{qcol}\"::text IS DISTINCT FROM o.\"{qcol}\"::text \
+                     THEN B'1' ELSE B'0' END)::varbit"
+                )
+            } else {
+                format!(
+                    "(CASE WHEN n.\"{qcol}\" IS DISTINCT FROM o.\"{qcol}\" \
+                     THEN B'1' ELSE B'0' END)::varbit"
+                )
+            }
         })
         .collect();
     Some(parts.join(" ||\n\t\t        "))

--- a/src/dvm/mod.rs
+++ b/src/dvm/mod.rs
@@ -885,6 +885,113 @@ pub(crate) fn reclassify_vector_aggregates(
     }
 }
 
+/// F4: Walk an OpTree and return `(output_alias, dimension)` for every
+/// `VectorAvg` / `VectorSum` aggregate whose source column has an explicit
+/// `vector(N)` / `halfvec(N)` dimension in `pg_attribute`.
+///
+/// This is used after stream-table creation to `ALTER COLUMN … TYPE vector(N)`
+/// so that HNSW / IVFFlat indexes (which require explicit dimensions) can be
+/// built on the centroid column.
+#[cfg(feature = "pg18")]
+pub(crate) fn extract_vector_agg_output_dims(tree: &parser::OpTree) -> Vec<(String, i32)> {
+    use parser::{AggFunc, Expr, OpTree};
+    use pgrx::prelude::*;
+
+    fn lookup_typmod(source_oids: &[u32], col_name: &str) -> i32 {
+        if source_oids.is_empty() {
+            return -1;
+        }
+        let oid_list = source_oids
+            .iter()
+            .map(|o| o.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        // Only consider vector/halfvec/sparsevec columns — others return -1.
+        let sql = format!(
+            "SELECT a.atttypmod \
+             FROM pg_catalog.pg_attribute a \
+             JOIN pg_catalog.pg_type t ON t.oid = a.atttypid \
+             WHERE a.attrelid IN ({oid_list}) \
+               AND a.attname = $1 \
+               AND t.typname IN ('vector', 'halfvec', 'sparsevec') \
+               AND a.attnum > 0 \
+               AND NOT a.attisdropped \
+             LIMIT 1",
+        );
+        Spi::get_one_with_args::<i32>(&sql, &[col_name.into()])
+            .unwrap_or(Some(-1))
+            .unwrap_or(-1)
+    }
+
+    fn walk(tree: &OpTree, result: &mut Vec<(String, i32)>) {
+        match tree {
+            OpTree::Aggregate {
+                aggregates, child, ..
+            } => {
+                walk(child, result);
+                let child_oids = child.source_oids();
+                for agg in aggregates {
+                    if !matches!(agg.function, AggFunc::VectorAvg | AggFunc::VectorSum) {
+                        continue;
+                    }
+                    let col_name = match &agg.argument {
+                        Some(Expr::ColumnRef { column_name, .. }) => column_name.as_str(),
+                        _ => continue,
+                    };
+                    let typmod = lookup_typmod(&child_oids, col_name);
+                    if typmod > 0 {
+                        result.push((agg.alias.clone(), typmod));
+                    }
+                }
+            }
+            OpTree::Filter { child, .. }
+            | OpTree::Project { child, .. }
+            | OpTree::Subquery { child, .. }
+            | OpTree::Window { child, .. }
+            | OpTree::Distinct { child }
+            | OpTree::LateralFunction { child, .. }
+            | OpTree::LateralSubquery { child, .. }
+            | OpTree::ScalarSubquery { child, .. } => walk(child, result),
+            OpTree::InnerJoin { left, right, .. }
+            | OpTree::LeftJoin { left, right, .. }
+            | OpTree::FullJoin { left, right, .. }
+            | OpTree::SemiJoin { left, right, .. }
+            | OpTree::AntiJoin { left, right, .. }
+            | OpTree::Intersect { left, right, .. }
+            | OpTree::Except { left, right, .. } => {
+                walk(left, result);
+                walk(right, result);
+            }
+            OpTree::UnionAll { children, .. } => {
+                for c in children {
+                    walk(c, result);
+                }
+            }
+            OpTree::RecursiveCte {
+                base, recursive, ..
+            } => {
+                walk(base, result);
+                walk(recursive, result);
+            }
+            OpTree::CteScan { body, .. } => {
+                if let Some(b) = body.as_ref() {
+                    walk(b, result);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut result = Vec::new();
+    walk(tree, &mut result);
+    result
+}
+
+#[cfg(not(feature = "pg18"))]
+pub(crate) fn extract_vector_agg_output_dims(_tree: &parser::OpTree) -> Vec<(String, i32)> {
+    Vec::new()
+}
+
 /// Check whether a defining query needs the `__pgt_count` auxiliary column
 /// (the top-level operator is Aggregate or Distinct).
 ///


### PR DESCRIPTION
## Summary

Two pgvector E2E tests were failing in CI:

- `test_pgvector_avg_centroid_update` — `operator does not exist: public.vector = public.vector`
- `test_pgvector_hnsw_index_on_stream_table` — `column does not have dimensions`

This PR fixes both.

---

## Fix 1 — CDC trigger: cast pgvector types to `::text` in `IS DISTINCT FROM`

**Root cause:** PostgreSQL's `IS DISTINCT FROM` internally resolves through the type's `=` operator. The pgvector extension registers distance operators (`<->`, `<=>`, etc.) but **not** an equality `=` operator for `vector`, `halfvec`, or `sparsevec`. When a CDC trigger fires on `UPDATE emb_upd SET embedding = '[0,0,1]' WHERE ...`, the changed-column bitmask expression evaluates `NEW."embedding" IS DISTINCT FROM OLD."embedding"`, which fails at runtime.

**Fix:** In `src/cdc.rs`, detect pgvector base type names (`vector`, `halfvec`, `sparsevec`) in both:
- `build_changed_cols_bitmask_expr` (row-level triggers) — emits `NEW."col"::text IS DISTINCT FROM OLD."col"::text`
- `build_changed_cols_bitmask_stmt_expr` (statement-level triggers) — same cast on the `n."col"` / `o."col"` transition table aliases

Text comparison is semantically equivalent for these types (they are expressed as `[a,b,c]` literals) and avoids the missing operator.

---

## Fix 2 — Stream table: set correct `vector(N)` dimension after creation

**Root cause:** PostgreSQL's type inference does not carry `atttypmod` through aggregate results. `avg(embedding)` where `embedding :: vector(3)` is analyzed as returning undimensioned `vector` (no dimension). The stream table DDL therefore creates the output column as `vector` with no dimension, which prevents `CREATE INDEX ... USING hnsw` or `ivfflat` — both require an explicit dimension.

**Fix:** Two new pg18-only helpers:

1. `extract_vector_agg_output_dims(tree)` in `src/dvm/mod.rs` — walks the `OpTree` recursively, finds every `VectorAvg` / `VectorSum` node whose argument is a `ColumnRef`, then queries `pg_catalog.pg_attribute.atttypmod` for that column to obtain the true dimension.

2. `fix_vector_aggregate_column_types(schema, table, tree)` in `src/api/mod.rs` — calls the above and runs `ALTER TABLE … ALTER COLUMN … TYPE vector(N)` for each result.

This function is called in `create_stream_table_impl` immediately after `setup_storage_table`, guarded by `pg_trickle_enable_vector_agg()`.

---

## Testing

All 6 pgvector E2E tests now pass:

```
test test_pgvector_avg_centroid_update       ... ok
test test_pgvector_hnsw_index_on_stream_table ... ok
test test_pgvector_avg_centroid_delete       ... ok
test test_pgvector_avg_centroid_insert       ... ok
test test_pgvector_sum_differential          ... ok
test test_pgvector_distance_operator_fallback_to_full ... ok
```

`just lint` passes (zero clippy warnings, fmt-clean).
