### PR TITLE
chore(test): normalize IMMEDIATE_SKIP_ALLOWLIST to single-line &[]

### DIFF
--- a/tests/e2e_tpch_tests.rs
+++ b/tests/e2e_tpch_tests.rs
@@ -120,8 +120,7 @@ const LARGE_SCALE_DIFFERENTIAL_SKIP: &[&str] = &[
 /// The regression guard at the end of the test will fail if any query not in
 /// this list is skipped, catching silent regressions as the DVM evolves.
 #[rustfmt::skip]
-const IMMEDIATE_SKIP_ALLOWLIST: &[&str] = &[
-];
+const IMMEDIATE_SKIP_ALLOWLIST: &[&str] = &[];
 
 // ── P3.15: TPCH_STRICT mode ───────────────────────────────────────────
 //


### PR DESCRIPTION
## Summary

PR #708 (`fix(ivm): clear IMMEDIATE_SKIP_ALLOWLIST via EC-01 multiset reconciliation`)
landed with `IMMEDIATE_SKIP_ALLOWLIST = &[\n]` (the `&[]` declaration spread over
two lines due to `#[rustfmt::skip]` interplay). This normalises it to the canonical
single-line `&[]` for readability and consistency with `#[rustfmt::skip]` intent.

No functional change — the allowlist is already empty after PR #708.

## Changes

- `tests/e2e_tpch_tests.rs` — collapse `&[\n]` to `&[]` (whitespace only)

## Testing

No logic changed; this is a formatting-only cleanup. `cargo check` and
`just lint` pass unchanged.

## Notes

This commit was originally produced during a rebase conflict resolution
and accidentally landed on local `main`. Moved to a PR branch per project
convention (never commit directly to `main`).
