### PR TITLE
fix(outbox): use to_regprocedure for pg_tide presence check

### DIFF
--- a/src/api/outbox.rs
+++ b/src/api/outbox.rs
@@ -98,8 +98,9 @@ fn attach_outbox_impl(
     let meta = StreamTableMeta::get_by_name(&schema, &st_name)?;
 
     // Check that pg_tide is installed.
+    // `to_regprocedure` accepts argument-type lists; `to_regproc` does not.
     let pg_tide_present = Spi::get_one::<bool>(
-        "SELECT to_regproc('tide.outbox_create(text,integer,integer)') IS NOT NULL",
+        "SELECT to_regprocedure('tide.outbox_create(text,integer,integer)') IS NOT NULL",
     )
     .unwrap_or(None)
     .unwrap_or(false);


### PR DESCRIPTION
## Summary

`attach_outbox()` was using `to_regproc()` with a full function signature
(`tide.outbox_create(text,integer,integer)`). PostgreSQL's `to_regproc` does
not accept argument-type lists — it only accepts a bare function name —
so it always returned NULL, causing `attach_outbox()` to raise
`PgTideMissing` even when the pg_tide stub (or the real extension) was
installed. The fix is to use `to_regprocedure()`, which does parse
argument-type lists and is the correct built-in for this use case.

## Root Cause

```sql
-- WRONG: to_regproc ignores / cannot parse the argument-type list
SELECT to_regproc('tide.outbox_create(text,integer,integer)') IS NOT NULL;
-- always returns FALSE because there is no function literally named
-- "outbox_create(text,integer,integer)"

-- CORRECT: to_regprocedure parses the full signature
SELECT to_regprocedure('tide.outbox_create(text,integer,integer)') IS NOT NULL;
-- returns TRUE when tide.outbox_create(text,integer,integer) exists
```

## Changes

- `src/api/outbox.rs`: replace `to_regproc` with `to_regprocedure` in the
  pg_tide presence check inside `attach_outbox_impl`.

## Testing

- `just fmt && just lint` — passes (zero warnings)
- Fixes CI run #2121 (`e2e_outbox_tests` — all 9 tests in the failing suite):
  - `test_attach_outbox_creates_catalog_entry`
  - `test_attach_outbox_fails_on_duplicate`
  - `test_attach_outbox_publish_called_on_refresh`
  - `test_attach_outbox_stores_tide_outbox_name`
  - and the remaining outbox tests

## Notes

The companion test `test_attach_outbox_fails_without_pg_tide` (TIDE-3)
continues to work correctly because `to_regprocedure` returns NULL (not
an error) when the function does not exist, preserving the expected
"pg_tide absent" error path.
