### PR TITLE
roadmap: remove pgai references (pgai archived)

### DIFF
--- a/roadmap/v0.41.0.md
+++ b/roadmap/v0.41.0.md
@@ -6,8 +6,7 @@
 
 > After the v0.38.0-v0.40.0 hardening arc, the roadmap resumes the deferred
 > embedding programme with post-refresh actions, drift-based ANN maintenance,
-> vector-aware monitoring, AI/RAG cookbooks, and a bundled `pg_trickle` +
-> `pgvector` + `pgai` developer image.
+> vector-aware monitoring, and AI/RAG cookbooks.
 
 ---
 
@@ -30,12 +29,11 @@ and reindex pressure instead of inferring those signals indirectly.
 
 ---
 
-## pgvector + pgai integration
+## pgvector integration & RAG cookbook
 
-This release also adds the documentation and packaging needed for a serious
-self-hosted RAG workflow: a full cookbook for always-fresh embedding pipelines
-and a Docker image variant that bundles `pg_trickle`, `pgvector`, and `pgai`
-for fast experimentation and demos.
+This release adds the documentation needed for a serious self-hosted RAG
+workflow: a full cookbook for always-fresh embedding pipelines using
+`pg_trickle` + `pgvector`, with embeddings generated at the application layer.
 
 ---
 

--- a/roadmap/v0.41.0.md-full.md
+++ b/roadmap/v0.41.0.md-full.md
@@ -8,8 +8,7 @@
 > v0.41.0 resumes the deferred embedding programme once the roadmap has closed
 > the immediate correctness and operational gaps. It adds post-refresh action
 > hooks (ANALYZE, REINDEX, drift-based re-clustering), vector-aware monitoring,
-> pgai integration material, and a bundled development image for production
-> embedding pipelines on PostgreSQL.
+> and a pgvector RAG cookbook for production embedding pipelines on PostgreSQL.
 
 > **Hard prerequisite:** v0.38.0-v0.40.0 must complete their hardening exit
 > criteria first. The embedding programme is intentionally sequenced after the
@@ -24,9 +23,8 @@
 | VP-1 | `post_refresh_action` ST option (`none` / `analyze` / `reindex` / `reindex_if_drift`) | M | P1 |
 | VP-2 | `reindex_drift_threshold` ST option plus drift counter in catalog | M | P1 |
 | VP-3 | `pgtrickle.vector_status()` view: embedding lag, ANN age, drift % | S | P1 |
-| VP-4 | Cookbook: always-fresh RAG with pg_trickle + pgvector + pgai | S | P2 |
-| VP-5 | Docker image variant: `pg_trickle + pgvector + pgai` | S | P2 |
-| VP-6 | Citus vector-aggregate cases folded into distributed coverage | M | P2 |
+| VP-4 | Cookbook: always-fresh RAG with pg_trickle + pgvector | S | P2 |
+| VP-5 | Citus vector-aggregate cases folded into distributed coverage | M | P2 |
 
 **VP-1 — Post-refresh actions.**
 Add a `post_refresh_action` option to vector-heavy stream tables so operators can
@@ -48,18 +46,15 @@ usage. This view plugs into the monitoring foundation built in the hardening
 arc and gives RAG operators a first-class place to look for ANN maintenance
 pressure.
 
-**VP-4 — pgai cookbook.**
+**VP-4 — pgvector RAG cookbook.**
 Publish `docs/tutorials/PGVECTOR_RAG_COOKBOOK.md` with copy-paste workflows for
 pre-computed embeddings, denormalized corpora, hybrid search, and operational
-sizing guidance. The key outcome is that AI engineers can start with a working
-pattern instead of reverse-engineering examples from tests.
+sizing guidance. Embeddings are generated at the application layer (e.g. via
+OpenAI, Cohere, or Ollama APIs) before being stored with pgvector. The key
+outcome is that AI engineers can start with a working pattern instead of
+reverse-engineering examples from tests.
 
-**VP-5 — Docker image.**
-Ship a bundled development image containing `pg_trickle`, `pgvector`, and
-`pgai` so the cookbook and demo workflows run with one command. Keep version
-pinning explicit to avoid silent breakage from upstream minor releases.
-
-**VP-6 — Citus vector-aggregate cases folded into distributed coverage.**
+**VP-5 — Citus vector-aggregate cases folded into distributed coverage.**
 The v0.39 Citus rig becomes the place where shard-additive vector-aggregate
 behavior is verified. This keeps vector work honest in distributed deployments
 without treating Citus as an afterthought.
@@ -94,17 +89,13 @@ results still converge to the same answer as a global `avg(vector)` or
 - **VP-3** is observational, but large fleets still need scrape-friendly
   monitoring rather than expensive ad hoc queries across huge numbers of stream
   tables.
-- **VP-5** depends on careful dependency pinning; the image should be treated as
-  a reproducible bundle, not a floating latest tag.
-
 ### Exit Criteria
 
 - [ ] VP-1: `post_refresh_action` is stored in the catalog and dequeued correctly after refresh commit
 - [ ] VP-2: drift threshold logic increments and resets correctly over repeated refresh cycles
 - [ ] VP-3: `pgtrickle.vector_status()` reports correct lag and drift for vector stream tables
 - [ ] VP-4: RAG cookbook published with multiple worked examples
-- [ ] VP-5: bundled image builds and passes extension smoke tests
-- [ ] VP-6: vector-aggregate cases pass inside the Citus distributed test rig
+- [ ] VP-5: vector-aggregate cases pass inside the Citus distributed test rig
 - [ ] Extension upgrade path tested (`0.40.0 → 0.41.0`)
 - [ ] `just check-version-sync` passes
 

--- a/roadmap/v0.43.0.md
+++ b/roadmap/v0.43.0.md
@@ -41,7 +41,7 @@ changes can feed downstream agents, rerankers, or external services.
 ## Also in v0.43.0
 
 - Public starter repository and examples for the post-hardening AI stack
-- Best-effort ecosystem positioning with pgvector / pgai partners, but never as
+- Best-effort ecosystem positioning with pgvector partners, but never as
   a release gate
 
 ---

--- a/roadmap/v0.43.0.md-full.md
+++ b/roadmap/v0.43.0.md-full.md
@@ -48,7 +48,7 @@ embedding churn without polling.
 
 **VA-5 — Starter repo and ecosystem positioning.**
 Provide a public starter repository and best-effort ecosystem material that show
-how pg_trickle fits alongside pgvector and pgai after the hardening arc. This is
+how pg_trickle fits alongside pgvector after the hardening arc. This is
 useful, but it must never block the release.
 
 ### Test Coverage


### PR DESCRIPTION
## Summary

pgai has been archived and is no longer actively maintained. This PR removes all pgai references from the v0.41.0 and v0.43.0 roadmap files to avoid planning work around a dead dependency.

## Changes

- **v0.41.0 summary & full spec** — Release theme updated; VP-4 reframed as a pgvector-only RAG cookbook (embeddings generated at the application layer via OpenAI/Cohere/Ollama APIs); VP-5 (Docker image bundling `pg_trickle + pgvector + pgai`) dropped entirely; VP-6 → VP-5 and T-VP3 renumbered accordingly; VP-5 risk note removed from Conflicts & Risks section; exit criteria updated.
- **v0.43.0 summary & full spec** — VA-5 ecosystem positioning updated to reference pgvector only (pgai partner mention removed).

## Testing

Documentation-only change — no code or SQL changes. No tests required.

## Notes

The pgvector-only cookbook approach is more durable: it does not tie pg_trickle to any single embedding-helper extension and covers the broader class of users who call embedding APIs directly from their application.
