### PR TITLE
roadmap(v0.43.0): record ADR for changed_cols WB-1 symmetric bitmask in A44-10

### DIFF
--- a/roadmap/v0.43.0.md
+++ b/roadmap/v0.43.0.md
@@ -68,9 +68,12 @@ time via a 600-line, 5-CTE UNION ALL pipeline. v0.43.0 replaces this with the
 native D+I storage model: the CDC trigger emits `action='D'` (OLD values) and
 `action='I'` (NEW values) as separate rows, and the delta scan collapses to a
 single query with no UNION ALL or column-prefix aliasing. CB table width halves
-for all source tables. The `changed_cols` WB-1 bitmask computation moves to
-write time. This is a breaking schema migration — all existing change buffers
-are rebuilt and all CDC triggers are regenerated during upgrade.
+for all source tables. The `changed_cols` WB-1 bitmask is retained at read
+time: both the D-row and I-row of an UPDATE pair carry the same VARBIT, with
+`NULL` reserved for genuine INSERT or DELETE rows. This keeps the CB table
+fully decoupled from downstream view column selections. This is a breaking
+schema migration — all existing change buffers are rebuilt and all CDC
+triggers are regenerated during upgrade.
 
 See issue [#728](https://github.com/grove/pg-trickle/issues/728) and
 discussion [#726](https://github.com/grove/pg-trickle/discussions/726).

--- a/roadmap/v0.43.0.md-full.md
+++ b/roadmap/v0.43.0.md-full.md
@@ -108,7 +108,18 @@ a single-query scan with no UNION ALL, no column-prefix aliasing, no
 Changes required:
 - `src/cdc.rs`: CB table DDL, `build_change_buffer_columns()`,
   `alter_change_buffer_add_columns()`, `sync_change_buffer_columns()`,
-  row-level trigger body, statement-level trigger body, WAL decoder write path
+  row-level trigger body, statement-level trigger body, WAL decoder write path.
+  **Statement-level UPDATE trigger** (ADR): use a single
+  `INSERT INTO changes_<oid> … SELECT … UNION ALL SELECT …` to emit both the
+  D-row (from `__pgt_old JOIN __pgt_new`) and the I-row (from
+  `__pgt_new JOIN __pgt_old`) in one executor pass, opening the CB heap
+  relation once per UPDATE statement. This is strictly better than two
+  separate `INSERT … SELECT` statements for large batch UPDATEs.
+  *Rejected alternative:* two separate `INSERT … SELECT` statements — opens
+  the CB heap relation twice per UPDATE statement; acceptable for the row-level
+  trigger (which cannot batch) but avoidable for the statement-level path.
+  The row-level trigger emits two sequential `VALUES` inserts (one D, one I)
+  — no batching possible there.
 - `src/dvm/operators/scan.rs`: `diff_scan_change_buffer()` — collapse to
   single-query scan; remove `is_st_source` branch, `old_col_prefix`,
   `old_pk_hash_expr`, and 5-CTE pipeline

--- a/roadmap/v0.43.0.md-full.md
+++ b/roadmap/v0.43.0.md-full.md
@@ -113,8 +113,18 @@ Changes required:
   single-query scan; remove `is_st_source` branch, `old_col_prefix`,
   `old_pk_hash_expr`, and 5-CTE pipeline
 - `src/wal_decoder.rs`: UPDATE → D+I decomposition at decode time
-- `changed_cols` WB-1: move bitmask computation to CDC write time (trigger has
-  OLD/NEW in scope); remove post-hoc VARBIT filtering from scan
+- `changed_cols` WB-1 (ADR): both the D-row and I-row of an UPDATE pair carry
+  the **same** VARBIT bitmask (`NULL` = genuine INSERT or DELETE, not an UPDATE
+  half). The scan filter remains at read time, unchanged in structure — it tests
+  `changed_cols IS NULL OR (changed_cols & mask) != zero`. This preserves full
+  decoupling from view definitions (a single CB table can serve many STs each
+  with a different column mask), avoids write-time coupling to the query
+  definition, and requires no correlation between D and I rows. The CDC trigger
+  computes the bitmask once from OLD/NEW and writes it to both rows.
+  *Rejected alternatives:* (1) write-time filtering — requires the trigger to
+  know the union of all downstream referenced columns, coupling trigger rebuild
+  to view DDL changes; (2) bitmask on I-row only — requires D/I correlation at
+  read time to suppress phantom deletes, reintroducing complexity D+I eliminates.
 - Migration: rebuild all `changes_<oid>` tables and regenerate all CDC triggers
   during upgrade; discard in-flight buffer rows
 
@@ -194,9 +204,11 @@ regression detection works on PR.
 **T-A44-10.**
 E2E tests covering the full CDC lifecycle under D+I schema: INSERT, UPDATE, and
 DELETE correctness; net-effect idempotency (multiple UPDATEs to same row);
-keyless table path; ST-source path; WAL decoder path; `changed_cols` write-time
-filtering. Upgrade path tests: existing stream table with old wide-schema buffer
-successfully migrates to D+I on `ALTER EXTENSION pg_trickle UPDATE`.
+keyless table path; ST-source path; WAL decoder path; `changed_cols` symmetric
+bitmask (D-row and I-row both carry same VARBIT, NULL for genuine INSERT/DELETE);
+multi-ST fan-out (same CB served by two STs with different column masks). Upgrade
+path tests: existing stream table with old wide-schema buffer successfully
+migrates to D+I on `ALTER EXTENSION pg_trickle UPDATE`.
 
 **T-A44-11.**
 Run all four benchmark scenarios (write path, CB scan, multi-change, UNION ALL


### PR DESCRIPTION
## Summary

Records an explicit design decision (ADR) for the `changed_cols` / WB-1 optimization within the D+I change buffer schema refactor (A44-10, v0.43.0).

The previous A44-10 spec said "move `changed_cols` bitmask computation to CDC write time" without documenting why, or why the alternatives were rejected. This PR replaces that vague note with a proper ADR.

## The Decision

**Symmetric bitmask: both the D-row and I-row of an UPDATE pair carry the same VARBIT. `NULL` = genuine INSERT or DELETE.**

```
Genuine INSERT  →  action='I',  changed_cols=NULL
Genuine DELETE  →  action='D',  changed_cols=NULL
UPDATE D-side   →  action='D',  changed_cols=B'...'   (computed once at trigger time)
UPDATE I-side   →  action='I',  changed_cols=B'...'   (identical bitmask)
```

The WB-1 scan filter is unchanged in structure — it tests `changed_cols IS NULL OR (mask & bits) != zero`. Both rows of an UPDATE pair pass or fail the same predicate; no correlation between D and I rows is needed. Multiple stream tables with different column subsets each apply their own mask independently to the same CB rows.

## Alternatives Rejected

**Option 1 — write-time filtering (trigger skips D+I pair when no referenced column changed)**

A single CB table can serve many stream tables, each referencing different column subsets. The trigger would need the union of all referenced columns embedded in its body. View DDL changes (e.g. `ALTER STREAM TABLE` redefining the query) can change referenced columns without touching the source table schema — a coupling `sync_change_buffer_columns()` does not currently handle.

**Option 2 — bitmask on I-row only, D-row always passes filter**

Cannot suppress the D-row without correlating it to its I-row partner at read time. This reintroduces exactly the kind of paired-row complexity that D+I is designed to eliminate.

## Files Changed

- `roadmap/v0.43.0.md` — updated D+I summary paragraph
- `roadmap/v0.43.0.md-full.md` — A44-10 spec and T-A44-10 test spec updated with ADR and rejected alternatives documented inline

## Refs

Closes decision thread in #728 (comment).
Discussion: #726.
