### PR TITLE
docs(blog): add documentation link and expand informational note

### DIFF
--- a/blog/README.md
+++ b/blog/README.md
@@ -4,7 +4,11 @@
 > AI assistance (GitHub Copilot / Claude) as a way to explore how well
 > LLM-generated technical writing holds up for a niche systems engineering
 > topic. The technical content has been reviewed for accuracy, but treat the
-> posts as drafts — not as officially reviewed documentation.
+> posts as drafts — not as officially reviewed documentation. The blog is meant
+> for informative purposes — to learn about interesting topics in the context of
+> pg_trickle. It is a showcase for use-cases rather than a definitive
+> reference; for authoritative documentation see the
+> [pg_trickle documentation](https://grove.github.io/pg-trickle/).
 
 ---
 


### PR DESCRIPTION
## Summary

Extends the note at the top of `blog/README.md` to make the purpose of the
blog directory clearer: it is meant for informative, use-case-oriented writing
rather than authoritative reference material. A link to the official
pg_trickle documentation site is added so readers can easily navigate to the
canonical docs.

## Changes

- Expanded the opening note in `blog/README.md` to state that the blog is
  intended for informative purposes — to learn about interesting topics in the
  context of pg_trickle — and that it is a showcase of use-cases rather than a
  definitive reference.
- Added a hyperlink to the documentation root at
  <https://grove.github.io/pg-trickle/> at the end of the note.

## Testing

Documentation-only change — no code or SQL altered.

- `just fmt && just lint` — not applicable (Markdown only)
- Manual review of the rendered Markdown confirms the link and wording are
  correct.

## Notes

No migration steps required. This is a pure documentation improvement.
