### PR TITLE
fix(wal-cdc): scope pg_replication_slots to current_database() and fix WAL change buffer type casts

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1688,7 +1688,8 @@ fn check_cdc_health() -> TableIterator<
                 let lsn = dep.decoder_confirmed_lsn.clone();
 
                 let slot_exists = Spi::get_one_with_args::<bool>(
-                    "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+                    "SELECT EXISTS(SELECT 1 FROM pg_replication_slots \
+                     WHERE slot_name = $1 AND database = current_database())",
                     &[slot.as_str().into()],
                 )
                 .unwrap_or(Some(false))
@@ -1958,9 +1959,10 @@ fn check_wal_slot_existence() {
             None => crate::wal_decoder::slot_name_for_source(dep.source_relid),
         };
 
-        // Check if the replication slot exists
+        // Check if the replication slot exists (scoped to current database)
         let slot_exists = Spi::get_one_with_args::<bool>(
-            "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+            "SELECT EXISTS(SELECT 1 FROM pg_replication_slots \
+             WHERE slot_name = $1 AND database = current_database())",
             &[slot_name.as_str().into()],
         )
         .unwrap_or(Some(false))

--- a/src/wal_decoder.rs
+++ b/src/wal_decoder.rs
@@ -245,8 +245,13 @@ pub fn create_replication_slot_pristine(slot_name: &str) -> Result<String, PgTri
 /// This function does SPI reads and must NOT be called in the same
 /// transaction as `create_replication_slot_pristine`.
 pub fn get_existing_slot_lsn(slot_name: &str) -> Result<Option<String>, PgTrickleError> {
+    // Filter by database = current_database() so that identically-named slots
+    // belonging to other databases (e.g. parallel test databases in the same
+    // PostgreSQL instance) are not mistakenly reused.  pg_logical_slot_get_changes
+    // errors if called for a slot that belongs to a different database.
     let exists = Spi::get_one_with_args::<bool>(
-        "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+        "SELECT EXISTS(SELECT 1 FROM pg_replication_slots \
+         WHERE slot_name = $1 AND database = current_database())",
         &[slot_name.into()],
     )
     .map_err(|e| PgTrickleError::SpiError(e.to_string()))?
@@ -257,7 +262,8 @@ pub fn get_existing_slot_lsn(slot_name: &str) -> Result<Option<String>, PgTrickl
     }
 
     let lsn = Spi::get_one_with_args::<String>(
-        "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name = $1",
+        "SELECT confirmed_flush_lsn::text FROM pg_replication_slots \
+         WHERE slot_name = $1 AND database = current_database()",
         &[slot_name.into()],
     )
     .map_err(|e| PgTrickleError::SpiError(e.to_string()))?
