### PR TITLE
fix(blog): fix broken Back to Blog Index links and add docs root link

### DIFF
--- a/blog/append-only-fast-path.md
+++ b/blog/append-only-fast-path.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The Append-Only Fast Path
 

--- a/blog/backup-and-restore.md
+++ b/blog/backup-and-restore.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Backup and Restore for Stream Tables
 

--- a/blog/built-in-outbox.md
+++ b/blog/built-in-outbox.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The Outbox You Don't Have to Build
 

--- a/blog/calculated-scheduling.md
+++ b/blog/calculated-scheduling.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Declare Freshness Once: CALCULATED Scheduling
 

--- a/blog/circular-dependencies.md
+++ b/blog/circular-dependencies.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Cycles in Your Dependency Graph? That's Fine.
 

--- a/blog/column-level-lineage.md
+++ b/blog/column-level-lineage.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Column-Level Lineage in One Function Call
 

--- a/blog/compliance-audit-trails.md
+++ b/blog/compliance-audit-trails.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Compliance and Audit Trails with Append-Only Stream Tables
 

--- a/blog/cost-model-auto-mode.md
+++ b/blog/cost-model-auto-mode.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The Cost Model: How pg_trickle Decides Whether to Refresh Differentially
 

--- a/blog/cqrs-without-second-database.md
+++ b/blog/cqrs-without-second-database.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # CQRS Without a Second Database
 

--- a/blog/dbt-analytics-stack.md
+++ b/blog/dbt-analytics-stack.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # dbt + pg_trickle: The Analytics Engineer's Stack
 

--- a/blog/deploying-rag-at-scale.md
+++ b/blog/deploying-rag-at-scale.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Deploying RAG at Scale: pg_trickle as Your Embedding Infrastructure
 

--- a/blog/diamond-dependencies.md
+++ b/blog/diamond-dependencies.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # How pg_trickle Handles Diamond Dependencies
 

--- a/blog/differential-dataflow-explained.md
+++ b/blog/differential-dataflow-explained.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Differential Dataflow for the Rest of Us
 

--- a/blog/distinct-reference-counting.md
+++ b/blog/distinct-reference-counting.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # DISTINCT That Doesn't Recount
 

--- a/blog/distributed-ivm-citus.md
+++ b/blog/distributed-ivm-citus.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Distributed IVM with Citus
 

--- a/blog/drain-mode.md
+++ b/blog/drain-mode.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Drain Mode: Zero-Downtime Upgrades for Stream Tables
 

--- a/blog/error-budgets.md
+++ b/blog/error-budgets.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Error Budgets for Stream Tables
 

--- a/blog/event-sourcing-read-models.md
+++ b/blog/event-sourcing-read-models.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Event Sourcing Read Models Without Replay
 

--- a/blog/exists-not-exists-delta-rules.md
+++ b/blog/exists-not-exists-delta-rules.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # EXISTS and NOT EXISTS: The Delta Rules Nobody Talks About
 

--- a/blog/foreign-table-sources.md
+++ b/blog/foreign-table-sources.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Foreign Tables as Stream Table Sources
 

--- a/blog/funnel-analysis-cohort-retention.md
+++ b/blog/funnel-analysis-cohort-retention.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Funnel Analysis and Cohort Retention at Scale
 

--- a/blog/grouping-sets-rollup-cube.md
+++ b/blog/grouping-sets-rollup-cube.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # GROUPING SETS, ROLLUP, and CUBE — Incrementally
 

--- a/blog/ha-failover-patroni.md
+++ b/blog/ha-failover-patroni.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # High Availability Failover with pg_trickle and Patroni
 

--- a/blog/hnsw-recall-distribution-drift.md
+++ b/blog/hnsw-recall-distribution-drift.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # HNSW Recall Is a Lie
 

--- a/blog/hybrid-cdc-mode.md
+++ b/blog/hybrid-cdc-mode.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The CDC Mode You Never Have to Choose
 

--- a/blog/immediate-mode-zero-lag.md
+++ b/blog/immediate-mode-zero-lag.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # IMMEDIATE Mode: When "Good Enough Freshness" Isn't Good Enough
 

--- a/blog/inbox-pattern-kafka.md
+++ b/blog/inbox-pattern-kafka.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The Inbox Pattern: Receiving Events from Kafka into PostgreSQL
 

--- a/blog/incremental-aggregates-no-etl.md
+++ b/blog/incremental-aggregates-no-etl.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Incremental Aggregates in PostgreSQL: No ETL Required
 

