### PR TITLE
docs(pg_tide): finalise extraction plan and roadmap (Option C, trickle-labs/pg-tide)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -92,12 +92,18 @@
 | [v0.44.0](roadmap/v0.44.0.md) | Security hardening: IVM search_path fix, centralized SQL builder, RLS warnings, module decomposition | ✅ Released | Large | [Full details](roadmap/v0.44.0.md-full.md) |
 | [v0.45.0](roadmap/v0.45.0.md) | Operational readiness: preflight functions, scalability infrastructure, CI completeness, CNPG production examples | ✅ Released | Large | [Full details](roadmap/v0.45.0.md-full.md) |
 
-### Embedding & AI Programme (v0.46.x – v0.47.x)
+### `pg_tide` Extraction (v0.46.0)
 
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|------- |---------- |
-| [v0.46.0](roadmap/v0.46.0.md) | Embedding pipeline infrastructure: post-refresh hooks, drift-based reindex, vector monitoring | Planned | Medium | [Full details](roadmap/v0.46.0.md-full.md) |
-| [v0.47.0](roadmap/v0.47.0.md) | Complete embedding programme: sparse/half-precision vector aggregates, hybrid search, embedding_stream_table() API, per-tenant ANN, embedding outbox | Planned | Large | [Full details](roadmap/v0.47.0.md-full.md) |
+| [v0.46.0](roadmap/v0.46.0.md) | Extract `pg_tide`: standalone transactional outbox, inbox, and relay into `trickle-labs/pg-tide` | Planned | Large | [Full details](roadmap/v0.46.0.md-full.md) |
+
+### Embedding & AI Programme (v0.47.x – v0.48.x)
+
+| Version | Theme | Status | Scope | Full details |
+|---------|-------|--------|------- |---------- |
+| [v0.47.0](roadmap/v0.47.0.md) | Embedding pipeline infrastructure: post-refresh hooks, drift-based reindex, vector monitoring | Planned | Medium | [Full details](roadmap/v0.47.0.md-full.md) |
+| [v0.48.0](roadmap/v0.48.0.md) | Complete embedding programme: sparse/half-precision vector aggregates, hybrid search, embedding_stream_table() API, per-tenant ANN, embedding outbox | Planned | Large | [Full details](roadmap/v0.48.0.md-full.md) |
 
 ### Beyond v1.0
 
@@ -159,9 +165,11 @@ v0.44    ─── Security hardening: IVM search_path, SQL builder, RLS warning
     │
 v0.45    ─── Operational readiness: preflight, scalability, CI completeness, CNPG production
     │
-v0.46    ─── Embedding infrastructure: post-refresh actions, drift-based reindex, vector monitoring
+v0.46    ─── Extract pg_tide: standalone outbox/inbox/relay → trickle-labs/pg-tide; attach_outbox() integration
     │
-v0.47    ─── Complete embedding programme: sparse vectors, hybrid search, embedding_stream_table(), per-tenant ANN
+v0.47    ─── Embedding infrastructure: post-refresh actions, drift-based reindex, vector monitoring
+    │
+v0.48    ─── Complete embedding programme: sparse vectors, hybrid search, embedding_stream_table(), per-tenant ANN
     │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```
@@ -213,11 +221,13 @@ correctness (P0 cache-key and placeholder fixes), documentation truthfulness
 tunability (GUC-exposed thresholds, explain diagnostics), security
 (search_path hardening, centralized SQL building), and operational readiness
 (preflight functions, scalability infrastructure, CI completeness). Only after
-this arc does the roadmap resume the embedding programme in v0.46.0–v0.47.0,
+this arc does the roadmap resume the embedding programme in v0.47.0–v0.48.0,
 preserving the pgvector work while aligning the release order with the
 assessment's conclusion that closing correctness and operational gaps matters
 more than adding new surface area. The embedding programme itself is
-consolidated into two releases: v0.46.0 for infrastructure and ANN maintenance,
-and v0.47.0 completing the full feature set (sparse/half-precision aggregates,
+consolidated into two releases: v0.47.0 for infrastructure and ANN maintenance,
+and v0.48.0 completing the full feature set (sparse/half-precision aggregates,
 hybrid search, the ergonomic `embedding_stream_table()` API, per-tenant ANN
-patterns, and outbox-emitted embedding events).
+patterns, and outbox-emitted embedding events). v0.46.0 precedes this arc
+with the extraction of `pg_tide` — moving the outbox, inbox, and relay
+subsystems into a standalone extension at `trickle-labs/pg-tide`.

--- a/plans/PLAN_RELAY_STANDALONE.md
+++ b/plans/PLAN_RELAY_STANDALONE.md
@@ -4,27 +4,34 @@
 **Status:** Draft for discussion (revised after option-A vs option-C re-analysis)
 **Related:** [REPORT_SUPERFLOUS_FEATURES.md §7.2](REPORT_SUPERFLOUS_FEATURES.md)
 
-> **Reader's note (1 May 2026, revision 2):** the original draft below recommended
+> **Reader's note (1 May 2026, revision 3):** the original draft below recommended
 > option B with a "soft dependency" framing. On closer inspection that framing
 > oversold the reuse story — the *outbox row envelope* this repo emits is a
 > differential-refresh delta summary, not a generic transactional-outbox shape,
 > so no realistic third party would produce it. A new **§7 "Option C, properly
 > developed"** at the bottom of this document explores the *opposite* direction:
-> extract a **generic** outbox/inbox extension (`pg_outbox`) that is useful
+> extract a **generic** outbox/inbox extension (`pg_tide`) that is useful
 > *without* `pg_trickle`, and demote `pg_trickle`'s outbox/inbox API to a thin
 > producer that depends on it. That option is now the recommended one. Sections
 > 1–6 below are kept as the reference inventory of the current code and the
 > three weaker alternatives.
+>
+> **Naming decision (revision 3):** the new extension is named **`pg_tide`**,
+> continuing the water-motion lineage of `pg_trickle` (incremental view
+> maintenance — small steady drips of change) and `pg_ripple` (triplestore —
+> change propagating outward through relationships). Tides flow *in and out*,
+> matching the dual outbox/inbox nature of this extension. The relay binary is
+> named `pg-tide` (the binary *is* the tide).
 
 ---
 
 ## TL;DR (revised)
 
-**Recommended:** **Option C** — ship a new standalone extension `pg_outbox`
+**Recommended:** **Option C** — ship a new standalone extension `pg_tide`
 that owns generic transactional outbox + inbox tables, retention, the relay
 catalog, and the relay binary. `pg_trickle` becomes a *consumer* of it: a thin
 `pg_trickle.attach_outbox()` wrapper installs a refresh-time hook that calls
-`outbox.publish()` from inside the refresh transaction. The standalone
+`tide.outbox_publish()` from inside the refresh transaction. The standalone
 extension is genuinely useful to anyone implementing the textbook outbox
 pattern, with or without `pg_trickle` ever being installed.
 
@@ -439,7 +446,7 @@ preparation window.
 
 ---
 
-## 7. Option C, properly developed — a generic `pg_outbox` extension
+## 7. Option C, properly developed — a generic `pg_tide` extension
 
 The original framing of option C ("also move the writer") missed the point.
 The point of pulling something out is *not* to make the core repo smaller
@@ -489,69 +496,71 @@ layers that are bundled together today:
   *only* genuine `pg_trickle` dependency on the inbox side. These could just
   as well be plain `VIEW`s.
 
-### 7.2 The proposed standalone extension: `pg_outbox`
+### 7.2 The proposed standalone extension: `pg_tide`
 
-A new repo `grove/pg-outbox` containing:
+A new repo `grove/pg-tide` containing:
 
 ```
-pg-outbox/
-├── extension/                # pgrx extension `pg_outbox`
-│   ├── pg_outbox.control     # no `requires` — fully standalone
+pg-tide/
+├── extension/                # pgrx extension `pg_tide`
+│   ├── pg_tide.control       # no `requires` — fully standalone
 │   └── src/
 │       ├── lib.rs            # GUCs, schema bootstrap
 │       ├── outbox.rs         # generic outbox API (lifted ~700 LOC from src/api/outbox.rs)
 │       ├── inbox.rs          # generic inbox API   (lifted ~1,150 LOC from src/api/inbox.rs)
 │       ├── relay_catalog.rs  # relay config tables + helper functions (~240 LOC of SQL)
 │       └── retention.rs      # background worker for draining old rows
-├── relay/                    # the binary, today's pgtrickle-relay/
+├── relay/                    # the `pg-tide` binary, today's pgtrickle-relay/
 └── docs/
 ```
 
-**Public SQL surface** (schemas `outbox`, `inbox`, `relay`):
+**Public SQL surface** (single schema `tide`):
 
 ```sql
+CREATE EXTENSION pg_tide;
+
 -- ── Outbox: write business events transactionally with your domain change ──
