### PR TITLE
fix(ci): resolve merge conflict markers in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,9 @@ jobs:
           # Copy docs
           cp README.md LICENSE INSTALL.md "dist/${ARCHIVE_NAME}/" 2>/dev/null || true
 
-<<<<<<< HEAD
-          # Copy pgtrickle TUI binary
-          cp target/release/pgtrickle "dist/${ARCHIVE_NAME}/"
-
           # Copy pgtrickle-relay binary
           cp target/release/pgtrickle-relay "dist/${ARCHIVE_NAME}/"
 
-=======
->>>>>>> e1ea949 (chore: remove pgtrickle-tui TUI from the project)
           cd dist
           tar czf "${ARCHIVE_NAME}.tar.gz" "${ARCHIVE_NAME}"
           echo "Archive: ${ARCHIVE_NAME}.tar.gz ($(du -h "${ARCHIVE_NAME}.tar.gz" | cut -f1))"


### PR DESCRIPTION
## Summary

The `release.yml` workflow had unresolved Git merge conflict markers
(`<<<<<<<`, `=======`, `>>>>>>>`) committed to `main`, causing every
triggered release run to fail immediately with "This run likely failed because
of a workflow file issue" — no jobs ran at all.

The conflict was introduced when the TUI-removal commit (`e1ea949`) was not
properly resolved before merging.

## Changes

- Removed the unresolved conflict markers from `.github/workflows/release.yml`
  (lines 122–130)
- Kept the `pgtrickle-relay` binary copy step — the relay build step and all
  relay Docker publish jobs still depend on it
- Dropped the `pgtrickle` TUI binary copy step — the TUI has been removed from
  the project

## Testing

- YAML validated locally: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — passes
- The release workflow will be exercisable again on the next version tag push

## Notes

Fixes the broken run: https://github.com/grove/pg-trickle/actions/runs/25072284774
