### PR TITLE
fix(upgrade): correct DROP FUNCTION signatures in 0.45.0→0.46.0 upgrade script

### DIFF
--- a/scripts/check_upgrade_completeness.sh
+++ b/scripts/check_upgrade_completeness.sh
@@ -41,16 +41,16 @@ find_full_sql() {
         [[ -f "$candidate" ]] && echo "$candidate" && return
     fi
 
-    # 2. Search target/ for the generated SQL
-    local found
-    found=$(find target/ -name "pg_trickle--${version}.sql" -type f 2>/dev/null | head -1)
-    if [[ -n "$found" ]]; then echo "$found"; return; fi
-
-    # 3. Check sql/archive/
+    # 2. Check sql/archive/ before searching target/ (target/ can be very large)
     if [[ -f "sql/archive/pg_trickle--${version}.sql" ]]; then
         echo "sql/archive/pg_trickle--${version}.sql"
         return
     fi
+
+    # 3. Search target/ for the generated SQL (fallback for non-archived versions)
+    local found
+    found=$(find target/ -name "pg_trickle--${version}.sql" -type f 2>/dev/null | head -1)
+    if [[ -n "$found" ]]; then echo "$found"; return; fi
 
     return 1
 }

--- a/sql/pg_trickle--0.45.0--0.46.0.sql
+++ b/sql/pg_trickle--0.45.0--0.46.0.sql
@@ -53,23 +53,23 @@
 --     pgtrickle.disable_outbox(text, boolean)
 --     pgtrickle.outbox_status(text)
 --     pgtrickle.outbox_rows_consumed(text, bigint)
---     pgtrickle.create_consumer_group(text, text, text, boolean)
+--     pgtrickle.create_consumer_group(text, text, text)
 --     pgtrickle.drop_consumer_group(text, boolean)
 --     pgtrickle.poll_outbox(text, text, integer, integer)
 --     pgtrickle.commit_offset(text, text, bigint)
---     pgtrickle.extend_lease(text, text, interval)
+--     pgtrickle.extend_lease(text, text, integer)
 --     pgtrickle.seek_offset(text, text, bigint)
 --     pgtrickle.consumer_heartbeat(text, text)
 --     pgtrickle.consumer_lag(text)
---     pgtrickle.create_inbox(text, ...)
---     pgtrickle.drop_inbox(text, boolean)
---     pgtrickle.enable_inbox_tracking(text, ...)
+--     pgtrickle.create_inbox(text, text, integer, text, boolean, boolean, integer)
+--     pgtrickle.drop_inbox(text, boolean, boolean)
+--     pgtrickle.enable_inbox_tracking(text, text, text, text, text, text, text, text, integer, text)
 --     pgtrickle.inbox_health(text)
 --     pgtrickle.inbox_status(text)
 --     pgtrickle.replay_inbox_messages(text, text[])
 --     pgtrickle.enable_inbox_ordering(text, text, text)
 --     pgtrickle.disable_inbox_ordering(text, boolean)
---     pgtrickle.enable_inbox_priority(text, text, text[])
+--     pgtrickle.enable_inbox_priority(text, text, jsonb)
 --     pgtrickle.disable_inbox_priority(text, boolean)
 --     pgtrickle.inbox_ordering_gaps(text)
 --     pgtrickle.inbox_is_my_partition(text, integer, integer)
@@ -112,15 +112,15 @@ DROP TABLE IF EXISTS pgtrickle.pgt_inbox_priority_config CASCADE;
 DROP TABLE IF EXISTS pgtrickle.pgt_inbox_ordering_config  CASCADE;
 DROP TABLE IF EXISTS pgtrickle.pgt_inbox_config           CASCADE;
 
-DROP FUNCTION IF EXISTS pgtrickle.create_inbox(text, text, text, boolean, integer, integer, integer, integer, integer);
-DROP FUNCTION IF EXISTS pgtrickle.drop_inbox(text, boolean);
-DROP FUNCTION IF EXISTS pgtrickle.enable_inbox_tracking(text, text, text, text, boolean, integer, boolean, integer);
+DROP FUNCTION IF EXISTS pgtrickle."create_inbox"(text, text, integer, text, boolean, boolean, integer);
+DROP FUNCTION IF EXISTS pgtrickle."drop_inbox"(text, boolean, boolean);
+DROP FUNCTION IF EXISTS pgtrickle."enable_inbox_tracking"(text, text, text, text, text, text, text, text, integer, text);
 DROP FUNCTION IF EXISTS pgtrickle.inbox_health(text);
 DROP FUNCTION IF EXISTS pgtrickle.inbox_status(text);
 DROP FUNCTION IF EXISTS pgtrickle.replay_inbox_messages(text, text[]);
 DROP FUNCTION IF EXISTS pgtrickle.enable_inbox_ordering(text, text, text);
 DROP FUNCTION IF EXISTS pgtrickle.disable_inbox_ordering(text, boolean);