-SELECT outbox.create('orders_events',
+SELECT tide.outbox_create('orders_events',
     retention_hours       => 24,
     inline_threshold_rows => 10000);
 
 -- App writes from inside its own transaction:
 BEGIN;
   UPDATE orders SET status = 'paid' WHERE id = 42;
-  PERFORM outbox.publish('orders_events',
+  PERFORM tide.outbox_publish('orders_events',
       payload => '{"order_id": 42, "event": "paid"}'::jsonb,
       headers => '{"trace_id": "abc-123"}'::jsonb);
 COMMIT;
--- ↑ both rows are durable together; relay forwards to NATS/Kafka/etc.
+-- ↑ both rows are durable together; the relay forwards to NATS/Kafka/etc.
 
-SELECT outbox.status('orders_events');
-SELECT outbox.disable('orders_events');
+SELECT tide.outbox_status('orders_events');
+SELECT tide.outbox_disable('orders_events');
 
 -- ── Inbox: idempotently receive events from external systems ──
-SELECT inbox.create('orders_inbox',
+SELECT tide.inbox_create('orders_inbox',
     max_retries      => 3,
     with_dead_letter => true,
     with_stats       => true,
     retention_hours  => 72);
 
 -- Relay (or app) writes incoming events:
-INSERT INTO inbox.orders_inbox (event_id, event_type, payload)
+INSERT INTO tide.orders_inbox (event_id, event_type, payload)
 VALUES ('msg-123', 'order.created', '{...}'::jsonb)
 ON CONFLICT (event_id) DO NOTHING;
 
 -- App marks results:
-SELECT inbox.mark_processed('orders_inbox', 'msg-123');
-SELECT inbox.mark_failed   ('orders_inbox', 'msg-123', 'parse error');
+SELECT tide.inbox_mark_processed('orders_inbox', 'msg-123');
+SELECT tide.inbox_mark_failed   ('orders_inbox', 'msg-123', 'parse error');
 
 -- Built-in views (plain VIEWs — no pg_trickle required):
-SELECT * FROM inbox.orders_inbox_pending;
-SELECT * FROM inbox.orders_inbox_dlq;
-SELECT * FROM inbox.orders_inbox_stats;
+SELECT * FROM tide.orders_inbox_pending;
+SELECT * FROM tide.orders_inbox_dlq;
+SELECT * FROM tide.orders_inbox_stats;
 
--- ── Relay configuration (consumed by the relay binary) ──
-SELECT relay.set_outbox('orders-to-nats', ...);
-SELECT relay.set_inbox ('nats-to-orders', ...);
-SELECT relay.enable    ('orders-to-nats');
+-- ── Relay configuration (consumed by the `pg-tide` binary) ──
+SELECT tide.relay_set_outbox('orders-to-nats', ...);
+SELECT tide.relay_set_inbox ('nats-to-orders', ...);
+SELECT tide.relay_enable    ('orders-to-nats');
 ```
 
 The inbox helper views are **plain views** by default. If `pg_trickle` is
@@ -563,7 +572,7 @@ SELECT pg_trickle.materialize_inbox_views('orders_inbox', schedule => '1s');
 -- ↑ replaces the views with stream tables. Optional, additive, lazy.
 ```
 
-This is the key insight: **`pg_outbox` works fully without `pg_trickle`,
+This is the key insight: **`pg_tide` works fully without `pg_trickle`,
 and `pg_trickle` enhances it when present.** That is the inversion of the
 current relationship and is the only version of "standalone extension" that
 genuinely justifies the name.
@@ -578,16 +587,16 @@ the storage and the outbound plumbing:
 SELECT pgtrickle.attach_outbox('orders_stream',
     inline_threshold_rows => 10000);
 -- Internally:
---   1. Calls outbox.create('outbox_orders_stream', ...) (the standalone API)
+--   1. Calls tide.outbox_create('outbox_orders_stream', ...) (the standalone API)
 --   2. Registers a refresh hook that, inside the refresh transaction,
---      calls outbox.publish('outbox_orders_stream', delta_payload, headers).
+--      calls tide.outbox_publish('outbox_orders_stream', delta_payload, headers).
 ```
 
 `write_outbox_row()` becomes a 30-line wrapper that:
 
 1. Builds the delta-summary JSON envelope (`{v:1, refresh_id, inserted,
    deleted, full_refresh}`) — this stays as a `pg_trickle`-private detail.
-2. Calls `SELECT outbox.publish($1, $2, $3)` via SPI.
+2. Calls `SELECT tide.outbox_publish($1, $2, $3)` via SPI.
 
 **Atomicity:** SPI calls run inside the current transaction, so the outbox
 row and the refresh MERGE still commit together. ADR-001/ADR-002 guarantees
@@ -605,7 +614,7 @@ runs the user's SELECT query.
 Unlike the option-B framing ("anyone with an outbox-shaped table"), the
 target audience here is concrete and large:
 
-| User | What they need today | What `pg_outbox` would give them |
+| User | What they need today | What `pg_tide` would give them |
 |---|---|---|
 | Microservices teams adopting the textbook outbox pattern (Richardson, Kleppmann) | Hand-rolled outbox table + a custom poller in their app, or a Debezium cluster | A 5-minute install of one extension + one binary, six backends out of the box |
 | Teams already on Debezium who want to cut JVM ops | Maintain a Kafka Connect cluster | Replace with a single Rust binary that reads a Postgres table |
@@ -624,7 +633,7 @@ people would actually install for its own sake.
 
 ### 7.5 Comparison of all four options
 
-| Dimension | A: binary only | B: binary + relay-only ext | C-original: also move writer | **C-revised: generic `pg_outbox`** |
+| Dimension | A: binary only | B: binary + relay-only ext | C-original: also move writer | **C-revised: generic `pg_tide`** |
 |---|---|---|---|---|
 | Standalone usefulness without `pg_trickle` | None | Marginal (relay needs an outbox to poll) | None | **High — full outbox/inbox primitive** |
 | Core LOC removed from this repo | ~3,650 Rust | ~3,890 (3,650 + 240 SQL) | ~6,150 (3,890 + 2,260) | **~6,150 + ~2,500 SQL** |
@@ -640,10 +649,10 @@ people would actually install for its own sake.
 |---|---|---|---|
 | Two-extension install becomes a friction point for `pg_trickle` users | Medium | Medium | Ship an `pg_trickle_outbox_compat` SQL package that re-creates the old `pgtrickle.enable_outbox(...)` signatures as `attach_outbox(...)` shims. Keep one release of deprecation overlap. |
 | The SPI round-trip from `write_outbox_row` shows up in benchmarks | Low | Low | Cache the prepared `outbox.publish` plan; benchmark before/after on the existing `e2e_bench_refresh_matrix`. |
-| Generic outbox table shape diverges from `pg_trickle`'s envelope needs | Low | Medium | The standalone outbox already has `payload JSONB` + `headers JSONB`; `pg_trickle` puts its `v:1` envelope inside `payload`. No schema collision. |
-| Inbox helper views (pending/DLQ/stats) lose IVM acceleration by default | Medium | Low | They're plain VIEWs in `pg_outbox`; `pg_trickle.materialize_inbox_views()` is a one-liner upgrade for users who want incremental maintenance. |
+| Generic outbox table shape diverges from `pg_trickle`'s envelope needs | Low | Medium | `pg_tide`'s outbox row already has `payload JSONB` + `headers JSONB`; `pg_trickle` puts its `v:1` envelope inside `payload`. No schema collision. |
+| Inbox helper views (pending/DLQ/stats) lose IVM acceleration by default | Medium | Low | They're plain VIEWs in `pg_tide`; `pg_trickle.materialize_inbox_views()` is a one-liner upgrade for users who want incremental maintenance. |
 | Bigger surface to maintain in a separate repo | Medium | Medium | The new repo is *the* place outbox/inbox bugs go now; today they're awkwardly mixed with refresh-engine bugs. Net cognitive load is probably lower. |
-| Project is called `pg_outbox` but does inbox + relay too | Low | Low | Naming sweep: `pg_outbox` is the friendliest name for the dominant use case; document inbox/relay as part of the same primitive. Alternatives: `pg_messaging`, `pg_relay`. |
+| Project name `pg_tide` is metaphorical, not literal | Low | Low | Continues the established water-motion lineage (`pg_trickle`, `pg_ripple`); the metaphor honestly covers both directions (tides go in *and* out) where `pg_outbox` would have undersold the inbox half. README leads with "transactional outbox + inbox + multi-backend relay for PostgreSQL" so SEO works. |
 | ADR-001/002 atomicity regression | Very low | High | The SPI call runs in the *current* transaction; this is the same atomicity guarantee Postgres gives any plpgsql function. Add a regression test that crashes the session between `outbox.publish()` and `COMMIT` and asserts both the refresh MERGE and the outbox row are absent after recovery. |
 
 ### 7.7 Migration path for existing `pg_trickle` outbox/inbox users
@@ -651,21 +660,21 @@ people would actually install for its own sake.
 A single SQL migration shipped with the new release:
 
 ```sql
--- Run once, after installing pg_outbox and upgrading pg_trickle.
-CREATE EXTENSION pg_outbox;
-SELECT pgtrickle.migrate_outboxes_to_pg_outbox();
+-- Run once, after installing pg_tide and upgrading pg_trickle.
+CREATE EXTENSION pg_tide;
+SELECT pgtrickle.migrate_outboxes_to_pg_tide();
 -- ↑ for each row in pgtrickle.pgt_outbox_config:
---   1. CREATE the equivalent outbox via outbox.create()
---   2. Copy historical rows from pgtrickle.outbox_<st> into outbox.<st>
+--   1. CREATE the equivalent outbox via tide.outbox_create()
+--   2. Copy historical rows from pgtrickle.outbox_<st> into tide.<st>
 --   3. Re-attach pg_trickle's refresh hook via attach_outbox()
 --   4. Drop the old pgtrickle.outbox_<st> table
-SELECT pgtrickle.migrate_inboxes_to_pg_outbox();
+SELECT pgtrickle.migrate_inboxes_to_pg_tide();
 -- Same pattern for inboxes.
 ```
 
 Old `pgtrickle.enable_outbox(...)` / `pgtrickle.create_inbox(...)` remain as
 deprecation shims for one release that internally call the new `attach_outbox`
-/ `pg_outbox.inbox.create` paths and emit a `WARNING`.
+/ `tide.inbox_create` paths and emit a `WARNING`.
 
 ### 7.8 Why this is worth doing despite being the largest option
 
@@ -690,23 +699,24 @@ deprecation shims for one release that internally call the new `attach_outbox`
 
 ### 7.9 Suggested order of work for option C-revised
 
-1. **Days 1–2** — Stand up the new `pg_outbox` repo. Lift
+1. **Days 1–2** — Stand up the new `pg-tide` repo. Lift
    [src/api/outbox.rs](../src/api/outbox.rs) and
-   [src/api/inbox.rs](../src/api/inbox.rs) into the new extension; rename
-   schemas; replace the `create_stream_table` calls in the inbox helper
-   with plain `CREATE VIEW`. Carry over tests.
+   [src/api/inbox.rs](../src/api/inbox.rs) into the new extension; collapse
+   into a single `tide` schema; replace the `create_stream_table` calls in
+   the inbox helper with plain `CREATE VIEW`. Carry over tests.
 2. **Day 3** — Lift the relay catalog SQL from
-   [src/lib.rs](../src/lib.rs#L1095-L1335) into `pg_outbox`'s extension
-   crate. Lift `pgtrickle-relay/` into the new repo.
+   [src/lib.rs](../src/lib.rs#L1095-L1335) into `pg_tide`'s extension
+   crate. Lift `pgtrickle-relay/` into the new repo as the `pg-tide`
+   binary.
 3. **Day 4** — In this repo, replace `enable_outbox()` /
    `create_inbox()` with thin `attach_outbox()` / `attach_inbox()` wrappers
-   that delegate to `pg_outbox`. Add the deprecation shims. Implement
+   that delegate to `pg_tide`. Add the deprecation shims. Implement
    `pg_trickle.materialize_inbox_views()` for the optional IVM upgrade.
 4. **Days 5–6** — Migration SQL; integration tests that exercise both
    "with `pg_trickle`" and "without `pg_trickle`" deployments; benchmark
    the SPI hop on the refresh hot path.
 5. **Day 7** — Documentation: cross-link the two repos; rewrite
-   docs/SQL_REFERENCE.md outbox/inbox sections to point at `pg_outbox`;
+   docs/SQL_REFERENCE.md outbox/inbox sections to point at `pg_tide`;
    pre-release tags on both repos.
 
 Roughly **two weeks** end to end, but the result is two cleanly-scoped
@@ -714,19 +724,22 @@ products instead of one entangled one.
 
 ### 7.10 Open questions specific to option C
 
-1. **Naming.** Is `pg_outbox` the right umbrella name for something that
-   also ships the inbox pattern and a relay binary? Alternatives:
-   `pg_messaging`, `pg_relay`, `pg_event_relay`. The dominant pattern by
-   far in the literature is "transactional outbox," so leading with
-   `pg_outbox` is probably right; the rest can be subordinate.
-2. **License.** `pg_trickle` is Apache-2.0; `pg_outbox` should match so
+1. **License.** `pg_trickle` is Apache-2.0; `pg_tide` should match so
    the integration story is frictionless.
-3. **Repo home.** Same `grove/` org, or somewhere more neutral if the
+2. **Repo home.** Same `grove/` org, or somewhere more neutral if the
    intent is to attract contributors who don't think of it as a
    `pg_trickle` accessory?
-4. **Relay rename.** With the standalone framing, the binary should
-   probably be `pg-outbox-relay` rather than `pgtrickle-relay`.
-5. **Backwards-compatible shims.** How many releases do we keep
+3. **Backwards-compatible shims.** How many releases do we keep
    `pgtrickle.enable_outbox(...)` etc. before removing them? One release
    feels right for a pre-1.0 codebase; if anyone's running the outbox in
    production, two releases is safer.
+4. **Schema layout.** Single `tide` schema (with `outbox_*` / `inbox_*` /
+   `relay_*` function prefixes), or three sibling schemas (`tide_outbox`,
+   `tide_inbox`, `tide_relay`)? The plan currently assumes the single
+   schema for ergonomics, but the three-schema layout would let users
+   `SET search_path = tide_outbox, public` and drop the prefix.
+5. **Naming the lineage.** Should the README explicitly call out the
+   `pg_trickle` / `pg_ripple` / `pg_tide` family? Helps with
+   recognisability if multiple extensions are deployed together; risks
+   tying `pg_tide`'s identity to `pg_trickle` more tightly than option C
+   intends.

--- a/plans/PLAN_RELAY_STANDALONE.md
+++ b/plans/PLAN_RELAY_STANDALONE.md
@@ -1,7 +1,7 @@
-# Pulling `pgtrickle-relay` Out as a Standalone Project
+# Extracting `pg_tide` — Outbox, Inbox, and Relay as a Standalone Extension
 
 **Date:** 1 May 2026
-**Status:** Draft for discussion (revised after option-A vs option-C re-analysis)
+**Status:** ✅ DECIDED — Option C: extract `pg_tide` into a new repository `trickle-labs/pg-tide`
 **Related:** [REPORT_SUPERFLOUS_FEATURES.md §7.2](REPORT_SUPERFLOUS_FEATURES.md)
 
 > **Reader's note (1 May 2026, revision 4):** the relay binary, outbox, and
@@ -33,29 +33,36 @@
 
 ---
 
-## TL;DR (revised)
+## TL;DR — Decision
 
-**Recommended:** **Option C** — ship a new standalone extension `pg_tide`
-that owns generic transactional outbox + inbox tables, retention, the relay
-catalog, and the relay binary. `pg_trickle` becomes a *consumer* of it: a thin
+> **We are going with Option C.**
+> Extract `pg_tide` into a new repository `trickle-labs/pg-tide`.
+
+**Decision: Option C** — ship a new standalone extension `pg_tide` that owns
+generic transactional outbox + inbox tables, retention, the relay catalog, and
+the relay binary. `pg_trickle` becomes a *consumer* of it: a thin
 `pg_trickle.attach_outbox()` wrapper installs a refresh-time hook that calls
 `tide.outbox_publish()` from inside the refresh transaction. The standalone
 extension is genuinely useful to anyone implementing the textbook outbox
 pattern, with or without `pg_trickle` ever being installed.
 
-**Effort: ~1 week** as a clean break (no shims, no migration tooling) since
-the relay/outbox/inbox features have no known users today. Send a one-line
-"is anyone using these?" check to the discussions board before merging — if
-real users surface, the migration plan from revision 3 gets restored and the
-estimate goes back to ~2 weeks.
+**Effort: ~6 working days** as a clean break (no shims, no migration tooling)
+since the relay/outbox/inbox features have no known users today. Send a
+one-line "is anyone using these?" check to the discussions board before
+merging — if real users surface, the migration plan from revision 3 gets
+restored and the estimate goes back to ~2 weeks.
 
-The original three options (A, B, the no-op C) and the inventory of today's
-coupling surface are kept below as the reference material that informs the new
-recommendation.
+**The active plan is §7 below.** The original three options (A, B, C-original)
+and the inventory of today's coupling surface are kept in §§1–6 as the
+reference material that led to this decision.
 
 ---
 
-## TL;DR (original draft, kept for reference)
+## ~~TL;DR~~ (original draft, superseded — Option B no longer recommended)
+
+> **Kept for reference only.** The recommendation below (Option B) was
+> superseded in revision 3. The project is going with Option C — see the
+> "TL;DR — Decision" section above.
 
 **Yes — extracting the relay is feasible, low-risk, and worth doing for 1.0.**
 The relay is already a self-contained Rust crate with zero Rust-level
@@ -232,7 +239,7 @@ option B prevents doing C later.
 
 ---
 
-## 3. Detailed plan for option B
+## 3. ~~Detailed plan for option B~~ (superseded — see §7 for the active plan)
 
 ### 3.1 New repository layout (`grove/pg-trickle-relay`)
 
@@ -425,10 +432,14 @@ loose-coupling boundary that justifies the split.
 
 ---
 
-## 6. Recommendation and next steps
+## 6. ~~Recommendation and next steps~~ (superseded by Option C — see §7)
 
-**Recommendation:** Adopt **option B**. Schedule the cut for the v1.0
-preparation window.
+> ⚠️ **This section recommended Option B. That recommendation has been
+> superseded. The project is going with Option C (`pg_tide` standalone
+> extension). See §7 for the active plan.**
+
+**Original recommendation (now superseded):** Adopt **option B**. Schedule the
+cut for the v1.0 preparation window.
 
 **Suggested order of work:**
 
@@ -460,7 +471,14 @@ preparation window.
 
 ---
 
-## 7. Option C, properly developed — a generic `pg_tide` extension
+## 7. The plan — Option C: a standalone `pg_tide` extension
+
+> **This is the active plan.** Sections 1–6 above are historical context;
+> this section is what we are actually building.
+
+**Repository:** https://github.com/trickle-labs/pg-tide
+**Local checkout:** `../pg-tide` (relative to this repo)
+**Status:** Repository created ✅ — ready for implementation
 
 The original framing of option C ("also move the writer") missed the point.
 The point of pulling something out is *not* to make the core repo smaller
@@ -516,7 +534,7 @@ layers that are bundled together today:
 
 ### 7.2 The proposed standalone extension: `pg_tide`
 
-A new repo `grove/pg-tide` containing:
+A new repo `trickle-labs/pg-tide` containing:
 
 ```
 pg-tide/
@@ -647,7 +665,7 @@ soft-depending on `pg_tide`. Concretely:
   IF to_regproc('tide.outbox_create(...)') IS NULL THEN
       RAISE EXCEPTION 'pg_trickle.attach_outbox() requires the pg_tide
                        extension. Install it with: CREATE EXTENSION pg_tide;'
-          USING HINT = 'See https://github.com/grove/pg-tide';
+          USING HINT = 'See https://github.com/trickle-labs/pg-tide';
   END IF;
   ```
   Clear actionable error rather than a `function does not exist` cryptic
@@ -761,30 +779,55 @@ undocumented internal API that gets restructured before 1.0.
    tables. Outbox/inbox/relay become a separate product that integrates
    with it.
 
-### 7.9 Suggested order of work for option C-revised
+### 7.9 Work plan
 
-1. **Days 1–2** — Stand up the new `pg-tide` repo. Lift
-   [src/api/outbox.rs](../src/api/outbox.rs) and
-   [src/api/inbox.rs](../src/api/inbox.rs) into the new extension; collapse
-   into a single `tide` schema; replace the `create_stream_table` calls in
-   the inbox helper with plain `CREATE VIEW`. Carry over tests.
-2. **Day 3** — Lift the relay catalog SQL from
-   [src/lib.rs](../src/lib.rs#L1095-L1335) into `pg_tide`'s extension
-   crate. Lift `pgtrickle-relay/` into the new repo as the `pg-tide`
-   binary.
-3. **Day 4** — In this repo, *delete* `enable_outbox()` / `create_inbox()`
-   and the relay catalog SQL outright (no shims — see §7.7). Add the new
-   thin `attach_outbox()` wrapper that delegates to `pg_tide` (refresh-time
-   publisher; this is the *only* integration point — see §7.2). No
-   `attach_inbox()` or `materialize_inbox_views()` is needed: inbox helper
-   views stay as plain VIEWs in `pg_tide` and `pg_trickle` does not wrap
-   the inbox API at all.
-4. **Day 5** — Integration tests that exercise both "with `pg_trickle`"
-   and "without `pg_trickle`" deployments; benchmark the SPI hop on the
-   refresh hot path. Documentation: cross-link the two repos; rewrite
-   docs/SQL_REFERENCE.md outbox/inbox sections to point at `pg_tide`.
-   CHANGELOG entry calls out the rename as a breaking change with a
-   one-line equivalence table. Pre-release tags on both repos.
+> **Starting point:** `https://github.com/trickle-labs/pg-tide` has been
+> created and checked out at `../pg-tide`. It currently contains only a
+> LICENSE file. The repo skeleton step is done; begin at step 1 below.
+
+1. **Days 1–2 — Bootstrap the extension in `../pg-tide`**
+   - Initialise the workspace: add `Cargo.toml`, `extension/` and `relay/`
+     crates, `pg_tide.control`, `justfile`.
+   - Lift [src/api/outbox.rs](../src/api/outbox.rs) and
+     [src/api/inbox.rs](../src/api/inbox.rs) into the new extension;
+     collapse into a single `tide` schema; replace the
+     `create_stream_table` calls in the inbox helpers with plain
+     `CREATE VIEW`. Carry over tests.
+   - `git mv plans/relay/*` into `../pg-tide/plans/`; sweep
+     `pgtrickle-relay` → `pg-tide` in those docs.
+2. **Day 3 — Complete the relay lift**
+   - Lift the relay catalog SQL from
+     [src/lib.rs](../src/lib.rs#L1095-L1335) into `pg_tide`'s extension
+     crate.
+   - Move `pgtrickle-relay/` into `../pg-tide/relay/` using
+     `git filter-repo --subdirectory-filter pgtrickle-relay` to preserve
+     history.
+3. **Day 4 — Cut from this repo**
+   - *Delete* `enable_outbox()` / `create_inbox()` and the relay catalog
+     SQL outright (no shims — see §7.7).
+   - Add the thin `attach_outbox()` wrapper that delegates to
+     `tide.outbox_publish()` via SPI (the only integration point — §7.2).
+     No `attach_inbox()` or `materialize_inbox_views()` needed.
+   - Write `sql/pg_trickle--0.42.0--1.0.0.sql` dropping all old objects.
+   - Remove `pgtrickle-relay` from workspace `members` in
+     [Cargo.toml](../Cargo.toml), delete [Dockerfile.relay](../Dockerfile.relay),
+     remove the 4 relay CI jobs from
+     [.github/workflows/release.yml](../.github/workflows/release.yml),
+     drop the SQS security exception from
+     [.github/workflows/security.yml](../.github/workflows/security.yml).
+4. **Day 5a — Documentation**
+   - Move `docs/OUTBOX.md`, `docs/INBOX.md`, `docs/RELAY.md`,
+     `docs/RELAY_GUIDE.md` to `../pg-tide/docs/`; rewrite to lead with
+     the generic pattern.
+   - Trim ~12 docs in this repo (SQL_REFERENCE, ARCHITECTURE, WHATS_NEW,
+     etc.) to a "see pg-tide" pointer.
+   - CHANGELOG entry: call the rename a breaking change with a one-line
+     equivalence table.
+5. **Day 5b — CI / packaging**
+   - Clone CI templates into `../pg-tide` (lint, test, coverage, benchmarks,
+     release — see §7.10 for the full list).
+   - Verify both repos build clean; cut pre-release tags on both.
+
 
 ### 7.10 Ancillary assets that need to move, be rewritten, or be deleted
 

--- a/plans/PLAN_RELAY_STANDALONE.md
+++ b/plans/PLAN_RELAY_STANDALONE.md
@@ -632,6 +632,45 @@ Measured baseline of `outbox` write today is ~50µs; an SPI function call
 adds ~5µs of plan-cache lookup. Negligible against a refresh that already
 runs the user's SELECT query.
 
+**Dependency direction (soft, not hard):** `pg_trickle.control` does
+**not** declare `requires = 'pg_tide'`. The relationship is the mirror
+of option B's old "soft dependency" framing — option B had the relay
+soft-depending on `pg_trickle`; option C-revised has `pg_trickle`
+soft-depending on `pg_tide`. Concretely:
+
+- Installing `pg_trickle` on a database without `pg_tide` succeeds.
+  All IVM features (stream tables, refresh, scheduler, CDC) work
+  unchanged. `pg_trickle` is fundamentally an IVM engine; outbox
+  publishing is an *optional* downstream concern.
+- `pgtrickle.attach_outbox()` probes at call time:
+  ```sql
+  IF to_regproc('tide.outbox_create(...)') IS NULL THEN
+      RAISE EXCEPTION 'pg_trickle.attach_outbox() requires the pg_tide
+                       extension. Install it with: CREATE EXTENSION pg_tide;'
+          USING HINT = 'See https://github.com/grove/pg-tide';
+  END IF;
+  ```
+  Clear actionable error rather than a `function does not exist` cryptic
+  failure or a hard-fail at `CREATE EXTENSION pg_trickle` time.
+- `pg_trickle`'s test suite continues to cover the IVM core without
+  installing `pg_tide`. A *separate* integration tier exercises the
+  with-`pg_tide` paths and runs only when both extensions are present.
+
+**Why soft and not hard:**
+
+| Concern | Hard dep (`requires`) | Soft dep (runtime probe) ✓ |
+|---|---|---|
+| Install simplicity | Both extensions install in one DDL chain | Two `CREATE EXTENSION` statements, but only if you want outbox |
+| `pg_trickle` for IVM-only users | Forced to also install `pg_tide` | Pay-for-what-you-use |
+| Failure mode if `pg_tide` missing | `CREATE EXTENSION pg_trickle` fails | `attach_outbox()` raises with install hint; everything else works |
+| Packaging coupling (PGXN, distro packages) | `pg_trickle` package metadata pulls `pg_tide` | Independent packages |
+| Aligns with §7.4 "useful to users who don't know what IVM is" | Forces the inverse coupling | Each extension genuinely standalone |
+| Aligns with `pg_tide.control` (also `# no requires`) | Asymmetric | Symmetric — both are first-class citizens |
+
+The soft direction is consistent with the whole point of the cut: each
+extension stands on its own, the integration is opt-in. A hard `requires`
+would re-introduce the coupling we are deliberately removing.
+
 ### 7.4 Why this is realistic for non-`pg_trickle` users
 
 Unlike the option-B framing ("anyone with an outbox-shaped table"), the
@@ -851,7 +890,11 @@ this is acceptable because there are no known users.
   — drop the `aws-smithy-http-client` exception (only existed for the
   relay's optional SQS feature)
 - [tests/Dockerfile.e2e](tests/Dockerfile.e2e) lines 36–48 — drop relay
-  placeholder
+  placeholdert reads a Postgres table *(once `WireFormat` phase 2 ships — see §7.10)* |
+| Postgres-first stacks (Supabase, Crunchy, Neon, plain self-hosted) wanting "publish-to-Kafka" | Roll their own | Install one extension |
+| Anyone needing the inbox pattern (idempotent receive + DLQ) | Hand-roll | Built-in |
+| `pg_trickle` users who also want to publish change events | Today: `enable_outbox()` | Same UX via `attach_outbox()`, plus the option to use the same outbox infrastructure for non-stream-table events |
+
 - [Cargo.toml](Cargo.toml): drop `pgtrickle-relay` from the workspace
   `members` list
 - [deny.toml](deny.toml) lines 44–45 — drop the SQS-feature license

--- a/plans/PLAN_RELAY_STANDALONE.md
+++ b/plans/PLAN_RELAY_STANDALONE.md
@@ -640,7 +640,7 @@ target audience here is concrete and large:
 | User | What they need today | What `pg_tide` would give them |
 |---|---|---|
 | Microservices teams adopting the textbook outbox pattern (Richardson, Kleppmann) | Hand-rolled outbox table + a custom poller in their app, or a Debezium cluster | A 5-minute install of one extension + one binary, six backends out of the box |
-| Teams already on Debezium who want to cut JVM ops | Maintain a Kafka Connect cluster | Replace with a single Rust binary that reads a Postgres table |
+| Teams already on Debezium who want to cut JVM ops | Maintain a Kafka Connect cluster | Replace with a single Rust binary that reads a Postgres table *(once `WireFormat` phase 2 ships — see §7.10)* |
 | Postgres-first stacks (Supabase, Crunchy, Neon, plain self-hosted) wanting "publish-to-Kafka" | Roll their own | Install one extension |
 | Anyone needing the inbox pattern (idempotent receive + DLQ) | Hand-roll | Built-in |
 | `pg_trickle` users who also want to publish change events | Today: `enable_outbox()` | Same UX via `attach_outbox()`, plus the option to use the same outbox infrastructure for non-stream-table events |
@@ -661,7 +661,7 @@ people would actually install for its own sake.
 | Standalone usefulness without `pg_trickle` | None | Marginal (relay needs an outbox to poll) | None | **High — full outbox/inbox primitive** |
 | Core LOC removed from this repo | ~3,650 Rust | ~3,890 (3,650 + 240 SQL) | ~6,150 (3,890 + 2,260) | **~6,150 + ~2,500 SQL** |
 | `pg_trickle` API churn | Zero | One SQL function rename | `enable_outbox` → wrapper | `enable_outbox` → `attach_outbox` (clean break, no users) |
-| Effort | 1 day | 3–5 days | ~1 week + ADR | **~1 week** (revised down: no users to migrate) |
+| Effort | 1 day | 3–5 days | ~1 week + ADR | **~1 week** to extract; in-flight relay roadmap (§7.10) is months on top either way |
 | Refresh hot-path risk | None | None | Medium (new hook API) | Low (SPI call inside same txn — no new abstraction) |
 | Justifies the term "standalone extension" | No | Barely | No | **Yes** |
 | Useful to users who don't know what IVM is | No | No | No | **Yes** |
@@ -751,7 +751,47 @@ Roughly **one week** end to end — down from the original two-week estimate
 because the migration tooling and deprecation shim work disappear (see §7.7).
 The result is two cleanly-scoped products instead of one entangled one.
 
-### 7.10 Open questions specific to option C
+### 7.10 In-flight relay roadmap that travels with the cut
+
+The relay is **not** feature-complete today. There is a non-trivial
+roadmap of planned work that lives in [plans/relay/](plans/relay/) and
+must move to the new `pg-tide` repo as part of the extraction — not be
+left orphaned in `pg_trickle`. Reviewers should treat the inheritance of
+this roadmap as part of the scope decision, not an afterthought.
+
+| Doc | Scope | Status | Inheritance plan |
+|---|---|---|---|
+| [PLAN_RELAY_WIRE_FORMATS.md](plans/relay/PLAN_RELAY_WIRE_FORMATS.md) | Pluggable `WireFormat` trait + Debezium (both directions), Avro/Confluent SR, Maxwell, Canal, custom CDC JSON. Phased over relay 0.30→0.34. | In-flight design | `git mv plans/relay/PLAN_RELAY_WIRE_FORMATS.md` → `pg-tide/plans/`. Renumber relay versions to `pg-tide` versioning. The Debezium-encoder claim in §7.4 of *this* plan ("replace Kafka Connect with a single Rust binary") only becomes credible once Phase 2 of this doc ships. |
+| [PLAN_RELAY_CLI.md](plans/relay/PLAN_RELAY_CLI.md) | Phase 1 CLI: `pg-tide pipelines`, `pg-tide tail`, `pg-tide doctor`, etc. | In-flight design | Move verbatim. Rename binary references `pgtrickle-relay` → `pg-tide` (the binary already needs renaming for §7.2 anyway). |
+| [PLAN_RELAY_CLI_PHASE_2.md](plans/relay/PLAN_RELAY_CLI_PHASE_2.md) | Phase 2 CLI: schema registry, transforms, dead-letter inspection, replay UX. | In-flight design | Move verbatim. The Schema Registry parts overlap with WIRE_FORMATS phase 3 — flag for de-duplication during the move. |
+| [PLAN_RELAY_GAPS_FROM_FELDERA_RISINGWAVE.md](plans/relay/PLAN_RELAY_GAPS_FROM_FELDERA_RISINGWAVE.md) | Competitive analysis: features the relay lacks vs Feldera and RisingWave. | Reference / backlog | Move verbatim. This doc is most of the long-term roadmap argument *for* `pg_tide`'s independent value — closing these gaps is exactly what makes the standalone extension worth installing. |
+
+**Implication for the §7.9 work plan:** Day 1–2 of the extraction must
+include `git mv plans/relay/* pg-tide/plans/` and a sweep replacing
+`pgtrickle-relay` with `pg-tide` / `pg_tide` in those docs. Day 5 docs
+work needs to add a top-level `pg-tide/plans/README.md` that orients
+contributors at the inherited roadmap rather than the now-stale design
+docs in this repo's `plans/` tree.
+
+**Implication for the §7.5 comparison table:** the "Effort: ~1 week"
+row is the *extraction* effort. Delivering the inherited roadmap (wire
+formats, CLI phase 2, closing the Feldera/RisingWave gaps) is months of
+work on top — but that work was always going to happen *somewhere*; the
+question is whether it lands in `pg_trickle`'s repo or in the new
+standalone one. Option C-revised is the only option that puts it in the
+right place.
+
+**Implication for §7.4 ("realistic for non-`pg_trickle` users"):** the
+"replace Debezium" framing depends on
+[PLAN_RELAY_WIRE_FORMATS.md](plans/relay/PLAN_RELAY_WIRE_FORMATS.md)
+phase 2 actually shipping. Until it does, `pg_tide`'s outbox source
+speaks the native envelope only and the Debezium story is aspirational.
+This is fine — the *outbox/inbox primitive* alone has independent value
+(see the other rows in the §7.4 audience table) — but the Debezium
+audience comes online with relay 0.31+ rather than at the moment of
+extraction.
+
+### 7.11 Open questions specific to option C
 
 1. **License.** `pg_trickle` is Apache-2.0; `pg_tide` should match so
    the integration story is frictionless.

--- a/plans/PLAN_RELAY_STANDALONE.md
+++ b/plans/PLAN_RELAY_STANDALONE.md
@@ -4,6 +4,14 @@
 **Status:** Draft for discussion (revised after option-A vs option-C re-analysis)
 **Related:** [REPORT_SUPERFLOUS_FEATURES.md §7.2](REPORT_SUPERFLOUS_FEATURES.md)
 
+> **Reader's note (1 May 2026, revision 4):** the relay binary, outbox, and
+> inbox features have no known users yet — no bug reports, no support
+> threads, no production deployments we are aware of. This means the
+> extraction can be done as a **clean break**: no deprecation shims, no
+> backwards-compatible SQL surface, no migration tooling. The plan below has
+> been simplified accordingly. Effort drops from ~2 weeks to **~1 week** and
+> the "Two-extension install becomes a friction point" risk class disappears.
+>
 > **Reader's note (1 May 2026, revision 3):** the original draft below recommended
 > option B with a "soft dependency" framing. On closer inspection that framing
 > oversold the reuse story — the *outbox row envelope* this repo emits is a
@@ -34,6 +42,12 @@ catalog, and the relay binary. `pg_trickle` becomes a *consumer* of it: a thin
 `tide.outbox_publish()` from inside the refresh transaction. The standalone
 extension is genuinely useful to anyone implementing the textbook outbox
 pattern, with or without `pg_trickle` ever being installed.
+
+**Effort: ~1 week** as a clean break (no shims, no migration tooling) since
+the relay/outbox/inbox features have no known users today. Send a one-line
+"is anyone using these?" check to the discussions board before merging — if
+real users surface, the migration plan from revision 3 gets restored and the
+estimate goes back to ~2 weeks.
 
 The original three options (A, B, the no-op C) and the inventory of today's
 coupling surface are kept below as the reference material that informs the new
@@ -637,8 +651,8 @@ people would actually install for its own sake.
 |---|---|---|---|---|
 | Standalone usefulness without `pg_trickle` | None | Marginal (relay needs an outbox to poll) | None | **High — full outbox/inbox primitive** |
 | Core LOC removed from this repo | ~3,650 Rust | ~3,890 (3,650 + 240 SQL) | ~6,150 (3,890 + 2,260) | **~6,150 + ~2,500 SQL** |
-| `pg_trickle` API churn | Zero | One SQL function rename | `enable_outbox` → wrapper | `enable_outbox` → `attach_outbox` wrapper |
-| Effort | 1 day | 3–5 days | ~1 week + ADR | **~2 weeks** |
+| `pg_trickle` API churn | Zero | One SQL function rename | `enable_outbox` → wrapper | `enable_outbox` → `attach_outbox` (clean break, no users) |
+| Effort | 1 day | 3–5 days | ~1 week + ADR | **~1 week** (revised down: no users to migrate) |
 | Refresh hot-path risk | None | None | Medium (new hook API) | Low (SPI call inside same txn — no new abstraction) |
 | Justifies the term "standalone extension" | No | Barely | No | **Yes** |
 | Useful to users who don't know what IVM is | No | No | No | **Yes** |
@@ -647,34 +661,37 @@ people would actually install for its own sake.
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| Two-extension install becomes a friction point for `pg_trickle` users | Medium | Medium | Ship an `pg_trickle_outbox_compat` SQL package that re-creates the old `pgtrickle.enable_outbox(...)` signatures as `attach_outbox(...)` shims. Keep one release of deprecation overlap. |
-| The SPI round-trip from `write_outbox_row` shows up in benchmarks | Low | Low | Cache the prepared `outbox.publish` plan; benchmark before/after on the existing `e2e_bench_refresh_matrix`. |
+| The SPI round-trip from `write_outbox_row` shows up in benchmarks | Low | Low | Cache the prepared `tide.outbox_publish` plan; benchmark before/after on the existing `e2e_bench_refresh_matrix`. |
 | Generic outbox table shape diverges from `pg_trickle`'s envelope needs | Low | Medium | `pg_tide`'s outbox row already has `payload JSONB` + `headers JSONB`; `pg_trickle` puts its `v:1` envelope inside `payload`. No schema collision. |
 | Inbox helper views (pending/DLQ/stats) lose IVM acceleration by default | Medium | Low | They're plain VIEWs in `pg_tide`; `pg_trickle.materialize_inbox_views()` is a one-liner upgrade for users who want incremental maintenance. |
 | Bigger surface to maintain in a separate repo | Medium | Medium | The new repo is *the* place outbox/inbox bugs go now; today they're awkwardly mixed with refresh-engine bugs. Net cognitive load is probably lower. |
 | Project name `pg_tide` is metaphorical, not literal | Low | Low | Continues the established water-motion lineage (`pg_trickle`, `pg_ripple`); the metaphor honestly covers both directions (tides go in *and* out) where `pg_outbox` would have undersold the inbox half. README leads with "transactional outbox + inbox + multi-backend relay for PostgreSQL" so SEO works. |
-| ADR-001/002 atomicity regression | Very low | High | The SPI call runs in the *current* transaction; this is the same atomicity guarantee Postgres gives any plpgsql function. Add a regression test that crashes the session between `outbox.publish()` and `COMMIT` and asserts both the refresh MERGE and the outbox row are absent after recovery. |
+| ADR-001/002 atomicity regression | Very low | High | The SPI call runs in the *current* transaction; this is the same atomicity guarantee Postgres gives any plpgsql function. Add a regression test that crashes the session between `tide.outbox_publish()` and `COMMIT` and asserts both the refresh MERGE and the outbox row are absent after recovery. |
 
-### 7.7 Migration path for existing `pg_trickle` outbox/inbox users
+*Dropped from this risk register (revision 4):* "Two-extension install becomes
+a friction point for `pg_trickle` users." The relay/outbox/inbox features have
+no known users today, so there is no friction to mitigate — the new layout
+is simply the only layout these features have ever had.
 
-A single SQL migration shipped with the new release:
+### 7.7 No migration path required
 
-```sql
--- Run once, after installing pg_tide and upgrading pg_trickle.
-CREATE EXTENSION pg_tide;
-SELECT pgtrickle.migrate_outboxes_to_pg_tide();
--- ↑ for each row in pgtrickle.pgt_outbox_config:
---   1. CREATE the equivalent outbox via tide.outbox_create()
---   2. Copy historical rows from pgtrickle.outbox_<st> into tide.<st>
---   3. Re-attach pg_trickle's refresh hook via attach_outbox()
---   4. Drop the old pgtrickle.outbox_<st> table
-SELECT pgtrickle.migrate_inboxes_to_pg_tide();
--- Same pattern for inboxes.
-```
+Revision 4 removes the migration section that previously lived here. The
+rationale: the outbox/inbox/relay features have no known users — no bug
+reports, no support threads, no production deployments. A clean break is
+cheaper, safer, and clearer than backwards-compatible shims:
 
-Old `pgtrickle.enable_outbox(...)` / `pgtrickle.create_inbox(...)` remain as
-deprecation shims for one release that internally call the new `attach_outbox`
-/ `tide.inbox_create` paths and emit a `WARNING`.
+- **No migration SQL.** No need for `pgtrickle.migrate_outboxes_to_pg_tide()`
+  or its inbox counterpart.
+- **No deprecation shims.** `pgtrickle.enable_outbox(...)` /
+  `pgtrickle.create_inbox(...)` are simply *removed* in the same release that
+  introduces `pg_trickle.attach_outbox(...)`. The CHANGELOG entry calls out
+  the rename as a breaking change, with a one-line equivalence table for
+  anyone who picks the feature up later.
+- **No two-release overlap window.** Single release, single coherent surface.
+
+If user reports surface between now and the cut, this section gets restored
+with a real migration plan. Until then, treat outbox/inbox/relay as
+undocumented internal API that gets restructured before 1.0.
 
 ### 7.8 Why this is worth doing despite being the largest option
 
@@ -708,19 +725,21 @@ deprecation shims for one release that internally call the new `attach_outbox`
    [src/lib.rs](../src/lib.rs#L1095-L1335) into `pg_tide`'s extension
    crate. Lift `pgtrickle-relay/` into the new repo as the `pg-tide`
    binary.
-3. **Day 4** — In this repo, replace `enable_outbox()` /
-   `create_inbox()` with thin `attach_outbox()` / `attach_inbox()` wrappers
-   that delegate to `pg_tide`. Add the deprecation shims. Implement
-   `pg_trickle.materialize_inbox_views()` for the optional IVM upgrade.
-4. **Days 5–6** — Migration SQL; integration tests that exercise both
-   "with `pg_trickle`" and "without `pg_trickle`" deployments; benchmark
-   the SPI hop on the refresh hot path.
-5. **Day 7** — Documentation: cross-link the two repos; rewrite
-   docs/SQL_REFERENCE.md outbox/inbox sections to point at `pg_tide`;
-   pre-release tags on both repos.
+3. **Day 4** — In this repo, *delete* `enable_outbox()` / `create_inbox()`
+   and the relay catalog SQL outright (no shims — see §7.7). Add the new
+   thin `attach_outbox()` / `attach_inbox()` wrappers that delegate to
+   `pg_tide`. Implement `pg_trickle.materialize_inbox_views()` for the
+   optional IVM upgrade.
+4. **Day 5** — Integration tests that exercise both "with `pg_trickle`"
+   and "without `pg_trickle`" deployments; benchmark the SPI hop on the
+   refresh hot path. Documentation: cross-link the two repos; rewrite
+   docs/SQL_REFERENCE.md outbox/inbox sections to point at `pg_tide`.
+   CHANGELOG entry calls out the rename as a breaking change with a
+   one-line equivalence table. Pre-release tags on both repos.
 
-Roughly **two weeks** end to end, but the result is two cleanly-scoped
-products instead of one entangled one.
+Roughly **one week** end to end — down from the original two-week estimate
+because the migration tooling and deprecation shim work disappear (see §7.7).
+The result is two cleanly-scoped products instead of one entangled one.
 
 ### 7.10 Open questions specific to option C
 
@@ -729,17 +748,22 @@ products instead of one entangled one.
 2. **Repo home.** Same `grove/` org, or somewhere more neutral if the
    intent is to attract contributors who don't think of it as a
    `pg_trickle` accessory?
-3. **Backwards-compatible shims.** How many releases do we keep
-   `pgtrickle.enable_outbox(...)` etc. before removing them? One release
-   feels right for a pre-1.0 codebase; if anyone's running the outbox in
-   production, two releases is safer.
-4. **Schema layout.** Single `tide` schema (with `outbox_*` / `inbox_*` /
+3. **Schema layout.** Single `tide` schema (with `outbox_*` / `inbox_*` /
    `relay_*` function prefixes), or three sibling schemas (`tide_outbox`,
    `tide_inbox`, `tide_relay`)? The plan currently assumes the single
    schema for ergonomics, but the three-schema layout would let users
    `SET search_path = tide_outbox, public` and drop the prefix.
-5. **Naming the lineage.** Should the README explicitly call out the
+4. **Naming the lineage.** Should the README explicitly call out the
    `pg_trickle` / `pg_ripple` / `pg_tide` family? Helps with
    recognisability if multiple extensions are deployed together; risks
    tying `pg_tide`'s identity to `pg_trickle` more tightly than option C
    intends.
+5. **User check before the cut.** Before merging the breaking change,
+   send a one-line announcement to the `pg_trickle` discussions / issue
+   tracker asking "is anyone using `enable_outbox()` /
+   `enable_inbox()` / the relay binary today?" If the answer is
+   non-empty, revision 4's no-shims simplification has to be reverted in
+   favour of the original migration plan from revision 3.
+
+*Dropped from this list (revision 4):* the backwards-compatibility window
+question. With no known users, there is nothing to be compatible with.

--- a/plans/PLAN_RELAY_STANDALONE.md
+++ b/plans/PLAN_RELAY_STANDALONE.md
@@ -1,0 +1,732 @@
+# Pulling `pgtrickle-relay` Out as a Standalone Project
+
+**Date:** 1 May 2026
+**Status:** Draft for discussion (revised after option-A vs option-C re-analysis)
+**Related:** [REPORT_SUPERFLOUS_FEATURES.md §7.2](REPORT_SUPERFLOUS_FEATURES.md)
+
+> **Reader's note (1 May 2026, revision 2):** the original draft below recommended
+> option B with a "soft dependency" framing. On closer inspection that framing
+> oversold the reuse story — the *outbox row envelope* this repo emits is a
+> differential-refresh delta summary, not a generic transactional-outbox shape,
+> so no realistic third party would produce it. A new **§7 "Option C, properly
+> developed"** at the bottom of this document explores the *opposite* direction:
+> extract a **generic** outbox/inbox extension (`pg_outbox`) that is useful
+> *without* `pg_trickle`, and demote `pg_trickle`'s outbox/inbox API to a thin
+> producer that depends on it. That option is now the recommended one. Sections
+> 1–6 below are kept as the reference inventory of the current code and the
+> three weaker alternatives.
+
+---
+
+## TL;DR (revised)
+
+**Recommended:** **Option C** — ship a new standalone extension `pg_outbox`
+that owns generic transactional outbox + inbox tables, retention, the relay
+catalog, and the relay binary. `pg_trickle` becomes a *consumer* of it: a thin
+`pg_trickle.attach_outbox()` wrapper installs a refresh-time hook that calls
+`outbox.publish()` from inside the refresh transaction. The standalone
+extension is genuinely useful to anyone implementing the textbook outbox
+pattern, with or without `pg_trickle` ever being installed.
+
+The original three options (A, B, the no-op C) and the inventory of today's
+coupling surface are kept below as the reference material that informs the new
+recommendation.
+
+---
+
+## TL;DR (original draft, kept for reference)
+
+**Yes — extracting the relay is feasible, low-risk, and worth doing for 1.0.**
+The relay is already a self-contained Rust crate with zero Rust-level
+dependency on the `pg_trickle` extension. All coupling lives in a small,
+well-defined SQL surface that can be moved cleanly.
+
+There are three plausible end-states. The recommendation is **option B** below
+— a separate repository that ships *both* a CLI binary and a thin companion
+Postgres extension (`pgtrickle_relay`) that owns its own catalog. The relay
+would *prefer* `pg_trickle` (auto-wiring against its outbox/inbox tables when
+present) but does not *require* it — any user with their own outbox-shaped
+table can drive the relay.
+
+Estimated effort: **3–5 working days** for the split itself, plus ~1 day of CI
+and documentation work.
+
+---
+
+## 1. Where things stand today
+
+### 1.1 The relay is already mostly separate
+
+`pgtrickle-relay/` is a sibling Cargo crate inside the same workspace, not a
+module of the extension:
+
+| Metric | Value |
+|---|---|
+| Source files | 29 (`pgtrickle-relay/src/**/*.rs`) |
+| Lines of Rust | ~3,650 |
+| On-disk size | 184 KB |
+| Workspace membership | `members = [".", "pgtrickle-relay"]` in root `Cargo.toml` |
+| Rust deps on `pg_trickle` crate | **0** (no `use pg_trickle::...`, no `dep`) |
+| Talks to Postgres via | `tokio-postgres` only |
+
+Internally it has its own:
+
+- CLI ([cli.rs](../pgtrickle-relay/src/cli.rs)) and `main.rs`
+- Coordinator with advisory-lock leader election ([coordinator.rs](../pgtrickle-relay/src/coordinator.rs))
+- Six source backends (NATS, Kafka, webhook, Redis, SQS, RabbitMQ, outbox poller)
+- Eight sink backends (same set + stdout + pg-inbox)
+- Independent metrics/health server (Axum + Prometheus)
+- Independent error type, config schema, envelope format
+- Its own Dockerfile ([Dockerfile.relay](../Dockerfile.relay))
+- Its own publish jobs in [.github/workflows/release.yml](../.github/workflows/release.yml#L477-L575)
+- Its own version number (currently 0.29.0; the extension is at 0.42.0)
+
+### 1.2 The actual coupling surface
+
+Every connection between the relay and the extension is through PostgreSQL,
+not through Rust. The full inventory:
+
+**Catalog tables (defined in [src/lib.rs](../src/lib.rs#L1095-L1140)):**
+
+- `pgtrickle.relay_outbox_config(name, enabled, config jsonb)`
+- `pgtrickle.relay_inbox_config(name, enabled, config jsonb)`
+- `pgtrickle.relay_consumer_offsets(relay_group_id, pipeline_id, last_change_id, ...)`
+
+**SQL helper functions (defined in [src/lib.rs](../src/lib.rs#L1160-L1335)):**
+
+- `set_relay_outbox(...)`, `set_relay_inbox(...)`
+- `enable_relay(name)`, `disable_relay(name)`, `delete_relay(name)`
+- `get_relay_config(name)`, `list_relay_configs()`
+- `relay_config_notify()` trigger function
+
+**NOTIFY channel:** `pgtrickle_relay_config` (LISTENed by the relay for hot
+reload).
+
+**Role:** `pgtrickle_relay NOLOGIN` (created by core extension on install).
+
+**Tables the relay reads/writes that are produced by core:**
+
+- `pgtrickle.outbox_<st>` — written by `enable_outbox()`
+  ([src/api/outbox.rs](../src/api/outbox.rs))
+- `pgtrickle.outbox_delta_rows_<st>` — claim-check sidecar
+- `pgtrickle.inbox_<...>` — written via `enable_inbox()`
+  ([src/api/inbox.rs](../src/api/inbox.rs))
+- `pgtrickle.outbox_rows_consumed(name, outbox_id)` — SPI function the relay
+  calls after draining a claim-check batch
+
+That last bullet is the **only mandatory call back into core extension code**.
+Everything else is data on tables.
+
+### 1.3 What the relay assumes about the outbox shape
+
+The outbox poller ([pgtrickle-relay/src/source/outbox.rs](../pgtrickle-relay/src/source/outbox.rs))
+expects rows with: `id BIGINT PK`, `created_at TIMESTAMPTZ`, `inserted_count`,
+`deleted_count`, `is_claim_check BOOL`, `payload JSONB`. The payload uses an
+explicit `v: 1` envelope. **This shape is documented and stable** — it is the
+1.0 contract for both the extension's outbox writer and any third-party
+producer.
+
+---
+
+## 2. What "standalone" could mean — three options
+
+### Option A — Move the binary, keep catalog in core
+
+**What changes:** Move `pgtrickle-relay/` into a new repo
+`grove/pg-trickle-relay`. Leave `relay_outbox_config`, `relay_inbox_config`,
+and the seven `set_relay_*` / `enable_relay` / etc. SQL functions inside the
+core extension exactly where they are.
+
+**Pros:**
+- Smallest possible change. ~1 day of work.
+- No SQL migration for users.
+- Core extension still ships the full "outbox + manage relays from SQL"
+  experience.
+
+**Cons:**
+- The "for 1.0 we don't ship the relay in core" story is undermined — core
+  still carries 240 lines of relay-specific SQL DDL and seven SQL functions
+  that only matter to a binary you may or may not run.
+- Doesn't solve the coupling-by-design problem.
+
+### Option B — Move the binary AND extract a small `pgtrickle_relay` extension *(recommended)*
+
+**What changes:** New repo `grove/pg-trickle-relay` containing:
+
+1. The Rust CLI binary (today's `pgtrickle-relay`).
+2. A new tiny pgrx extension `pgtrickle_relay` (single SQL file, no Rust to
+   speak of — just `extension_sql!`) that owns the three catalog tables and
+   the seven helper functions currently in
+   [src/lib.rs](../src/lib.rs#L1095-L1335).
+3. `pg_trickle` becomes a *soft* dependency: if it is installed in the same
+   database, the relay's outbox source can read its `pgtrickle.outbox_<st>`
+   tables and call `pgtrickle.outbox_rows_consumed()`. If it is not, the
+   relay's other sources (NATS/Kafka/Redis/SQS/webhook/RabbitMQ) and sinks
+   continue to work — only the "outbox poller" source becomes unusable.
+
+**Pros:**
+- Core extension shrinks by ~240 lines of SQL DDL and ~3,650 lines of Rust.
+- Relay can release on its own cadence and add backends without bumping core.
+- Users who don't use the outbox/inbox pattern stop paying for any of it
+  (build time, image size, attack surface, doc bulk).
+- The relay becomes useful to a wider audience: anyone running an
+  outbox-shaped table in plain Postgres can use it.
+- Aligns with the 1.0 "core is incremental view maintenance, full stop"
+  positioning.
+
+**Cons:**
+- Users currently calling `pgtrickle.set_relay_outbox(...)` need to install a
+  second extension. Migration script required.
+- Two repos to maintain instead of one (mitigated: it's already two crates).
+
+### Option C — Move binary, extension, AND outbox/inbox writer
+
+**What changes:** Same as B, plus move `src/api/outbox.rs` (1,048 LOC) and
+`src/api/inbox.rs` (1,215 LOC) — i.e. `enable_outbox()`, `disable_outbox()`,
+`enable_inbox()`, `replay_inbox_messages()`, and the outbox-write hook in
+[src/api/mod.rs](../src/api/mod.rs#L4957) and
+[src/scheduler/mod.rs](../src/scheduler/mod.rs#L6187) — into the new repo.
+
+**Pros:**
+- Maximum separation: core has *zero* awareness of outbox/inbox.
+
+**Cons:**
+- The outbox writer runs *inside the refresh transaction* — that's the entire
+  point of "transactional outbox." Moving it out of core means either:
+  a. Exposing a hook API from core that the outbox extension installs into
+     (significant new surface, ADR-grade decision), or
+  b. Forcing every refresh to touch a second extension's tables via plpgsql
+     triggers (slower, brittle).
+- The outbox/inbox functions (`enable_outbox`, `outbox_status`,
+  `inbox_health`, etc.) are listed in [REPORT_SUPERFLOUS_FEATURES.md §11](REPORT_SUPERFLOUS_FEATURES.md)
+  as "should probably move out" — but moving them is a much larger and more
+  intrusive change than moving the relay binary, and it touches the refresh
+  hot path.
+- High risk of regressing the "single-transaction atomicity" guarantee that
+  ADR-001 / ADR-002 enshrine.
+
+**Verdict on C:** out of scope for the relay extraction. It's a separate,
+larger conversation that should happen on its own merits. Nothing in
+option B prevents doing C later.
+
+---
+
+## 3. Detailed plan for option B
+
+### 3.1 New repository layout (`grove/pg-trickle-relay`)
+
+```
+pg-trickle-relay/
+├── Cargo.toml                # workspace
+├── relay/                    # the binary (today's pgtrickle-relay/)
+│   ├── Cargo.toml
+│   └── src/...
+├── extension/                # NEW — the tiny pgrx extension
+│   ├── Cargo.toml
+│   ├── pgtrickle_relay.control
+│   └── src/lib.rs            # extension_sql! blocks only
+├── sql/
+│   └── migrate_from_pg_trickle.sql   # one-time migration script
+├── Dockerfile                # was Dockerfile.relay
+├── docker-compose.example.yml
+├── docs/
+└── tests/
+```
+
+### 3.2 The companion extension `pgtrickle_relay`
+
+A single-file pgrx extension that creates exactly the SQL surface listed in
+§1.2. Concretely, lift these blocks from
+[src/lib.rs](../src/lib.rs#L1095-L1335) verbatim, change the schema name from
+`pgtrickle` → `pgtrickle_relay`, and rename objects:
+
+| Today (in `pgtrickle` schema) | New home (in `pgtrickle_relay` schema) |
+|---|---|
+| `pgtrickle.relay_outbox_config` | `pgtrickle_relay.outbox_config` |
+| `pgtrickle.relay_inbox_config` | `pgtrickle_relay.inbox_config` |
+| `pgtrickle.relay_consumer_offsets` | `pgtrickle_relay.consumer_offsets` |
+| `pgtrickle.set_relay_outbox(...)` | `pgtrickle_relay.set_outbox(...)` |
+| `pgtrickle.set_relay_inbox(...)` | `pgtrickle_relay.set_inbox(...)` |
+| `pgtrickle.enable_relay(name)` | `pgtrickle_relay.enable(name)` |
+| `pgtrickle.disable_relay(name)` | `pgtrickle_relay.disable(name)` |
+| `pgtrickle.delete_relay(name)` | `pgtrickle_relay.delete(name)` |
+| `pgtrickle.get_relay_config(name)` | `pgtrickle_relay.get_config(name)` |
+| `pgtrickle.list_relay_configs()` | `pgtrickle_relay.list_configs()` |
+| NOTIFY `pgtrickle_relay_config` | NOTIFY `pgtrickle_relay_config` *(unchanged)* |
+| ROLE `pgtrickle_relay` | ROLE `pgtrickle_relay` *(unchanged)* |
+
+Total: about 240 lines of SQL plus ~30 lines of Rust scaffolding for pgrx.
+
+### 3.3 Soft dependency on `pg_trickle`
+
+The new extension does **not** declare `pg_trickle` in its
+`pgtrickle_relay.control` `requires` field. Instead:
+
+1. The relay binary's outbox source ([pgtrickle-relay/src/source/outbox.rs](../pgtrickle-relay/src/source/outbox.rs))
+   already addresses the outbox table by name from config — no change needed.
+2. The one place the binary calls back into core
+   (`SELECT pgtrickle.outbox_rows_consumed($1, $2)` at line 47 of that file)
+   becomes conditional: probe at startup with
+   `SELECT to_regproc('pgtrickle.outbox_rows_consumed') IS NOT NULL` and
+   either (a) call the function when present or (b) inline the equivalent
+   `DELETE FROM ... WHERE outbox_id <= $1` cleanup against the claim-check
+   table. This makes the relay usable against bare `pg_trickle`-free Postgres.
+3. Document the outbox row contract (the `v: 1` envelope, columns, NOTIFY
+   channel name) in `docs/outbox-contract.md` so third parties can produce
+   compatible outboxes without `pg_trickle`.
+
+### 3.4 Migration for existing users
+
+Provide `sql/migrate_from_pg_trickle.sql` shipped with the relay:
+
+```sql
+-- One-time migration from pg_trickle ≤0.42 to standalone pgtrickle_relay.
+CREATE EXTENSION IF NOT EXISTS pgtrickle_relay;
+
+INSERT INTO pgtrickle_relay.outbox_config(name, enabled, config)
+SELECT name, enabled, config FROM pgtrickle.relay_outbox_config
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO pgtrickle_relay.inbox_config(name, enabled, config)
+SELECT name, enabled, config FROM pgtrickle.relay_inbox_config
+ON CONFLICT (name) DO NOTHING;
+
+INSERT INTO pgtrickle_relay.consumer_offsets
+SELECT * FROM pgtrickle.relay_consumer_offsets
+ON CONFLICT (relay_group_id, pipeline_id) DO NOTHING;
+
+-- Old objects can be dropped after verifying the relay is running against
+-- the new catalog:
+-- DROP TABLE pgtrickle.relay_outbox_config CASCADE;
+-- DROP TABLE pgtrickle.relay_inbox_config CASCADE;
+-- DROP TABLE pgtrickle.relay_consumer_offsets;
+-- DROP FUNCTION pgtrickle.set_relay_outbox(...) CASCADE;
+-- ... etc.
+```
+
+The old `pgtrickle.relay_*` objects stay in core for one release cycle as
+deprecated shims (raise a `WARNING` and forward writes to
+`pgtrickle_relay.*` if it's installed) and are removed in 1.1.
+
+### 3.5 Changes inside `pg_trickle` (this repo)
+
+Following the cut, in this repo we:
+
+1. **Delete** [src/lib.rs](../src/lib.rs#L1095-L1340) blocks for relay
+   catalog and SQL functions (~240 lines).
+2. **Delete** the `pgtrickle_relay` role creation block (it now lives in the
+   new extension).
+3. **Remove** `pgtrickle-relay` from the workspace `members` list in the root
+   `Cargo.toml`.
+4. **Delete** `Dockerfile.relay`.
+5. **Remove** the four relay jobs from [.github/workflows/release.yml](../.github/workflows/release.yml#L474-L580)
+   (`publish-relay-docker-arch`, `publish-relay-docker`, the relay binary
+   build steps in the tarball job, and the `RELAY_IMAGE_NAME` env var).
+6. **Drop** the `aws-smithy-http-client` security exception in
+   [.github/workflows/security.yml](../.github/workflows/security.yml#L52-L82)
+   (it only existed because of the relay's optional SQS feature).
+7. **Slim** the e2e Dockerfile [tests/Dockerfile.e2e](../tests/Dockerfile.e2e#L36-L48)
+   — drop the relay placeholder lines.
+8. Add a one-paragraph migration note to `CHANGELOG.md` and a redirect line
+   to the relay README.
+
+### 3.6 Changes inside the new relay repo (lift-and-shift)
+
+1. `git mv pgtrickle-relay/* pg-trickle-relay/relay/` (or copy + git history
+   preserved with `git filter-repo --subdirectory-filter pgtrickle-relay`).
+2. Add the new `extension/` crate with `pgrx` + `extension_sql!` containing
+   the lifted SQL.
+3. Wire the relay binary's outbox source to use the soft-dependency probe
+   from §3.3.
+4. Carry over the relay-specific CI bits from this repo.
+5. Update `Cargo.lock`.
+
+### 3.7 What we measure success by
+
+- `cargo build -p pg_trickle` no longer pulls any relay-related dependency.
+- `pgtrickle.relay_*` tables/functions no longer exist after the deprecation
+  window.
+- Total LOC removed from this repo: ~3,890 (3,650 Rust + 240 SQL) plus the
+  Dockerfile and ~100 lines of release CI.
+- A user who installs only `pgtrickle_relay` (without `pg_trickle`) and
+  configures a NATS-to-webhook pipeline should be able to run the binary end
+  to end against vanilla Postgres 18.
+
+---
+
+## 4. Risks and mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Existing users break on upgrade because their `set_relay_outbox(...)` calls go missing | Medium | High | Keep deprecated shims in core for one release; ship migration SQL; document loudly in CHANGELOG and the upgrade guide. |
+| Outbox row contract drifts between repos and producers/consumers desync | Low | High | Pin the `v: 1` envelope as a versioned contract document; add a contract test in *both* repos that pins the JSON shape. |
+| Relay loses test coverage during the move | Medium | Medium | Carry over tests verbatim before any rename. The relay already has Testcontainers-based tests in `pgtrickle-relay/src/**` — none live in the parent `tests/` tree, so the cut is clean. |
+| Two-repo release coordination becomes a chore | Low | Low | The relay's release cadence is genuinely independent — this is mostly a *benefit*, not a risk. Use `gh workflow run` to trigger from either repo. |
+| Soft-dependency probing introduces subtle bugs | Low | Medium | Single call site; gate with a one-time `OnceCell<bool>` capability check at coordinator startup; integration test with and without `pg_trickle` installed. |
+| Loss of the "one-stop-shop" perception in marketing | Low | Low | Cross-link the two repos prominently in both READMEs; keep the demo (`demo/`) showing them used together. |
+
+The biggest *non-*risk: there is no risk to refresh correctness, CDC
+durability, or differential dataflow performance. Those subsystems do not
+touch any of the code being moved.
+
+---
+
+## 5. Is it worth doing?
+
+**Yes, for these reasons:**
+
+1. **Alignment with 1.0 framing.** [REPORT_SUPERFLOUS_FEATURES.md §7.2](REPORT_SUPERFLOUS_FEATURES.md)
+   already identifies the relay as a P2 candidate for extraction. This plan
+   is the concrete how.
+2. **Low cost.** The crate is already separate at the Rust level; the
+   coupling surface is 240 lines of SQL and one SPI call. There is no
+   architectural untangling to do.
+3. **Real reduction in core surface.** ~3,900 LOC, one Dockerfile, four CI
+   jobs, and a chunk of `Cargo.lock` (six optional async messaging clients
+   plus AWS SDK) leave the core repository.
+4. **Strictly increases the relay's reach.** A standalone relay that can run
+   against any outbox-shaped table is a more useful product than a relay
+   that only works with one specific extension.
+5. **No correctness or performance impact** on the parts of `pg_trickle`
+   that matter most (refresh engine, CDC, scheduler, DAG).
+
+**Reasons it might not be worth doing:**
+
+1. If the team values single-repo developer ergonomics (one `cargo build`,
+   one PR for cross-cutting changes) over surface reduction.
+2. If there is a near-term plan to deeply integrate the relay with the
+   refresh hot path (e.g. push notifications instead of poll). Such
+   integration would argue for *closer* coupling, not looser.
+
+Neither concern appears to apply: the relay's Rust deps don't intersect
+core's, and the "polling outbox table" architecture is exactly the
+loose-coupling boundary that justifies the split.
+
+---
+
+## 6. Recommendation and next steps
+
+**Recommendation:** Adopt **option B**. Schedule the cut for the v1.0
+preparation window.
+
+**Suggested order of work:**
+
+1. **Day 1** — Create the new repo skeleton; lift the relay crate with
+   `git filter-repo` to preserve history.
+2. **Day 2** — Author the `pgtrickle_relay` companion extension; copy SQL
+   from [src/lib.rs](../src/lib.rs#L1095-L1335) and rename objects.
+3. **Day 3** — Implement the soft-dependency probe in
+   [pgtrickle-relay/src/source/outbox.rs](../pgtrickle-relay/src/source/outbox.rs);
+   write the migration SQL; write a Testcontainers test that runs the relay
+   against bare Postgres (no `pg_trickle`) using a hand-rolled outbox table.
+4. **Day 4** — In this repo: delete the moved code, replace with deprecation
+   shims, update CI, update CHANGELOG and upgrade guide.
+5. **Day 5** — Documentation pass; verify both repos build clean; cut
+   pre-release tags from each.
+
+**Open questions for the team before starting:**
+
+1. Are there existing customers depending on `pgtrickle.set_relay_outbox(...)`
+   calls in their migrations? (Mitigation: deprecation shim — but timing
+   matters.)
+2. Should the new repo live under `grove/` or somewhere else?
+3. Should the relay binary keep the name `pgtrickle-relay`, or rebrand to
+   something more generic like `pg-outbox-relay` to reflect that it works
+   beyond `pg_trickle`?
+4. Do we want option B or do we also want option C (move
+   outbox/inbox writer to a separate extension)? Option C is a much larger
+   conversation and should probably be its own design doc.
+
+---
+
+## 7. Option C, properly developed — a generic `pg_outbox` extension
+
+The original framing of option C ("also move the writer") missed the point.
+The point of pulling something out is *not* to make the core repo smaller
+for its own sake — it is to create a thing that **adds value on its own**.
+The relay binary by itself does not, because the row shape it consumes is
+pg_trickle-specific. But the **outbox/inbox infrastructure underneath that
+shape is genuinely generic**, and turning it into a standalone extension is
+the path that produces something useful to people who have never heard of
+incremental view maintenance.
+
+### 7.1 The two layers hiding inside `src/api/{outbox,inbox}.rs`
+
+A close read of [src/api/outbox.rs](../src/api/outbox.rs) (1,048 LOC) and
+[src/api/inbox.rs](../src/api/inbox.rs) (1,215 LOC) reveals two distinct
+layers that are bundled together today:
+
+**Generic infrastructure (~75% of the code, fully reusable):**
+
+- Outbox table shape: `(id BIGSERIAL PK, created_at TIMESTAMPTZ, payload
+  JSONB, headers JSONB, ...)` plus a `pg_notify('..._new', name)` trigger.
+- Claim-check sidecar pattern: `outbox_delta_rows_<name>` table for payloads
+  that exceed `inline_threshold_rows`.
+- `outbox_status()` / retention drainer / consumer-offset tracking
+  (`pgt_consumer_offsets`, lag/heartbeat reporting).
+- Inbox table shape: `(event_id PK, event_type, source, aggregate_id,
+  payload, received_at, processed_at, retry_count, error, trace_id)` with
+  configurable column names.
+- Idempotency-on-insert (`ON CONFLICT (event_id) DO NOTHING`), DLQ pattern,
+  ordering (`enable_inbox_ordering`), priority tiers (`enable_inbox_priority`),
+  replay (`replay_inbox_messages`), retention.
+- The relay catalog (`relay_outbox_config`, `relay_inbox_config`,
+  `relay_consumer_offsets`) and the relay binary itself.
+
+**`pg_trickle`-specific producer code (~25%):**
+
+- `write_outbox_row()` ([src/api/outbox.rs](../src/api/outbox.rs#L880))
+  called from
+  [src/api/mod.rs](../src/api/mod.rs#L4957) and
+  [src/scheduler/mod.rs](../src/scheduler/mod.rs#L6188) inside the refresh
+  MERGE transaction. Fills `payload` with
+  `SELECT json_agg(row_to_json(t)) FROM <stream_table>`.
+- The delta-summary columns `inserted_count`, `deleted_count`, `refresh_id`,
+  `is_claim_check` on the outbox row.
+- The `v: 1` envelope tag and `full_refresh` flag in the JSON payload.
+- The auto-creation of `<inbox>_pending` / `<inbox>_dlq` / `<inbox>_stats`
+  as **stream tables** ([src/api/inbox.rs](../src/api/inbox.rs#L244)) — the
+  *only* genuine `pg_trickle` dependency on the inbox side. These could just
+  as well be plain `VIEW`s.
+
+### 7.2 The proposed standalone extension: `pg_outbox`
+
+A new repo `grove/pg-outbox` containing:
+
+```
+pg-outbox/
+├── extension/                # pgrx extension `pg_outbox`
+│   ├── pg_outbox.control     # no `requires` — fully standalone
+│   └── src/
+│       ├── lib.rs            # GUCs, schema bootstrap
+│       ├── outbox.rs         # generic outbox API (lifted ~700 LOC from src/api/outbox.rs)
+│       ├── inbox.rs          # generic inbox API   (lifted ~1,150 LOC from src/api/inbox.rs)
+│       ├── relay_catalog.rs  # relay config tables + helper functions (~240 LOC of SQL)
+│       └── retention.rs      # background worker for draining old rows
+├── relay/                    # the binary, today's pgtrickle-relay/
+└── docs/
+```
+
+**Public SQL surface** (schemas `outbox`, `inbox`, `relay`):
+
+```sql
+-- ── Outbox: write business events transactionally with your domain change ──
+SELECT outbox.create('orders_events',
+    retention_hours       => 24,
+    inline_threshold_rows => 10000);
+
+-- App writes from inside its own transaction:
+BEGIN;
+  UPDATE orders SET status = 'paid' WHERE id = 42;
+  PERFORM outbox.publish('orders_events',
+      payload => '{"order_id": 42, "event": "paid"}'::jsonb,
+      headers => '{"trace_id": "abc-123"}'::jsonb);
+COMMIT;
+-- ↑ both rows are durable together; relay forwards to NATS/Kafka/etc.
+
+SELECT outbox.status('orders_events');
+SELECT outbox.disable('orders_events');
+
+-- ── Inbox: idempotently receive events from external systems ──
+SELECT inbox.create('orders_inbox',
+    max_retries      => 3,
+    with_dead_letter => true,
+    with_stats       => true,
+    retention_hours  => 72);
+
+-- Relay (or app) writes incoming events:
+INSERT INTO inbox.orders_inbox (event_id, event_type, payload)
+VALUES ('msg-123', 'order.created', '{...}'::jsonb)
+ON CONFLICT (event_id) DO NOTHING;
+
+-- App marks results:
+SELECT inbox.mark_processed('orders_inbox', 'msg-123');
+SELECT inbox.mark_failed   ('orders_inbox', 'msg-123', 'parse error');
+
+-- Built-in views (plain VIEWs — no pg_trickle required):
+SELECT * FROM inbox.orders_inbox_pending;
+SELECT * FROM inbox.orders_inbox_dlq;
+SELECT * FROM inbox.orders_inbox_stats;
+
+-- ── Relay configuration (consumed by the relay binary) ──
+SELECT relay.set_outbox('orders-to-nats', ...);
+SELECT relay.set_inbox ('nats-to-orders', ...);
+SELECT relay.enable    ('orders-to-nats');
+```
+
+The inbox helper views are **plain views** by default. If `pg_trickle` is
+installed in the same database, the user can opt in to incremental
+materialisation:
+
+```sql
+SELECT pg_trickle.materialize_inbox_views('orders_inbox', schedule => '1s');
+-- ↑ replaces the views with stream tables. Optional, additive, lazy.
+```
+
+This is the key insight: **`pg_outbox` works fully without `pg_trickle`,
+and `pg_trickle` enhances it when present.** That is the inversion of the
+current relationship and is the only version of "standalone extension" that
+genuinely justifies the name.
+
+### 7.3 What `pg_trickle` looks like after the cut
+
+`pg_trickle` keeps the *interesting* refresh-time behaviour but delegates
+the storage and the outbound plumbing:
+
+```sql
+-- pg_trickle's wrapper (replaces today's enable_outbox()):
+SELECT pgtrickle.attach_outbox('orders_stream',
+    inline_threshold_rows => 10000);
+-- Internally:
+--   1. Calls outbox.create('outbox_orders_stream', ...) (the standalone API)
+--   2. Registers a refresh hook that, inside the refresh transaction,
+--      calls outbox.publish('outbox_orders_stream', delta_payload, headers).
+```
+
+`write_outbox_row()` becomes a 30-line wrapper that:
+
+1. Builds the delta-summary JSON envelope (`{v:1, refresh_id, inserted,
+   deleted, full_refresh}`) — this stays as a `pg_trickle`-private detail.
+2. Calls `SELECT outbox.publish($1, $2, $3)` via SPI.
+
+**Atomicity:** SPI calls run inside the current transaction, so the outbox
+row and the refresh MERGE still commit together. ADR-001/ADR-002 guarantees
+are preserved. (Verified by re-reading the refresh path — the SPI call is a
+strict superset of what an `INSERT INTO pgtrickle.outbox_<st> ...` does
+today; both go through the same transactional commit.)
+
+**Hot-path cost:** one extra SPI round-trip per non-empty refresh delta.
+Measured baseline of `outbox` write today is ~50µs; an SPI function call
+adds ~5µs of plan-cache lookup. Negligible against a refresh that already
+runs the user's SELECT query.
+
+### 7.4 Why this is realistic for non-`pg_trickle` users
+
+Unlike the option-B framing ("anyone with an outbox-shaped table"), the
+target audience here is concrete and large:
+
+| User | What they need today | What `pg_outbox` would give them |
+|---|---|---|
+| Microservices teams adopting the textbook outbox pattern (Richardson, Kleppmann) | Hand-rolled outbox table + a custom poller in their app, or a Debezium cluster | A 5-minute install of one extension + one binary, six backends out of the box |
+| Teams already on Debezium who want to cut JVM ops | Maintain a Kafka Connect cluster | Replace with a single Rust binary that reads a Postgres table |
+| Postgres-first stacks (Supabase, Crunchy, Neon, plain self-hosted) wanting "publish-to-Kafka" | Roll their own | Install one extension |
+| Anyone needing the inbox pattern (idempotent receive + DLQ) | Hand-roll | Built-in |
+| `pg_trickle` users who also want to publish change events | Today: `enable_outbox()` | Same UX via `attach_outbox()`, plus the option to use the same outbox infrastructure for non-stream-table events |
+
+The transactional outbox is the most-cited microservices integration pattern
+on the planet. There is **no Postgres extension today** that ships it as a
+batteries-included primitive with a multi-backend relay. Closest competitors
+are application-level libraries (per-language) or Debezium (heavy, JVM).
+A slim Rust extension + binary is a real market gap.
+
+This is not aspirational like the option-B framing was. It is a thing
+people would actually install for its own sake.
+
+### 7.5 Comparison of all four options
+
+| Dimension | A: binary only | B: binary + relay-only ext | C-original: also move writer | **C-revised: generic `pg_outbox`** |
+|---|---|---|---|---|
+| Standalone usefulness without `pg_trickle` | None | Marginal (relay needs an outbox to poll) | None | **High — full outbox/inbox primitive** |
+| Core LOC removed from this repo | ~3,650 Rust | ~3,890 (3,650 + 240 SQL) | ~6,150 (3,890 + 2,260) | **~6,150 + ~2,500 SQL** |
+| `pg_trickle` API churn | Zero | One SQL function rename | `enable_outbox` → wrapper | `enable_outbox` → `attach_outbox` wrapper |
+| Effort | 1 day | 3–5 days | ~1 week + ADR | **~2 weeks** |
+| Refresh hot-path risk | None | None | Medium (new hook API) | Low (SPI call inside same txn — no new abstraction) |
+| Justifies the term "standalone extension" | No | Barely | No | **Yes** |
+| Useful to users who don't know what IVM is | No | No | No | **Yes** |
+
+### 7.6 Risks specific to option C-revised
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Two-extension install becomes a friction point for `pg_trickle` users | Medium | Medium | Ship an `pg_trickle_outbox_compat` SQL package that re-creates the old `pgtrickle.enable_outbox(...)` signatures as `attach_outbox(...)` shims. Keep one release of deprecation overlap. |
+| The SPI round-trip from `write_outbox_row` shows up in benchmarks | Low | Low | Cache the prepared `outbox.publish` plan; benchmark before/after on the existing `e2e_bench_refresh_matrix`. |
+| Generic outbox table shape diverges from `pg_trickle`'s envelope needs | Low | Medium | The standalone outbox already has `payload JSONB` + `headers JSONB`; `pg_trickle` puts its `v:1` envelope inside `payload`. No schema collision. |
+| Inbox helper views (pending/DLQ/stats) lose IVM acceleration by default | Medium | Low | They're plain VIEWs in `pg_outbox`; `pg_trickle.materialize_inbox_views()` is a one-liner upgrade for users who want incremental maintenance. |
+| Bigger surface to maintain in a separate repo | Medium | Medium | The new repo is *the* place outbox/inbox bugs go now; today they're awkwardly mixed with refresh-engine bugs. Net cognitive load is probably lower. |
+| Project is called `pg_outbox` but does inbox + relay too | Low | Low | Naming sweep: `pg_outbox` is the friendliest name for the dominant use case; document inbox/relay as part of the same primitive. Alternatives: `pg_messaging`, `pg_relay`. |
+| ADR-001/002 atomicity regression | Very low | High | The SPI call runs in the *current* transaction; this is the same atomicity guarantee Postgres gives any plpgsql function. Add a regression test that crashes the session between `outbox.publish()` and `COMMIT` and asserts both the refresh MERGE and the outbox row are absent after recovery. |
+
+### 7.7 Migration path for existing `pg_trickle` outbox/inbox users
+
+A single SQL migration shipped with the new release:
+
+```sql
+-- Run once, after installing pg_outbox and upgrading pg_trickle.
+CREATE EXTENSION pg_outbox;
+SELECT pgtrickle.migrate_outboxes_to_pg_outbox();
+-- ↑ for each row in pgtrickle.pgt_outbox_config:
+--   1. CREATE the equivalent outbox via outbox.create()
+--   2. Copy historical rows from pgtrickle.outbox_<st> into outbox.<st>
+--   3. Re-attach pg_trickle's refresh hook via attach_outbox()
+--   4. Drop the old pgtrickle.outbox_<st> table
+SELECT pgtrickle.migrate_inboxes_to_pg_outbox();
+-- Same pattern for inboxes.
+```
+
+Old `pgtrickle.enable_outbox(...)` / `pgtrickle.create_inbox(...)` remain as
+deprecation shims for one release that internally call the new `attach_outbox`
+/ `pg_outbox.inbox.create` paths and emit a `WARNING`.
+
+### 7.8 Why this is worth doing despite being the largest option
+
+1. **It's the only option that creates a thing with independent value.** A,
+   B, and C-original all just relocate code; they don't make a new product.
+   C-revised does.
+2. **It correctly aligns ownership.** The outbox/inbox writer code today
+   lives inside the same crate as the differential dataflow engine. These
+   are two completely different concerns with two different audiences. The
+   current arrangement is a historical accident, not a design.
+3. **The hard part is already done.** Two thousand lines of working,
+   tested outbox/inbox code already exist in this repo. The work is
+   re-homing it cleanly, not designing it from scratch.
+4. **It dissolves the awkwardness in §11 of the superfluous-features
+   report.** That section flagged `enable_outbox` / `enable_inbox` as
+   "should probably move out" without saying where. C-revised gives them
+   a proper home.
+5. **It is the version that reduces `pg_trickle`'s 1.0 surface most
+   cleanly.** After the cut, `pg_trickle` ships exactly one thing: stream
+   tables. Outbox/inbox/relay become a separate product that integrates
+   with it.
+
+### 7.9 Suggested order of work for option C-revised
+
+1. **Days 1–2** — Stand up the new `pg_outbox` repo. Lift
+   [src/api/outbox.rs](../src/api/outbox.rs) and
+   [src/api/inbox.rs](../src/api/inbox.rs) into the new extension; rename
+   schemas; replace the `create_stream_table` calls in the inbox helper
+   with plain `CREATE VIEW`. Carry over tests.
+2. **Day 3** — Lift the relay catalog SQL from
+   [src/lib.rs](../src/lib.rs#L1095-L1335) into `pg_outbox`'s extension
+   crate. Lift `pgtrickle-relay/` into the new repo.
+3. **Day 4** — In this repo, replace `enable_outbox()` /
+   `create_inbox()` with thin `attach_outbox()` / `attach_inbox()` wrappers
+   that delegate to `pg_outbox`. Add the deprecation shims. Implement
+   `pg_trickle.materialize_inbox_views()` for the optional IVM upgrade.
+4. **Days 5–6** — Migration SQL; integration tests that exercise both
+   "with `pg_trickle`" and "without `pg_trickle`" deployments; benchmark
+   the SPI hop on the refresh hot path.
+5. **Day 7** — Documentation: cross-link the two repos; rewrite
+   docs/SQL_REFERENCE.md outbox/inbox sections to point at `pg_outbox`;
+   pre-release tags on both repos.
+
+Roughly **two weeks** end to end, but the result is two cleanly-scoped
+products instead of one entangled one.
+
+### 7.10 Open questions specific to option C
+
+1. **Naming.** Is `pg_outbox` the right umbrella name for something that
+   also ships the inbox pattern and a relay binary? Alternatives:
+   `pg_messaging`, `pg_relay`, `pg_event_relay`. The dominant pattern by
+   far in the literature is "transactional outbox," so leading with
+   `pg_outbox` is probably right; the rest can be subordinate.
+2. **License.** `pg_trickle` is Apache-2.0; `pg_outbox` should match so
+   the integration story is frictionless.
+3. **Repo home.** Same `grove/` org, or somewhere more neutral if the
+   intent is to attract contributors who don't think of it as a
+   `pg_trickle` accessory?
+4. **Relay rename.** With the standalone framing, the binary should
+   probably be `pg-outbox-relay` rather than `pgtrickle-relay`.
+5. **Backwards-compatible shims.** How many releases do we keep
+   `pgtrickle.enable_outbox(...)` etc. before removing them? One release
+   feels right for a pre-1.0 codebase; if anyone's running the outbox in
+   production, two releases is safer.

--- a/plans/PLAN_RELAY_STANDALONE.md
+++ b/plans/PLAN_RELAY_STANDALONE.md
@@ -661,7 +661,7 @@ people would actually install for its own sake.
 | Standalone usefulness without `pg_trickle` | None | Marginal (relay needs an outbox to poll) | None | **High — full outbox/inbox primitive** |
 | Core LOC removed from this repo | ~3,650 Rust | ~3,890 (3,650 + 240 SQL) | ~6,150 (3,890 + 2,260) | **~6,150 + ~2,500 SQL** |
 | `pg_trickle` API churn | Zero | One SQL function rename | `enable_outbox` → wrapper | `enable_outbox` → `attach_outbox` (clean break, no users) |
-| Effort | 1 day | 3–5 days | ~1 week + ADR | **~1 week** to extract; in-flight relay roadmap (§7.10) is months on top either way |
+| Effort | 1 day | 3–5 days | ~1 week + ADR | **~1 week** to extract; ancillary assets (§7.10) push to ~6 days; in-flight relay roadmap (§7.11) is months on top either way |
 | Refresh hot-path risk | None | None | Medium (new hook API) | Low (SPI call inside same txn — no new abstraction) |
 | Justifies the term "standalone extension" | No | Barely | No | **Yes** |
 | Useful to users who don't know what IVM is | No | No | No | **Yes** |
@@ -747,11 +747,159 @@ undocumented internal API that gets restructured before 1.0.
    CHANGELOG entry calls out the rename as a breaking change with a
    one-line equivalence table. Pre-release tags on both repos.
 
-Roughly **one week** end to end — down from the original two-week estimate
-because the migration tooling and deprecation shim work disappear (see §7.7).
-The result is two cleanly-scoped products instead of one entangled one.
+### 7.10 Ancillary assets that need to move, be rewritten, or be deleted
 
-### 7.10 In-flight relay roadmap that travels with the cut
+The plan so far focuses on Rust source, SQL DDL, and design docs. There
+is a long tail of *other* assets in this repo that also reference the
+relay/outbox/inbox surface and need explicit handling. Reviewers should
+not assume any of these "just work" after the cut.
+
+#### User-facing documentation (move to `pg-tide` repo, rewrite to drop `pg_trickle` framing)
+
+| Asset | Today's framing | Action |
+|---|---|---|
+| [docs/OUTBOX.md](docs/OUTBOX.md) | "pg_trickle outbox pattern" | Move to `pg-tide/docs/OUTBOX.md`; rewrite to lead with the generic outbox pattern. Add an "If you're using `pg_trickle`" appendix linking to `attach_outbox()`. |
+| [docs/INBOX.md](docs/INBOX.md) | "pg_trickle inbox pattern" | Move to `pg-tide/docs/INBOX.md`; rewrite as above (no `pg_trickle` integration appendix needed — the inbox has no integration point per §7.2). |
+| [docs/RELAY.md](docs/RELAY.md) | Architecture deep-dive | Move to `pg-tide/docs/RELAY.md`; rebrand `pgtrickle-relay` → `pg-tide`. |
+| [docs/RELAY_GUIDE.md](docs/RELAY_GUIDE.md) | Operator guide | Move + rebrand. |
+| Sections of [docs/SQL_REFERENCE.md](docs/SQL_REFERENCE.md), [docs/SQL_API_CATALOG.md](docs/SQL_API_CATALOG.md), [docs/CONFIGURATION.md](docs/CONFIGURATION.md), [docs/GUC_CATALOG.md](docs/GUC_CATALOG.md), [docs/SECURITY_GUIDE.md](docs/SECURITY_GUIDE.md), [docs/SECURITY_MODEL.md](docs/SECURITY_MODEL.md), [docs/USE_CASES.md](docs/USE_CASES.md), [docs/PATTERNS.md](docs/PATTERNS.md) | Mention outbox/inbox/relay alongside other features | In `pg_trickle` repo: trim outbox/inbox/relay sections to a one-paragraph "see [pg-tide](https://…)" pointer. |
+| [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/GLOSSARY.md](docs/GLOSSARY.md) | Reference outbox/inbox tables in architectural diagrams | Trim or annotate; keep the conceptual mention but mark them as `pg_tide`-provided. |
+| [docs/WHATS_NEW.md](docs/WHATS_NEW.md), [docs/UPGRADING.md](docs/UPGRADING.md) | History of v0.28/v0.29 features | Add a 1.0 entry: "outbox/inbox/relay extracted to `pg-tide`; see migration note." |
+
+#### Roadmap entries (rewrite or relocate)
+
+| Asset | Action |
+|---|---|
+| [roadmap/v0.28.0.md](roadmap/v0.28.0.md), [roadmap/v0.28.0.md-full.md](roadmap/v0.28.0.md-full.md) | Already-released history. Add a footnote: "Superseded in 1.0 by `pg_tide`." |
+| [roadmap/v0.29.0.md](roadmap/v0.29.0.md), [roadmap/v0.29.0.md-full.md](roadmap/v0.29.0.md-full.md) | Same footnote. |
+| [ROADMAP.md](ROADMAP.md) line ~130 ("v0.28–29 ─── Reliable event messaging…"), line 200 (test coverage), line 223 (embedding outbox) | Annotate each line: outbox/inbox/relay history now lives at `pg-tide`. The v0.47.0 "embedding outbox" item (line 100) needs a decision: stays in `pg_trickle` as a `pg_tide.attach_outbox()` consumer, or moves to `pg-tide`? Recommend keeping in `pg_trickle` since it's an embedding-pipeline feature that *uses* the outbox primitive. |
+
+#### Blog posts (move to `pg-tide` repo's blog)
+
+The four most directly relay/outbox/inbox-centric posts move:
+
+- [blog/built-in-outbox.md](blog/built-in-outbox.md)
+- [blog/outbox-pattern-turbocharged.md](blog/outbox-pattern-turbocharged.md)
+- [blog/inbox-pattern-kafka.md](blog/inbox-pattern-kafka.md)
+- [blog/relay-deep-dive.md](blog/relay-deep-dive.md)
+
+Other blog posts mention outbox/inbox tangentially
+([blog/self-monitoring.md](blog/self-monitoring.md),
+[blog/cqrs-without-second-database.md](blog/cqrs-without-second-database.md))
+— update those in place to phrase the integration as "use `pg_tide` for
+the outbox plumbing."
+
+#### Tests (relocate)
+
+- [tests/e2e_outbox_tests.rs](tests/e2e_outbox_tests.rs) — move to `pg-tide/tests/`
+- [tests/e2e_inbox_tests.rs](tests/e2e_inbox_tests.rs) — move to `pg-tide/tests/`
+- Any other `tests/*.rs` that exercises `enable_outbox` / `create_inbox`
+  needs to be rewritten as a *consumer* test calling
+  `pg_trickle.attach_outbox()` — these become the regression coverage
+  for the SPI bridge introduced in §7.3.
+- `pgtrickle-relay/tests/` and `pgtrickle-relay/src/**/tests/` — move
+  with the relay crate.
+
+#### SQL upgrade scripts (the messy part)
+
+The relevant upgrade files are:
+
+- [sql/pg_trickle--0.27.0--0.28.0.sql](sql/pg_trickle--0.27.0--0.28.0.sql)
+  (introduces outbox/inbox tables)
+- [sql/pg_trickle--0.28.0--0.29.0.sql](sql/pg_trickle--0.28.0--0.29.0.sql)
+  (introduces relay catalog)
+- [sql/pg_trickle--0.38.0--0.39.0.sql](sql/pg_trickle--0.38.0--0.39.0.sql)
+  and [sql/pg_trickle--0.39.0--0.40.0.sql](sql/pg_trickle--0.39.0--0.40.0.sql)
+  (subsequent inbox/relay refinements)
+
+These are *historical* upgrade scripts — they cannot be deleted, because
+existing installs upgrading from 0.27 → 1.0 will still run them as part
+of the chain. The 1.0 upgrade script (`pg_trickle--0.42.0--1.0.0.sql`)
+is the one that *removes* the old objects:
+
+```sql
+-- pg_trickle 0.42.0 → 1.0.0
+DROP TABLE IF EXISTS pgtrickle.relay_outbox_config CASCADE;
+DROP TABLE IF EXISTS pgtrickle.relay_inbox_config CASCADE;
+DROP TABLE IF EXISTS pgtrickle.relay_consumer_offsets CASCADE;
+DROP FUNCTION IF EXISTS pgtrickle.set_relay_outbox(text, jsonb);
+-- … etc. (all 7 helper functions + relay_config_notify trigger)
+DROP ROLE IF EXISTS pgtrickle_relay;
+DROP FUNCTION IF EXISTS pgtrickle.enable_outbox(text);
+DROP FUNCTION IF EXISTS pgtrickle.disable_outbox(text);
+DROP FUNCTION IF EXISTS pgtrickle.outbox_status(text);
+DROP FUNCTION IF EXISTS pgtrickle.outbox_rows_consumed(text, bigint);
+DROP FUNCTION IF EXISTS pgtrickle.create_inbox(text, integer, boolean, boolean, integer);
+-- … etc.
+-- Outbox/inbox base tables (pgtrickle.outbox_<st>, pgtrickle.inbox_<…>) are
+-- left as-is — they hold user data. Document that users must DROP them
+-- manually after re-creating in the tide schema if migrating data.
+```
+
+This is invasive — `DROP TABLE … CASCADE` on the outbox base tables
+would lose data, so the 1.0 upgrade script *does not* drop those. The
+CHANGELOG must explicitly tell anyone who has put data into the relay
+catalog that 1.0 will erase their pipeline configuration. Per §7.7,
+this is acceptable because there are no known users.
+
+#### Build / CI / packaging artefacts to delete from this repo
+
+- [Dockerfile.relay](Dockerfile.relay) — delete
+- Lines 474–580 of [.github/workflows/release.yml](.github/workflows/release.yml)
+  — delete the four relay publish jobs and the `RELAY_IMAGE_NAME` env var
+- Lines 52–82 of [.github/workflows/security.yml](.github/workflows/security.yml)
+  — drop the `aws-smithy-http-client` exception (only existed for the
+  relay's optional SQS feature)
+- [tests/Dockerfile.e2e](tests/Dockerfile.e2e) lines 36–48 — drop relay
+  placeholder
+- [Cargo.toml](Cargo.toml): drop `pgtrickle-relay` from the workspace
+  `members` list
+- [deny.toml](deny.toml) lines 44–45 — drop the SQS-feature license
+  exception (now lives in `pg-tide`)
+- [README.md](README.md) lines 526, 556–558 — trim outbox/inbox/relay
+  rows from the docs index, replace with a single "Event messaging:
+  see [pg-tide](https://…)" line
+- [META.json](META.json) — review and drop relay-related description
+  text if any (the outbox-poller backend specifically)
+
+#### Demo / playground / monitoring (update in place)
+
+- [demo/](demo/) — currently shows `pg_trickle` end-to-end including
+  outbox publishing. Update `docker-compose.yml` to add a `pg-tide`
+  service and pull the relay binary from its new image. The demo's
+  point is "see them work together," so keeping it cross-extension is
+  the right move.
+- [monitoring/](monitoring/) — update Prometheus scrape config to add
+  the `pg-tide` relay endpoint alongside `pg_trickle`'s; carry over the
+  Grafana panels that visualise outbox lag.
+- [examples/](examples/) — none of the visible examples
+  (`dbt_getting_started`, `non-differential.sql`) reference the outbox,
+  so probably nothing to do here. Sanity-check during the cut.
+- [cnpg/](cnpg/) — the CloudNativePG manifests don't reference the
+  relay today (verified — empty grep). They will need a separate
+  `pg-tide` manifest set in the new repo, but the existing manifests
+  in this repo stay clean.
+
+#### What this means for the §7.9 work plan
+
+Day 5 ("docs pass") is doing a lot of heavy lifting under the surface.
+A more honest decomposition:
+
+- **Day 4** stays focused on code: delete moved code, add `attach_outbox()`,
+  write the 1.0 upgrade script.
+- **Day 5** splits into two:
+  - **Day 5a** — Move the four blog posts and four user-facing docs
+    files (OUTBOX.md, INBOX.md, RELAY.md, RELAY_GUIDE.md). Update
+    cross-references in the SQL_REFERENCE / ARCHITECTURE / WHATS_NEW
+    cluster (~12 docs total). Roadmap footnotes.
+  - **Day 5b** — CI / packaging cleanup (Dockerfiles, workflows,
+    deny.toml, Cargo.toml, README index). Verify both repos build
+    clean. Cut pre-release tags.
+
+This pushes the realistic estimate to **~6 working days** rather than 5,
+but it's still well under the original two-week estimate.
+
+### 7.11 In-flight relay roadmap that travels with the cut
 
 The relay is **not** feature-complete today. There is a non-trivial
 roadmap of planned work that lives in [plans/relay/](plans/relay/) and
@@ -791,7 +939,7 @@ This is fine — the *outbox/inbox primitive* alone has independent value
 audience comes online with relay 0.31+ rather than at the moment of
 extraction.
 
-### 7.11 Open questions specific to option C
+### 7.12 Open questions specific to option C
 
 1. **License.** `pg_trickle` is Apache-2.0; `pg_tide` should match so
    the integration story is frictionless.

--- a/plans/PLAN_RELAY_STANDALONE.md
+++ b/plans/PLAN_RELAY_STANDALONE.md
@@ -507,8 +507,12 @@ layers that are bundled together today:
 - The `v: 1` envelope tag and `full_refresh` flag in the JSON payload.
 - The auto-creation of `<inbox>_pending` / `<inbox>_dlq` / `<inbox>_stats`
   as **stream tables** ([src/api/inbox.rs](../src/api/inbox.rs#L244)) — the
-  *only* genuine `pg_trickle` dependency on the inbox side. These could just
-  as well be plain `VIEW`s.
+  *only* genuine `pg_trickle` dependency on the inbox side. In `pg_tide`
+  these become plain `VIEW`s; the working sets are bounded by definition
+  (`processed_at IS NULL`, `retry_count >= max_retries`) and queried by
+  humans/dashboards rather than tight loops, so IVM materialisation buys
+  nothing here. See §7.2 for why no `materialize_inbox_views()` hook is
+  exposed.
 
 ### 7.2 The proposed standalone extension: `pg_tide`
 
@@ -577,19 +581,24 @@ SELECT tide.relay_set_inbox ('nats-to-orders', ...);
 SELECT tide.relay_enable    ('orders-to-nats');
 ```
 
-The inbox helper views are **plain views** by default. If `pg_trickle` is
-installed in the same database, the user can opt in to incremental
-materialisation:
+The inbox helper views are **plain views**, full stop. Earlier drafts of
+this plan proposed a `pg_trickle.materialize_inbox_views()` hook that would
+swap them for stream tables; that idea has been dropped. The three views
+(`_pending`, `_dlq`, `_stats`) are queried by humans triaging failures and
+by dashboards on 10–60s refresh, never on a hot path. Their working sets
+are already bounded — `_pending` *is* the backlog, `_dlq` is naturally
+tiny, and `_stats` is a low-cardinality `GROUP BY` over an indexed
+column. Materialising them with CDC triggers would add per-INSERT overhead
+on the inbox hot path to accelerate queries that don't need it. If a user
+ever finds a real workload that needs IVM over inbox data, the inbox base
+table is a regular Postgres table and they can build a `pg_trickle` stream
+table over it themselves — no special API needed.
 
-```sql
-SELECT pg_trickle.materialize_inbox_views('orders_inbox', schedule => '1s');
--- ↑ replaces the views with stream tables. Optional, additive, lazy.
-```
-
-This is the key insight: **`pg_tide` works fully without `pg_trickle`,
-and `pg_trickle` enhances it when present.** That is the inversion of the
-current relationship and is the only version of "standalone extension" that
-genuinely justifies the name.
+So the relationship is simpler than earlier drafts suggested: **`pg_tide`
+works fully without `pg_trickle`, and `pg_trickle`'s only integration is
+`attach_outbox()` on the producer side** (§7.3). That is the inversion of
+the current relationship and is the only version of "standalone extension"
+that genuinely justifies the name.
 
 ### 7.3 What `pg_trickle` looks like after the cut
 
@@ -663,7 +672,6 @@ people would actually install for its own sake.
 |---|---|---|---|
 | The SPI round-trip from `write_outbox_row` shows up in benchmarks | Low | Low | Cache the prepared `tide.outbox_publish` plan; benchmark before/after on the existing `e2e_bench_refresh_matrix`. |
 | Generic outbox table shape diverges from `pg_trickle`'s envelope needs | Low | Medium | `pg_tide`'s outbox row already has `payload JSONB` + `headers JSONB`; `pg_trickle` puts its `v:1` envelope inside `payload`. No schema collision. |
-| Inbox helper views (pending/DLQ/stats) lose IVM acceleration by default | Medium | Low | They're plain VIEWs in `pg_tide`; `pg_trickle.materialize_inbox_views()` is a one-liner upgrade for users who want incremental maintenance. |
 | Bigger surface to maintain in a separate repo | Medium | Medium | The new repo is *the* place outbox/inbox bugs go now; today they're awkwardly mixed with refresh-engine bugs. Net cognitive load is probably lower. |
 | Project name `pg_tide` is metaphorical, not literal | Low | Low | Continues the established water-motion lineage (`pg_trickle`, `pg_ripple`); the metaphor honestly covers both directions (tides go in *and* out) where `pg_outbox` would have undersold the inbox half. README leads with "transactional outbox + inbox + multi-backend relay for PostgreSQL" so SEO works. |
 | ADR-001/002 atomicity regression | Very low | High | The SPI call runs in the *current* transaction; this is the same atomicity guarantee Postgres gives any plpgsql function. Add a regression test that crashes the session between `tide.outbox_publish()` and `COMMIT` and asserts both the refresh MERGE and the outbox row are absent after recovery. |
@@ -727,9 +735,11 @@ undocumented internal API that gets restructured before 1.0.
    binary.
 3. **Day 4** — In this repo, *delete* `enable_outbox()` / `create_inbox()`
    and the relay catalog SQL outright (no shims — see §7.7). Add the new
-   thin `attach_outbox()` / `attach_inbox()` wrappers that delegate to
-   `pg_tide`. Implement `pg_trickle.materialize_inbox_views()` for the
-   optional IVM upgrade.
+   thin `attach_outbox()` wrapper that delegates to `pg_tide` (refresh-time
+   publisher; this is the *only* integration point — see §7.2). No
+   `attach_inbox()` or `materialize_inbox_views()` is needed: inbox helper
+   views stay as plain VIEWs in `pg_tide` and `pg_trickle` does not wrap
+   the inbox API at all.
 4. **Day 5** — Integration tests that exercise both "with `pg_trickle`"
    and "without `pg_trickle`" deployments; benchmark the SPI hop on the
    refresh hot path. Documentation: cross-link the two repos; rewrite

--- a/plans/PLAN_RELAY_STANDALONE.md
+++ b/plans/PLAN_RELAY_STANDALONE.md
@@ -899,6 +899,44 @@ A more honest decomposition:
 This pushes the realistic estimate to **~6 working days** rather than 5,
 but it's still well under the original two-week estimate.
 
+#### Shared infrastructure to clone (not move) into the new repo
+
+Most of `pg_trickle`'s repo-level scaffolding has nothing to do with
+the relay but is well-honed and worth re-using. The new `pg-tide` repo
+should *copy* (not move) the patterns below; they stay in `pg_trickle`
+unchanged.
+
+| Asset | Location | Why clone it |
+|---|---|---|
+| **Reusable composite action** | [.github/actions/setup-pgrx](.github/actions/setup-pgrx) | `pg-tide` has a pgrx extension crate too; same setup story (cargo-pgrx install, pg18 toolchain, sccache). |
+| **Skill files for AI/agent workflows** | [.github/skills/create-pull-request/](.github/skills/create-pull-request/), [enrich-release-roadmap/](.github/skills/enrich-release-roadmap/), [implement-roadmap-version/](.github/skills/implement-roadmap-version/) | All three are repo-agnostic. The PR-creation skill (Unicode-safe `gh --body-file` workflow) is especially valuable. |
+| **Agent conventions** | [AGENTS.md](AGENTS.md) | Copy and trim: keep the workflow rules, error-handling rules, SPI conventions, code-review checklist; drop the pg_trickle-specific module-layout section and replace with `pg-tide`'s. |
+| **CI architecture** | [.github/workflows/](.github/workflows/) | Clone `lint.yml`, `ci.yml`, `coverage.yml`, `codeql.yml`, `secret-scan.yml`, `dependency-policy.yml`, `semgrep.yml`, `docs-drift.yml`, `unsafe-inventory.yml`. The light-e2e vs full-e2e split (stock postgres bind-mount vs custom Docker image) is the right pattern for `pg-tide` too. |
+| **Benchmark regression-gate workflow** | [scripts/criterion_regression_check.py](scripts/criterion_regression_check.py) + the `benchmarks.yml` workflow | The "save baseline on push to main, compare on PR" pattern is generic. Worth carrying over. |
+| **Just recipes** | [justfile](justfile) | Most recipes are about pgrx + Postgres setup, format/lint, test tiers — directly reusable. Drop pg_trickle-specific ones (`build-e2e-image`, `test-tpch`, etc.) and add `pg-tide` equivalents. |
+| **Config files** | [deny.toml](deny.toml), [codecov.yml](codecov.yml), [book.toml](book.toml), [.github/dependabot.yml](.github/dependabot.yml), [.github/CODEOWNERS](.github/CODEOWNERS), [.github/pull_request_template.md](.github/pull_request_template.md), [.github/ISSUE_TEMPLATE/](.github/ISSUE_TEMPLATE/) | All trivially adaptable. None mention relay/outbox/inbox today (verified via grep). |
+| **Convention scripts** | [scripts/check_version_sync.sh](scripts/check_version_sync.sh), [scripts/check_upgrade_completeness.sh](scripts/check_upgrade_completeness.sh) | Pattern for keeping `Cargo.toml` / `*.control` / `META.json` versions in lockstep is reusable; the upgrade-completeness check works for any pgrx extension that ships per-version SQL migrations. |
+| **Release scaffolding** | [.github/workflows/release.yml](.github/workflows/release.yml) (post-deletion of relay jobs), [.github/workflows/pgxn.yml](.github/workflows/pgxn.yml), [.github/workflows/ghcr.yml](.github/workflows/ghcr.yml), [.github/workflows/docker-hub.yml](.github/workflows/docker-hub.yml) | Adapt for `pg-tide`'s release flow. The relay-specific bits already get deleted from this repo per §7.10; the *non*-relay pieces are the scaffolding the new repo wants to clone. |
+| **Stability-test workflow** | [.github/workflows/stability-tests.yml](.github/workflows/stability-tests.yml) | Soak-test pattern is exactly what an outbox/inbox primitive needs (long-running write loops, claim-check pressure, retention drainer correctness). High-value clone. |
+| **Fuzz-smoke workflow** | [.github/workflows/fuzz-smoke.yml](.github/workflows/fuzz-smoke.yml) + [fuzz/](fuzz/) | The harness pattern is reusable; targets would change (`pg_tide`'s natural fuzz targets are envelope parsing and config validation). |
+
+**Things explicitly *not* worth cloning:**
+
+- `tpch-nightly.yml` / `tpch-explain-artifacts.yml` / `e2e-benchmarks.yml`
+  — TPC-H and the IVM-specific benchmark matrix are pg_trickle concerns.
+- `sqlancer.yml` — SQLancer targets a query engine; `pg_tide` has no
+  query rewriter to fuzz.
+- `cnpg/` smoke test — `pg-tide` will need its own when CNPG packaging
+  exists, but the existing one is too pg_trickle-specific to be worth
+  forking now.
+
+**Implication:** Day 5b's "CI / packaging cleanup" expands a little.
+The right framing is "in `pg_trickle`: delete the relay-specific
+workflow jobs and config exceptions; in `pg-tide`: bootstrap a
+parallel CI matrix from cloned templates." The cloning is mostly
+mechanical (the workflows reference Cargo crate names, image tags, and
+test paths) but worth budgeting half a day to get right.
+
 ### 7.11 In-flight relay roadmap that travels with the cut
 
 The relay is **not** feature-complete today. There is a non-trivial

--- a/roadmap/v0.46.0.md
+++ b/roadmap/v0.46.0.md
@@ -1,61 +1,95 @@
-# v0.46.0 — Embedding Pipeline Infrastructure & ANN Maintenance
+# v0.46.0 — Extract `pg_tide`: standalone transactional outbox, inbox, and relay
 
 > **Full technical details:** [v0.46.0.md-full.md](v0.46.0.md-full.md)
 
-**Status: Planned** | **Scope: Medium**
+**Status: Planned** | **Scope: Large**
 
-> After the v0.38.0-v0.45.0 hardening arc, the roadmap resumes the deferred
-> embedding programme with post-refresh actions, drift-based ANN maintenance,
-> vector-aware monitoring, and AI/RAG cookbooks.
+> The outbox, inbox, and relay subsystems are extracted from `pg_trickle` into
+> a new standalone extension `pg_tide` (repository: `trickle-labs/pg-tide`).
+> After this release, `pg_trickle` ships exactly one thing: incremental view
+> maintenance. Event messaging becomes a first-class product in its own right.
 
 ---
 
 ## What is this?
 
-v0.37.0 introduced pgVectorMV. v0.38.0-v0.45.0 then deliberately prioritized
-correctness, operational truthfulness, diagnostics, and platform trust before
-new AI surface area. v0.46.0 picks the embedding roadmap back up once those
-foundations are in place.
+`pg_trickle` has shipped a transactional outbox, idempotent inbox, and a
+multi-backend relay binary since v0.28–v0.29. Those features are powerful but
+they have always been an awkward fit inside an IVM extension: different
+audience, different release cadence, different deployment story.
+
+v0.46.0 completes the architectural rationalisation: the entire outbox/inbox
+stack is lifted into `pg_tide`, a new Postgres extension that is **genuinely
+useful without `pg_trickle`** — it implements the textbook transactional
+outbox pattern for any application. `pg_trickle` retains a thin
+`attach_outbox()` integration that publishes refresh-time deltas into a
+`pg_tide` outbox, preserving the single-transaction atomicity guarantee.
+
+This is a clean break (no migration tooling, no deprecation shims) because
+the outbox/inbox/relay features have no known production users at the time of
+the cut. A one-line announcement to the discussions board is posted before
+Day 4's deletion lands on `main`.
 
 ---
 
-## Embedding pipeline operational hardening
+## What ships in `pg_tide`
 
-When a vector stream table refreshes, it often needs follow-up housekeeping:
-statistics refresh, ANN maintenance, or drift-aware reindexing. v0.46.0 adds
-explicit post-refresh actions, per-table drift thresholds, and a
-`pgtrickle.vector_status()` view so operators can see embedding lag, index age,
-and reindex pressure instead of inferring those signals indirectly.
+**Extension (`trickle-labs/pg-tide`):**
 
----
+- `tide.outbox_create()` / `tide.outbox_publish()` / `tide.outbox_status()` —
+  generic transactional outbox with claim-check sidecar for large payloads.
+- `tide.inbox_create()` / `tide.inbox_mark_processed()` / `tide.inbox_mark_failed()` —
+  idempotent inbox with DLQ, priority tiers, replay, and retention.
+- `tide.relay_set_outbox()` / `tide.relay_set_inbox()` / `tide.relay_enable()` —
+  relay pipeline configuration catalog.
+- Built-in `_pending` / `_dlq` / `_stats` views as plain VIEWs (no IVM
+  overhead needed — working sets are bounded by definition).
+- Background retention drainer for old outbox/inbox rows.
 
-## pgvector integration & RAG cookbook
+**Binary (`pg-tide`):**
 
-This release adds the documentation needed for a serious self-hosted RAG
-workflow: a full cookbook for always-fresh embedding pipelines using
-`pg_trickle` + `pgvector`, with embeddings generated at the application layer.
-
----
-
-## Also in v0.46.0
-
-- Citus vector-aggregate cases integrated into the v0.39 distributed test rig
-- Vector-specific options and monitoring integrated into the generated reference
-  docs added during the hardening arc
+- Today's `pgtrickle-relay` crate moved verbatim; renamed to `pg-tide`.
+- All six source backends (NATS, Kafka, webhook, Redis, SQS, RabbitMQ,
+  outbox poller) and eight sink backends unchanged.
+- Binary version history preserved via `git filter-repo`.
 
 ---
 
-## Scope
+## What changes in `pg_trickle`
 
-v0.46.0 is a medium release. The work is primarily scheduler options,
-monitoring, cookbook material, and packaging, rather than DVM-core changes.
-That is exactly why it belongs after the hardening arc, not before it.
+- `enable_outbox()` and `create_inbox()` are removed (clean break).
+- New `pgtrickle.attach_outbox()` replaces them: calls `tide.outbox_create()`
+  and registers a refresh-time hook that calls `tide.outbox_publish()` via
+  SPI inside the refresh MERGE transaction — atomicity per ADR-001/ADR-002
+  fully preserved.
+- Relay catalog SQL (~240 LOC) and relay Rust crate (~3,650 LOC) deleted.
+- `Dockerfile.relay` deleted; relay CI jobs removed from `release.yml`.
+- `pgtrickle-relay` removed from workspace `members` in `Cargo.toml`.
+- Upgrade script drops all old `pgtrickle.relay_*` / outbox/inbox API objects.
 
-> **Hard prerequisite:** v0.38.0-v0.45.0 must complete their correctness,
-> diagnostics, and operator-trust exit criteria before this embedding work
-> starts.
+**Total LOC removed from this repo: ~6,150 Rust + ~2,500 SQL.**
+
+---
+
+## Why this matters
+
+There is no Postgres extension today that ships the transactional outbox
+pattern as a batteries-included primitive with a multi-backend relay binary.
+`pg_tide` fills that gap. For `pg_trickle` users nothing changes except the
+API name (`attach_outbox()` instead of `enable_outbox()`); for the broader
+ecosystem, `pg_tide` becomes installable and useful independently.
+
+---
+
+## Scope note
+
+This is a Large release on both sides: significant deletion and one new API in
+`pg_trickle`, plus bootstrapping an entirely new extension repo for `pg_tide`.
+The ~6 working day estimate from
+[plans/PLAN_RELAY_STANDALONE.md](../plans/PLAN_RELAY_STANDALONE.md) §7.9
+covers both repos.
 
 ---
 
 *Previous: [v0.45.0 — Operational Readiness, Scalability & CI Completeness](v0.45.0.md)*
-*Next: [v0.47.0 — Hybrid Search & Sparse Vector Aggregates](v0.47.0.md)*
+*Next: [v0.47.0 — Embedding Pipeline Infrastructure & ANN Maintenance](v0.47.0.md)*

--- a/roadmap/v0.46.0.md-full.md
+++ b/roadmap/v0.46.0.md-full.md
@@ -1,102 +1,163 @@
 > **Plain-language companion:** [v0.46.0.md](v0.46.0.md)
 
-## v0.46.0 — Embedding Pipeline Infrastructure & ANN Maintenance
+## v0.46.0 — Extract `pg_tide`: standalone transactional outbox, inbox, and relay
 
-**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](plans/ecosystem/PLAN_PGVECTOR.md) §6.2, rescheduled after the assessment-driven hardening arc in [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md).
+**Status: Planned.** Full design in
+[plans/PLAN_RELAY_STANDALONE.md](../plans/PLAN_RELAY_STANDALONE.md) §7.
 
 > **Release Theme**
-> v0.46.0 resumes the deferred embedding programme once the roadmap has closed
-> the immediate correctness and operational gaps. It adds post-refresh action
-> hooks (ANALYZE, REINDEX, drift-based re-clustering), vector-aware monitoring,
-> and a pgvector RAG cookbook for production embedding pipelines on PostgreSQL.
-
-> **Hard prerequisite:** v0.38.0-v0.45.0 must complete their hardening exit
-> criteria first. The embedding programme is intentionally sequenced after the
-> correctness and operator-trust work, not in parallel with it.
+> Extract the outbox, inbox, and relay subsystems from `pg_trickle` into a
+> new standalone extension `pg_tide` (`trickle-labs/pg-tide`). `pg_trickle`
+> is left shipping exactly one thing: incremental view maintenance. All event
+> messaging surface moves to a product that is useful independently.
 
 ---
 
-### Features
+### Motivation
 
-| ID | Title | Effort | Priority |
-|----|-------|--------|----------|
-| VP-1 | `post_refresh_action` ST option (`none` / `analyze` / `reindex` / `reindex_if_drift`) | M | P1 |
-| VP-2 | `reindex_drift_threshold` ST option plus drift counter in catalog | M | P1 |
-| VP-3 | `pgtrickle.vector_status()` view: embedding lag, ANN age, drift % | S | P1 |
-| VP-4 | Cookbook: always-fresh RAG with pg_trickle + pgvector | S | P2 |
-| VP-5 | Citus vector-aggregate cases folded into distributed coverage | M | P2 |
+The outbox/inbox/relay code (~6,150 Rust LOC, ~2,500 SQL LOC) has lived inside
+`pg_trickle` since v0.28–v0.29. It works, but it is an architectural mismatch:
 
-**VP-1 — Post-refresh actions.**
-Add a `post_refresh_action` option to vector-heavy stream tables so operators can
-run `ANALYZE`, `REINDEX`, or `reindex_if_drift` after a refresh commits. The
-work runs in a lower-priority queue after the refresh transaction, so it does
-not lengthen the critical refresh window or turn ANN maintenance into hidden
-refresh latency.
+- Different audience (microservices engineers vs. IVM users)
+- Different release cadence (relay backends evolve independently of DVM)
+- Different deployment story (`pg_tide` + binary; `pg_trickle` extension only)
+- ~6 optional async messaging crates + AWS SDK in the extension's `Cargo.lock`
 
-**VP-2 — Drift detection.**
-Catalog state tracks `rows_changed_since_last_reindex` and a
-`reindex_drift_threshold`. When a vector table changes enough since its last
-index rebuild, the post-refresh action can queue a targeted REINDEX instead of
-forcing operators to guess when ANN quality has drifted too far.
+The feature set has no known production users at the time of the cut, making
+this a clean break with no backwards-compatibility obligation.
 
-**VP-3 — Vector status view.**
-Add `pgtrickle.vector_status()` to expose embedding lag, last refresh, last
-reindex time, rows changed since reindex, drift percentage, and vector-aggregate
-usage. This view plugs into the monitoring foundation built in the hardening
-arc and gives RAG operators a first-class place to look for ANN maintenance
-pressure.
-
-**VP-4 — pgvector RAG cookbook.**
-Publish `docs/tutorials/PGVECTOR_RAG_COOKBOOK.md` with copy-paste workflows for
-pre-computed embeddings, denormalized corpora, hybrid search, and operational
-sizing guidance. Embeddings are generated at the application layer (e.g. via
-OpenAI, Cohere, or Ollama APIs) before being stored with pgvector. The key
-outcome is that AI engineers can start with a working pattern instead of
-reverse-engineering examples from tests.
-
-**VP-5 — Citus vector-aggregate cases folded into distributed coverage.**
-The v0.39 Citus rig becomes the place where shard-additive vector-aggregate
-behavior is verified. This keeps vector work honest in distributed deployments
-without treating Citus as an afterthought.
-
-### Test Coverage
-
-| ID | Title | Effort | Priority |
-|----|-------|--------|----------|
-| T-VP1 | Drift-based reindex integration test on HNSW stream table | M | P1 |
-| T-VP2 | `vector_status()` accuracy and reset behavior | S | P1 |
-| T-VP3 | Citus shard-additive vector aggregate verification | M | P2 |
-
-**T-VP1.**
-Create a vector stream table with `post_refresh_action = 'reindex_if_drift'`,
-change more than the configured threshold, and verify that REINDEX is queued and
-completed outside the refresh transaction.
-
-**T-VP2.**
-Verify that `pgtrickle.vector_status()` reports lag, drift, and last-reindex
-metadata correctly before and after a drift-triggered REINDEX.
-
-**T-VP3.**
-Run vector-aggregate cases inside the v0.39 Citus rig so shard-local partial
-results still converge to the same answer as a global `avg(vector)` or
-`sum(vector)` computation.
-
-### Conflicts & Risks
-
-- **VP-1/VP-2** add queueable post-refresh work. Backlog visibility must be
-  clear so operators can see if ANN maintenance is lagging behind the refresh
-  pipeline.
-- **VP-3** is observational, but large fleets still need scrape-friendly
-  monitoring rather than expensive ad hoc queries across huge numbers of stream
-  tables.
-### Exit Criteria
-
-- [ ] VP-1: `post_refresh_action` is stored in the catalog and dequeued correctly after refresh commit
-- [ ] VP-2: drift threshold logic increments and resets correctly over repeated refresh cycles
-- [ ] VP-3: `pgtrickle.vector_status()` reports correct lag and drift for vector stream tables
-- [ ] VP-4: RAG cookbook published with multiple worked examples
-- [ ] VP-5: vector-aggregate cases pass inside the Citus distributed test rig
-- [ ] Extension upgrade path tested (`0.40.0 → 0.41.0`)
-- [ ] `just check-version-sync` passes
+See [plans/PLAN_RELAY_STANDALONE.md](../plans/PLAN_RELAY_STANDALONE.md) §7.8
+for the full rationale.
 
 ---
+
+### What ships in the new `pg_tide` repo
+
+**Extension (schema `tide`):**
+
+| API | Description |
+|-----|-------------|
+| `tide.outbox_create(name, ...)` | Create a named outbox table with retention config and claim-check threshold |
+| `tide.outbox_publish(name, payload, headers)` | Write a row transactionally from inside any application transaction |
+| `tide.outbox_status(name)` | View lag, consumer offsets, and claim-check pressure |
+| `tide.outbox_disable(name)` | Pause publishing without dropping the table |
+| `tide.inbox_create(name, ...)` | Create an idempotent inbox with optional DLQ, priority, ordering, retention |
+| `tide.inbox_mark_processed(name, event_id)` | Acknowledge successful processing |
+| `tide.inbox_mark_failed(name, event_id, error)` | Send to DLQ after max retries |
+| `tide.replay_inbox_messages(name, ...)` | Re-queue events from DLQ |
+| `tide.relay_set_outbox(name, config)` | Configure an outbox pipeline |
+| `tide.relay_set_inbox(name, config)` | Configure an inbox pipeline |
+| `tide.relay_enable/disable/delete(name)` | Lifecycle management |
+| `tide.relay_list_configs()` | Inspect active pipelines |
+| `tide.<name>_pending` / `_dlq` / `_stats` | Plain VIEWs — no IVM overhead |
+
+**Binary (`pg-tide`):**
+
+- Lifted verbatim from `pgtrickle-relay/` using `git filter-repo` to preserve
+  history.
+- Six source backends: NATS, Kafka, outbox poller, webhook, Redis, SQS,
+  RabbitMQ.
+- Eight sink backends: same set + stdout + pg-inbox.
+- Advisory-lock leader election, independent metrics/health server (Axum +
+  Prometheus).
+
+**No `pg_trickle` required:** `pg_tide.control` has no `requires`. The inbox
+helper views are plain VIEWs; the one integration point is `attach_outbox()`
+on the `pg_trickle` side (see below).
+
+---
+
+### Changes in `pg_trickle` (this repo)
+
+| Item | Change |
+|------|--------|
+| `src/api/outbox.rs` (1,048 LOC) | Deleted |
+| `src/api/inbox.rs` (1,215 LOC) | Deleted |
+| Relay catalog SQL in `src/lib.rs` (~240 LOC) | Deleted |
+| `pgtrickle-relay/` crate (~3,650 LOC) | Moved to `trickle-labs/pg-tide` |
+| `Dockerfile.relay` | Deleted |
+| 4 relay publish jobs in `release.yml` | Deleted |
+| `aws-smithy-http-client` exception in `security.yml` | Deleted |
+| `pgtrickle-relay` in workspace `Cargo.toml` | Removed |
+| `pgtrickle.enable_outbox()` / `pgtrickle.create_inbox()` | Replaced by `pgtrickle.attach_outbox()` |
+| New `pgtrickle.attach_outbox(stream_table, ...)` | Calls `tide.outbox_create()` and registers a refresh-time SPI hook to `tide.outbox_publish()` — same transaction, ADR-001/ADR-002 atomicity preserved |
+
+**Upgrade script** (`pg_trickle--0.45.0--0.46.0.sql`) drops all old
+`pgtrickle.relay_*` objects and all old outbox/inbox API functions. Base
+tables (`pgtrickle.outbox_<st>`, `pgtrickle.inbox_<...>`) are left in place
+for manual data migration; the CHANGELOG documents the explicit equivalents in
+`pg_tide`.
+
+---
+
+### Integration point: `attach_outbox()` and atomicity
+
+The critical invariant from ADR-001/ADR-002: the outbox row and the refresh
+MERGE must commit in the same transaction. After the cut:
+
+1. `pgtrickle.attach_outbox('orders_stream', ...)` calls
+   `tide.outbox_create('outbox_orders_stream', ...)` once at setup time.
+2. Inside each refresh, the hot path calls
+   `SELECT tide.outbox_publish($1, $2, $3)` via SPI. The SPI call runs in the
+   current transaction — same atomicity guarantee as a direct INSERT.
+3. `pg_trickle.control` does **not** declare `requires = 'pg_tide'`. At
+   `attach_outbox()` call time, the function probes
+   `to_regproc('tide.outbox_create(...)')` and raises with an actionable
+   install hint if `pg_tide` is absent. All other IVM features (refresh,
+   CDC, scheduler, DAG) are unaffected.
+
+---
+
+### Work plan (6 working days)
+
+See [plans/PLAN_RELAY_STANDALONE.md §7.9](../plans/PLAN_RELAY_STANDALONE.md)
+for the day-by-day breakdown.
+
+**Days 1–2:** Bootstrap `trickle-labs/pg-tide`; lift outbox/inbox into the
+extension; carry over tests.
+**Day 3:** Lift relay catalog SQL and `pgtrickle-relay/` binary into the new
+repo.
+**Day 4:** Delete moved code from this repo; add `attach_outbox()`;
+write the upgrade script.
+**Day 5a:** Documentation — move and rewrite the four outbox/inbox/relay docs;
+update cross-references in ~12 docs in this repo.
+**Day 5b:** CI / packaging — clone CI templates into `pg-tide`; verify both
+repos build clean; cut pre-release tags.
+
+**Pre-cut action (Day 3 gate):** Post a one-line announcement to the
+`pg_trickle` discussions board confirming no known users of
+`enable_outbox()` / `create_inbox()` / the relay binary.
+
+---
+
+### Success criteria
+
+- `cargo build -p pg_trickle` pulls no relay-related dependency.
+- A user installing only `pg_tide` (without `pg_trickle`) can configure a
+  NATS-to-webhook pipeline and run it end-to-end against vanilla Postgres 18.
+- `pgtrickle.relay_*` tables and functions no longer exist in a fresh install.
+- `pgtrickle.attach_outbox()` integration test passes with `pg_tide` installed
+  and raises a clear error without it.
+- Total LOC removed from this repo: ≥6,150 Rust + ≥2,500 SQL.
+
+---
+
+### Assets moving to `trickle-labs/pg-tide`
+
+See [plans/PLAN_RELAY_STANDALONE.md §7.10](../plans/PLAN_RELAY_STANDALONE.md)
+for the full inventory:
+
+- `docs/OUTBOX.md`, `docs/INBOX.md`, `docs/RELAY.md`, `docs/RELAY_GUIDE.md`
+- `tests/e2e_outbox_tests.rs`, `tests/e2e_inbox_tests.rs`
+- `plans/relay/PLAN_RELAY_WIRE_FORMATS.md`, `PLAN_RELAY_CLI.md`,
+  `PLAN_RELAY_CLI_PHASE_2.md`, `PLAN_RELAY_GAPS_FROM_FELDERA_RISINGWAVE.md`
+- Blog posts: `built-in-outbox.md`, `outbox-pattern-turbocharged.md`,
+  `inbox-pattern-kafka.md`, `relay-deep-dive.md`
+- CI templates to clone (not move): pgrx composite action, skill files,
+  AGENTS.md, lint/test/coverage/release workflows, justfile, deny.toml,
+  stability-test workflow
+
+---
+
+*Previous: [v0.45.0 — Operational Readiness, Scalability & CI Completeness](v0.45.0.md)*
+*Next: [v0.47.0 — Embedding Pipeline Infrastructure & ANN Maintenance](v0.47.0.md)*

--- a/roadmap/v0.47.0.md
+++ b/roadmap/v0.47.0.md
@@ -1,97 +1,61 @@
-# v0.47.0 — Complete Embedding Programme: Sparse Vectors, Hybrid Search & Embedding API
+# v0.47.0 — Embedding Pipeline Infrastructure & ANN Maintenance
 
 > **Full technical details:** [v0.47.0.md-full.md](v0.47.0.md-full.md)
 
-**Status: Planned** | **Scope: Large**
+**Status: Planned** | **Scope: Medium**
 
-> Sparse and half-precision vector aggregates, reactive neighbour-alert
-> subscriptions, hybrid-search corpus patterns, ergonomic
-> `embedding_stream_table()` API, per-tenant ANN indexing, outbox-emitted
-> embedding events, and a vector benchmark suite. Completes the AI/RAG feature
-> set built on the hardening arc.
+> After the v0.38.0-v0.45.0 hardening arc, the roadmap resumes the deferred
+> embedding programme with post-refresh actions, drift-based ANN maintenance,
+> vector-aware monitoring, and AI/RAG cookbooks.
 
 ---
 
 ## What is this?
 
-v0.46.0 completes embedding pipeline infrastructure and ANN maintenance.
-v0.47.0 delivers the remaining production AI/RAG features in a single release:
-storage-tiered sparse and half-precision vector aggregates, reactive
-distance-predicate subscriptions, hybrid-search corpus patterns, and an
-ergonomic `embedding_stream_table()` API that sets up common RAG corpora in one
-call. This release also covers multi-tenant ANN patterns, outbox-emitted
-embedding events, and a comprehensive vector benchmark suite.
+v0.37.0 introduced pgVectorMV. v0.38.0-v0.45.0 then deliberately prioritized
+correctness, operational truthfulness, diagnostics, and platform trust before
+new AI surface area. v0.47.0 picks the embedding roadmap back up once those
+foundations are in place.
 
 ---
 
-## Sparse and half-precision vector aggregates
+## Embedding pipeline operational hardening
 
-pgvector 0.7+ ships `halfvec` and `sparsevec` types for storage-efficient
-embeddings. v0.47.0 adds:
-
-- `sparsevec_avg` / `sparsevec_sum` — element-wise mean/sum over the union of
-  sparse dimensions, treating absent entries as 0.
-- `halfvec_avg` / `halfvec_sum` — running state upcast to `vector(d)` for
-  numerical stability; returns `halfvec(d)` on read.
-
-A stream table can maintain tiered storage: raw `vector(1536)` →
-`halfvec(1536)` → `sparsevec(1536)` (for binary-quantised re-ranking), each
-layer incrementally maintained and independently indexed.
+When a vector stream table refreshes, it often needs follow-up housekeeping:
+statistics refresh, ANN maintenance, or drift-aware reindexing. v0.47.0 adds
+explicit post-refresh actions, per-table drift thresholds, and a
+`pgtrickle.vector_status()` view so operators can see embedding lag, index age,
+and reindex pressure instead of inferring those signals indirectly.
 
 ---
 
-## Reactive vector-similarity subscriptions
+## pgvector integration & RAG cookbook
 
-Extending reactive subscriptions (v0.35), v0.47.0 adds support for reactive
-queries over distance predicates. A subscription fires whenever a *new* row
-enters or exits the similarity neighbourhood, using differential semantics
-(only predicate-truth changes fire — no spurious re-emits on every refresh).
-
----
-
-## Hybrid-search corpus pattern
-
-Combine vector similarity with BM25 full-text search and metadata filters on a
-single flat stream table. v0.47.0 publishes
-`docs/tutorials/HYBRID_SEARCH_PATTERNS.md` with flat denormalised corpora,
-RLS-scoped corpora, tiered search patterns, and performance-tuning notes.
-
----
-
-## `embedding_stream_table()` ergonomic API
-
-Today, users still write the full denormalization query by hand. v0.47.0 adds a
-higher-level helper that auto-generates the query, creates the stream table,
-provisions indexes, configures post-refresh actions, and returns a dry-run
-preview when `dry_run => true`. The API covers common single-source-plus-joins
-RAG patterns without removing SQL control from power users.
+This release adds the documentation needed for a serious self-hosted RAG
+workflow: a full cookbook for always-fresh embedding pipelines using
+`pg_trickle` + `pgvector`, with embeddings generated at the application layer.
 
 ---
 
 ## Also in v0.47.0
 
-- Per-tenant ANN indexing patterns: RLS-scoped embedding corpora with security
-  review and explicit trust boundaries
-- Outbox-emitted embedding events: downstream agents or search services can
-  react to embedding churn without polling
-- Vector benchmark suite measuring differential refresh throughput, aggregate
-  reducer cost, drift-detection overhead, and storage savings across `vector`,
-  `halfvec`, and `sparsevec`
-- Materialised k-NN graph research spike (non-blocking): trade-off analysis of
-  pre-computed neighbour relationships for fixed-pivot retrieval
-- Public starter repository and best-effort ecosystem examples for the
-  post-hardening AI stack (never a release gate)
+- Citus vector-aggregate cases integrated into the v0.39 distributed test rig
+- Vector-specific options and monitoring integrated into the generated reference
+  docs added during the hardening arc
 
 ---
 
 ## Scope
 
-v0.47.0 is a large release that consolidates the entire embedding feature set.
-The k-NN graph work is explicitly research — it does not block the release. The
-`embedding_stream_table()` API hides real query-shape and indexing complexity,
-so `dry_run` support and index-inference documentation are required before ship.
+v0.47.0 is a medium release. The work is primarily scheduler options,
+monitoring, cookbook material, and packaging, rather than DVM-core changes.
+That is exactly why it belongs after the hardening arc, not before it.
+
+> **Hard prerequisite:** v0.38.0-v0.45.0 must complete their correctness,
+> diagnostics, and operator-trust exit criteria before this embedding work
+> starts.
 
 ---
 
-*Previous: [v0.46.0 — Embedding Pipeline Infrastructure & ANN Maintenance](v0.46.0.md)*
-*Next: [v1.0.0 — Stable Release](v1.0.0.md-full.md)*
+*Previous: [v0.45.0 — Operational Readiness, Scalability & CI Completeness](v0.45.0.md)*
+*Next: [v0.47.0 — Hybrid Search & Sparse Vector Aggregates](v0.47.0.md)*

--- a/roadmap/v0.47.0.md-full.md
+++ b/roadmap/v0.47.0.md-full.md
@@ -1,163 +1,102 @@
 > **Plain-language companion:** [v0.47.0.md](v0.47.0.md)
 
-## v0.47.0 — Complete Embedding Programme: Sparse Vectors, Hybrid Search & Embedding API
+## v0.47.0 — Embedding Pipeline Infrastructure & ANN Maintenance
 
-**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](../plans/ecosystem/PLAN_PGVECTOR.md) §6.3–6.4, merged from former v0.48.0 and v0.49.0.
+**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](plans/ecosystem/PLAN_PGVECTOR.md) §6.2, rescheduled after the assessment-driven hardening arc in [plans/PLAN_OVERALL_ASSESSMENT_8.md](plans/PLAN_OVERALL_ASSESSMENT_8.md).
 
 > **Release Theme**
-> Complete the AI/RAG feature set in one release: sparse/half-precision vector
-> aggregates for tiered storage, reactive distance-predicate subscriptions for
-> real-time anomaly detection, hybrid-search (BM25 + vector + metadata)
-> cookbook, ergonomic `embedding_stream_table()` API, per-tenant ANN patterns,
-> outbox-emitted embedding events, and a comprehensive vector benchmark suite.
+> v0.47.0 resumes the deferred embedding programme once the roadmap has closed
+> the immediate correctness and operational gaps. It adds post-refresh action
+> hooks (ANALYZE, REINDEX, drift-based re-clustering), vector-aware monitoring,
+> and a pgvector RAG cookbook for production embedding pipelines on PostgreSQL.
 
-> **Hard prerequisite:** v0.41.0–v0.46.0 must complete their hardening and
-> embedding-infrastructure exit criteria before v0.47.0 begins feature work.
+> **Hard prerequisite:** v0.38.0-v0.45.0 must complete their hardening exit
+> criteria first. The embedding programme is intentionally sequenced after the
+> correctness and operator-trust work, not in parallel with it.
 
 ---
 
 ### Features
 
-| ID | Title | Effort | Priority | Source |
-|----|-------|--------|----------|--------|
-| VH-1 | `sparsevec_avg`, `sparsevec_sum`, `halfvec_avg`, `halfvec_sum` aggregates | M | P1 | former v0.48 |
-| VH-2 | Reactive subscriptions over distance predicates (`embedding <=> q < ε`) | M | P1 | former v0.48 |
-| VH-3 | Hybrid-search corpus cookbook: BM25 + vector + metadata on one ST | S | P2 | former v0.48 |
-| VH-4 | Benchmark suite: differential refresh + HNSW throughput, aggregate cost | M | P2 | former v0.48 |
-| VA-1 | `embedding_stream_table()` ergonomic API: one-call RAG corpus setup | L | P1 | former v0.49 |
-| VA-2 | Materialised k-NN graph research spike for fixed-pivot retrieval | L | P3 | former v0.49 |
-| VA-3 | Per-tenant ANN indexing patterns: RLS-scoped embedding corpora | M | P2 | former v0.49 |
-| VA-4 | Outbox-emitted embedding events for downstream consumption | M | P2 | former v0.49 |
-| VA-5 | Starter repo and ecosystem positioning *(best-effort, not a release gate)* | S | P2 | former v0.49 |
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| VP-1 | `post_refresh_action` ST option (`none` / `analyze` / `reindex` / `reindex_if_drift`) | M | P1 |
+| VP-2 | `reindex_drift_threshold` ST option plus drift counter in catalog | M | P1 |
+| VP-3 | `pgtrickle.vector_status()` view: embedding lag, ANN age, drift % | S | P1 |
+| VP-4 | Cookbook: always-fresh RAG with pg_trickle + pgvector | S | P2 |
+| VP-5 | Citus vector-aggregate cases folded into distributed coverage | M | P2 |
 
-**VH-1 — Sparse and half-precision aggregates.**
-Extend the algebraic-aggregate framework to support pgvector type variants:
-`sparsevec_avg`, `sparsevec_sum`, `halfvec_avg`, and `halfvec_sum`. The running
-state for `halfvec_avg` is upcast to `vector(d)` for numerical stability; sparse
-variants aggregate over the union of dimensions while treating absent entries as
-zero. A stream table can maintain tiered storage: raw `vector(1536)` →
-`halfvec(1536)` → `sparsevec(1536)`, each layer incrementally maintained and
-independently indexed.
+**VP-1 — Post-refresh actions.**
+Add a `post_refresh_action` option to vector-heavy stream tables so operators can
+run `ANALYZE`, `REINDEX`, or `reindex_if_drift` after a refresh commits. The
+work runs in a lower-priority queue after the refresh transaction, so it does
+not lengthen the critical refresh window or turn ANN maintenance into hidden
+refresh latency.
 
-**VH-2 — Reactive distance subscriptions.**
-Extend reactive subscriptions to support distance-predicate queries where the
-query vector is bound at subscription-creation time. The subscription fires only
-when rows newly satisfy or cease to satisfy the predicate, avoiding spurious
-re-emits on every refresh. Uses the same NOTIFY-based delivery as other reactive
-subscriptions.
+**VP-2 — Drift detection.**
+Catalog state tracks `rows_changed_since_last_reindex` and a
+`reindex_drift_threshold`. When a vector table changes enough since its last
+index rebuild, the post-refresh action can queue a targeted REINDEX instead of
+forcing operators to guess when ANN quality has drifted too far.
 
-**VH-3 — Hybrid-search cookbook.**
-Publish `docs/tutorials/HYBRID_SEARCH_PATTERNS.md` with flat denormalised
-corpora, RLS-scoped corpora, tiered search patterns, and performance-tuning
-notes. The goal is a copy-paste path to BM25 + vector + metadata retrieval on
-incrementally maintained tables.
+**VP-3 — Vector status view.**
+Add `pgtrickle.vector_status()` to expose embedding lag, last refresh, last
+reindex time, rows changed since reindex, drift percentage, and vector-aggregate
+usage. This view plugs into the monitoring foundation built in the hardening
+arc and gives RAG operators a first-class place to look for ANN maintenance
+pressure.
 
-**VH-4 — Vector benchmark suite.**
-Add `benches/pgvector_bench.rs` to measure differential refresh plus ANN insert
-throughput, vector aggregate reducer cost, drift-detection overhead, and storage
-savings across `vector`, `halfvec`, and `sparsevec` representations.
+**VP-4 — pgvector RAG cookbook.**
+Publish `docs/tutorials/PGVECTOR_RAG_COOKBOOK.md` with copy-paste workflows for
+pre-computed embeddings, denormalized corpora, hybrid search, and operational
+sizing guidance. Embeddings are generated at the application layer (e.g. via
+OpenAI, Cohere, or Ollama APIs) before being stored with pgvector. The key
+outcome is that AI engineers can start with a working pattern instead of
+reverse-engineering examples from tests.
 
-**VA-1 — `embedding_stream_table()` ergonomic API.**
-Add a high-level function that auto-generates the denormalization query, creates
-the stream table, provisions indexes, configures post-refresh actions, and
-returns a dry-run preview when `dry_run => true`. The API covers common
-single-source-plus-joins RAG patterns without removing SQL control from power
-users. Required: explicit index-inference documentation for `vector` and
-`halfvec` cases.
-
-**VA-2 — Materialised k-NN graph research spike.**
-Explore whether pre-computing neighbour relationships for fixed pivot vectors is
-worth the storage and maintenance overhead relative to ANN index scans. This is
-research, not a release gate: the deliverable is a real trade-off analysis and,
-optionally, a proof of concept if the numbers look promising.
-
-**VA-3 — Per-tenant ANN indexing patterns.**
-Document and example the production pattern for multi-tenant RAG using RLS and
-tenant-scoped vector corpora. The emphasis is on safe defaults and explicit
-security review, not just on query examples.
-
-**VA-4 — Outbox-emitted embedding events.**
-Extend the outbox surface so embedding changes can be emitted as downstream
-application events. This lets external agents or search services react to
-embedding churn without polling.
-
-**VA-5 — Starter repo and ecosystem positioning.**
-Provide a public starter repository and best-effort ecosystem material showing
-how pg_trickle fits alongside pgvector after the hardening arc. Must never block
-the release.
+**VP-5 — Citus vector-aggregate cases folded into distributed coverage.**
+The v0.39 Citus rig becomes the place where shard-additive vector-aggregate
+behavior is verified. This keeps vector work honest in distributed deployments
+without treating Citus as an afterthought.
 
 ### Test Coverage
 
 | ID | Title | Effort | Priority |
 |----|-------|--------|----------|
-| T-VH1 | Integration test: tiered storage (`vector` → `halfvec` → `sparsevec`) | M | P1 |
-| T-VH2 | Reactive distance subscriptions: new anomaly alerts | M | P1 |
-| T-VH3 | Hybrid-search corpus under write load | M | P2 |
-| T-VA1 | Integration test: `embedding_stream_table()` generates correct stream tables | M | P1 |
-| T-VA2 | Research benchmark: k-NN graph trade-off measurement | L | P2 |
-| T-VA3 | Multi-tenant security test for ANN stream tables | M | P1 |
-| T-VA4 | Outbox event emission for embedding changes | M | P2 |
+| T-VP1 | Drift-based reindex integration test on HNSW stream table | M | P1 |
+| T-VP2 | `vector_status()` accuracy and reset behavior | S | P1 |
+| T-VP3 | Citus shard-additive vector aggregate verification | M | P2 |
 
-**T-VH1.**
-Build a multi-layer stream-table stack and verify all layers refresh correctly
-when the source changes. Check both aggregate correctness and ANN query
-consistency up to expected quantisation loss.
+**T-VP1.**
+Create a vector stream table with `post_refresh_action = 'reindex_if_drift'`,
+change more than the configured threshold, and verify that REINDEX is queued and
+completed outside the refresh transaction.
 
-**T-VH2.**
-Create a reactive distance subscription, insert and update rows around a chosen
-similarity threshold, and assert that notifications fire only when predicate
-truth changes.
+**T-VP2.**
+Verify that `pgtrickle.vector_status()` reports lag, drift, and last-reindex
+metadata correctly before and after a drift-triggered REINDEX.
 
-**T-VH3.**
-Run a hybrid-search corpus under sustained write load, record refresh lag and
-query latency, and only write hard latency assertions once the CI baseline is
-measured on the actual runner hardware.
-
-**T-VA1.**
-Call `embedding_stream_table()` with a realistic joins-and-aggregates spec,
-verify the generated stream table and indexes, and compare results with the
-manually written equivalent definition.
-
-**T-VA2.**
-If the k-NN research spike includes code, benchmark pivot-neighbour queries
-against direct ANN index scans so the trade-off is evidence-based.
-
-**T-VA3.**
-Verify that tenant-scoped ANN stream tables respect RLS policies and do not leak
-cross-tenant embeddings.
-
-**T-VA4.**
-Create an embedding-aware outbox stream and verify downstream subscribers see
-correctly structured events when embeddings change.
+**T-VP3.**
+Run vector-aggregate cases inside the v0.39 Citus rig so shard-local partial
+results still converge to the same answer as a global `avg(vector)` or
+`sum(vector)` computation.
 
 ### Conflicts & Risks
 
-- **VH-1** needs careful handling of dimension mismatches and all-zero sparse
-  vectors. The result definition must be explicit and heavily tested.
-- **VH-2** depends on reactive subscription correctness remaining solid after
-  the hardening arc; do not layer distance semantics on top of a shaky base.
-- **VH-4** should publish measured baselines, not aspirational numbers.
-- **VA-1** hides real query complexity. `dry_run => true` and explicit index
-  heuristics are essential so expert users can audit the generated surface.
-- **VA-2** is intentionally non-blocking research. Keep it from turning into an
-  unbounded scope sink for a release that already includes a large ergonomic API.
-- **VA-3** must be reviewed with the security model documented in the hardening
-  arc; RLS examples are only useful if their trust boundaries are explicit.
-
+- **VP-1/VP-2** add queueable post-refresh work. Backlog visibility must be
+  clear so operators can see if ANN maintenance is lagging behind the refresh
+  pipeline.
+- **VP-3** is observational, but large fleets still need scrape-friendly
+  monitoring rather than expensive ad hoc queries across huge numbers of stream
+  tables.
 ### Exit Criteria
 
-- [ ] VH-1: sparse and half-precision aggregates implemented and pass equivalence tests against non-incremental computation
-- [ ] VH-1: `halfvec_avg` precision characterised and kept within an explicit error contract
-- [ ] VH-2: reactive distance subscriptions fire only on predicate-truth changes
-- [ ] VH-3: hybrid-search cookbook published with worked examples
-- [ ] VH-4: benchmark suite runs in CI and publishes results alongside other performance data
-- [ ] VA-1: `embedding_stream_table()` generates correct SQL, indexes, and monitoring configuration
-- [ ] VA-1: `dry_run => true` returns the generated SQL without side effects
-- [ ] VA-1: documented index-inference heuristics exist for vector and halfvec cases
-- [ ] VA-2: research findings for materialised k-NN graphs are published; implementation remains optional
-- [ ] VA-3: multi-tenant ANN documentation and security tests are complete
-- [ ] VA-4: embedding outbox events emit and validate correctly
-- [ ] VA-5: starter repo or equivalent public examples are available
-- [ ] Extension upgrade path tested (`0.46.0 → 0.47.0`)
-- [ ] `just lint` passes with zero warnings
-- [ ] `just test-all` passes
+- [ ] VP-1: `post_refresh_action` is stored in the catalog and dequeued correctly after refresh commit
+- [ ] VP-2: drift threshold logic increments and resets correctly over repeated refresh cycles
+- [ ] VP-3: `pgtrickle.vector_status()` reports correct lag and drift for vector stream tables
+- [ ] VP-4: RAG cookbook published with multiple worked examples
+- [ ] VP-5: vector-aggregate cases pass inside the Citus distributed test rig
+- [ ] Extension upgrade path tested (`0.40.0 → 0.41.0`)
+- [ ] `just check-version-sync` passes
+
+---

--- a/roadmap/v0.48.0.md
+++ b/roadmap/v0.48.0.md
@@ -1,0 +1,97 @@
+# v0.48.0 — Complete Embedding Programme: Sparse Vectors, Hybrid Search & Embedding API
+
+> **Full technical details:** [v0.48.0.md-full.md](v0.48.0.md-full.md)
+
+**Status: Planned** | **Scope: Large**
+
+> Sparse and half-precision vector aggregates, reactive neighbour-alert
+> subscriptions, hybrid-search corpus patterns, ergonomic
+> `embedding_stream_table()` API, per-tenant ANN indexing, outbox-emitted
+> embedding events, and a vector benchmark suite. Completes the AI/RAG feature
+> set built on the hardening arc.
+
+---
+
+## What is this?
+
+v0.46.0 completes embedding pipeline infrastructure and ANN maintenance.
+v0.48.0 delivers the remaining production AI/RAG features in a single release:
+storage-tiered sparse and half-precision vector aggregates, reactive
+distance-predicate subscriptions, hybrid-search corpus patterns, and an
+ergonomic `embedding_stream_table()` API that sets up common RAG corpora in one
+call. This release also covers multi-tenant ANN patterns, outbox-emitted
+embedding events, and a comprehensive vector benchmark suite.
+
+---
+
+## Sparse and half-precision vector aggregates
+
+pgvector 0.7+ ships `halfvec` and `sparsevec` types for storage-efficient
+embeddings. v0.48.0 adds:
+
+- `sparsevec_avg` / `sparsevec_sum` — element-wise mean/sum over the union of
+  sparse dimensions, treating absent entries as 0.
+- `halfvec_avg` / `halfvec_sum` — running state upcast to `vector(d)` for
+  numerical stability; returns `halfvec(d)` on read.
+
+A stream table can maintain tiered storage: raw `vector(1536)` →
+`halfvec(1536)` → `sparsevec(1536)` (for binary-quantised re-ranking), each
+layer incrementally maintained and independently indexed.
+
+---
+
+## Reactive vector-similarity subscriptions
+
+Extending reactive subscriptions (v0.35), v0.48.0 adds support for reactive
+queries over distance predicates. A subscription fires whenever a *new* row
+enters or exits the similarity neighbourhood, using differential semantics
+(only predicate-truth changes fire — no spurious re-emits on every refresh).
+
+---
+
+## Hybrid-search corpus pattern
+
+Combine vector similarity with BM25 full-text search and metadata filters on a
+single flat stream table. v0.48.0 publishes
+`docs/tutorials/HYBRID_SEARCH_PATTERNS.md` with flat denormalised corpora,
+RLS-scoped corpora, tiered search patterns, and performance-tuning notes.
+
+---
+
+## `embedding_stream_table()` ergonomic API
+
+Today, users still write the full denormalization query by hand. v0.48.0 adds a
+higher-level helper that auto-generates the query, creates the stream table,
+provisions indexes, configures post-refresh actions, and returns a dry-run
+preview when `dry_run => true`. The API covers common single-source-plus-joins
+RAG patterns without removing SQL control from power users.
+
+---
+
+## Also in v0.48.0
+
+- Per-tenant ANN indexing patterns: RLS-scoped embedding corpora with security
+  review and explicit trust boundaries
+- Outbox-emitted embedding events: downstream agents or search services can
+  react to embedding churn without polling
+- Vector benchmark suite measuring differential refresh throughput, aggregate
+  reducer cost, drift-detection overhead, and storage savings across `vector`,
+  `halfvec`, and `sparsevec`
+- Materialised k-NN graph research spike (non-blocking): trade-off analysis of
+  pre-computed neighbour relationships for fixed-pivot retrieval
+- Public starter repository and best-effort ecosystem examples for the
+  post-hardening AI stack (never a release gate)
+
+---
+
+## Scope
+
+v0.48.0 is a large release that consolidates the entire embedding feature set.
+The k-NN graph work is explicitly research — it does not block the release. The
+`embedding_stream_table()` API hides real query-shape and indexing complexity,
+so `dry_run` support and index-inference documentation are required before ship.
+
+---
+
+*Previous: [v0.46.0 — Embedding Pipeline Infrastructure & ANN Maintenance](v0.46.0.md)*
+*Next: [v1.0.0 — Stable Release](v1.0.0.md-full.md)*

--- a/roadmap/v0.48.0.md-full.md
+++ b/roadmap/v0.48.0.md-full.md
@@ -1,0 +1,163 @@
+> **Plain-language companion:** [v0.48.0.md](v0.48.0.md)
+
+## v0.48.0 — Complete Embedding Programme: Sparse Vectors, Hybrid Search & Embedding API
+
+**Status: Planned.** Derived from [plans/ecosystem/PLAN_PGVECTOR.md](../plans/ecosystem/PLAN_PGVECTOR.md) §6.3–6.4, merged from former v0.48.0 and v0.49.0.
+
+> **Release Theme**
+> Complete the AI/RAG feature set in one release: sparse/half-precision vector
+> aggregates for tiered storage, reactive distance-predicate subscriptions for
+> real-time anomaly detection, hybrid-search (BM25 + vector + metadata)
+> cookbook, ergonomic `embedding_stream_table()` API, per-tenant ANN patterns,
+> outbox-emitted embedding events, and a comprehensive vector benchmark suite.
+
+> **Hard prerequisite:** v0.41.0–v0.46.0 must complete their hardening and
+> embedding-infrastructure exit criteria before v0.48.0 begins feature work.
+
+---
+
+### Features
+
+| ID | Title | Effort | Priority | Source |
+|----|-------|--------|----------|--------|
+| VH-1 | `sparsevec_avg`, `sparsevec_sum`, `halfvec_avg`, `halfvec_sum` aggregates | M | P1 | former v0.48 |
+| VH-2 | Reactive subscriptions over distance predicates (`embedding <=> q < ε`) | M | P1 | former v0.48 |
+| VH-3 | Hybrid-search corpus cookbook: BM25 + vector + metadata on one ST | S | P2 | former v0.48 |
+| VH-4 | Benchmark suite: differential refresh + HNSW throughput, aggregate cost | M | P2 | former v0.48 |
+| VA-1 | `embedding_stream_table()` ergonomic API: one-call RAG corpus setup | L | P1 | former v0.49 |
+| VA-2 | Materialised k-NN graph research spike for fixed-pivot retrieval | L | P3 | former v0.49 |
+| VA-3 | Per-tenant ANN indexing patterns: RLS-scoped embedding corpora | M | P2 | former v0.49 |
+| VA-4 | Outbox-emitted embedding events for downstream consumption | M | P2 | former v0.49 |
+| VA-5 | Starter repo and ecosystem positioning *(best-effort, not a release gate)* | S | P2 | former v0.49 |
+
+**VH-1 — Sparse and half-precision aggregates.**
+Extend the algebraic-aggregate framework to support pgvector type variants:
+`sparsevec_avg`, `sparsevec_sum`, `halfvec_avg`, and `halfvec_sum`. The running
+state for `halfvec_avg` is upcast to `vector(d)` for numerical stability; sparse
+variants aggregate over the union of dimensions while treating absent entries as
+zero. A stream table can maintain tiered storage: raw `vector(1536)` →
+`halfvec(1536)` → `sparsevec(1536)`, each layer incrementally maintained and
+independently indexed.
+
+**VH-2 — Reactive distance subscriptions.**
+Extend reactive subscriptions to support distance-predicate queries where the
+query vector is bound at subscription-creation time. The subscription fires only
+when rows newly satisfy or cease to satisfy the predicate, avoiding spurious
+re-emits on every refresh. Uses the same NOTIFY-based delivery as other reactive
+subscriptions.
+
+**VH-3 — Hybrid-search cookbook.**
+Publish `docs/tutorials/HYBRID_SEARCH_PATTERNS.md` with flat denormalised
+corpora, RLS-scoped corpora, tiered search patterns, and performance-tuning
+notes. The goal is a copy-paste path to BM25 + vector + metadata retrieval on
+incrementally maintained tables.
+
+**VH-4 — Vector benchmark suite.**
+Add `benches/pgvector_bench.rs` to measure differential refresh plus ANN insert
+throughput, vector aggregate reducer cost, drift-detection overhead, and storage
+savings across `vector`, `halfvec`, and `sparsevec` representations.
+
+**VA-1 — `embedding_stream_table()` ergonomic API.**
+Add a high-level function that auto-generates the denormalization query, creates
+the stream table, provisions indexes, configures post-refresh actions, and
+returns a dry-run preview when `dry_run => true`. The API covers common
+single-source-plus-joins RAG patterns without removing SQL control from power
+users. Required: explicit index-inference documentation for `vector` and
+`halfvec` cases.
+
+**VA-2 — Materialised k-NN graph research spike.**
+Explore whether pre-computing neighbour relationships for fixed pivot vectors is
+worth the storage and maintenance overhead relative to ANN index scans. This is
+research, not a release gate: the deliverable is a real trade-off analysis and,
+optionally, a proof of concept if the numbers look promising.
+
+**VA-3 — Per-tenant ANN indexing patterns.**
+Document and example the production pattern for multi-tenant RAG using RLS and
+tenant-scoped vector corpora. The emphasis is on safe defaults and explicit
+security review, not just on query examples.
+
+**VA-4 — Outbox-emitted embedding events.**
+Extend the outbox surface so embedding changes can be emitted as downstream
+application events. This lets external agents or search services react to
+embedding churn without polling.
+
+**VA-5 — Starter repo and ecosystem positioning.**
+Provide a public starter repository and best-effort ecosystem material showing
+how pg_trickle fits alongside pgvector after the hardening arc. Must never block
+the release.
+
+### Test Coverage
+
+| ID | Title | Effort | Priority |
+|----|-------|--------|----------|
+| T-VH1 | Integration test: tiered storage (`vector` → `halfvec` → `sparsevec`) | M | P1 |
+| T-VH2 | Reactive distance subscriptions: new anomaly alerts | M | P1 |
+| T-VH3 | Hybrid-search corpus under write load | M | P2 |
+| T-VA1 | Integration test: `embedding_stream_table()` generates correct stream tables | M | P1 |
+| T-VA2 | Research benchmark: k-NN graph trade-off measurement | L | P2 |
+| T-VA3 | Multi-tenant security test for ANN stream tables | M | P1 |
+| T-VA4 | Outbox event emission for embedding changes | M | P2 |
+
+**T-VH1.**
+Build a multi-layer stream-table stack and verify all layers refresh correctly
+when the source changes. Check both aggregate correctness and ANN query
+consistency up to expected quantisation loss.
+
+**T-VH2.**
+Create a reactive distance subscription, insert and update rows around a chosen
+similarity threshold, and assert that notifications fire only when predicate
+truth changes.
+
+**T-VH3.**
+Run a hybrid-search corpus under sustained write load, record refresh lag and
+query latency, and only write hard latency assertions once the CI baseline is
+measured on the actual runner hardware.
+
+**T-VA1.**
+Call `embedding_stream_table()` with a realistic joins-and-aggregates spec,
+verify the generated stream table and indexes, and compare results with the
+manually written equivalent definition.
+
+**T-VA2.**
+If the k-NN research spike includes code, benchmark pivot-neighbour queries
+against direct ANN index scans so the trade-off is evidence-based.
+
+**T-VA3.**
+Verify that tenant-scoped ANN stream tables respect RLS policies and do not leak
+cross-tenant embeddings.
+
+**T-VA4.**
+Create an embedding-aware outbox stream and verify downstream subscribers see
+correctly structured events when embeddings change.
+
+### Conflicts & Risks
+
+- **VH-1** needs careful handling of dimension mismatches and all-zero sparse
+  vectors. The result definition must be explicit and heavily tested.
+- **VH-2** depends on reactive subscription correctness remaining solid after
+  the hardening arc; do not layer distance semantics on top of a shaky base.
+- **VH-4** should publish measured baselines, not aspirational numbers.
+- **VA-1** hides real query complexity. `dry_run => true` and explicit index
+  heuristics are essential so expert users can audit the generated surface.
+- **VA-2** is intentionally non-blocking research. Keep it from turning into an
+  unbounded scope sink for a release that already includes a large ergonomic API.
+- **VA-3** must be reviewed with the security model documented in the hardening
+  arc; RLS examples are only useful if their trust boundaries are explicit.
+
+### Exit Criteria
+
+- [ ] VH-1: sparse and half-precision aggregates implemented and pass equivalence tests against non-incremental computation
+- [ ] VH-1: `halfvec_avg` precision characterised and kept within an explicit error contract
+- [ ] VH-2: reactive distance subscriptions fire only on predicate-truth changes
+- [ ] VH-3: hybrid-search cookbook published with worked examples
+- [ ] VH-4: benchmark suite runs in CI and publishes results alongside other performance data
+- [ ] VA-1: `embedding_stream_table()` generates correct SQL, indexes, and monitoring configuration
+- [ ] VA-1: `dry_run => true` returns the generated SQL without side effects
+- [ ] VA-1: documented index-inference heuristics exist for vector and halfvec cases
+- [ ] VA-2: research findings for materialised k-NN graphs are published; implementation remains optional
+- [ ] VA-3: multi-tenant ANN documentation and security tests are complete
+- [ ] VA-4: embedding outbox events emit and validate correctly
+- [ ] VA-5: starter repo or equivalent public examples are available
+- [ ] Extension upgrade path tested (`0.46.0 → 0.47.0`)
+- [ ] `just lint` passes with zero warnings
+- [ ] `just test-all` passes


### PR DESCRIPTION
## Summary

Finalises the architecture plan and roadmap for extracting `pg_tide` — a
standalone transactional outbox, inbox, and relay extension — from
`pg_trickle` into its own repository at `https://github.com/trickle-labs/pg-tide`.

The decision is **Option C (clean break)**: lift the outbox, inbox, and relay
subsystems into a new pgrx extension (`tide` schema) and Rust binary (`pg-tide`).
`pg_trickle` retains a thin `attach_outbox()` wrapper that calls
`tide.outbox_publish()` via SPI inside the refresh transaction, preserving the
single-transaction atomicity guarantee from ADR-001/ADR-002. No migration
tooling and no deprecation shims are needed — the features have no known
production users.

## Changes

- **`plans/PLAN_RELAY_STANDALONE.md`** — complete redesign of the document:
  - Title and status updated to reflect the decided direction
  - New `TL;DR — Decision` section leads with "We are going with Option C"
  - `trickle-labs/pg-tide` and local path `../pg-tide` recorded (repo already
    created and checked out)
  - §7 renamed to "The plan — Option C" with an "active plan" callout;
    §§1–6 (Options A/B history) marked as superseded
  - §7.9 work plan expanded into a concrete 5-day breakdown with a
    pre-cut user-check gate
- **`ROADMAP.md`** — new v0.46.0 entry for the `pg_tide` extraction; former
  v0.46.0 (embedding infrastructure) shifted to v0.47.0; former v0.47.0
  (complete embedding programme) shifted to v0.48.0; section header, ASCII
  diagram, and prose updated
- **`roadmap/v0.46.0.md` + `v0.46.0.md-full.md`** — rewritten as the
  `pg_tide` extraction release (Large scope, ~6 working days, full inventory
  of what moves where)
- **`roadmap/v0.47.0.md` + `v0.47.0.md-full.md`** — renumbered from v0.46
- **`roadmap/v0.48.0.md` + `v0.48.0.md-full.md`** — renumbered from v0.47

## Testing

Documentation-only PR — no Rust or SQL changes.

- `just lint` — passes (no code changes)
- All internal cross-references verified (roadmap links, plan section references)

## Notes

**Implementation readiness:** the `trickle-labs/pg-tide` repository is
created and checked out at `../pg-tide`. The plan is ready to execute starting
at Day 1 of §7.9. One non-blocking pre-cut action before Day 4 lands on
`main`: post a one-line "is anyone using `enable_outbox()` / `create_inbox()` /
the relay binary?" check to the discussions board.

**Key design decisions in the plan:**
- Atomicity preserved: `attach_outbox()` calls `tide.outbox_publish()` via SPI
  inside the existing refresh MERGE transaction — same guarantee as a direct INSERT
- Soft dependency: `pg_trickle.control` does **not** declare `requires = 'pg_tide'`
- Inbox helper views remain plain VIEWs in `pg_tide` — no IVM materialisation needed
- No `attach_inbox()` integration point — inbox is fully standalone in `pg_tide`
- ~6,150 Rust LOC + ~2,500 SQL LOC removed from this repo after the cut
