### PR TITLE
fix(ci): use github.event.inputs in job name instead of env context

### DIFF
--- a/.github/workflows/tpch-explain-artifacts.yml
+++ b/.github/workflows/tpch-explain-artifacts.yml
@@ -44,7 +44,7 @@ env:
 jobs:
   # ── O39-10: Capture EXPLAIN ANALYZE BUFFERS artifacts ─────────────────────
   tpch-explain-artifacts:
-    name: TPC-H EXPLAIN artifacts (SF-${{ env.TPCH_SCALE }})
+    name: TPC-H EXPLAIN artifacts (SF-${{ github.event.inputs.tpch_scale || '1.0' }})
     runs-on: ubuntu-latest
     timeout-minutes: 120
 


### PR DESCRIPTION
## Summary

Fix an invalid workflow file error in `tpch-explain-artifacts.yml`. The `env` context is not available in job-level `name:` fields in GitHub Actions — only `github`, `needs`, `strategy`, and `matrix` are valid there.

## Changes

- `.github/workflows/tpch-explain-artifacts.yml` — Replace `${{ env.TPCH_SCALE }}` in the job `name:` with `${{ github.event.inputs.tpch_scale || '1.0' }}`, which is the same default expression used when the `env.TPCH_SCALE` variable is set.

## Root Cause

```
Invalid workflow file: .github/workflows/tpch-explain-artifacts.yml#L1
(Line: 47, Col: 11): Unrecognized named-value: 'env'.
Located at position 1 within expression: env.TPCH_SCALE
```

Job-level `name:` fields are evaluated before environment variables are available. The two other `env.TPCH_SCALE` references in step-level contexts (line 87 in a step `env:` block, line 114 in a step `name:`) are valid and unchanged.

## Testing

- Workflow file validation passes.
- `just test-unit` — no code changes, not required.
