### PR TITLE
fix: drain mode — wire scheduler hook, fix parameter name and schedule syntax

### DIFF
--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -2579,6 +2579,16 @@ pub extern "C-unwind" fn pg_trickle_scheduler_main(_arg: pg_sys::Datum) {
             break;
         }
 
+        // A35 (v0.36.0): Process pending drain requests on every tick — even
+        // when the scheduler is disabled — so that pgtrickle.drain() never
+        // hangs indefinitely.  When a drain is requested and no refresh workers
+        // are active, this marks the drain as completed (DRAIN_COMPLETED =
+        // DRAIN_REQUESTED) and returns true.  We skip new dispatches for that
+        // tick so callers see a clean quiesced state before drain() returns.
+        if crate::shmem::scheduler_check_and_complete_drain() {
+            continue;
+        }
+
         if !config::pg_trickle_enabled() {
             continue;
         }

--- a/tests/e2e_drain_mode_tests.rs
+++ b/tests/e2e_drain_mode_tests.rs
@@ -40,7 +40,7 @@ async fn test_drain_idle_returns_true() {
 
     // With no stream tables, drain() should return true immediately.
     let drained: bool = db
-        .query_scalar("SELECT pgtrickle.drain(timeout => 30)")
+        .query_scalar("SELECT pgtrickle.drain(timeout_s => 30)")
         .await;
     assert!(
         drained,
@@ -55,7 +55,7 @@ async fn test_drain_is_drained_when_idle() {
     configure_fast_scheduler(&db).await;
 
     // Drain first to ensure clean state.
-    db.execute("SELECT pgtrickle.drain(timeout => 30)").await;
+    db.execute("SELECT pgtrickle.drain(timeout_s => 30)").await;
 
     let drained: bool = db.query_scalar("SELECT pgtrickle.is_drained()").await;
     assert!(
@@ -87,7 +87,7 @@ async fn test_drain_resume_catches_up() {
 
     // Drain the scheduler.
     let drained: bool = db
-        .query_scalar("SELECT pgtrickle.drain(timeout => 30)")
+        .query_scalar("SELECT pgtrickle.drain(timeout_s => 30)")
         .await;
     assert!(
         drained,
@@ -155,7 +155,7 @@ async fn test_drain_under_workload() {
 
     // Call drain — should complete within the timeout even under load.
     let drained: bool = db
-        .query_scalar("SELECT pgtrickle.drain(timeout => 60)")
+        .query_scalar("SELECT pgtrickle.drain(timeout_s => 60)")
         .await;
     assert!(
         drained,
@@ -215,7 +215,7 @@ async fn test_drain_timeout_returns_false_or_true() {
 
     // With no work in flight, drain(1) should return true immediately.
     let result: bool = db
-        .query_scalar("SELECT pgtrickle.drain(timeout => 1)")
+        .query_scalar("SELECT pgtrickle.drain(timeout_s => 1)")
         .await;
     // Either outcome (true = idle fast, false = timeout) is valid here,
     // but we must not panic or deadlock.
@@ -244,7 +244,7 @@ async fn test_drain_buffer_accumulates_during_drain() {
 
     // Drain the scheduler.
     let _drained: bool = db
-        .query_scalar("SELECT pgtrickle.drain(timeout => 30)")
+        .query_scalar("SELECT pgtrickle.drain(timeout_s => 30)")
         .await;
 
     // Insert rows — these should accumulate in the change buffer.

--- a/tests/e2e_drain_mode_tests.rs
+++ b/tests/e2e_drain_mode_tests.rs
@@ -77,7 +77,7 @@ async fn test_drain_resume_catches_up() {
         "SELECT pgtrickle.create_stream_table(\
              'public.drain_view', \
              'SELECT id, val FROM public.drain_src', \
-             schedule => '1 second'\
+             schedule => '1s'\
          )",
     )
     .await;
@@ -135,7 +135,7 @@ async fn test_drain_under_workload() {
         "SELECT pgtrickle.create_stream_table(\
              'public.drain_wl_view', \
              'SELECT id, val FROM public.drain_wl_src', \
-             schedule => '1 second'\
+             schedule => '1s'\
          )",
     )
     .await;
@@ -236,7 +236,7 @@ async fn test_drain_buffer_accumulates_during_drain() {
         "SELECT pgtrickle.create_stream_table(\
              'public.drain_buf_view', \
              'SELECT id, v FROM public.drain_buf_src', \
-             schedule => '1 second'\
+             schedule => '1s'\
          )",
     )
     .await;


### PR DESCRIPTION
## Fix drain mode E2E test failures (CI run #25120804057)

### Root causes

Three separate issues caused all 4 drain-mode tests to fail in CI:

1. **Wrong parameter name** (`timeout` → `timeout_s`)
   All 6 call sites in `tests/e2e_drain_mode_tests.rs` used
   `pgtrickle.drain(timeout => ...)` but the pgrx-generated SQL
   function signature is `pgtrickle.drain(timeout_s => ...)`.
   This caused PostgreSQL to reject the call with:
   ```
   function pgtrickle.drain(timeout => integer) does not exist
   ```

2. **Missing scheduler hook** — `scheduler_check_and_complete_drain()` was never called
   The drain mechanism in shmem increments `DRAIN_REQUESTED` when a
   client calls `drain()`, and expects the scheduler to respond by
   setting `DRAIN_COMPLETED = DRAIN_REQUESTED`. This scheduler-side
   acknowledgement was never wired into the main loop, so `drain()`
   always timed out (30 s) and returned `false`.

3. **Invalid schedule syntax** (`'1 second'` → `'1s'`)
   Three tests passed `schedule => '1 second'` to `create_stream_table`.
   The schedule parser detects spaces → treats the string as a cron
   expression → rejects it with "expected 5 or 6 fields, got 2".
   The correct short-hand for a 1-second duration is `'1s'`.

### Changes

| File | Change |
|------|--------|
| `tests/e2e_drain_mode_tests.rs` | 6× `timeout =>` → `timeout_s =>`; 3× `'1 second'` → `'1s'` |
| `src/scheduler/mod.rs` | Call `scheduler_check_and_complete_drain()` at the top of each scheduler tick, before the `enabled` check, so drain requests are acknowledged even when `pg_trickle.enabled = off` |

### Verification

All 6 drain-mode tests now pass locally:
```
PASS test_drain_idle_returns_true
PASS test_drain_is_drained_when_idle
PASS test_drain_timeout_returns_false_or_true
PASS test_drain_buffer_accumulates_during_drain
PASS test_drain_resume_catches_up
PASS test_drain_under_workload
Summary: 6 tests run: 6 passed, 0 skipped
```

`just lint` passes cleanly (cargo fmt + clippy -D warnings).

### Safety of the scheduler change

`scheduler_check_and_complete_drain()` returns `false` immediately when
`DRAIN_REQUESTED == DRAIN_COMPLETED` (the initial/normal state). For all
tests that never call `drain()`, this is a zero-cost no-op. The new `continue`
only fires when drain is explicitly requested.
