### PR TITLE
fix(A41-4): pool worker ProcessConfigFile on SIGHUP + test query fix

### DIFF
--- a/.unsafe-baseline
+++ b/.unsafe-baseline
@@ -1,4 +1,4 @@
-# pg_trickle unsafe { block baseline — generated 2026-04-29
+# pg_trickle unsafe { block baseline — generated 2026-04-30
 # Tracks `grep -c "unsafe {"` counts per source file.
 # Files with 0 unsafe blocks are omitted.
 #
@@ -15,7 +15,7 @@ src/dvm/parser/validation.rs 2
 src/lib.rs 2
 src/scheduler/citus.rs 1
 src/scheduler/mod.rs 13
+src/scheduler/pool.rs 1
 src/shmem.rs 20
 src/wal_decoder.rs 4
 
-Baseline written to stdout. Redirect to .unsafe-baseline to save.

--- a/src/scheduler/pool.rs
+++ b/src/scheduler/pool.rs
@@ -116,6 +116,16 @@ pub extern "C-unwind" fn pg_trickle_pool_worker_main(_arg: pg_sys::Datum) {
             break;
         }
 
+        // A41-4: Process any pending SIGHUP config reload so that GUC
+        // changes (e.g. pg_trickle.enabled toggled back to on) take effect
+        // without requiring a process restart.
+        unsafe {
+            if pg_sys::ConfigReloadPending != 0 {
+                pg_sys::ConfigReloadPending = 0;
+                pg_sys::ProcessConfigFile(pg_sys::GucContext::PGC_SIGHUP);
+            }
+        }
+
         // A41-4: Check pg_trickle.enabled before claiming any job.
         // When the extension is disabled, defer all work and sleep until
         // re-enabled to avoid processing jobs while maintenance is in progress.

--- a/tests/e2e_bgworker_tests.rs
+++ b/tests/e2e_bgworker_tests.rs
@@ -614,7 +614,8 @@ async fn test_pool_worker_does_not_run_while_disabled() {
     let count_before: i64 = db
         .query_scalar(
             "SELECT count(*) FROM pgtrickle.pgt_refresh_history \
-             WHERE pgt_name = 'disabled_st' AND status = 'success'",
+             WHERE pgt_id = (SELECT pgt_id FROM pgtrickle.pgt_stream_tables WHERE pgt_name = 'disabled_st') \
+             AND status = 'COMPLETED'",
         )
         .await;
 
@@ -636,7 +637,8 @@ async fn test_pool_worker_does_not_run_while_disabled() {
     let count_disabled: i64 = db
         .query_scalar(
             "SELECT count(*) FROM pgtrickle.pgt_refresh_history \
-             WHERE pgt_name = 'disabled_st' AND status = 'success'",
+             WHERE pgt_id = (SELECT pgt_id FROM pgtrickle.pgt_stream_tables WHERE pgt_name = 'disabled_st') \
+             AND status = 'COMPLETED'",
         )
         .await;
     assert_eq!(


### PR DESCRIPTION
## Problem

CI run [#2030](https://github.com/grove/pg-trickle/actions/runs/25154164948) failed in the **E2E tests** job with exit code 100.

The failing test: `test_pool_worker_does_not_run_while_disabled` (T-A41-4).

Two bugs were found:

### Bug 1 — Wrong column name and status literal in test SQL (test regression)

The test queried `pgtrickle.pgt_refresh_history WHERE pgt_name = '...' AND status = 'success'`.

- `pgt_name` does not exist on `pgt_refresh_history` — it belongs to `pgt_stream_tables`
- The correct status value is `'COMPLETED'`, not `'success'`

### Bug 2 — Pool worker never reloads config after SIGHUP (real bug)

The pool worker registered `SignalWakeFlags::SIGHUP` but never called `ProcessConfigFile(PGC_SIGHUP)` when `ConfigReloadPending` was set. This meant that once `pg_trickle.enabled = off` was applied via `ALTER SYSTEM SET + pg_reload_conf()`, the pool worker's cached GUC value was permanently `false` — it could never be re-enabled without a process restart.

The scheduler main loop already had the correct pattern (`if ConfigReloadPending != 0 { ProcessConfigFile }`) but this was missing from the pool worker.

## Fix

**`src/scheduler/pool.rs`**: Add `ConfigReloadPending` check + `ProcessConfigFile(PGC_SIGHUP)` call at the top of the pool worker main loop, matching the scheduler's pattern.

**`tests/e2e_bgworker_tests.rs`**: Fix the two SQL queries to join `pgt_stream_tables` by `pgt_name` and use the correct `'COMPLETED'` status value.

## Verification

- `just test-e2e-fast` — **1333/1333 passed**
- `just test-tpch-fast` — **21/21 passed**
- `test_pool_worker_does_not_run_while_disabled` specifically: **PASS in ~16s** (previously always failed)