### PR TITLE
fix(test): use refresh history count instead of data_timestamp in T-A41-4 test

### DIFF
--- a/tests/e2e_bgworker_tests.rs
+++ b/tests/e2e_bgworker_tests.rs
@@ -657,8 +657,24 @@ async fn test_pool_worker_does_not_run_while_disabled() {
     );
 
     // After re-enabling the data inserted while disabled should trigger a refresh.
+    // We check pgt_refresh_history directly rather than data_timestamp:
+    // data_timestamp is set to now() at refresh-transaction start, and on
+    // Linux CI the first post-re-enable refresh can complete before
+    // initial_ts is captured, so wait_for_auto_refresh would need *two*
+    // refreshes to observe a change — an unnecessary timing dependency.
     let resumed = db
-        .wait_for_auto_refresh("disabled_st", Duration::from_secs(60))
+        .wait_for_condition(
+            "new refresh should complete after re-enabling",
+            &format!(
+                "SELECT count(*) > {count_before} \
+                 FROM pgtrickle.pgt_refresh_history \
+                 WHERE pgt_id = (SELECT pgt_id FROM pgtrickle.pgt_stream_tables \
+                                 WHERE pgt_name = 'disabled_st') \
+                 AND status = 'COMPLETED'"
+            ),
+            Duration::from_secs(30),
+            Duration::from_millis(500),
+        )
         .await;
     assert!(
         resumed,


### PR DESCRIPTION
# fix(test): use refresh history count instead of `data_timestamp` in T-A41-4 test

## Problem

The `test_pool_worker_does_not_run_while_disabled` E2E test was added in PR #727
to verify that the scheduler resumes refreshes after `pg_trickle.enabled` is
restored to `on`. It was consistently failing on Linux CI (amd64) with a 60-second
timeout, while passing locally on macOS (arm64).

**Root cause:** The test used `wait_for_auto_refresh`, which waits for
`data_timestamp` to change on `pgtrickle.pgt_stream_tables`. On Linux CI the
scheduler processes the SIGHUP and runs the first post-re-enable refresh
*faster* — completing before `initial_ts` is captured inside
`wait_for_auto_refresh`. The helper then needs a **second** refresh to observe a
`data_timestamp` delta, creating a race between transaction timestamps that
reliably loses on CI.

The fix passed locally on macOS because the scheduler there typically hadn't
completed a refresh yet when `initial_ts` was captured (`None`), so the first
post-re-enable refresh (setting `data_timestamp = Some(T)`) was always detected.

## Fix

Replace `wait_for_auto_refresh("disabled_st", 60s)` with
`wait_for_condition` that checks `pgt_refresh_history` count directly:

```sql
SELECT count(*) > {count_before}
FROM pgtrickle.pgt_refresh_history
WHERE pgt_id = (SELECT pgt_id FROM pgtrickle.pgt_stream_tables
                WHERE pgt_name = 'disabled_st')
AND status = 'COMPLETED'
```

This detects the **first** completed refresh after re-enabling, regardless of
`data_timestamp` semantics or transaction timing. The timeout is also reduced
from 60s to 30s since the scheduler re-enables within a few hundred
milliseconds on all platforms.

## Files changed

- `tests/e2e_bgworker_tests.rs` — replaced `wait_for_auto_refresh` with
  `wait_for_condition` on refresh history count; reduced timeout 60s → 30s

## CI

- No logic changes; only the test assertion strategy changed
- All other tests in `e2e_bgworker_tests.rs` are unaffected
