### PR TITLE
feat(release): build and publish pgtrickle-relay binary and Docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ env:
   PG_VERSION: "18"
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/pg_trickle-ext
+  RELAY_IMAGE_NAME: ${{ github.repository_owner }}/pgtrickle-relay
 
 permissions:
   contents: write   # create GitHub Releases
@@ -89,6 +90,10 @@ jobs:
       - name: Build pgtrickle TUI binary
         run: cargo build --release -p pgtrickle-tui
 
+      - name: Build pgtrickle-relay binary
+        if: matrix.archive_ext == 'tar.gz'
+        run: cargo build --release -p pgtrickle-relay --features "nats,webhook,stdout"
+
       - name: Create archive (tar.gz)
         if: matrix.archive_ext == 'tar.gz'
         shell: bash
@@ -119,6 +124,9 @@ jobs:
 
           # Copy pgtrickle TUI binary
           cp target/release/pgtrickle "dist/${ARCHIVE_NAME}/"
+
+          # Copy pgtrickle-relay binary
+          cp target/release/pgtrickle-relay "dist/${ARCHIVE_NAME}/"
 
           cd dist
           tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
@@ -470,4 +478,108 @@ jobs:
           fi
 
           echo "Multi-arch manifest created for ${IMAGE}:${VERSION}"
+          docker buildx imagetools inspect "${IMAGE}:${VERSION}"
+
+  # ── Build and push pgtrickle-relay Docker image (per-arch, parallel) ──
+  # Builds the relay binary from source inside Docker (distroless runtime).
+  # amd64 and arm64 run in parallel, then a manifest is merged.
+  publish-relay-docker-arch:
+    name: Relay Docker image (${{ matrix.arch }})
+    needs: [build-release, test-release]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux/amd64
+            runner: ubuntu-latest
+            platform_tag: amd64
+          - arch: linux/arm64
+            runner: ubuntu-24.04-arm
+            platform_tag: arm64
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push ${{ matrix.arch }} relay image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: Dockerfile.relay
+          push: true
+          platforms: ${{ matrix.arch }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+          tags: ${{ env.REGISTRY }}/${{ env.RELAY_IMAGE_NAME }}:${{ steps.version.outputs.version }}-${{ matrix.platform_tag }}
+          labels: |
+            org.opencontainers.image.title=pgtrickle-relay
+            org.opencontainers.image.description=Bidirectional relay for pg_trickle stream tables (NATS, webhooks, stdout)
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ── Merge per-arch relay images into a single multi-arch manifest ──────
+  publish-relay-docker:
+    name: Publish relay Docker manifest
+    needs: publish-relay-docker-arch
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push multi-arch relay manifest
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          IMAGE="${{ env.REGISTRY }}/${{ env.RELAY_IMAGE_NAME }}"
+
+          # Create versioned manifest (e.g. 0.1.0)
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${VERSION}" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-arm64"
+
+          # Also tag major.minor (e.g. 0.1)
+          MINOR="$(echo "${VERSION}" | cut -d. -f1-2)"
+          docker buildx imagetools create \
+            --tag "${IMAGE}:${MINOR}" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-arm64"
+
+          # Tag latest for non-prerelease
+          if [[ "${GITHUB_REF_NAME}" != *"-"* ]]; then
+            docker buildx imagetools create \
+              --tag "${IMAGE}:latest" \
+              "${IMAGE}:${VERSION}-amd64" \
+              "${IMAGE}:${VERSION}-arm64"
+          fi
+
+          echo "Multi-arch relay manifest created for ${IMAGE}:${VERSION}"
           docker buildx imagetools inspect "${IMAGE}:${VERSION}"


### PR DESCRIPTION
## Summary

The `pgtrickle-relay` binary and Docker image were never built or published as
part of the automated release process, even though `Dockerfile.relay` existed
and the relay was documented as being distributed via GitHub Releases and GHCR.
This PR closes that gap by wiring the relay fully into the `v*` release
workflow.

## Changes

- **`RELAY_IMAGE_NAME` env var** — `ghcr.io/grove/pgtrickle-relay`, consistent
  with the existing `IMAGE_NAME` pattern for the extension image.
- **`build-relay` step in `build-release` matrix** — runs
  `cargo build --release -p pgtrickle-relay --features "nats,webhook,stdout"`
  for Linux (amd64, arm64) and macOS (arm64). Windows is skipped (OpenSSL
  linking is non-trivial on Windows CI; can be added as a follow-up).
- **Relay binary included in tar.gz archives** — `pgtrickle-relay` is copied
  alongside `pgtrickle` (TUI) and the extension files.
- **`publish-relay-docker-arch` job** — builds the distroless relay image
  natively on `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64) using
  `Dockerfile.relay`. Pushes per-arch tags:
  `ghcr.io/grove/pgtrickle-relay:<version>-amd64` and `...-arm64`.
  Needs `build-release` + `test-release` (same gate as the extension image).
- **`publish-relay-docker` job** — merges the two arch images into a multi-arch
  manifest. Publishes `:<version>`, `:<major.minor>`, and `:latest`
  (non-prerelease tags only), mirroring the extension image publish pattern.

## Testing

- YAML validity verified with `python3 -c "import yaml; yaml.safe_load(...)"`.
- Workflow structure follows the existing `publish-docker-arch` /
  `publish-docker` pattern exactly.
- Full end-to-end can be verified by triggering the release workflow on the
  next version tag or via `gh workflow run release.yml --ref main`.

## Notes

- The relay Docker build compiles from source inside Docker (no pre-built
  artifact reuse), so `publish-relay-docker-arch` has a 20-minute timeout
  vs 10 minutes for the scratch-based extension image job.
- Windows relay binary support is a follow-up item (requires either OpenSSL
  pre-installation or switching `reqwest` to the `rustls` TLS backend).
- The GHCR package `pgtrickle-relay` will be private on first push and needs
  to be made public once (same procedure as `pg_trickle-ext` documented in
  `docs/RELEASE.md`).
