### PR TITLE
fix(ci): clear BASH_FUNC_ env vars on Windows before Rust install

### DIFF
--- a/.github/actions/setup-pgrx/action.yml
+++ b/.github/actions/setup-pgrx/action.yml
@@ -19,6 +19,25 @@ runs:
   using: composite
   steps:
     # ── Rust toolchain ────────────────────────────────────────────────────
+    # On Windows runners, spurious BASH_FUNC_* environment variables are
+    # occasionally injected by prior steps, causing dtolnay/rust-toolchain
+    # to abort with "bash function injection" errors.
+    # See https://github.com/actions/partner-runner-images/issues/169
+    - name: Remove spurious BASH_FUNC_ env vars (Windows)
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $removed = @()
+        Get-ChildItem -Path Env: | Where-Object { $_.Name -like 'BASH_FUNC_*' } | ForEach-Object {
+          [Environment]::SetEnvironmentVariable($_.Name, $null, [EnvironmentVariableTarget]::Process)
+          $removed += $_.Name
+        }
+        if ($removed.Count -gt 0) {
+          Write-Host "Removed BASH_FUNC_ env vars: $($removed -join ', ')"
+        } else {
+          Write-Host "No BASH_FUNC_ env vars found"
+        }
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@master
       with:


### PR DESCRIPTION
## Summary

The v0.41.0 release workflow failed on the `Build (windows-amd64)` job because `dtolnay/rust-toolchain` detected spurious `BASH_FUNC_*` environment variables on the Windows runner and aborted with a "bash function injection" security error. This is a known flaky issue in GitHub's partner runner images (actions/runner-images#14052) that is unrelated to the extension code itself.

The failed re-run was already triggered. This PR adds a permanent preventive fix.

## Changes

- Added a PowerShell pre-step in `.github/actions/setup-pgrx/action.yml` that clears any `BASH_FUNC_*` environment variables before the `dtolnay/rust-toolchain` installation step on Windows runners. The step is a no-op when no such variables are present, so it has zero cost on clean runners.

## Testing

- No code changes — CI-only fix
- The `--failed` re-run of run [25176777784](https://github.com/grove/pg-trickle/actions/runs/25176777784) was triggered to recover the missing `release-windows-amd64` artifact for v0.41.0

## Notes

The root cause: on some Windows runner instances, prior runner setup steps inject `BASH_FUNC_*` env vars (e.g. `BASH_FUNC_which%%`). The `dtolnay/rust-toolchain` action includes a security check that refuses to proceed if those vars are present, then retries up to its limit and gives up with "installation failed due to bash startup failure". Clearing them with PowerShell before the step is the standard workaround.

After the `--failed` re-run completes and the `release-windows-amd64` artifact is available, attach it to the v0.41.0 release with:
```bash
gh run download 25176777784 --repo grove/pg-trickle --name release-windows-amd64 --dir /tmp/win-artifact
gh release upload v0.41.0 /tmp/win-artifact/*.zip --repo grove/pg-trickle
```