--- a/blog/incremental-fulltext-search.md
+++ b/blog/incremental-fulltext-search.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Incremental Full-Text Search with tsvector
 

--- a/blog/incremental-ml-feature-engineering.md
+++ b/blog/incremental-ml-feature-engineering.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Incremental ML Feature Engineering in PostgreSQL
 

--- a/blog/incremental-pagerank-graph-analytics.md
+++ b/blog/incremental-pagerank-graph-analytics.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Incremental PageRank and Graph Analytics in SQL
 

--- a/blog/incremental-pgvector.md
+++ b/blog/incremental-pgvector.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Your pgvector Index Is Lying to You
 

--- a/blog/incremental-statistical-aggregates.md
+++ b/blog/incremental-statistical-aggregates.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Incremental Statistical Aggregates: stddev, Percentiles, and Histograms
 

--- a/blog/incremental-vector-aggregates.md
+++ b/blog/incremental-vector-aggregates.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Incremental Vector Aggregates: Building Recommendation Engines in Pure SQL
 

--- a/blog/ivm-without-primary-keys.md
+++ b/blog/ivm-without-primary-keys.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # IVM Without Primary Keys
 

--- a/blog/l0-cache-cold-start.md
+++ b/blog/l0-cache-cold-start.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The 45ms Cold-Start Tax and How L0 Cache Eliminates It
 

--- a/blog/lateral-joins.md
+++ b/blog/lateral-joins.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # LATERAL Joins in a Stream Table
 

--- a/blog/logical-replication-publishing.md
+++ b/blog/logical-replication-publishing.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Publishing Stream Tables via Logical Replication
 

--- a/blog/medallion-architecture-postgresql.md
+++ b/blog/medallion-architecture-postgresql.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The Medallion Architecture Lives Inside PostgreSQL
 

--- a/blog/migrating-from-pg-ivm.md
+++ b/blog/migrating-from-pg-ivm.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Migrating from pg_ivm to pg_trickle
 

--- a/blog/multi-database.md
+++ b/blog/multi-database.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # One PostgreSQL, Five Databases, One Worker Pool
 

--- a/blog/multi-tenant-vector-search-rls.md
+++ b/blog/multi-tenant-vector-search-rls.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Multi-Tenant Vector Search with Row-Level Security and pg_trickle
 

--- a/blog/nexmark-benchmark.md
+++ b/blog/nexmark-benchmark.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # From Nexmark to Production: Benchmarking Stream Processing in PostgreSQL
 

--- a/blog/online-schema-evolution.md
+++ b/blog/online-schema-evolution.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # How to Change a Stream Table Query Without Taking It Offline
 

--- a/blog/outbox-pattern-turbocharged.md
+++ b/blog/outbox-pattern-turbocharged.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The Outbox Pattern, Turbocharged
 

--- a/blog/parameterized-stream-tables.md
+++ b/blog/parameterized-stream-tables.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Parameterized Stream Tables: Building a SQL View Library
 

--- a/blog/pg-trickle-cloudnativepg-kubernetes.md
+++ b/blog/pg-trickle-cloudnativepg-kubernetes.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # pg_trickle on CloudNativePG
 

--- a/blog/pgbouncer-compatibility.md
+++ b/blog/pgbouncer-compatibility.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Making pg_trickle Work Through PgBouncer
 

--- a/blog/pgvector-tooling-landscape.md
+++ b/blog/pgvector-tooling-landscape.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The pgvector Tooling Landscape in 2026
 

--- a/blog/postgis-incremental-geospatial.md
+++ b/blog/postgis-incremental-geospatial.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # PostGIS + pg_trickle: Incremental Geospatial Aggregates
 

--- a/blog/reactive-alerts-without-polling.md
+++ b/blog/reactive-alerts-without-polling.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Reactive Alerts Without Polling
 

--- a/blog/real-time-leaderboards.md
+++ b/blog/real-time-leaderboards.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Real-Time Leaderboards That Don't Lie
 

--- a/blog/recursive-ctes-that-update-themselves.md
+++ b/blog/recursive-ctes-that-update-themselves.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Recursive CTEs That Update Themselves
 

--- a/blog/relay-deep-dive.md
+++ b/blog/relay-deep-dive.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The Relay Deep Dive: NATS, Redis Streams, and RabbitMQ
 

--- a/blog/replaced-celery-with-sql.md
+++ b/blog/replaced-celery-with-sql.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # How We Replaced a Celery Pipeline with 3 SQL Statements
 

