### PR TITLE
fix: resolve GitHub Actions workflow syntax error in tpch-explain-artifacts

### DIFF
--- a/.github/workflows/tpch-explain-artifacts.yml
+++ b/.github/workflows/tpch-explain-artifacts.yml
@@ -38,13 +38,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   PG_VERSION: "18"
-  TPCH_SCALE: ${{ github.event.inputs.tpch_scale || '1.0' }}
-  TPCH_EXPLAIN_QUERIES: ${{ github.event.inputs.queries || '4,5,7,8,9,20,22' }}
 
 jobs:
   # ── O39-10: Capture EXPLAIN ANALYZE BUFFERS artifacts ─────────────────────
   tpch-explain-artifacts:
-    name: TPC-H EXPLAIN artifacts (SF-${{ github.event.inputs.tpch_scale || '1.0' }})
+    name: TPC-H EXPLAIN artifacts (SF-${{ inputs.tpch_scale || '1.0' }})
     runs-on: ubuntu-latest
     timeout-minutes: 120
 
@@ -84,7 +82,8 @@ jobs:
       # ── Run TPC-H EXPLAIN collection script ─────────────────────────────────
       - name: Collect TPC-H EXPLAIN ANALYZE BUFFERS
         env:
-          TPCH_SCALE: ${{ env.TPCH_SCALE }}
+          TPCH_SCALE: ${{ inputs.tpch_scale || '1.0' }}
+          TPCH_EXPLAIN_QUERIES: ${{ inputs.queries || '4,5,7,8,9,20,22' }}
           TPCH_EXPLAIN_OUTPUT_DIR: /tmp/tpch-explain-artifacts
         run: |
           # Start the E2E database container.
@@ -111,7 +110,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: tpch-explain-artifacts-sf${{ env.TPCH_SCALE }}-${{ github.run_number }}
+          name: tpch-explain-artifacts-sf${{ inputs.tpch_scale || '1.0' }}-${{ github.run_number }}
           path: /tmp/tpch-explain-artifacts/
           retention-days: 90
 


### PR DESCRIPTION
## Summary

Fixes a GitHub Actions workflow syntax error in `tpch-explain-artifacts.yml` that prevented the workflow from running. The error occurred when the workflow was triggered by schedule (weekly) because the global `env` section referenced `github.event.inputs`, which doesn't exist for schedule triggers.

## Changes

- Removed problematic conditionals from global `env` section that referenced `github.event.inputs`
- Updated job name to use `inputs.*` context (safe for workflow_dispatch, ignored for schedule)
- Fixed step environment variables to use `inputs.*` context directly instead of referencing global env
- Fixed artifact upload step to use `inputs.tpch_scale` directly instead of `env.TPCH_SCALE`
- All expressions now properly handle both schedule and workflow_dispatch trigger types

## Testing

- Workflow syntax is now valid and will parse without errors
- Scheduled runs will use default values (`TPCH_SCALE=1.0`, queries `4,5,7,8,9,20,22`)
- Manual dispatch runs can override defaults via workflow inputs

## Notes

GitHub Actions contexts have specific limitations — `github.event.inputs` is only available during `workflow_dispatch` triggers. The `inputs.*` context is safer as it gracefully handles both trigger types.
