### PR TITLE
fix: close all 6 Semgrep code-scanning alerts (725-730)

### DIFF
--- a/sql/pg_trickle--0.43.0--0.44.0.sql
+++ b/sql/pg_trickle--0.43.0--0.44.0.sql
@@ -15,7 +15,7 @@
 --             no SQL schema changes.
 --   A45-4:  Monitoring docker-compose credentials hardened — ops-only,
 --             no SQL schema changes.
---   A45-5:  SECURITY DEFINER CI check in scripts/check_security_definer.sh
+--   A45-5:  SECURITY DEFINER CI check in scripts/check_security_definer.sh -- nosemgrep: semgrep.sql.security-definer.present
 --             — CI change only, no SQL schema changes.
 --   A45-6:  docs/SECURITY_MODEL.md updated — docs change only.
 --   A45-7:  CDC module decomposed into rebuild + polling submodules —

--- a/src/api/helpers.rs
+++ b/src/api/helpers.rs
@@ -1117,7 +1117,7 @@ pub(super) fn warn_source_table_properties(source_relids: &[(pg_sys::Oid, String
 
         // A45-3: RLS bypass warning — if the source table has RLS enabled,
         // warn that source-table RLS does NOT protect stream-table contents.
-        // The refresh query runs as the superuser (SECURITY DEFINER), which
+        // The refresh query runs as the superuser (SECURITY DEFINER), which // nosemgrep: semgrep.sql.security-definer.present
         // bypasses RLS by default. To protect the stream table contents,
         // apply RLS directly on the stream table itself.
         let rls_enabled = Spi::get_one_with_args::<bool>(

--- a/src/cdc/polling.rs
+++ b/src/cdc/polling.rs
@@ -45,16 +45,16 @@ pub fn setup_foreign_table_polling(
         })?;
 
         // Create snapshot as an empty copy of the source table structure.
-        Spi::run(&format!(
+        // snapshot_table: extension-controlled name (change_schema + stable_name derived from OID);
+        // source_table: PostgreSQL's own regclass::text output — already properly quoted by the DB.
+        let create_snap_sql = format!(
             "CREATE TABLE IF NOT EXISTS {snapshot_table} (LIKE {source_table} INCLUDING ALL)"
-        ))
-        .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
+        );
+        Spi::run(&create_snap_sql).map_err(|e| PgTrickleError::SpiError(e.to_string()))?; // nosemgrep: semgrep.rust.spi.run.dynamic-format
 
         // Seed the snapshot with the current foreign table contents.
-        Spi::run(&format!(
-            "INSERT INTO {snapshot_table} SELECT * FROM {source_table}"
-        ))
-        .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
+        let seed_snap_sql = format!("INSERT INTO {snapshot_table} SELECT * FROM {source_table}");
+        Spi::run(&seed_snap_sql).map_err(|e| PgTrickleError::SpiError(e.to_string()))?; // nosemgrep: semgrep.rust.spi.run.dynamic-format
 
         // Record tracking with synthetic slot_name indicating polling CDC.
         Spi::run_with_args(
@@ -182,12 +182,11 @@ pub fn poll_foreign_table_changes(
     Spi::run(&inserted_sql).map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
 
     // ── Refresh snapshot — replace contents with current foreign table ──
-    Spi::run(&format!("TRUNCATE {snapshot_table}"))
-        .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
-    Spi::run(&format!(
-        "INSERT INTO {snapshot_table} SELECT * FROM {source_table}"
-    ))
-    .map_err(|e| PgTrickleError::SpiError(e.to_string()))?;
+    // snapshot_table: extension-controlled name; source_table: PostgreSQL regclass::text (safe).
+    let truncate_sql = format!("TRUNCATE {snapshot_table}");
+    Spi::run(&truncate_sql).map_err(|e| PgTrickleError::SpiError(e.to_string()))?; // nosemgrep: semgrep.rust.spi.run.dynamic-format
+    let refresh_sql = format!("INSERT INTO {snapshot_table} SELECT * FROM {source_table}");
+    Spi::run(&refresh_sql).map_err(|e| PgTrickleError::SpiError(e.to_string()))?; // nosemgrep: semgrep.rust.spi.run.dynamic-format
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Closes all 6 open GitHub Advanced Security code-scanning alerts introduced by PR #747 (v0.44.0 security hardening).

### Alerts 726-729 — `semgrep.rust.spi.run.dynamic-format` in `src/cdc/polling.rs`

- `snapshot_table`: extension-controlled name derived from `change_schema + stable_name(OID)` — never user input
- `source_table`: PostgreSQL's own `oid::regclass::text` output — already safely quoted by the DB engine

### Alert 725 — `semgrep.sql.security-definer.present` in `src/api/helpers.rs`

Add `// nosemgrep` to the comment that mentions SECURAdd `// nosemgrep` to the comment that mentions SECURAdd `// nosemgrep` to the comment that mentions SECURAdd `// nosemgrep` to the comment that mentions SECURAdd `// nosemgrep` to the c44.0Add `// nosemgrep` to the comment that mentions SECURAdd `// nosemgrep` to the comment that mentions SECURAxists Add `// nosemgrep` to the comment that mentions SECURAdd `// nosemgrep` to ust lint` — 0 clippy warnings, `check_security_definer.sh` passes (30 locations checked, 0 errors)
- `git diff --stat`: 3 files changed, 14 insertions(+), 15 deletions(-)