### PR TITLE
fix(ci): fix preflight() cdc_mode column error and extend autorefresh timeout

### DIFF
--- a/src/api/diagnostics.rs
+++ b/src/api/diagnostics.rs
@@ -1667,9 +1667,9 @@ pub(super) fn preflight() -> String {
     let wal_level_val = Spi::get_one::<String>("SELECT current_setting('wal_level', true)")
         .unwrap_or(None)
         .unwrap_or_else(|| "unknown".to_string());
-    // pgt_change_tracking.cdc_mode stores the active CDC mechanism per source
+    // pgt_dependencies.cdc_mode stores the active CDC mechanism per source edge
     let wal_source_count: i64 = Spi::get_one::<i64>(
-        "SELECT COUNT(*) FROM pgtrickle.pgt_change_tracking WHERE cdc_mode = 'WAL'",
+        "SELECT COUNT(DISTINCT source_relid) FROM pgtrickle.pgt_dependencies WHERE cdc_mode = 'WAL'",
     )
     .unwrap_or(None)
     .unwrap_or(0);

--- a/tests/e2e_dag_autorefresh_tests.rs
+++ b/tests/e2e_dag_autorefresh_tests.rs
@@ -577,7 +577,8 @@ async fn run_autorefresh_trace(seed: u64, config: &TraceConfig) {
     // the invariants to actually hold.  Under load the scheduler may fire a
     // NO_DATA cycle before the initial inserts' CDC rows are ingested by l1,
     // so we use settle_auto_invariants which retries until convergence.
-    settle_auto_invariants(&db, seed, 0, "init", Duration::from_secs(60)).await;
+    // 90s timeout gives extra headroom for loaded CI environments.
+    settle_auto_invariants(&db, seed, 0, "init", Duration::from_secs(90)).await;
 
     for cycle in 1..=(config.cycles / 2).max(1) {
         let op = rng.usize_range(0, 100);
@@ -603,7 +604,8 @@ async fn run_autorefresh_trace(seed: u64, config: &TraceConfig) {
         // Wait for the cascade to propagate the DML change and verify
         // invariants hold.  Retries if wait_for_refresh_cycle returned early
         // on a NO_DATA cycle before the DML was processed.
-        settle_auto_invariants(&db, seed, cycle, "auto", Duration::from_secs(60)).await;
+        // 90s timeout gives extra headroom for loaded CI environments.
+        settle_auto_invariants(&db, seed, cycle, "auto", Duration::from_secs(90)).await;
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes two E2E test failures from CI run [#2109](https://github.com/grove/pg-trickle/actions/runs/25281547113):

1. **`preflight()` SQL error**: `preflight()` queried `pgt_change_tracking.cdc_mode` which does not exist — `cdc_mode` is on `pgt_dependencies`, not `pgt_change_tracking`. Fixed to query `pgt_dependencies` instead.
2. **`test_prop_autorefresh_no_spurious_changes` timeout**: The property-based autorefresh trace test used a 60 s timeout for each settle cycle, which was too tight under CI load. Extended to 90 s.

## Changes

- `src/api/diagnostics.rs`: Fix `preflight()` WAL-source count query — `cdc_mode` lives in `pgt_dependencies`, not `pgt_change_tracking`
- `tests/e2e_dag_autorefresh_tests.rs`: Extend `settle_auto_invariants` timeout from 60 s to 90 s in `run_autorefresh_trace`

## Testing

- `just test-unit` — passes (2120 tests)
- `just lint` — passes (clippy + fmt + security check)
- `cargo test --test e2e_preflight_tests` — 9/9 pass
- `cargo test --test e2e_dag_autorefresh_tests -- test_prop_autorefresh_no_spurious_changes` — passes
