### PR TITLE
fix(cdc): escape reserved change-buffer column names with __usr_ prefix

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -58,6 +58,8 @@ jobs:
           # dependencies via sqlx's integration tests and are not reachable in the extension.
           # Will be resolved when upstream releases hickory-dns 0.26.1.
           ignore: RUSTSEC-2023-0071,RUSTSEC-2026-0104,RUSTSEC-2026-0098,RUSTSEC-2026-0099,RUSTSEC-2026-0118,RUSTSEC-2026-0119,RUSTSEC-2026-0120
+
+  audit-scheduled:
     if: github.event_name == 'schedule'
     name: cargo audit (scheduled)
     runs-on: ubuntu-latest

--- a/src/cdc.rs
+++ b/src/cdc.rs
@@ -49,6 +49,27 @@ use std::collections::HashMap;
 use crate::config;
 use crate::error::PgTrickleError;
 
+// ── Reserved change-buffer column names ────────────────────────────────────
+
+/// Built-in CDC metadata column names that live at the top of every change-buffer
+/// table.  A source table column with any of these names would collide with the
+/// metadata column in a flat (A44-10 D+I) change-buffer schema.
+const RESERVED_CB_COLS: &[&str] = &["change_id", "lsn", "action", "pk_hash", "changed_cols"];
+
+/// Map a *source* column name to its change-buffer storage name.
+///
+/// When a source column name matches one of [`RESERVED_CB_COLS`], the column is
+/// stored in the change buffer as `__usr_{name}` to prevent a
+/// `column "…" specified more than once` error in PostgreSQL.
+/// All other names pass through unchanged.
+pub fn cb_col_name(name: &str) -> String {
+    if RESERVED_CB_COLS.contains(&name) {
+        format!("__usr_{name}")
+    } else {
+        name.to_string()
+    }
+}
+
 // ── CITUS-4: Stable buffer naming helpers ──────────────────────────────────
 
 /// Return the base name (without schema) for the change buffer table of a source.
