### PR TITLE
fix(docker): bump relay builder to rust:1.85

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -3,7 +3,7 @@
 # Result: minimal distroless image (~30 MB) with the relay binary only.
 
 # ─── Stage 1: Build ────────────────────────────────────────────────────────────
-FROM rust:1.79-slim-bookworm AS builder
+FROM rust:1.85-slim-bookworm AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary

The `Dockerfile.relay` builder stage used `rust:1.79-slim-bookworm`, but `pgtrickle-relay/Cargo.toml` declares `edition = "2024"`, which requires Rust 1.85 or later. This mismatch caused the relay Docker image build to fail with exit code 101 during the release workflow.

## Changes

- Updated `Dockerfile.relay` builder image from `rust:1.79-slim-bookworm` to `rust:1.85-slim-bookworm`

## Testing

- `cargo check -p pgtrickle-relay --features "nats,webhook,stdout"` — passes locally
- Relay Docker image builds successfully with the new base image (verified against release workflow)

## Notes

Edition 2024 requires Rust 1.85+. The main `Cargo.toml` and `fuzz/Cargo.toml` also use edition 2024, so the relay build environment must match or exceed this requirement. The builder Dockerfile now aligns with the toolchain requirements.
