### PR TITLE
fix(docker): bump relay builder to rust:1.88 and add bench stubs

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -3,7 +3,7 @@
 # Result: minimal distroless image (~30 MB) with the relay binary only.
 
 # ─── Stage 1: Build ────────────────────────────────────────────────────────────
-FROM rust:1.85-slim-bookworm AS builder
+FROM rust:1.88-slim-bookworm AS builder
 
 WORKDIR /build
 
@@ -21,10 +21,14 @@ COPY Cargo.toml Cargo.lock ./
 COPY pgtrickle-relay/Cargo.toml ./pgtrickle-relay/Cargo.toml
 
 # Create dummy workspace member sources so Cargo can resolve dependencies.
-RUN mkdir -p src pgtrickle-relay/src && \
+# Also create stub bench files referenced in the workspace Cargo.toml.
+RUN mkdir -p src pgtrickle-relay/src benches && \
     echo "fn main() {}" > src/main.rs && \
     echo "" > src/lib.rs && \
-    echo "fn main() {}" > pgtrickle-relay/src/main.rs
+    echo "fn main() {}" > pgtrickle-relay/src/main.rs && \
+    echo "fn main() {}" > benches/diff_operators.rs && \
+    echo "fn main() {}" > benches/refresh_bench.rs && \
+    echo "fn main() {}" > benches/scheduler_bench.rs
 
 # Pre-fetch and compile dependencies (cached layer).
 RUN cargo build -p pgtrickle-relay --release --features "nats,webhook,stdout" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes the relay Docker image build failure seen in [release run #92](https://github.com/grove/pg-trickle/actions/runs/25116655211). Two root causes combined to produce exit code 101 from `cargo build -p pgtrickle-relay --release --features "nats,webhook,stdout"` inside the Docker build.

## Root Causes

**1. Rust version too old — `async-nats 0.47.0` requires Rust 1.88.0**

The Dockerfile used `rust:1.85-slim-bookworm`. After the recent dependency bump in #692/690/693, `async-nats 0.47.0` (pulled in by the `nats` feature) declares `rust-version = "1.88.0"`. Cargo enforces this MSRV at compile time, causing the build to abort.

**2. Missing bench file stubs in Docker build context**

The workspace `Cargo.toml` declares three `[[bench]]` targets (`diff_operators`, `refresh_bench`, `scheduler_bench`). Cargo validates that the source files for these targets exist when parsing the manifest — even when building an unrelated package with `-p pgtrickle-relay`. The Dockerfile copies `Cargo.toml` and `Cargo.lock` for layer caching but only created stubs for `src/` and `pgtrickle-relay/src/`, not for `benches/`. This caused:

```
error: failed to parse manifest at `/build/Cargo.toml`
Caused by:
  can't find `diff_operators` bench at `benches/diff_operators.rs`
```

## Changes

- `Dockerfile.relay`: bump builder image from `rust:1.85-slim-bookworm` to `rust:1.88-slim-bookworm`
- `Dockerfile.relay`: create stub `benches/diff_operators.rs`, `benches/refresh_bench.rs`, and `benches/scheduler_bench.rs` alongside the existing dummy source stubs, so Cargo can parse the workspace manifest during the dependency-caching layer

## Testing

- Built `Dockerfile.relay` locally (`docker build -f Dockerfile.relay .`) — succeeds, producing a valid distroless image with the `pgtrickle-relay` binary.
- Relay Rust unit tests are unaffected (no source changes).

## Notes

The bench stubs are only present during the Docker build caching layer; they are overwritten or irrelevant once the real source is copied and the final `cargo build` runs. The `benches/` directory itself is never copied into the runtime image.