-DROP FUNCTION IF EXISTS pgtrickle.enable_inbox_priority(text, text, text[]);
+DROP FUNCTION IF EXISTS pgtrickle."enable_inbox_priority"(text, text, jsonb);
 DROP FUNCTION IF EXISTS pgtrickle.disable_inbox_priority(text, boolean);
 DROP FUNCTION IF EXISTS pgtrickle.inbox_ordering_gaps(text);
 DROP FUNCTION IF EXISTS pgtrickle.inbox_is_my_partition(text, integer, integer);
@@ -131,11 +131,11 @@ DROP TABLE IF EXISTS pgtrickle.pgt_consumer_leases  CASCADE;
 DROP TABLE IF EXISTS pgtrickle.pgt_consumer_offsets CASCADE;
 DROP TABLE IF EXISTS pgtrickle.pgt_consumer_groups  CASCADE;
 
-DROP FUNCTION IF EXISTS pgtrickle.create_consumer_group(text, text, text, boolean);
+DROP FUNCTION IF EXISTS pgtrickle."create_consumer_group"(text, text, text);
 DROP FUNCTION IF EXISTS pgtrickle.drop_consumer_group(text, boolean);
 DROP FUNCTION IF EXISTS pgtrickle.poll_outbox(text, text, integer, integer);
 DROP FUNCTION IF EXISTS pgtrickle.commit_offset(text, text, bigint);
-DROP FUNCTION IF EXISTS pgtrickle.extend_lease(text, text, interval);
+DROP FUNCTION IF EXISTS pgtrickle."extend_lease"(text, text, integer);
 DROP FUNCTION IF EXISTS pgtrickle.seek_offset(text, text, bigint);
 DROP FUNCTION IF EXISTS pgtrickle.consumer_heartbeat(text, text);
 DROP FUNCTION IF EXISTS pgtrickle.consumer_lag(text);


### PR DESCRIPTION
## Summary

Fixes two CI failures introduced by the v0.46.0 TIDE release
(`Upgrade E2E (0.45.0 → 0.46.0)` and `Upgrade E2E (0.1.3 → 0.46.0)`,
[CI #2127](https://github.com/grove/pg-trickle/actions/runs/25333463483)).

Six `DROP FUNCTION IF EXISTS` statements in `sql/pg_trickle--0.45.0--0.46.0.sql`
had incorrect parameter-type lists. Because PostgreSQL uses `IF EXISTS`,
wrong signatures silently no-op instead of erroring. After the upgrade,
those six TIDE-removed functions remained registered in `pg_proc`,
giving an upgraded install 123 functions instead of the expected 117.

The completeness-check script is also fixed to check `sql/archive/` before
scanning `target/` (which can exceed 200 GB), making `just check-upgrade-all`
run in ~30 seconds instead of hanging.

## Changes

### `sql/pg_trickle--0.45.0--0.46.0.sql`

Six `DROP FUNCTION` signatures corrected to match the actual signatures in
`sql/archive/pg_trickle--0.45.0.sql`:

| Function | Was | Now |
|---|---|---|
| `create_consumer_group` | `(text,text,text,boolean)` | `(text,text,text)` |
| `create_inbox` | 9-param wrong list | `(text,text,integer,text,boolean,boolean,integer)` |
| `drop_inbox` | `(text,boolean)` | `(text,boolean,boolean)` |
| `enable_inbox_priority` | `(text,text,text[])` | `(text,text,jsonb)` |
| `enable_inbox_tracking` | 8-param wrong list | `(text,text,text,text,text,text,text,text,integer,text)` |
| `extend_lease` | `(text,text,interval)` | `(text,text,integer)` |

### `scripts/check_upgrade_completeness.sh`

Moved the `sql/archive/` lookup before the `find target/` scan so the
common fast path is taken first.

## Root Cause

The DROP statements were written against a proposed/future signature
rather than the actual signatures present in the 0.45.0 archive SQL.
`DROP FUNCTION IF EXISTS` masked the mismatch; the functions stayed in
`pg_proc` and the `test_upgrade_chain_function_parity_with_fresh_install`
assertion caught the count discrepancy (123 upgraded vs 117 fresh).

## Testing

- `just check-upgrade-all` — all 48 upgrade steps pass ✓
- `just check-version-sync` — passes ✓
- Fixes verified by re-running the signature analysis against
  `sql/archive/pg_trickle--0.45.0.sql` — all 32 DROP statements now
  resolve to the correct functions

## Notes

The PR targets `main` directly. Once merged, re-running CI with
`gh workflow run ci.yml --ref main` will confirm the two upgrade jobs
that were previously failing now pass.
