### PR TITLE
fix(test): use execute_seq for multi-statement SQL in otel test

### DIFF
--- a/tests/e2e_otel_tests.rs
+++ b/tests/e2e_otel_tests.rs
@@ -43,12 +43,14 @@ async fn test_otel_trace_context_captured_in_change_buffer() {
     )
     .await;
 
-    // Set a W3C traceparent and insert a row.
+    // Set a W3C traceparent and insert a row on the same connection so the
+    // session-local GUC is visible to the INSERT (prepared statements do not
+    // allow multiple commands in a single call).
     let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
-    db.execute(&format!(
-        "SET pg_trickle.trace_id = '{traceparent}'; \
-         INSERT INTO otel_src VALUES (1, 'hello');"
-    ))
+    db.execute_seq(&[
+        &format!("SET pg_trickle.trace_id = '{traceparent}'"),
+        "INSERT INTO otel_src VALUES (1, 'hello')",
+    ])
     .await;
 
     // Check whether the change buffer has the trace context column.


### PR DESCRIPTION
## Fix: use `execute_seq` for multi-statement SQL in otel test

### Problem

CI run #25105406098 failed consistently on `test_otel_trace_context_captured_in_change_buffer` with:

```
cannot insert multiple commands into a prepared statement
```

The test was attempting to execute two SQL commands in a single `execute()` call:

```rust
db.execute(&format!(
    "SET pg_trickle.trace_id = '{traceparent}'; \
     INSERT INTO otel_src VALUES (1, 'hello');"
))
.await;
```

PostgreSQL's prepared statement protocol enforces a single-command constraint — multiple semicolon-separated statements are rejected.

Additionally, even if the protocol allowed it, the `SET` and `INSERT` might be dispatched to different backend connections through the connection pool, making the session-local GUC invisible to the `INSERT`.

### Solution

Use `execute_seq()` which acquires a dedicated connection and runs statements sequentially, ensuring:
1. Each statement executes as a separate command (no prepared statement protocol violation)
2. Both statements run on the same connection, so the session GUC set by `SET pg_trickle.trace_id` is visible to the subsequent `INSERT`

```rust
let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
db.execute_seq(&[
    &format!("SET pg_trickle.trace_id = '{traceparent}'"),
    "INSERT INTO otel_src VALUES (1, 'hello')",
])
.await;
```

### Test Results

- `test_otel_trace_context_captured_in_change_buffer`: PASS (previously consistent FAIL)
- Full E2E suite: 1324/1324 passed
- TPC-H suite: 15/15 passed