@@ -273,10 +279,11 @@ pub fn get_existing_slot_lsn(slot_name: &str) -> Result<Option<String>, PgTrickl
 /// that the full refresh has already materialized (G3). Returns `Ok(())`
 /// immediately if the slot does not exist (e.g., trigger-based sources).
 pub fn advance_slot_to_current(slot_name: &str) -> Result<(), PgTrickleError> {
-    // Guard against missing slot before issuing the advance,
-    // which would otherwise raise a PostgreSQL ERROR.
+    // Guard against missing slot (or a slot owned by a different database)
+    // before issuing the advance, which would otherwise raise a PostgreSQL ERROR.
     let exists = Spi::get_one_with_args::<bool>(
-        "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+        "SELECT EXISTS(SELECT 1 FROM pg_replication_slots \
+         WHERE slot_name = $1 AND database = current_database())",
         &[slot_name.into()],
     )
     .map_err(|e| PgTrickleError::SpiError(e.to_string()))?
@@ -407,8 +414,11 @@ fn create_replication_slot_internal(slot_name: &str) -> Result<String, PgTrickle
 ///
 /// Safe to call even if the slot doesn't exist (checks first).
 pub fn drop_replication_slot(slot_name: &str) -> Result<(), PgTrickleError> {
+    // Filter by database = current_database() to avoid accidentally dropping a
+    // slot that belongs to a different database but shares the same name.
     let exists = Spi::get_one_with_args::<bool>(
-        "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+        "SELECT EXISTS(SELECT 1 FROM pg_replication_slots \
+         WHERE slot_name = $1 AND database = current_database())",
         &[slot_name.into()],
     )
     .map_err(|e| PgTrickleError::SpiError(e.to_string()))?
@@ -434,7 +444,8 @@ pub fn drop_replication_slot(slot_name: &str) -> Result<(), PgTrickleError> {
 /// Returns `None` if the slot doesn't exist.
 pub fn get_slot_confirmed_lsn(slot_name: &str) -> Result<Option<String>, PgTrickleError> {
     Spi::get_one_with_args::<String>(
-        "SELECT confirmed_flush_lsn::text FROM pg_replication_slots WHERE slot_name = $1",
+        "SELECT confirmed_flush_lsn::text FROM pg_replication_slots \
+         WHERE slot_name = $1 AND database = current_database()",
         &[slot_name.into()],
     )
     .map_err(|e| PgTrickleError::SpiError(e.to_string()))
@@ -446,7 +457,8 @@ pub fn get_slot_confirmed_lsn(slot_name: &str) -> Result<Option<String>, PgTrick
 pub fn get_slot_lag_bytes(slot_name: &str) -> Result<i64, PgTrickleError> {
     Spi::get_one_with_args::<i64>(
         "SELECT (pg_current_wal_lsn() - confirmed_flush_lsn)::bigint \
-         FROM pg_replication_slots WHERE slot_name = $1",
+         FROM pg_replication_slots \
+         WHERE slot_name = $1 AND database = current_database()",
         &[slot_name.into()],
     )
     .map_err(|e| PgTrickleError::SpiError(e.to_string()))
@@ -498,7 +510,13 @@ const MAX_CHANGES_PER_POLL: i64 = 10_000;
 /// Number of consecutive WAL poll errors before automatically falling back
 /// to trigger-based CDC. Prevents a permanently broken WAL decoder from
 /// blocking change capture indefinitely.
-const MAX_CONSECUTIVE_WAL_ERRORS: u32 = 5;
+///
+/// Set to 20 (≈ 20 seconds at a 1 s scheduler interval) so that transient
+/// slot contention under CI load does not trigger an irreversible fallback.
+/// The fallback should only fire for a genuinely broken slot that fails
+/// reliably across many ticks — not for the brief spike that can occur
+/// right after slot creation or on a loaded test machine.
+const MAX_CONSECUTIVE_WAL_ERRORS: u32 = 20;
 
 /// Poll WAL changes from a replication slot and write them to the buffer table.
 ///
@@ -783,7 +801,11 @@ fn write_decoded_change(
     }
 
     // Map parsed columns to new_<col> and/or old_<col> buffer columns.
-    for (col_name, _col_type) in columns {
+    // A42-14: Add explicit `::col_type` casts to each placeholder so that
+    // the text-typed SPI parameter datums are cast to the actual column type
+    // at query-plan time. Without explicit casts, PostgreSQL rejects text→integer
+    // (and other non-implicit-coercible) assignments in parameterized queries.
+    for (col_name, col_type) in columns {
         let safe_name = col_name.replace('"', "\"\"");
 
         match action {
@@ -791,26 +813,26 @@ fn write_decoded_change(
                 col_names.push(format!("\"new_{}\"", safe_name));
                 let val = parsed.get(col_name).cloned();
                 param_values.push(val);
-                placeholders.push(format!("${}", param_values.len()));
+                placeholders.push(format!("${}::{}", param_values.len(), col_type));
             }
             'U' => {
                 // new value
                 col_names.push(format!("\"new_{}\"", safe_name));
                 let new_val = parsed.get(col_name).cloned();
                 param_values.push(new_val);
-                placeholders.push(format!("${}", param_values.len()));
+                placeholders.push(format!("${}::{}", param_values.len(), col_type));
 
                 // G2.2: old value from pgoutput old-key section.
                 col_names.push(format!("\"old_{}\"", safe_name));
                 let old_val = old_parsed.get(col_name).cloned();
                 param_values.push(old_val);
-                placeholders.push(format!("${}", param_values.len()));
+                placeholders.push(format!("${}::{}", param_values.len(), col_type));
             }
             'D' => {
                 col_names.push(format!("\"old_{}\"", safe_name));
                 let val = parsed.get(col_name).cloned();
                 param_values.push(val);
-                placeholders.push(format!("${}", param_values.len()));
+                placeholders.push(format!("${}::{}", param_values.len(), col_type));
             }
             _ => {}
         }
@@ -1949,9 +1971,11 @@ pub fn check_decoder_health(
         return Ok(());
     }
 
-    // Check if the slot still exists
+    // Check if the slot still exists (scoped to the current database to avoid
+    // false positives from identically-named slots in other databases).
     let slot_exists = Spi::get_one_with_args::<bool>(
-        "SELECT EXISTS(SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)",
+        "SELECT EXISTS(SELECT 1 FROM pg_replication_slots \
+         WHERE slot_name = $1 AND database = current_database())",
         &[slot_name.as_str().into()],
     )
     .map_err(|e| PgTrickleError::SpiError(e.to_string()))?

--- a/tests/e2e_wal_cdc_tests.rs
+++ b/tests/e2e_wal_cdc_tests.rs
@@ -271,13 +271,20 @@ async fn test_wal_cdc_captures_insert() {
     let mode = wait_for_cdc_mode(&db, "wal_ins", "WAL", Duration::from_secs(60)).await;
     assert_eq!(mode, "WAL", "Should transition to WAL mode");
 
+    // Allow the WAL slot to stabilise: the first 1-2 scheduler ticks after a
+    // new slot is created can encounter transient poll errors (slot briefly in
+    // use or backend SPI context recovering).  Wait for a few ticks to clear
+    // before injecting DML so the DML changes are not in-flight when an error
+    // counter could trigger premature fallback to trigger mode.
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
     // Insert new rows — WAL decoder should capture them
     db.execute("INSERT INTO wal_ins VALUES (2, 'b'), (3, 'c')")
         .await;
 
     // Wait for the scheduler to do a refresh
     let refreshed = db
-        .wait_for_auto_refresh("wal_ins_st", Duration::from_secs(15))
+        .wait_for_auto_refresh("wal_ins_st", Duration::from_secs(30))
         .await;
     assert!(refreshed, "Scheduler should trigger a refresh");
 
@@ -314,11 +321,14 @@ async fn test_wal_cdc_captures_update() {
     let mode = wait_for_cdc_mode(&db, "wal_upd", "WAL", Duration::from_secs(60)).await;
     assert_eq!(mode, "WAL", "Should transition to WAL mode");
 
+    // Allow the WAL slot to stabilise (see test_wal_cdc_captures_insert for rationale).
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
     db.execute("UPDATE wal_upd SET val = 'new' WHERE id = 1")
         .await;
 
     let refreshed = db
-        .wait_for_auto_refresh("wal_upd_st", Duration::from_secs(15))
+        .wait_for_auto_refresh("wal_upd_st", Duration::from_secs(30))
         .await;
     assert!(refreshed, "Scheduler should trigger a refresh");
 
@@ -357,10 +367,13 @@ async fn test_wal_cdc_captures_delete() {
     let mode = wait_for_cdc_mode(&db, "wal_del", "WAL", Duration::from_secs(60)).await;
     assert_eq!(mode, "WAL", "Should transition to WAL mode");
 
+    // Allow the WAL slot to stabilise (see test_wal_cdc_captures_insert for rationale).
+    tokio::time::sleep(Duration::from_secs(3)).await;
+
     db.execute("DELETE FROM wal_del WHERE id = 2").await;
 
     let refreshed = db
-        .wait_for_auto_refresh("wal_del_st", Duration::from_secs(15))
+        .wait_for_auto_refresh("wal_del_st", Duration::from_secs(30))
         .await;
     assert!(refreshed, "Scheduler should trigger a refresh");
 


### PR DESCRIPTION
## Summary

Fixes two independent root causes that together prevented WAL CDC from
capturing changes in the E2E test suite.

---

## Root Cause 1 — Cross-database slot name collision

In the shared-container test environment, `pg_replication_slots` queries
that lacked `AND database = current_database()` would find slots belonging
to stale test-run databases. This caused `pg_logical_slot_get_changes` to
panic when it tried to use a slot from a different database.

**Fix**: Added `AND database = current_database()` to all 8
`pg_replication_slots` queries across `wal_decoder.rs` and `monitor.rs`.

---

## Root Cause 2 — `write_decoded_change` type-cast mismatch (the actual data-loss bug)

`write_decoded_change` built a parameterised `INSERT` where all column
values were passed as **text** `DatumWithOid` parameters (`$N` without
any cast). PostgreSQL's prepared-statement type resolution does **not**
apply implicit casts from `text` to `integer` (or other
non-implicit-coercible types), so inserting decoded WAL values into
integer/bigint/etc columns silently failed:

```
ERROR: column "old_id" is of type integer but expression is of type text
```

The panic was caught by `catch_unwind`, but `pg_logical_slot_get_changes`
had already advanced the slot's `confirmed_flush_lsn` non-transactionally
in shared memory, permanently consuming the change without writing it to
the change buffer. Every subsequent refresh saw an empty buffer and
returned `NO_DATA`.

**Fix**: Changed all column-value placeholders from `$N` to `$N::<col_type>`,
where `col_type` comes from `format_type(a.atttypid, a.atttypmod)` via
`resolve_source_column_defs`. This tells PostgreSQL to cast the text
parameter to the correct target type at query-plan time (annotated A42-14).

---

## Additional test hardening

- 3 s stabilisation sleep after WAL mode is confirmed in the
  delete/insert/update tests (lets the slot reach steady-state before
  the DML that needs capturing)
- `wait_for_auto_refresh` timeout widened from 15 s → 30 s
- `MAX_CONSECUTIVE_WAL_ERRORS` raised from 5 → 20 to tolerate transient
  errors (e.g. concurrent slot access from a health-check query)

---

## Test results

All 19 WAL CDC E2E tests pass:

```
PASS [  9.085s] test_wal_cdc_captures_delete
PASS [  9.216s] test_wal_cdc_captures_insert
PASS [  9.786s] test_wal_cdc_captures_update
Summary [42.254s] 19 tests run: 19 passed, 0 skipped
```