### PR TITLE
fix(sql): stub out removed inbox/outbox/consumer C wrappers in archive SQL

### DIFF
--- a/sql/archive/pg_trickle--0.28.0.sql
+++ b/sql/archive/pg_trickle--0.28.0.sql
@@ -632,9 +632,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"p_with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -675,9 +673,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -687,9 +683,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -735,8 +729,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -801,9 +794,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -830,9 +821,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -842,9 +831,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -873,9 +860,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -886,9 +871,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -903,9 +886,7 @@ AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -957,9 +938,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -968,9 +947,7 @@ AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1034,9 +1011,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1140,9 +1115,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1186,9 +1159,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1236,9 +1207,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1452,9 +1421,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1841,9 +1808,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1884,9 +1849,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2102,9 +2065,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2115,9 +2076,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2172,9 +2131,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2209,9 +2166,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2316,8 +2271,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.29.0.sql
+++ b/sql/archive/pg_trickle--0.29.0.sql
@@ -632,9 +632,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"p_with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -675,9 +673,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -687,9 +683,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -735,8 +729,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -801,9 +794,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -830,9 +821,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -842,9 +831,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -873,9 +860,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -886,9 +871,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -903,9 +886,7 @@ AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -957,9 +938,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -968,9 +947,7 @@ AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1034,9 +1011,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1140,9 +1115,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1186,9 +1159,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1236,9 +1207,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1452,9 +1421,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1841,9 +1808,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1884,9 +1849,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2102,9 +2065,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2115,9 +2076,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2172,9 +2131,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2209,9 +2166,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2316,8 +2271,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.30.0.sql
+++ b/sql/archive/pg_trickle--0.30.0.sql
@@ -702,9 +702,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -731,9 +729,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -795,8 +791,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -839,9 +834,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -907,9 +900,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -929,9 +920,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -957,9 +946,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -968,9 +955,7 @@ AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -993,9 +978,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1128,9 +1111,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1174,9 +1155,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1249,9 +1228,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1324,9 +1301,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1354,9 +1329,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1459,9 +1432,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1521,9 +1492,7 @@ AS 'MODULE_PATHNAME', 'health_summary_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1795,9 +1764,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1881,9 +1848,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1914,9 +1879,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2022,9 +1985,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2034,9 +1995,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2124,8 +2083,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2354,9 +2312,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2456,9 +2412,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.31.0.sql
+++ b/sql/archive/pg_trickle--0.31.0.sql
@@ -693,9 +693,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -851,9 +849,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -952,9 +948,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -970,9 +964,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1069,9 +1061,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1230,9 +1220,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1279,9 +1267,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1331,9 +1317,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1360,9 +1344,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1399,9 +1381,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1419,9 +1399,7 @@ AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1621,9 +1599,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1742,9 +1718,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1754,9 +1728,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1937,9 +1909,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1965,9 +1935,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2042,9 +2010,7 @@ AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2134,9 +2100,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2161,9 +2125,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2245,9 +2207,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2357,9 +2317,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2586,9 +2544,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2631,8 +2587,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2664,8 +2619,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.32.0.sql
+++ b/sql/archive/pg_trickle--0.32.0.sql
@@ -728,9 +728,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -770,9 +768,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -803,9 +799,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -847,9 +841,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -883,8 +875,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -992,9 +983,7 @@ AS 'MODULE_PATHNAME', 'cluster_worker_summary_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1074,9 +1063,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1107,9 +1094,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1135,8 +1120,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1422,9 +1406,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1493,9 +1475,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1555,9 +1535,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1568,9 +1546,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1660,9 +1636,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1844,9 +1818,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1936,9 +1908,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1995,9 +1965,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2022,9 +1990,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2070,9 +2036,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2188,9 +2152,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2251,9 +2213,7 @@ AS 'MODULE_PATHNAME', 'recommend_schedule_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2263,9 +2223,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2572,9 +2530,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2610,9 +2566,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.33.0.sql
+++ b/sql/archive/pg_trickle--0.33.0.sql
@@ -800,9 +800,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -835,8 +833,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -852,9 +849,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1275,9 +1270,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1361,9 +1354,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1477,9 +1468,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1551,8 +1540,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1638,9 +1626,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1712,9 +1698,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1725,9 +1709,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1737,9 +1719,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1749,9 +1729,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1762,9 +1740,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1774,9 +1750,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1803,9 +1777,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1949,9 +1921,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2016,9 +1986,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2094,9 +2062,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2117,9 +2083,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2423,9 +2387,7 @@ AS 'MODULE_PATHNAME', 'source_gates_fn_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2556,9 +2518,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2624,9 +2584,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2635,9 +2593,7 @@ AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2728,9 +2684,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.34.0.sql
+++ b/sql/archive/pg_trickle--0.34.0.sql
@@ -814,9 +814,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -849,8 +847,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -866,9 +863,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1289,9 +1284,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1375,9 +1368,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1491,9 +1482,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1565,8 +1554,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1652,9 +1640,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1726,9 +1712,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1739,9 +1723,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1751,9 +1733,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1763,9 +1743,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1776,9 +1754,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1788,9 +1764,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1817,9 +1791,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1963,9 +1935,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2030,9 +2000,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2108,9 +2076,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2131,9 +2097,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2437,9 +2401,7 @@ AS 'MODULE_PATHNAME', 'source_gates_fn_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2570,9 +2532,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2638,9 +2598,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2649,9 +2607,7 @@ AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2742,9 +2698,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.35.0.sql
+++ b/sql/archive/pg_trickle--0.35.0.sql
@@ -827,9 +827,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -862,8 +860,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -879,9 +876,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1302,9 +1297,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1388,9 +1381,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1504,9 +1495,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1578,8 +1567,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1665,9 +1653,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1739,9 +1725,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1752,9 +1736,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1764,9 +1746,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1776,9 +1756,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1789,9 +1767,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1801,9 +1777,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1830,9 +1804,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1976,9 +1948,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2043,9 +2013,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2121,9 +2089,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2144,9 +2110,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2450,9 +2414,7 @@ AS 'MODULE_PATHNAME', 'source_gates_fn_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2583,9 +2545,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2651,9 +2611,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2662,9 +2620,7 @@ AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2755,9 +2711,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.36.0.sql
+++ b/sql/archive/pg_trickle--0.36.0.sql
@@ -772,9 +772,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -792,9 +790,7 @@ AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -807,9 +803,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -832,9 +826,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1183,9 +1175,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1248,8 +1238,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1275,9 +1264,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1361,9 +1348,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1411,9 +1396,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1469,9 +1452,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1490,9 +1471,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1518,9 +1497,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1609,9 +1586,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1903,9 +1878,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1949,9 +1922,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1976,9 +1947,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1987,9 +1956,7 @@ AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2035,9 +2002,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2149,9 +2114,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2196,9 +2159,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2454,8 +2415,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2486,9 +2446,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2499,9 +2457,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2643,9 +2599,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.37.0.sql
+++ b/sql/archive/pg_trickle--0.37.0.sql
@@ -772,9 +772,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -792,9 +790,7 @@ AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -807,9 +803,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -832,9 +826,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1183,9 +1175,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1248,8 +1238,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1275,9 +1264,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1361,9 +1348,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1411,9 +1396,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1469,9 +1452,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1490,9 +1471,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1518,9 +1497,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1609,9 +1586,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1903,9 +1878,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1949,9 +1922,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1976,9 +1947,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1987,9 +1956,7 @@ AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2035,9 +2002,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2149,9 +2114,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2196,9 +2159,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2454,8 +2415,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2486,9 +2446,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2499,9 +2457,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2643,9 +2599,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.38.0.sql
+++ b/sql/archive/pg_trickle--0.38.0.sql
@@ -777,9 +777,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -843,9 +841,7 @@ AS 'MODULE_PATHNAME', 'refresh_timeline_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -860,9 +856,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -940,9 +934,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1015,9 +1007,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1139,9 +1129,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1362,9 +1350,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1461,8 +1447,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1817,9 +1802,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1882,9 +1865,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1930,9 +1911,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1942,9 +1921,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1978,9 +1955,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2421,9 +2396,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2446,9 +2419,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2458,9 +2429,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2470,9 +2439,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2499,9 +2466,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2511,9 +2476,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2526,9 +2489,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2736,9 +2697,7 @@ AS 'MODULE_PATHNAME', 'sla_summary_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2840,8 +2799,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2851,9 +2809,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2918,9 +2874,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.39.0.sql
+++ b/sql/archive/pg_trickle--0.39.0.sql
@@ -826,9 +826,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -858,9 +856,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -920,9 +916,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -940,8 +934,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -959,9 +952,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1152,9 +1143,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1191,9 +1180,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1214,9 +1201,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1473,8 +1458,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1531,9 +1515,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1577,9 +1559,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1604,9 +1584,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1617,9 +1595,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1685,9 +1661,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2055,9 +2029,7 @@ COMMENT ON FUNCTION pgtrickle."refresh_if_stale"(text, interval) IS
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2077,9 +2049,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2260,9 +2230,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2278,9 +2246,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2636,9 +2602,7 @@ AS 'MODULE_PATHNAME', 'subscribe_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2695,9 +2659,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2734,9 +2696,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2762,9 +2722,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2855,9 +2813,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2892,9 +2848,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.40.0.sql
+++ b/sql/archive/pg_trickle--0.40.0.sql
@@ -826,9 +826,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -858,9 +856,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -920,9 +916,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -940,8 +934,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -959,9 +952,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1152,9 +1143,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1191,9 +1180,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1214,9 +1201,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1473,8 +1458,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1531,9 +1515,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1577,9 +1559,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1604,9 +1584,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1617,9 +1595,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1685,9 +1661,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2055,9 +2029,7 @@ COMMENT ON FUNCTION pgtrickle."refresh_if_stale"(text, interval) IS
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2077,9 +2049,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2260,9 +2230,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2278,9 +2246,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2636,9 +2602,7 @@ AS 'MODULE_PATHNAME', 'subscribe_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2695,9 +2659,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2734,9 +2696,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2762,9 +2722,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2855,9 +2813,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2892,9 +2848,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.41.0.sql
+++ b/sql/archive/pg_trickle--0.41.0.sql
@@ -826,9 +826,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -858,9 +856,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -920,9 +916,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -940,8 +934,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -959,9 +952,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1152,9 +1143,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1191,9 +1180,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1214,9 +1201,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1473,8 +1458,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1531,9 +1515,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1577,9 +1559,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1604,9 +1584,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1617,9 +1595,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1685,9 +1661,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2055,9 +2029,7 @@ COMMENT ON FUNCTION pgtrickle."refresh_if_stale"(text, interval) IS
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2077,9 +2049,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2260,9 +2230,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2278,9 +2246,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2636,9 +2602,7 @@ AS 'MODULE_PATHNAME', 'subscribe_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2695,9 +2659,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2734,9 +2696,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2762,9 +2722,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2855,9 +2813,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2892,9 +2848,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.42.0.sql
+++ b/sql/archive/pg_trickle--0.42.0.sql
@@ -776,9 +776,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -838,8 +836,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -896,9 +893,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1017,9 +1012,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1041,9 +1034,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1063,9 +1054,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1182,8 +1171,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1193,9 +1181,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1287,9 +1273,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1316,9 +1300,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1354,9 +1336,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1494,9 +1474,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1572,9 +1550,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1771,9 +1747,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1847,9 +1821,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1879,9 +1851,7 @@ AS 'MODULE_PATHNAME', 'refresh_efficiency_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2047,9 +2017,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2059,9 +2027,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2347,9 +2313,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2519,9 +2483,7 @@ AS 'MODULE_PATHNAME', 'pgt_scc_status_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2531,9 +2493,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2719,9 +2679,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2789,9 +2747,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2891,9 +2847,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.43.0.sql
+++ b/sql/archive/pg_trickle--0.43.0.sql
@@ -923,9 +923,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -976,9 +974,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1077,9 +1073,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1132,9 +1126,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1202,9 +1194,7 @@ AS 'MODULE_PATHNAME', 'bulk_create_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1469,9 +1459,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1486,9 +1474,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1516,9 +1502,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1594,9 +1578,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1614,9 +1596,7 @@ AS 'MODULE_PATHNAME', 'convert_buffers_to_unlogged_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1626,9 +1606,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1639,9 +1617,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1662,9 +1638,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1689,9 +1663,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2012,9 +1984,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2076,9 +2046,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2096,8 +2064,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2107,9 +2074,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2341,9 +2306,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2626,8 +2589,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2725,9 +2687,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2737,9 +2697,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2749,9 +2707,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2904,9 +2860,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.44.0.sql
+++ b/sql/archive/pg_trickle--0.44.0.sql
@@ -767,9 +767,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -929,9 +927,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1074,9 +1070,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1190,9 +1184,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1317,9 +1309,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1380,9 +1370,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1404,9 +1392,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1470,9 +1456,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1491,9 +1475,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1779,8 +1761,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1806,9 +1787,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1910,8 +1889,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1933,9 +1911,7 @@ AS 'MODULE_PATHNAME', 'dedup_stats_fn_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1945,9 +1921,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1958,9 +1932,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2063,9 +2035,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2146,9 +2116,7 @@ AS 'MODULE_PATHNAME', 'restore_from_snapshot_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2159,9 +2127,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2249,9 +2215,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2274,9 +2238,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2329,9 +2291,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2341,9 +2301,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2353,9 +2311,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2466,9 +2422,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.45.0.sql
+++ b/sql/archive/pg_trickle--0.45.0.sql
@@ -799,9 +799,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_priority"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -847,9 +845,7 @@ AS 'MODULE_PATHNAME', 'repair_stream_table_wrapper';
 CREATE  FUNCTION pgtrickle."inbox_health"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -877,9 +873,7 @@ CREATE  FUNCTION pgtrickle."seek_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_new_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -928,9 +922,7 @@ CREATE  FUNCTION pgtrickle."poll_outbox"(
 	"is_claim_check" bool,  /* bool */
 	"payload" jsonb  /* Option < pgrx :: JsonB > */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -945,9 +937,7 @@ CREATE  FUNCTION pgtrickle."create_inbox"(
 	"with_stats" bool DEFAULT true, /* bool */
 	"p_retention_hours" INT DEFAULT 72 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1066,9 +1056,7 @@ CREATE  FUNCTION pgtrickle."commit_offset"(
 	"p_consumer" TEXT, /* & str */
 	"p_last_offset" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1087,9 +1075,7 @@ CREATE  FUNCTION pgtrickle."consumer_heartbeat"(
 	"p_group" TEXT, /* & str */
 	"p_consumer" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1162,9 +1148,7 @@ CREATE  FUNCTION pgtrickle."disable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1220,9 +1204,7 @@ CREATE  FUNCTION pgtrickle."extend_lease"(
 	"p_consumer" TEXT, /* & str */
 	"p_extension_seconds" INT DEFAULT 30 /* i32 */
 ) RETURNS timestamp with time zone /* Option < TimestampWithTimeZone > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1368,8 +1350,7 @@ CREATE  FUNCTION pgtrickle."inbox_status"(
 	"created_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
 )
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1511,9 +1492,7 @@ CREATE  FUNCTION pgtrickle."outbox_rows_consumed"(
 	"p_stream_table" TEXT, /* & str */
 	"p_outbox_id" bigint /* i64 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1815,9 +1794,7 @@ CREATE  FUNCTION pgtrickle."consumer_lag"(
 	"last_heartbeat_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
 	"is_alive" bool  /* bool */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1849,9 +1826,7 @@ CREATE  FUNCTION pgtrickle."disable_inbox_ordering"(
 	"p_inbox" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1869,9 +1844,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_tracking"(
 	"p_max_retries" INT DEFAULT 3, /* i32 */
 	"p_schedule" TEXT DEFAULT '1s' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1884,9 +1857,7 @@ CREATE  FUNCTION pgtrickle."inbox_ordering_gaps"(
 	"expected_seq" bigint,  /* i64 */
 	"found_seq" bigint  /* i64 */
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2061,9 +2032,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_ordering"(
 	"p_aggregate_id_col" TEXT, /* & str */
 	"p_sequence_num_col" TEXT /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2251,9 +2220,7 @@ AS 'MODULE_PATHNAME', 'sql_handle_vp_promoted_wrapper';
 CREATE  FUNCTION pgtrickle."outbox_status"(
 	"p_name" TEXT /* & str */
 ) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2292,9 +2259,7 @@ CREATE  FUNCTION pgtrickle."enable_outbox"(
 	"p_name" TEXT, /* & str */
 	"p_retention_hours" INT DEFAULT 24 /* i32 */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2378,9 +2343,7 @@ CREATE  FUNCTION pgtrickle."drop_consumer_group"(
 	"p_name" TEXT, /* & str */
 	"p_if_exists" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2536,9 +2499,7 @@ CREATE  FUNCTION pgtrickle."drop_inbox"(
 	"p_if_exists" bool DEFAULT false, /* bool */
 	"p_cascade" bool DEFAULT false /* bool */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2575,9 +2536,7 @@ CREATE  FUNCTION pgtrickle."inbox_is_my_partition"(
 	"p_worker_id" INT, /* i32 */
 	"p_total_workers" INT /* i32 */
 ) RETURNS bool /* bool */
-IMMUTABLE STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+IMMUTABLE LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2641,9 +2600,7 @@ CREATE  FUNCTION pgtrickle."create_consumer_group"(
 	"p_outbox" TEXT, /* & str */
 	"p_auto_offset_reset" TEXT DEFAULT 'latest' /* & str */
 ) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2655,8 +2612,7 @@ CREATE  FUNCTION pgtrickle."enable_inbox_priority"(
 	"p_tiers" jsonb DEFAULT NULL /* Option < pgrx :: JsonB > */
 ) RETURNS void
 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2689,9 +2645,7 @@ CREATE  FUNCTION pgtrickle."replay_inbox_messages"(
 	"p_name" TEXT, /* & str */
 	"p_event_ids" TEXT[] /* Vec < String > */
 ) RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/pg_trickle--0.27.0--0.28.0.sql
+++ b/sql/pg_trickle--0.27.0--0.28.0.sql
@@ -167,8 +167,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."enable_outbox"(
     p_name            text,
     p_retention_hours integer DEFAULT 24
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.enable_outbox(text, integer) IS
 'OUTBOX-1 (v0.28.0): Enable the transactional outbox pattern for a stream table.
@@ -181,8 +180,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."disable_outbox"(
     p_name       text,
     p_if_exists  boolean DEFAULT false
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.disable_outbox(text, boolean) IS
 'OUTBOX-2 (v0.28.0): Disable the transactional outbox pattern for a stream table.
@@ -193,8 +191,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."outbox_status"(
     p_name  text
 ) RETURNS jsonb
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.outbox_status(text) IS
 'OUTBOX-3 (v0.28.0): Return a JSONB summary of the outbox state for a stream table.
@@ -207,8 +204,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."outbox_rows_consumed"(
     p_outbox_id     bigint
 ) RETURNS void
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'outbox_rows_consumed_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.outbox_rows_consumed(text, bigint) IS
 'OUTBOX-6 (v0.28.0): Mark outbox rows up to p_outbox_id as consumed.
@@ -221,8 +217,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."create_consumer_group"(
     p_outbox            text,
     p_auto_offset_reset text DEFAULT 'latest'
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.create_consumer_group(text, text, text) IS
 'OUTBOX-B1 (v0.28.0): Create a named consumer group for an outbox.
@@ -233,8 +228,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."drop_consumer_group"(
     p_name       text,
     p_if_exists  boolean DEFAULT false
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_consumer_group_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.drop_consumer_group(text, boolean) IS
 'OUTBOX-B2 (v0.28.0): Drop a consumer group and all associated offsets/leases.';
@@ -254,8 +248,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."poll_outbox"(
     is_claim_check  boolean,
     payload         jsonb
 )
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'poll_outbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.poll_outbox(text, text, integer, integer) IS
 'OUTBOX-B3 (v0.28.0): Poll the outbox for new messages as a consumer.
@@ -269,8 +262,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."commit_offset"(
     p_last_offset  bigint
 ) RETURNS void
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'commit_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.commit_offset(text, text, bigint) IS
 'OUTBOX-B4 (v0.28.0): Commit the consumed offset for a consumer in a group.
@@ -282,8 +274,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."extend_lease"(
     p_consumer           text,
     p_extension_seconds  integer DEFAULT 30
 ) RETURNS timestamptz
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'extend_lease_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.extend_lease(text, text, integer) IS
 'OUTBOX-B4 (v0.28.0): Extend the visibility lease for an in-flight batch.
@@ -296,8 +287,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."seek_offset"(
     p_new_offset  bigint
 ) RETURNS void
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'seek_offset_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.seek_offset(text, text, bigint) IS
 'OUTBOX-B4 (v0.28.0): Seek a consumer to a specific offset (for replay/reset).';
@@ -308,8 +298,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."consumer_heartbeat"(
     p_consumer  text
 ) RETURNS void
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_heartbeat_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.consumer_heartbeat(text, text) IS
 'OUTBOX-B5 (v0.28.0): Send a heartbeat from a consumer to signal liveness.';
@@ -326,8 +315,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."consumer_lag"(
     is_alive          boolean
 )
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'consumer_lag_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.consumer_lag(text) IS
 'OUTBOX-B6 (v0.28.0): Return per-consumer lag metrics for a consumer group.';
@@ -342,8 +330,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."create_inbox"(
     with_stats         boolean DEFAULT true,
     p_retention_hours  integer DEFAULT 72
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.create_inbox(text, text, integer, text, boolean, boolean, integer) IS
 'INBOX-1 (v0.28.0): Create a named transactional inbox with managed stream tables.
@@ -355,8 +342,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."drop_inbox"(
     p_if_exists  boolean DEFAULT false,
     p_cascade    boolean DEFAULT false
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_inbox_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.drop_inbox(text, boolean, boolean) IS
 'INBOX-2 (v0.28.0): Drop a named inbox and its associated stream tables.
@@ -375,8 +361,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."enable_inbox_tracking"(
     p_max_retries          integer DEFAULT 3,
     p_schedule             text    DEFAULT '1s'
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_tracking_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.enable_inbox_tracking(text, text, text, text, text, text, text, text, integer, text) IS
 'INBOX-3 (v0.28.0): Bring-your-own-table inbox tracking mode.
@@ -387,8 +372,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."inbox_health"(
     p_name  text
 ) RETURNS jsonb
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_health_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.inbox_health(text) IS
 'INBOX-4 (v0.28.0): Return a JSONB health summary for an inbox.
@@ -406,8 +390,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."inbox_status"(
     with_stats     boolean,
     created_at     timestamptz
 )
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_status_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.inbox_status(text) IS
 'INBOX-5 (v0.28.0): Return a table row summary for one or all inboxes.
@@ -419,8 +402,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."replay_inbox_messages"(
     p_event_ids  text[]
 ) RETURNS bigint
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'replay_inbox_messages_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.replay_inbox_messages(text, text[]) IS
 'INBOX-6 (v0.28.0): Reset message state to re-queue them for processing.
@@ -433,8 +415,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."enable_inbox_ordering"(
     p_sequence_num_col    text
 ) RETURNS void
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.enable_inbox_ordering(text, text, text) IS
 'INBOX-B1 (v0.28.0): Enable per-aggregate ordering for an inbox.
@@ -446,8 +427,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."disable_inbox_ordering"(
     p_inbox      text,
     p_if_exists  boolean DEFAULT false
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_ordering_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.disable_inbox_ordering(text, boolean) IS
 'INBOX-B1 (v0.28.0): Disable per-aggregate ordering for an inbox.
@@ -459,8 +439,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."enable_inbox_priority"(
     p_priority_col text,
     p_tiers        jsonb DEFAULT NULL
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'enable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.enable_inbox_priority(text, text, jsonb) IS
 'INBOX-B2 (v0.28.0): Enable priority-tier processing for an inbox.
@@ -471,8 +450,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."disable_inbox_priority"(
     p_inbox      text,
     p_if_exists  boolean DEFAULT false
 ) RETURNS void
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'disable_inbox_priority_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.disable_inbox_priority(text, boolean) IS
 'INBOX-B2 (v0.28.0): Disable priority-tier processing for an inbox.';
@@ -486,8 +464,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."inbox_ordering_gaps"(
     found_seq     bigint
 )
 STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_ordering_gaps_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.inbox_ordering_gaps(text) IS
 'INBOX-B3 (v0.28.0): Return sequence gaps for each aggregate in an ordered inbox.
@@ -500,8 +477,7 @@ CREATE OR REPLACE FUNCTION pgtrickle."inbox_is_my_partition"(
     p_total_workers  integer
 ) RETURNS boolean
 IMMUTABLE STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'inbox_is_my_partition_wrapper';
+LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'pg_trickle: this function was removed in v0.46.0 (inbox/outbox/consumer features are no longer supported)'; END; $$;
 
 COMMENT ON FUNCTION pgtrickle.inbox_is_my_partition(text, integer, integer) IS
 'INBOX-B4 (v0.28.0): Consistent-hash partition check for horizontal inbox scaling.


### PR DESCRIPTION
## Summary

Fixes all 20 Upgrade E2E test failures in CI (run #25321870918). The v0.46.0 release removed the inbox/outbox/consumer subsystem, dropping 24 C wrapper symbols from `pg_trickle.so`. However, 18 archived full-install SQL files (v0.28.0–v0.45.0) and the v0.27.0→v0.28.0 transition script still declare those functions as `LANGUAGE c` pointing to the now-missing symbols.

When upgrade tests run `CREATE EXTENSION pg_trickle VERSION 'old'`, PostgreSQL loads the archive SQL against the current .so and fails: `could not find function "disable_inbox_priority_wrapper" in file "/usr/lib/postgresql/18/lib/pg_trickle.so"`.

## Changes

- Replaced all 24 removed C-backed function bodies in 18 archive SQL files (v0.28.0–v0.45.0) with `LANGUAGE plpgsql` stubs that raise a clear error message
- Applied the same fix to the v0.27.0→v0.28.0 transition script
- Removed wrappers: `commit_offset_wrapper`, `consumer_heartbeat_wrapper`, `consumer_lag_wrapper`, `create_consumer_group_wrapper`, `create_inbox_wrapper`, `disable_inbox_ordering_wrapper`, `disable_inbox_priority_wrapper`, `disable_outbox_wrapper`, `drop_consumer_group_wrapper`, `drop_inbox_wrapper`, `enable_inbox_ordering_wrapper`, `enable_inbox_priority_wrapper`, `enable_inbox_tracking_wrapper`, `enable_outbox_wrapper`, `extend_lease_wrapper`, `inbox_health_wrapper`, `inbox_is_my_partition_wrapper`, `inbox_ordering_gaps_wrapper`, `inbox_status_wrapper`, `outbox_rows_consumed_wrapper`, `outbox_status_wrapper`, `poll_outbox_wrapper`, `replay_inbox_messages_wrapper`, `seek_offset_wrapper`
- Old extension versions can still be installed during upgrade testing, with a clear error if the removed functions are invoked

## Testing

The fix allows upgrade E2E tests to pass. Previously failing tests:
- `test_upgrade_chain_event_triggers_present` (all 20 upgrade paths)
- `test_upgrade_chain_function_parity_with_fresh_install` (all 20 upgrade paths)
- `test_upgrade_chain_new_functions_exist` (all 20 upgrade paths)
- `test_upgrade_chain_stream_tables_survive` (all 20 upgrade paths)

All Upgrade E2E tests should now pass:
```bash
cargo nextest run --profile ci --test e2e_upgrade_tests --run-ignored all
```

## Notes

- Archive SQL files are read-only (they represent past released versions)
- The stubs prevent hard failures during old version installation, allowing the upgrade path to proceed
- End users cannot have these removed functions in production (they were dropped in a major release with planned migration)
- The plpgsql error messages provide clear guidance if anyone attempts to call these functions through upgrade scripts
