### PR TITLE
fix(semgrep): exclude separate-file test modules from rust.panic-in-sql-path

### DIFF
--- a/.semgrep/pg_trickle.yml
+++ b/.semgrep/pg_trickle.yml
@@ -129,3 +129,10 @@ rules:
         - /src/dvm/**
         # Standalone CLI binary — not loaded into the PostgreSQL process
         - /src/bin/**
+        # Separate-file test modules (declared as `mod tests;` inside
+        # `#[cfg(test)] mod tests` in the parent module).  Semgrep's AST
+        # does not see the `#[cfg(test)]` wrapper in the parent file when
+        # analysing the child file in isolation, so `pattern-not-inside:
+        # mod tests { ... }` above cannot match.  These files are compiled
+        # only for `cargo test` and never loaded into a PostgreSQL backend.
+        - /src/**/tests.rs


### PR DESCRIPTION
## Summary

The semgrep `rust.panic-in-sql-path` rule was firing a false positive on
`src/refresh/tests.rs` (alert #722) because Semgrep analyses each file in
isolation and cannot see the `#[cfg(test)]` guard that wraps `mod tests;` in
the parent `src/refresh/mod.rs`. The existing `pattern-not-inside: mod tests
{ ... }` exclusion only works for **inline** test modules; it does not match
when the module body lives in a separate file.

## Changes

- Added `/src/**/tests.rs` to the `exclude` paths of the
  `rust.panic-in-sql-path` rule in `.semgrep/pg_trickle.yml`.
- Added a comment explaining why file-based test modules need a separate
  exclude entry (the `#[cfg(test)]` wrapper is invisible to Semgrep when it
  scans the child file in isolation).

## Testing

- `semgrep scan --config .semgrep/pg_trickle.yml src/refresh/tests.rs` —
  **0 findings** (was 1 before this change).
- `semgrep scan --config .semgrep/pg_trickle.yml src/` — no new findings
  introduced; all remaining findings are pre-existing, unrelated rules.

## Notes

This is a static-analysis configuration fix only — no production Rust code
was changed. The `.unwrap()` in `resolve_lsn_placeholders_test` is correct
test code and has always been guarded by `#[cfg(test)]`; it was never
reachable from a SQL-callable function.

Closes security alert #722.
