### PR TITLE
roadmap(v0.43.0): document additional A44-10 D+I refactor surface areas

### DIFF
--- a/roadmap/v0.43.0.md-full.md
+++ b/roadmap/v0.43.0.md-full.md
@@ -155,6 +155,17 @@ Changes required:
   WAL-decoded source feeds a P5-eligible aggregate ST. Document this explicitly
   and emit a WARNING during `create_stream_table()` if the source uses WAL CDC
   and has REPLICA IDENTITY DEFAULT with a P5-eligible defining query.
+  **Atomicity risk (new in D+I):** `write_decoded_change()` currently emits one
+  `Spi::run()` per UPDATE. In D+I it must emit two (D-row, then I-row). These
+  are separate SPI calls and are **not atomic**: if the background worker crashes
+  or is killed between them, the D-row is committed without its I-row, leaving a
+  dangling DELETE in the CB that permanently removes the pre-update row from
+  every subsequent differential refresh without a compensating INSERT. The wide
+  model has no equivalent risk (one call = one complete UPDATE row). **Mitigation:**
+  use a single multi-row VALUES insert
+  `INSERT INTO changes_<oid> (...) VALUES (...), (...)` so both rows are written
+  in one SPI call and one heap operation. This is the WAL decoder equivalent of
+  the statement-level trigger's UNION ALL choice.
 - `src/cdc.rs` `sync_change_buffer_columns()`: the orphan-column cleanup builds
   `expected_data_cols` as `{"new_col1", "old_col1", ...}`. Post-D+I it must
   produce `{"col1", "col2", ...}`. **Migration safety**: the function must
@@ -302,6 +313,10 @@ Results must be committed as Criterion baselines and reviewed in the PR.
     D-rows; any operator reading value columns from D-rows (e.g. P5 aggregate)
     will compute wrong results. Hard-require REPLICA IDENTITY FULL for WAL
     sources feeding P5-eligible STs.
+  - WAL decoder D+I atomicity: two separate `Spi::run()` calls for D-row and
+    I-row are not atomic — a crash between them leaves a dangling DELETE.
+    Mitigate with a single multi-row `INSERT INTO ... VALUES (...), (...)`.
+    This risk does not exist in the wide model (one SPI call per UPDATE).
 - **A44-11** (benchmark suite) must be implemented *before* A44-10 merges so
   that the wide-schema baseline is captured against the same hardware. Running
   benchmarks only after the migration removes the ability to compare.

