### PR TITLE
fix(dbt): add temporal and storage_backend params to create_or_replace_stream_table

### DIFF
--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -961,6 +961,10 @@ fn create_or_replace_stream_table(
     max_delta_fraction: default!(Option<f64>, "NULL"),
     // CITUS-7: Distribution column for the output (stream table storage) table.
     output_distribution_column: default!(Option<&str>, "NULL"),
+    // CORR-1/UX-1 (v0.36.0): temporal IVM mode
+    temporal: default!(bool, false),
+    // CORR-2/UX-3 (v0.36.0): columnar storage backend
+    storage_backend: default!(Option<&str>, "NULL"),
 ) {
     let result = create_or_replace_stream_table_impl(
         name,
@@ -977,6 +981,8 @@ fn create_or_replace_stream_table(
         max_differential_joins,
         max_delta_fraction,
         output_distribution_column,
+        temporal,
+        storage_backend,
     );
     if let Err(e) = result {
         raise_error_with_context(e);
@@ -1113,6 +1119,10 @@ fn create_or_replace_stream_table_impl(
     max_delta_fraction: Option<f64>,
     // CITUS-7: Distribution column for the output table (used only on first creation).
     output_distribution_column: Option<&str>,
+    // CORR-1/UX-1 (v0.36.0): temporal IVM mode (used only on first creation).
+    temporal_mode: bool,
+    // CORR-2/UX-3 (v0.36.0): columnar storage backend (used only on first creation).
+    storage_backend: Option<&str>,
 ) -> Result<(), PgTrickleError> {
     let (schema, table_name) = parse_qualified_name(name)?;
 
@@ -1205,8 +1215,8 @@ fn create_or_replace_stream_table_impl(
                 max_differential_joins,
                 max_delta_fraction,
                 output_distribution_column,
-                temporal_mode: false, // default off for create_or_replace
-                storage_backend: None,
+                temporal_mode,   // passed through from caller
+                storage_backend, // passed through from caller
             })
         }
         Err(e) => Err(e),


### PR DESCRIPTION
## Summary

The dbt adapter macro `pgtrickle_create_or_replace_stream_table` was updated in v0.36.0 to pass two new arguments — `temporal` and `storage_backend` — but the corresponding Rust `pg_extern` function was never updated to accept them. This caused all dbt integration and getting-started CI jobs to fail with:

```
function pgtrickle.create_or_replace_stream_table(unknown, unknown, unknown, unknown, boolean, unknown, unknown, unknown, boolean, boolean, unknown, unknown, unknown, unknown, boolean, unknown) does not exist
```

## Changes

- Added `temporal: default!(bool, false)` and `storage_backend: default!(Option<&str>, "NULL")` parameters to `create_or_replace_stream_table` (`#[pg_extern]`)
- Added the same two parameters to `create_or_replace_stream_table_impl`
- Threaded the values through to `create_stream_table_impl` on first creation (replacing the previous hardcoded `false` / `None` defaults)

## Testing

- `just lint` — passes (zero warnings)
- dbt integration CI: https://github.com/grove/pg-trickle/actions/runs/25275747110/job/74105343708 (was failing, fixed by this PR)
- dbt getting-started CI: https://github.com/grove/pg-trickle/actions/runs/25275747110/job/74105343642 (was failing, fixed by this PR)

## Notes

The `temporal` and `storage_backend` parameters only take effect on **first creation** (when the stream table does not yet exist). On subsequent idempotent calls the `create_or_replace` path delegates to `alter_stream_table_impl`, which handles config changes separately. This matches the existing behaviour for `partition_by` and `output_distribution_column`.