@@ -607,7 +628,8 @@ fn build_typed_col_defs(columns: &[(String, String)]) -> String {
     columns
         .iter()
         .map(|(name, type_name)| {
-            let qname = name.replace('"', "\"\"");
+            let cb_name = cb_col_name(name);
+            let qname = cb_name.replace('"', "\"\"");
             format!(",\"{qname}\" {type_name}")
         })
         .collect::<Vec<_>>()
@@ -1460,8 +1482,10 @@ pub fn alter_change_buffer_add_columns(
 
     for (col_name, col_type) in &source_cols {
         // A44-10 (D+I schema): add flat column "col" instead of "new_col"/"old_col".
-        if !existing_set.contains(col_name.as_str()) {
-            let qcol = col_name.replace('"', "\"\"");
+        // Use cb_col_name() so reserved names (e.g. "action") are stored as "__usr_action".
+        let cb_name = cb_col_name(col_name);
+        if !existing_set.contains(cb_name.as_str()) {
+            let qcol = cb_name.replace('"', "\"\"");
             let qtype = col_type.as_str();
             let add_flat = format!(
                 "ALTER TABLE {schema}.{buf} \
@@ -1743,12 +1767,14 @@ fn build_row_trigger_fn_sql(
         .unwrap_or_default();
 
     // A44-10: Flat column names (no new_/old_ prefix).
+    // Use cb_col_name() so reserved names (e.g. "action") are stored as "__usr_action".
     let cn: String = columns
         .iter()
-        .map(|(n, _)| format!(", \"{}\"", n.replace('"', "\"\"")))
+        .map(|(n, _)| format!(", \"{}\"", cb_col_name(n).replace('"', "\"\"")))
         .collect::<Vec<_>>()
         .join("");
     // NEW row values (for INSERT and the I-row of UPDATE).
+    // Always reference the source record with the original column name.
     let nv: String = columns
         .iter()
         .map(|(n, _)| format!(", NEW.\"{}\"", n.replace('"', "\"\"")))
@@ -1852,12 +1878,14 @@ fn build_stmt_trigger_fn_sql(
     let pko = build_pk_hash_stmt_expr("o", pk_columns, columns);
 
     // A44-10: Flat column names (no new_/old_ prefix) for INSERT/DELETE/UPDATE.
+    // Use cb_col_name() so reserved names (e.g. "action") are stored as "__usr_action".
     let cn: String = columns
         .iter()
-        .map(|(n, _)| format!(", \"{}\"", n.replace('"', "\"\"")))
+        .map(|(n, _)| format!(", \"{}\"", cb_col_name(n).replace('"', "\"\"")))
         .collect::<Vec<_>>()
         .join("");
     // New-row values (n.col from __pgt_new).
+    // Always reference the transition table with the original column name.
     let ncr: String = columns
         .iter()
         .map(|(n, _)| format!(", n.\"{}\"", n.replace('"', "\"\"")))
@@ -2929,7 +2957,13 @@ pub fn poll_foreign_table_changes(
     // Build column lists for INSERT into change buffer.
     // A44-10: Flat column names (no new_/old_ prefix) matching base table
     // change buffer schema created by create_change_buffer_table().
-    let col_names: Vec<String> = col_defs
+    // cb_col_names: change-buffer INSERT target names (uses cb_col_name() for reserved cols).
+    // src_col_names: SELECT source names from the actual table (original names).
+    let cb_col_names: Vec<String> = col_defs
+        .iter()
+        .map(|(name, _)| format!("\"{}\"", cb_col_name(name).replace('"', "\"\"")))
+        .collect();
+    let src_col_names: Vec<String> = col_defs
         .iter()
         .map(|(name, _)| format!("\"{}\"", name.replace('"', "\"\"")))
         .collect();
@@ -2954,17 +2988,20 @@ pub fn poll_foreign_table_changes(
         )
     };
 
-    let col_list = col_names.join(", ");
+    let cb_col_list = cb_col_names.join(", ");
+    let src_col_list = src_col_names.join(", ");
 
     // ── Deleted rows: in snapshot but not in current foreign table ──
     // These appear as 'D' (delete) rows in the change buffer.
+    // INSERT target uses cb_col_list (change-buffer names); SELECT uses src_col_list
+    // (original source names). Values are matched positionally.
     let deleted_sql = format!(
-        "INSERT INTO {change_table} (lsn, action, pk_hash, {col_list}) \
-         SELECT pg_current_wal_insert_lsn(), 'D', {pk_hash_expr}, {col_list} \
+        "INSERT INTO {change_table} (lsn, action, pk_hash, {cb_col_list}) \
+         SELECT pg_current_wal_insert_lsn(), 'D', {pk_hash_expr}, {src_col_list} \
          FROM (\
-           SELECT {col_list} FROM {snapshot_table} \
+           SELECT {src_col_list} FROM {snapshot_table} \
            EXCEPT ALL \
-           SELECT {col_list} FROM {source_table}\
+           SELECT {src_col_list} FROM {source_table}\
          ) __pgt_del"
     );
     Spi::run(&deleted_sql).map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
@@ -2972,12 +3009,12 @@ pub fn poll_foreign_table_changes(
     // ── Inserted rows: in current foreign table but not in snapshot ──
     // These appear as 'I' (insert) rows in the change buffer.
     let inserted_sql = format!(
-        "INSERT INTO {change_table} (lsn, action, pk_hash, {col_list}) \
-         SELECT pg_current_wal_insert_lsn(), 'I', {pk_hash_expr}, {col_list} \
+        "INSERT INTO {change_table} (lsn, action, pk_hash, {cb_col_list}) \
+         SELECT pg_current_wal_insert_lsn(), 'I', {pk_hash_expr}, {src_col_list} \
          FROM (\
-           SELECT {col_list} FROM {source_table} \
+           SELECT {src_col_list} FROM {source_table} \
            EXCEPT ALL \
-           SELECT {col_list} FROM {snapshot_table}\
+           SELECT {src_col_list} FROM {snapshot_table}\
          ) __pgt_ins"
     );
     Spi::run(&inserted_sql).map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
@@ -3797,6 +3834,47 @@ mod tests {
         let cols = vec![("ts".to_string(), "timestamp with time zone".to_string())];
         let result = build_typed_col_defs(&cols);
         assert!(result.contains("timestamp with time zone"));
+    }
+
+    #[test]
+    fn test_typed_col_defs_reserved_name_prefixed() {
+        // A source column named "action" must be stored as "__usr_action" to
+        // avoid colliding with the built-in change-buffer metadata column.
+        let cols = vec![
+            ("id".to_string(), "integer".to_string()),
+            ("action".to_string(), "text".to_string()),
+            ("lsn".to_string(), "bigint".to_string()),
+        ];
+        let result = build_typed_col_defs(&cols);
+        assert!(
+            result.contains(r#","id" integer"#),
+            "non-reserved column unchanged: {result}"
+        );
+        assert!(
+            result.contains(r#","__usr_action" text"#),
+            "reserved 'action' should become '__usr_action': {result}"
+        );
+        assert!(
+            result.contains(r#","__usr_lsn" bigint"#),
+            "reserved 'lsn' should become '__usr_lsn': {result}"
+        );
+        assert!(
+            !result.contains(r#","action" text"#),
+            "bare 'action' must not appear: {result}"
+        );
+    }
+
+    #[test]
+    fn test_cb_col_name_reserved_names() {
+        assert_eq!(cb_col_name("action"), "__usr_action");
+        assert_eq!(cb_col_name("lsn"), "__usr_lsn");
+        assert_eq!(cb_col_name("pk_hash"), "__usr_pk_hash");
+        assert_eq!(cb_col_name("changed_cols"), "__usr_changed_cols");
+        assert_eq!(cb_col_name("change_id"), "__usr_change_id");
+        // Non-reserved names pass through unchanged.
+        assert_eq!(cb_col_name("id"), "id");
+        assert_eq!(cb_col_name("status"), "status");
+        assert_eq!(cb_col_name("amount"), "amount");
     }
 
     // ── F15: Selective CDC Column Capture ─────────────────────────────────────

--- a/src/dvm/operators/scan.rs
+++ b/src/dvm/operators/scan.rs
@@ -284,9 +284,10 @@ fn diff_scan_change_buffer(
     // D-rows carry old values in c."col"; I-rows carry new values.
     // The ST-source (is_st_source) distinction is gone — both base and ST
     // change buffers use the same flat schema.
+    // Use cb_col_name() to map reserved names (e.g. user column "action" → "__usr_action").
     let col_refs: Vec<String> = columns
         .iter()
-        .map(|c| format!("c.{}", quote_ident(&c.name)))
+        .map(|c| format!("c.{}", quote_ident(&crate::cdc::cb_col_name(&c.name))))
         .collect();
     let typed_col_refs_str = col_refs.join(",\n       ");
 
@@ -294,7 +295,13 @@ fn diff_scan_change_buffer(
     // The alias is the original column name for downstream CTE compatibility.
     let col_ref_aliased: Vec<String> = columns
         .iter()
-        .map(|c| format!("c.{} AS {}", quote_ident(&c.name), quote_ident(&c.name),))
+        .map(|c| {
+            format!(
+                "c.{} AS {}",
+                quote_ident(&crate::cdc::cb_col_name(&c.name)),
+                quote_ident(&c.name),
+            )
+        })
         .collect();
     let old_col_refs: Vec<String> = col_ref_aliased.clone();
     let new_col_refs: Vec<String> = col_ref_aliased;
@@ -413,9 +420,16 @@ fn diff_scan_change_buffer(
     // (D-row + I-row), so no UNION ALL for 'U' rows is needed here.
     if is_keyless {
         // A44-10: Flat column references (no new_/old_ prefix).
+        // Use cb_col_name() to map reserved source column names to their CB storage names.
         let col_refs_raw: Vec<String> = columns
             .iter()
-            .map(|c| format!("c.{} AS {}", quote_ident(&c.name), quote_ident(&c.name),))
+            .map(|c| {
+                format!(
+                    "c.{} AS {}",
+                    quote_ident(&crate::cdc::cb_col_name(&c.name)),
+                    quote_ident(&c.name),
+                )
+            })
             .collect();
         // Use array_agg(col)[1] instead of MAX(col) so that types without a
         // comparison operator (e.g. jsonb, json, arrays, composites) are handled
@@ -858,7 +872,10 @@ pub fn rewrite_predicate_for_scan(expr: &Expr, prefix: &str) -> String {
     match expr {
         Expr::ColumnRef { column_name, .. } => {
             // A44-10 (D+I schema): prefix is "" — just use the flat column name.
-            format!("c.\"{}{}\"", prefix, column_name.replace('"', "\"\""))
+            // Apply cb_col_name() so reserved source column names (e.g. "action")
+            // resolve to their change-buffer storage name ("__usr_action").
+            let cb_name = crate::cdc::cb_col_name(column_name);
+            format!("c.\"{}{}\"", prefix, cb_name.replace('"', "\"\""))
         }
         Expr::Literal(val) => val.clone(),
         Expr::BinaryOp { op, left, right } => {

--- a/src/wal_decoder.rs
+++ b/src/wal_decoder.rs
@@ -841,8 +841,9 @@ fn write_decoded_change(
         }
 
         for (col_name, col_type) in columns {
-            let safe_name = col_name.replace('"', "\"\"");
-            flat_col_names.push(format!("\"{}\"", safe_name));
+            let cb_name = crate::cdc::cb_col_name(col_name);
+            let safe_cb_name = cb_name.replace('"', "\"\"");
+            flat_col_names.push(format!("\"{}\"", safe_cb_name));
             d_params.push(old_parsed.get(col_name).cloned());
             i_params.push(parsed.get(col_name).cloned());
             let d_idx = d_params.len();
@@ -865,7 +866,10 @@ fn write_decoded_change(
         // Build col list (excluding lsn, action, pk_hash — handled separately).
         let data_col_names: Vec<String> = columns
             .iter()
-            .map(|(n, _)| format!("\"{}\"", n.replace('"', "\"\"")))
+            .map(|(n, _)| {
+                let cb_name = crate::cdc::cb_col_name(n);
+                format!("\"{}\"", cb_name.replace('"', "\"\""))
+            })
             .collect();
         let data_col_str = if data_col_names.is_empty() {
             String::new()
@@ -943,19 +947,21 @@ fn write_decoded_change(
     }
 
     for (col_name, col_type) in columns {
-        let safe_name = col_name.replace('"', "\"\"");
+        let cb_name = crate::cdc::cb_col_name(col_name);
+        let safe_cb_name = cb_name.replace('"', "\"\"");
 
         match action {
             'I' => {
                 // A44-10: flat column "col" (was "new_col").
-                col_names.push(format!("\"{}\"", safe_name));
+                // Use cb_col_name() so reserved names are stored as "__usr_{name}".
+                col_names.push(format!("\"{}\"", safe_cb_name));
                 let val = parsed.get(col_name).cloned();
                 param_values.push(val);
                 placeholders.push(format!("${}::{}", param_values.len(), col_type));
             }
             'D' => {
                 // A44-10: flat column "col" (was "old_col").
-                col_names.push(format!("\"{}\"", safe_name));
+                col_names.push(format!("\"{}\"", safe_cb_name));
                 let val = parsed.get(col_name).cloned();
                 param_values.push(val);
                 placeholders.push(format!("${}::{}", param_values.len(), col_type));

--- a/tests/e2e_fuse_tests.rs
+++ b/tests/e2e_fuse_tests.rs
@@ -329,7 +329,12 @@ async fn test_fuse_reset_reinitialize() {
     let blown = wait_for_fuse_blown(&db, "st_fuse_reinit", Duration::from_secs(30)).await;
     assert!(blown, "fuse should have blown");
 
-    // Raise ceiling to prevent re-blow, then reset with reinitialize
+    // Raise ceiling to prevent re-blow, then reset with reinitialize.
+    // Pause the scheduler first so it cannot process needs_reinit before we assert it.
+    db.execute("ALTER SYSTEM SET pg_trickle.enabled = off")
+        .await;
+    db.reload_config_and_wait().await;
+
     db.execute("SELECT pgtrickle.alter_stream_table('st_fuse_reinit', fuse_ceiling => 100000)")
         .await;
     db.execute("SELECT pgtrickle.reset_fuse('st_fuse_reinit', 'reinitialize')")
@@ -344,6 +349,10 @@ async fn test_fuse_reset_reinitialize() {
         needs_reinit,
         "needs_reinit should be true after reinitialize reset"
     );
+
+    // Re-enable scheduler.
+    db.execute("ALTER SYSTEM RESET pg_trickle.enabled").await;
+    db.reload_config_and_wait().await;
 }
 
 /// fuse_status() introspection function returns expected rows.


### PR DESCRIPTION
## Problem

A44-10 (v0.43.0) introduced flat column names in change buffers. When a source table contains a column with the same name as a built-in change-buffer metadata column (`change_id`, `lsn`, `action`, `pk_hash`, `changed_cols`), PostgreSQL raises:

```
ERROR: column "action" specified more than once
```

**Root cause:** `pgtrickle.pgt_refresh_history` has an `action TEXT` column. `setup_self_monitoring()` attaches CDC to that table, causing all `e2e_self_monitoring_tests` to fail (4 tests).

Also fixes: `test_fuse_reset_reinitialize` — the 100 ms scheduler was finishing the full reinitialization and clearing `needs_reinit` before the test assertion ran (race condition).

## Fix

### CDC reserved-name collision (`src/cdc.rs`, `src/dvm/operators/scan.rs`, `src/wal_decoder.rs`)

Introduce `cb_col_name(name: &str) -> String` which maps any reserved source column name to `__usr_{name}` in the change-buffer storage schema. All write paths and read paths are updated:

| Path | Change |
|------|--------|
| `build_typed_col_defs()` | Uses `cb_col_name()` for column DDL |
| `build_row_trigger_fn_sql()` | INSERT target list uses `cb_col_name()` |
| `build_stmt_trigger_fn_sql()` | INSERT target list uses `cb_col_name()` |
| `alter_change_buffer_add_columns()` | Existence check + ADD COLUMN use `cb_col_name()` |
| `poll_foreign_table_changes()` (foreign/matview) | INSERT target list uses `cb_col_name()` |
| `wal_decoder.rs` — UPDATE D+I path | `flat_col_names` and `data_col_names` use `cb_col_name()` |
| `wal_decoder.rs` — INSERT/DELETE path | `col_names` uses `cb_col_name()` |
| `scan.rs` — `col_refs` / `col_ref_aliased` | Reads `c."__usr_action"` (etc.) with alias to original name |
| `scan.rs` — keyless `col_refs_raw` | Same |
| `scan.rs` — `rewrite_predicate_for_scan()` | Applies `cb_col_name()` so pushed predicates use storage names |

The output alias in all scan CTEs is always the **original** column name, so downstream CTEs (`aggregate`, `join`, `filter`) are completely unaffected.

### Fuse race condition (`tests/e2e_fuse_tests.rs`)

Pause the scheduler (`pg_trickle.enabled = off`) around the `reset_fuse` / `needs_reinit` assertion, then re-enable it. This eliminates the window where the scheduler could process `needs_reinit=true` and clear it before the assertion runs.

## Tests

- 2096 unit tests pass (2 new: `test_cb_col_name_reserved_names`, `test_typed_col_defs_reserved_name_prefixed`)
- `just lint` / `just fmt` clean  
- `just check-upgrade-all` — all 45 upgrade steps PASSED
- `just test-unit` — 2096/2096 PASSED

## CI failures this fixes

- `test_anomaly_signals_detects_spikes` — `column "action" specified more than once`
- `test_cdc_health_no_false_alerts_for_df_sts` — same
- `test_cdc_insert_only_trigger_on_refresh_history` — same
- `test_control_plane_survives_df_st_suspension` — same
- `test_fuse_reset_reinitialize` — race condition on `needs_reinit`