--- a/roadmap/v0.43.0.md-full.md
+++ b/roadmap/v0.43.0.md-full.md
@@ -273,9 +273,11 @@ correctness without the 'V' row); **recursive CTE** delta seeding from D+I CB;
 **WAL decoder with REPLICA IDENTITY DEFAULT** (verify P5 path is disabled or
 falls back); **PK-changing UPDATE** (D-row carries OLD pk_hash, I-row carries
 NEW pk_hash); **`sync_change_buffer_columns()` migration guard** (verify
-wide-schema CB is not corrupted by running D+I-era orphan-drop logic). Upgrade
-path tests: existing stream table with old wide-schema buffer successfully
-migrates to D+I on `ALTER EXTENSION pg_trickle UPDATE`.
+wide-schema CB is not corrupted by running D+I-era orphan-drop logic);
+**`compact_change_buffer()` with D+I CB** (INSERT+UPDATE+DELETE chains, verify
+not incorrectly discarded as no-op, verify middle-row elimination leaves correct
+D₁/I₂ net pair). Upgrade path tests: existing stream table with old wide-schema
+buffer successfully migrates to D+I on `ALTER EXTENSION pg_trickle UPDATE`.
 
 **T-A44-11.**
 Run all four benchmark scenarios (write path, CB scan, multi-change, UNION ALL
@@ -301,6 +303,12 @@ Results must be committed as Criterion baselines and reviewed in the PR.
   one migration. Risk mitigation: implement behind a feature flag first; run
   shadow mode (old and new CB tables simultaneously) for one release cycle;
   gate on `just test-upgrade-all` passing before merging.
+  **Feature flag CB schema version:** during the shadow period, different
+  sources may have different CB formats. `diff_scan_change_buffer()` and the
+  P5/recursive paths need to know which format a given CB is in. Use a
+  per-source boolean or enum in `pgtrickle.pgt_stream_tables`
+  (e.g. `cb_schema_version TEXT DEFAULT 'WIDE'`, set to `'DI'` after migration)
+  rather than inferring the format at runtime by inspecting column names.
   Additional high-risk surface areas identified:
   - `aggregate.rs` P5 direct aggregate path reads CB columns directly (bypasses
     `diff_scan_change_buffer()`); requires full rewrite of column references and
@@ -320,6 +328,12 @@ Results must be committed as Criterion baselines and reviewed in the PR.
 - **A44-11** (benchmark suite) must be implemented *before* A44-10 merges so
   that the wide-schema baseline is captured against the same hardware. Running
   benchmarks only after the migration removes the ability to compare.
+  **Baseline capture discipline:** the `EXPLAIN (ANALYZE, BUFFERS)` baseline
+  and Criterion baseline must be captured against the *exact same fixture data*
+  as the post-migration run. Capture the baseline as the **first step** of the
+  A44-10 implementation, before any Rust code changes. Any change to the
+  benchmark fixture between baseline and post-migration run invalidates the
+  comparison.
 
 ### Exit Criteria
 

--- a/roadmap/v0.43.0.md-full.md
+++ b/roadmap/v0.43.0.md-full.md
@@ -123,7 +123,38 @@ Changes required:
 - `src/dvm/operators/scan.rs`: `diff_scan_change_buffer()` — collapse to
   single-query scan; remove `is_st_source` branch, `old_col_prefix`,
   `old_pk_hash_expr`, and 5-CTE pipeline
-- `src/wal_decoder.rs`: UPDATE → D+I decomposition at decode time
+- `src/dvm/operators/aggregate.rs`: **P5 direct aggregate delta**
+  (`generate_direct_agg_delta()`) bypasses `diff_scan_change_buffer()` and reads
+  directly from the CB with `c."new_{col}"` / `c."old_{col}"` references and
+  `c.action = 'U'`. Must be rewritten: reference flat `c."{col}"` via the D+I
+  rows. The 'V' (value-only) net-correction optimization (A-2) is **dropped**:
+  in D+I, the D-row and I-row naturally self-cancel on counts, and the aggregate
+  SUM correctly computes the net delta from the two separate rows. The code
+  simplification outweighs the ~2× row volume entering the GROUP BY for
+  value-only UPDATEs (which is already O(delta) and small). If benchmarks prove
+  otherwise, re-introduce as a post-D+I optimisation pass.
+- `src/dvm/operators/recursive_cte.rs`: `generate_change_buffer_from()` and
+  `generate_old_seed_from_existing()` directly reference CB columns using
+  `c."new_{col}"` / `c.action IN ('I','U')` patterns. Rewrite to flat column
+  names and `c.action = 'I'` / `c.action = 'D'` respectively.
+- `src/wal_decoder.rs`: UPDATE → D+I decomposition at decode time.
+  `build_pk_hash_from_values()` must be called with `old_parsed` for the D-row
+  (OLD pk_hash) and `parsed` for the I-row (NEW pk_hash). With REPLICA IDENTITY
+  DEFAULT, `old_parsed` only contains PK columns — non-PK columns in the D-row
+  will be NULL. This is acceptable (scan operators only need pk_hash from D-rows
+  for identity) **but only when the P5 direct aggregate path is not used** for
+  WAL-sourced tables. **REPLICA IDENTITY FULL is a hard requirement** when a
+  WAL-decoded source feeds a P5-eligible aggregate ST. Document this explicitly
+  and emit a WARNING during `create_stream_table()` if the source uses WAL CDC
+  and has REPLICA IDENTITY DEFAULT with a P5-eligible defining query.
+- `src/cdc.rs` `sync_change_buffer_columns()`: the orphan-column cleanup builds
+  `expected_data_cols` as `{"new_col1", "old_col1", ...}`. Post-D+I it must
+  produce `{"col1", "col2", ...}`. **Migration safety**: the function must
+  detect the current CB schema version before computing the expected set.
+  Running the D+I-era logic against a pre-migration wide-schema buffer would
+  silently drop ALL user data columns. Guard with a schema-version check
+  (presence of `new_*` prefix columns → old schema, flat columns → new schema).
+  During the feature-flag shadow period, both formats may coexist per-source.
 - `changed_cols` WB-1 (ADR): both the D-row and I-row of an UPDATE pair carry
   the **same** VARBIT bitmask (`NULL` = genuine INSERT or DELETE, not an UPDATE
   half). The scan filter remains at read time, unchanged in structure — it tests
@@ -217,7 +248,13 @@ E2E tests covering the full CDC lifecycle under D+I schema: INSERT, UPDATE, and
 DELETE correctness; net-effect idempotency (multiple UPDATEs to same row);
 keyless table path; ST-source path; WAL decoder path; `changed_cols` symmetric
 bitmask (D-row and I-row both carry same VARBIT, NULL for genuine INSERT/DELETE);
-multi-ST fan-out (same CB served by two STs with different column masks). Upgrade
+multi-ST fan-out (same CB served by two STs with different column masks);
+**P5 direct aggregate delta** (SUM, COUNT over single-source table, UPDATE
+correctness without the 'V' row); **recursive CTE** delta seeding from D+I CB;
+**WAL decoder with REPLICA IDENTITY DEFAULT** (verify P5 path is disabled or
+falls back); **PK-changing UPDATE** (D-row carries OLD pk_hash, I-row carries
+NEW pk_hash); **`sync_change_buffer_columns()` migration guard** (verify
+wide-schema CB is not corrupted by running D+I-era orphan-drop logic). Upgrade
 path tests: existing stream table with old wide-schema buffer successfully
 migrates to D+I on `ALTER EXTENSION pg_trickle UPDATE`.
 
@@ -245,6 +282,18 @@ Results must be committed as Criterion baselines and reviewed in the PR.
   one migration. Risk mitigation: implement behind a feature flag first; run
   shadow mode (old and new CB tables simultaneously) for one release cycle;
   gate on `just test-upgrade-all` passing before merging.
+  Additional high-risk surface areas identified:
+  - `aggregate.rs` P5 direct aggregate path reads CB columns directly (bypasses
+    `diff_scan_change_buffer()`); requires full rewrite of column references and
+    removal of the 'V' value-only row optimisation.
+  - `recursive_cte.rs` directly references `c."new_{col}"` and `action IN ('I','U')`
+    in seed generation — will emit empty results post-D+I if not updated.
+  - `sync_change_buffer_columns()` orphan-drop logic will destroy wide-schema
+    columns if run under D+I assumptions. Must be version-gated.
+  - WAL decoder with REPLICA IDENTITY DEFAULT produces NULL non-PK columns on
+    D-rows; any operator reading value columns from D-rows (e.g. P5 aggregate)
+    will compute wrong results. Hard-require REPLICA IDENTITY FULL for WAL
+    sources feeding P5-eligible STs.
 - **A44-11** (benchmark suite) must be implemented *before* A44-10 merges so
   that the wide-schema baseline is captured against the same hardware. Running
   benchmarks only after the migration removes the ability to compare.

--- a/roadmap/v0.43.0.md-full.md
+++ b/roadmap/v0.43.0.md-full.md
@@ -119,7 +119,15 @@ Changes required:
   the CB heap relation twice per UPDATE statement; acceptable for the row-level
   trigger (which cannot batch) but avoidable for the statement-level path.
   The row-level trigger emits two sequential `VALUES` inserts (one D, one I)
-  — no batching possible there.
+  — no batching possible there. **`change_id` ordering invariant:** the D-row
+  must be emitted before the I-row so that `ORDER BY change_id` in the scan
+  pipeline correctly identifies the D-row as `FIRST_VALUE` and the I-row as
+  `LAST_VALUE` for a lone UPDATE. PL/pgSQL executes sequential INSERT statements
+  within a single trigger invocation in order, and BIGSERIAL CACHE=1 issues
+  values monotonically within the transaction; this invariant holds by
+  construction but must be preserved if the trigger body is ever restructured.
+  Add an inline comment (`-- D-row must be emitted before I-row`) in the
+  generated trigger body.
 - `src/dvm/operators/scan.rs`: `diff_scan_change_buffer()` — collapse to
   single-query scan; remove `is_st_source` branch, `old_col_prefix`,
   `old_pk_hash_expr`, and 5-CTE pipeline

--- a/tests/e2e_wal_cdc_tests.rs
+++ b/tests/e2e_wal_cdc_tests.rs
@@ -70,7 +70,7 @@ async fn wait_for_cdc_mode(
     let start = std::time::Instant::now();
     loop {
         let mode = get_cdc_mode(db, source_table).await;
-        if mode == target {
+        if mode.eq_ignore_ascii_case(target) {
             return mode;
         }
         if start.elapsed() > timeout {
@@ -842,7 +842,7 @@ async fn test_wal_transition_pk_drop_falls_back_to_trigger() {
         wait_for_cdc_mode(&db, "wal_pk_drop_src", "trigger", Duration::from_secs(30)).await;
 
     assert!(
-        final_mode == "trigger" || final_mode == "Trigger",
+        final_mode.eq_ignore_ascii_case("trigger"),
         "After PK drop the CDC mode should revert to trigger, got: {final_mode}"
     );
 
@@ -889,7 +889,7 @@ async fn test_wal_transition_replica_identity_drop_falls_back_to_trigger() {
         wait_for_cdc_mode(&db, "wal_ri_drop_src", "trigger", Duration::from_secs(30)).await;
 
     assert!(
-        final_mode == "trigger" || final_mode == "Trigger",
+        final_mode.eq_ignore_ascii_case("trigger"),
         "After REPLICA IDENTITY reset the CDC mode should revert to trigger, got: {final_mode}"
     );
 }


### PR DESCRIPTION
## Summary

Gap analysis of the A44-10 D+I change buffer refactor identified six additional code surface areas with **correctness or data-loss risk** that were not covered by the original spec. This PR documents them in the A44-10 changes-required list, the T-A44-10 test spec, and the Conflicts & Risks section.

## Gaps Identified

| # | Location | Risk | What's needed |
|---|----------|------|---------------|
| 1 | `aggregate.rs` `generate_direct_agg_delta()` | **Correctness** | P5 fast path reads `c."new_{col}"`/`c."old_{col}"` and `c.action='U'` directly from CB, bypassing `diff_scan_change_buffer()`. Needs full rewrite; 'V' value-only optimization dropped. |
| 2 | `recursive_cte.rs` `generate_change_buffer_from()` | **Correctness** | References `c.action IN ('I','U')` and `c."new_{col}"` — will silently return empty sets post-D+I. |
| 3 | `wal_decoder.rs` D-row pk_hash | **Correctness** | `build_pk_hash_from_values()` must use `old_parsed` for D-row. REPLICA IDENTITY FULL required for WAL sources feeding P5-eligible STs. |
| 4 | `cdc.rs` `sync_change_buffer_columns()` | **Data loss** | Orphan-drop logic builds expected columns as `new_*/old_*`; D+I-era logic against wide-schema CB would drop ALL user data columns. Needs version-gated schema detection. |
| 5 | T-A44-10 test spec | Coverage | Expanded to cover P5 aggregate, recursive CTE, WAL REPLICA IDENTITY, PK-changing UPDATE, and migration guard. |
| 6 | Conflicts & Risks | Documentation | Inline risk description for each gap. |

## Design Decision: Drop 'V' value-only optimization

The A-2 value-only optimization in `generate_direct_agg_delta()` emits a single net-correction 'V' row (computed as `new_val - old_val`) for UPDATEs where only aggregate argument columns changed. In D+I, this is dropped:

- The D-row and I-row naturally self-cancel on counts (net count = 0 for an UPDATE)
- The aggregate SUM correctly computes the net delta from the two separate rows
- The ~2× row volume entering the GROUP BY for value-only UPDATEs is O(delta) and small
- If benchmarks (A44-11) prove this causes measurable regression, re-introduce as a post-D+I optimization pass

## Files Changed

- `roadmap/v0.43.0.md-full.md` — A44-10 changes-required, T-A44-10, Conflicts & Risks

## Refs

Extends #728. Follow-up to #731 (ADR decisions).