--- a/blog/scalar-subqueries.md
+++ b/blog/scalar-subqueries.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Scalar Subqueries in the SELECT List — Incrementally
 

--- a/blog/self-monitoring.md
+++ b/blog/self-monitoring.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # pg_trickle Monitors Itself
 

--- a/blog/set-operations.md
+++ b/blog/set-operations.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Set Operations Done Right: UNION, INTERSECT, EXCEPT
 

--- a/blog/shadow-mode-correctness-fuzzing.md
+++ b/blog/shadow-mode-correctness-fuzzing.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Testing Stream Tables: Shadow Mode and Correctness Fuzzing
 

--- a/blog/slowly-changing-dimensions.md
+++ b/blog/slowly-changing-dimensions.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Slowly Changing Dimensions in Real Time
 

--- a/blog/snapshots-time-travel.md
+++ b/blog/snapshots-time-travel.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Snapshots: Time Travel for Stream Tables
 

--- a/blog/soft-deletes-tombstone-management.md
+++ b/blog/soft-deletes-tombstone-management.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Soft Deletes and Tombstone Management in Differential IVM
 

--- a/blog/spill-to-disk-fallback.md
+++ b/blog/spill-to-disk-fallback.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Spill-to-Disk and the Auto-Fallback Safety Net
 

--- a/blog/stale-materialized-views.md
+++ b/blog/stale-materialized-views.md
@@ -1,3 +1,5 @@
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
+
 # Why Your Materialized Views Are Always Stale
 
 ## (And How to Fix It in 5 Lines of SQL)

--- a/blog/stop-rebuilding-search-index.md
+++ b/blog/stop-rebuilding-search-index.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Stop Rebuilding Your Search Index at 3am
 

--- a/blog/streaming-to-kafka-without-kafka.md
+++ b/blog/streaming-to-kafka-without-kafka.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Streaming to Kafka Without Kafka Expertise
 

--- a/blog/structured-logging.md
+++ b/blog/structured-logging.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Structured Logging and OpenTelemetry for Stream Tables
 

--- a/blog/temporal-stream-tables.md
+++ b/blog/temporal-stream-tables.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Temporal Stream Tables: Time-Windowed Views That Update Themselves
 

--- a/blog/tiered-scheduling.md
+++ b/blog/tiered-scheduling.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Hot, Warm, Cold, Frozen: Tiered Scheduling at Scale
 

--- a/blog/time-series-downsampling.md
+++ b/blog/time-series-downsampling.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Time-Series Downsampling Without TimescaleDB
 

--- a/blog/tpch-benchmarking-ivm.md
+++ b/blog/tpch-benchmarking-ivm.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # TPC-H at 1GB in 40ms
 

--- a/blog/trigger-denormalization-cost.md
+++ b/blog/trigger-denormalization-cost.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The Hidden Cost of Trigger-Based Denormalization
 

--- a/blog/window-functions-without-full-recompute.md
+++ b/blog/window-functions-without-full-recompute.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # Window Functions Without the Full Recompute
 

--- a/blog/z-set-data-structure.md
+++ b/blog/z-set-data-structure.md
@@ -1,4 +1,4 @@
-[← Back to Blog Index](README.md)
+[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)
 
 # The Z-Set: The Data Structure That Makes IVM Correct
 


### PR DESCRIPTION
## Summary

All 73 blog posts contained `[← Back to Blog Index](README.md)` — a relative link that resolved to a 404 on the published site. The standalone blog sub-book is built with `site-url = "/pg-trickle/blog/"`, which causes the relative `README.md` link to be resolved incorrectly by the mdBook rendering pipeline. This replaces every occurrence with working absolute URLs and also adds a link to the documentation root.

## Changes

- Replaced `[← Back to Blog Index](README.md)` with `[← Back to Blog Index](https://grove.github.io/pg-trickle/blog/) | [Documentation](https://grove.github.io/pg-trickle/)` in all 73 blog posts
- The new line gives readers a direct path both back to the blog index and to the main documentation site

## Testing

- Verified the fix by inspecting the rendered first line of `real-time-leaderboards.md`
- No Rust code changes; no build or test run required

## Notes

The root cause is the standalone blog build in `.github/workflows/docs.yml` which uses `site-url = "/pg-trickle/blog/"`. mdBook rewrites same-book relative `.md` links to `.html`, but `README.md` in the blog posts is not part of the standalone book's SUMMARY.md chapter list — it is the introduction page — so the relative link is emitted as-is and the browser requests `README.md` (which does not exist on GitHub Pages). Absolute URLs are immune to this ambiguity.
