### PR TITLE
fix(v0.48.0): fix 3 pgvector E2E test failures

### DIFF
--- a/docs/SQL_API_CATALOG.md
+++ b/docs/SQL_API_CATALOG.md
@@ -4,7 +4,7 @@
 
 # SQL API Reference — pg_trickle
 
-**89 SQL-callable functions** discovered via `#[pg_extern]` in `src/`.
+**116 SQL-callable functions** discovered via `#[pg_extern]` in `src/`.
 
 See [docs/SQL_REFERENCE.md](SQL_REFERENCE.md) for full signatures and examples.
 
@@ -12,7 +12,11 @@ See [docs/SQL_REFERENCE.md](SQL_REFERENCE.md) for full signatures and examples.
 | Function | Schema | Returns | Description |
 |----------|--------|---------|-------------|
 | `pgtrickle._signal_launcher_rescan()` | `pgtrickle` | `` | Also safe to call manually if the launcher needs a nudge. |
+| `pgtrickle.advance_watermark()` | `pgtrickle` | `Result<(), PgTrickleError>` | - **Monotonic:** rejects watermarks that go backward. |
+| `pgtrickle.alter_stream_table()` | `pgtrickle` | `` | Alter properties of an existing stream table. |
+| `pgtrickle.attach_outbox()` | `pgtrickle` | `` | Requires `pg_tide` to be installed. |
 | `pgtrickle.bootstrap_gate_status_fn()` | `pgtrickle` | `TableIterator<` | BOOT-F3: Designed for debugging "why isn't my stream table refreshing?" situations by showing the full gate lifecycle at a glance. |
+| `pgtrickle.build_init_decision()` | `pgtrickle` | `InitDecision` |  |
 | `pgtrickle.bulk_alter_stream_tables()` | `pgtrickle` | `i32` | # Example ```sql SELECT pgtrickle.bulk_alter_stream_tables(     ARRAY['public.orders_summary', 'public.daily_revenue'],     '{"schedule": "5m", "tier": "warm"}'::jsonb ); ```. |
 | `pgtrickle.bulk_create()` | `pgtrickle` | `pgrx::JsonB` | On any error, the entire transaction is rolled back (standard PostgreSQL transactional semantics). |
 | `pgtrickle.bulk_drop_stream_tables()` | `pgtrickle` | `i32` | # Example ```sql SELECT pgtrickle.bulk_drop_stream_tables(     ARRAY['public.orders_summary', 'public.stale_view'] ); ```. |
@@ -23,9 +27,15 @@ See [docs/SQL_REFERENCE.md](SQL_REFERENCE.md) for full signatures and examples.
 | `pgtrickle.clear_caches()` | `pgtrickle` | `i64` | Use during debugging, emergency migration rollback, or after a query definition change that was not captured by the normal DDL invalidation path. |
 | `pgtrickle.cluster_worker_summary()` | `pgtrickle` | `TableIterator<` | Reads from `pg_stat_activity` (shared catalog) so the calling role needs `pg_monitor` or superuser privilege. |
 | `pgtrickle.convert_buffers_to_unlogged()` | `pgtrickle` | `Result<i64, PgTrickleError>` | **Warning:** After conversion, buffer contents will be lost on crash recovery. |
+| `pgtrickle.create_or_replace_stream_table()` | `pgtrickle` | `` | This is the declarative API for idempotent deployments (dbt, migrations, GitOps). |
+| `pgtrickle.create_refresh_group()` | `pgtrickle` | `` | # Arguments - `group_name`: Unique human-readable name for the group. |
+| `pgtrickle.create_stream_table()` | `pgtrickle` | `` | # Arguments - `name`: Schema-qualified name (`'schema.table'`) or unqualified (`'table'`). |
+| `pgtrickle.create_stream_table_if_not_exists()` | `pgtrickle` | `` | This is useful for migration scripts that should be safe to re-run. |
+| `pgtrickle.create_watermark_group()` | `pgtrickle` | `` | - `group_name`: unique name for this group. |
 | `pgtrickle.dedup_stats_fn()` | `pgtrickle` | `TableIterator<` | Example: ```sql SELECT * FROM pgtrickle.dedup_stats(); ```. |
 | `pgtrickle.dependency_tree()` | `pgtrickle` | `TableIterator<` | Exposed as `pgtrickle.dependency_tree()`. |
 | `pgtrickle.detach_outbox()` | `pgtrickle` | `` | Removes the entry from `pgtrickle.pgt_outbox_config`. |
+| `pgtrickle.diagnose_errors()` | `pgtrickle` | `TableIterator<` | # SQL usage ```sql SELECT * FROM pgtrickle.diagnose_errors('my_stream_table'); ```. |
 | `pgtrickle.diamond_groups()` | `pgtrickle` | `TableIterator<` | Returns one row per group member, indicating which group it belongs to, whether it is a convergence (fan-in) node, the group's current epoch, and the effective schedule policy. |
 | `pgtrickle.drain()` | `pgtrickle` | `` | # Example ```sql -- Quiesce before pg_upgrade or rolling restart: SELECT pgtrickle.drain(); -- Confirm drained: SELECT pgtrickle.is_drained(); -- Resume normal operation after maintenance: UPDATE pgtrickle.pgt_stream_tables SET status = status; -- noop, scheduler picks up ```. |
 | `pgtrickle.drop_refresh_group()` | `pgtrickle` | `Result<(), PgTrickleError>` | Drop a refresh group by name. |
@@ -33,36 +43,50 @@ See [docs/SQL_REFERENCE.md](SQL_REFERENCE.md) for full signatures and examples.
 | `pgtrickle.drop_stream_table()` | `pgtrickle` | `` | Changed in v0.19.0 (UX-6): default flipped from `true` to `false` to prevent accidental cascading drops. |
 | `pgtrickle.drop_stream_table_publication()` | `pgtrickle` | `` | CDC-PUB-2: Drop the logical replication publication for a stream table. |
 | `pgtrickle.drop_watermark_group()` | `pgtrickle` | `Result<(), PgTrickleError>` | Drop a watermark group by name. |
+| `pgtrickle.embedding_stream_table()` | `pgtrickle` | `` | # Returns A single-column table with one row per action taken (or SQL line for dry_run). |
 | `pgtrickle.exec_stream_ddl()` | `pgtrickle` | `bool` | # Example ```sql SELECT pgtrickle.exec_stream_ddl(   'CREATE STREAM TABLE revenue AS SELECT SUM(amount) FROM orders' ); ```. |
 | `pgtrickle.explain_dag()` | `pgtrickle` | `` | Node colours: user STs = blue, self-monitoring STs = green, suspended = red, fused = orange. |
+| `pgtrickle.explain_delta_text()` | `pgtrickle` | `` | Example: ```sql SELECT line FROM pgtrickle.explain_delta('public.orders_summary'); SELECT line FROM pgtrickle.explain_delta('public.orders_summary', 'json'); ```. |
 | `pgtrickle.explain_diff_sql()` | `pgtrickle` | `Option<String>` | Exposed as `pgtrickle.explain_diff_sql(name)`. |
+| `pgtrickle.explain_query_rewrite()` | `pgtrickle` | `TableIterator<` | # SQL usage ```sql SELECT * FROM pgtrickle.explain_query_rewrite(   'SELECT customer_id, SUM(amount) FROM orders GROUP BY customer_id' ); ```. |
+| `pgtrickle.explain_refresh_mode()` | `pgtrickle` | `TableIterator<` | Example: ```sql SELECT * FROM pgtrickle.explain_refresh_mode('public.orders_summary'); ```. |
+| `pgtrickle.explain_st()` | `pgtrickle` | `` | PERF-3: When `with_analyze` is true, the defining query is EXPLAINed with ANALYZE to show actual row counts, timings, and buffer usage. |
 | `pgtrickle.explain_stream_table()` | `pgtrickle` | `Result<String, PgTrickleError>` | v0.39.0 extends the output to include: - Explicit DIFF/FULL fallback reason from the stream table catalog - Whether `force_full_refresh` GUC is overriding the mode - The effective refresh mode from the last completed refresh cycle - Whether the backpressure or CDC-pause state is active. |
 | `pgtrickle.export_definition()` | `pgtrickle` | `Result<String, PgTrickleError>` | Returns a `DROP STREAM TABLE IF EXISTS` + `CREATE STREAM TABLE . |
 | `pgtrickle.fuse_status()` | `pgtrickle` | `TableIterator<` | Returns one row per stream table with fuse configuration and state. |
 | `pgtrickle.gate_source()` | `pgtrickle` | `Result<(), PgTrickleError>` | `source` is the source table name, optionally schema-qualified. |
+| `pgtrickle.get_refresh_history()` | `pgtrickle` | `` | Exposed as `pgtrickle.get_refresh_history(name, limit)`. |
 | `pgtrickle.get_staleness()` | `pgtrickle` | `Option<f64>` |  |
 | `pgtrickle.health_check()` | `pgtrickle` | `TableIterator<` | Exposed as `pgtrickle.health_check()`. |
 | `pgtrickle.health_summary()` | `pgtrickle` | `TableIterator<` | Exposed as `pgtrickle.health_summary()`. |
 | `pgtrickle.is_drained()` | `pgtrickle` | `bool` | A scheduler is considered drained when `DRAIN_COMPLETED >= DRAIN_REQUESTED` in shared memory. |
-| `pgtrickle.list_distance_subscriptions()` | `pgtrickle` | `TableIterator<` | VH-2 (v0.48.0): List all active distance-predicate subscriptions. |
+| `pgtrickle.list_auxiliary_columns()` | `pgtrickle` | `TableIterator<` | # SQL usage ```sql SELECT * FROM pgtrickle.list_auxiliary_columns('my_stream_table'); ```. |
+| `pgtrickle.list_distance_subscriptions()` | `pgtrickle` | `` | When `p_stream_table` is provided (e.g. |
+| `pgtrickle.list_snapshots()` | `pgtrickle` | `TableIterator<` | Returns one row per snapshot ordered by creation time descending. |
+| `pgtrickle.list_sources()` | `pgtrickle` | `TableIterator<` | Exposed as `pgtrickle.list_sources(name)`. |
 | `pgtrickle.list_subscriptions()` | `pgtrickle` | `TableIterator<` | Returns a table with columns (stream_table TEXT, channel TEXT, created_at TIMESTAMPTZ). |
 | `pgtrickle.metrics_summary()` | `pgtrickle` | `TableIterator<` | v0.31.0 (PERF-3): Added `ivm_lock_parse_error_count` — cumulative count of IMMEDIATE-mode lock-mode downgrades due to query parse failures. |
 | `pgtrickle.migrate()` | `pgtrickle` | `String` | This is a convenience function for users who upgrade the extension without using `ALTER EXTENSION pg_trickle UPDATE` — it ensures the catalog schema matches the library expectations. |
+| `pgtrickle.parallel_job_status()` | `pgtrickle` | `` | Exposed as `pgtrickle.parallel_job_status(max_age_seconds)`. |
 | `pgtrickle.parse_duration_seconds()` | `pgtrickle` | `Option<i64>` | Used by SQL views to compare schedule. |
 | `pgtrickle.pg_trickle_hash()` | `pgtrickle` | `i64` | NULL input is mapped to a deterministic sentinel (`\x00NULL\x00`) — the same encoding used by [`pg_trickle_hash_multi`] — so that rows with NULL-valued group keys receive a non-NULL `__pgt_row_id`. |
 | `pgtrickle.pg_trickle_hash_multi()` | `pgtrickle` | `i64` | The hash output is identical to the previous xxh64-based implementation **except** that it now uses xxh3 which produces different numeric values. |
 | `pgtrickle.pg_trickle_on_ddl_end()` | `pgtrickle` | `` | Registered via `extension_sql!()` in lib.rs as: ```sql CREATE FUNCTION pgtrickle._on_ddl_end() RETURNS event_trigger . |
 | `pgtrickle.pg_trickle_on_sql_drop()` | `pgtrickle` | `` | Detects when upstream source tables or ST storage tables themselves are dropped and reacts accordingly. |
+| `pgtrickle.pgt_ivm_apply_delta()` | `pgtrickle` | `Result<(), PgTrickleError>` | Delta SQL templates are cached per (pgt_id, source_oid, has_new, has_old) to avoid re-parsing the defining query on every trigger invocation. |
+| `pgtrickle.pgt_ivm_apply_delta_enr()` | `pgtrickle` | `Result<(), PgTrickleError>` | Requires PostgreSQL 18+ which propagates ENRs to nested SPI calls within trigger execution contexts. |
 | `pgtrickle.pgt_ivm_handle_truncate()` | `pgtrickle` | `Result<(), PgTrickleError>` | Truncates the stream table (equivalent to a full refresh with empty base table for simple views). |
 | `pgtrickle.pgt_scc_status()` | `pgtrickle` | `TableIterator<` | Returns one row per SCC, summarising its members, most recent fixpoint iteration count, and last convergence time. |
 | `pgtrickle.pgt_status()` | `pgtrickle` | `TableIterator<` | Returns a summary row per stream table including schedule configuration, data timestamp, and computed staleness interval. |
 | `pgtrickle.pgtrickle_refresh_stats()` | `pgtrickle` | `TableIterator<` | Exposed as `pgtrickle.pgtrickle_refresh_stats()`. |
 | `pgtrickle.preflight()` | `pgtrickle` | `String` | Returns a JSON string with one entry per check: `pass` (bool), `check` (name), `detail` (human-readable message). |
 | `pgtrickle.rebuild_cdc_triggers()` | `pgtrickle` | `&'static str` | Returns `'done'` on success. |
+| `pgtrickle.recommend_refresh_mode()` | `pgtrickle` | `` | Read-only — no side effects. |
 | `pgtrickle.recommend_schedule()` | `pgtrickle` | `pgrx::JsonB` | PLAN-1 (v0.27.0): Return a schedule recommendation for the given stream table as a JSONB object with keys: `recommended_interval_seconds`, `peak_window_cron`, `confidence` (0–1), `reasoning`. |
 | `pgtrickle.refresh_efficiency()` | `pgtrickle` | `Result<` | Returns operational metrics for each stream table: FULL vs DIFFERENTIAL timing, change ratios, speedup factor, and refresh counts. |
 | `pgtrickle.refresh_groups_fn()` | `pgtrickle` | `TableIterator<` | Return all user-declared refresh groups with member details. |
 | `pgtrickle.refresh_stream_table()` | `pgtrickle` | `` | Manually trigger a synchronous refresh of a stream table. |
+| `pgtrickle.refresh_timeline()` | `pgtrickle` | `` | Exposed as `pgtrickle.refresh_timeline(limit)`. |
 | `pgtrickle.repair_stream_table()` | `pgtrickle` | `String` | Steps performed (actions taken are summarized in the return text): 1. |
 | `pgtrickle.reset_fuse()` | `pgtrickle` | `` | Returns nothing on success; raises an ERROR if the stream table does not exist or the fuse is not blown. |
 | `pgtrickle.restore_from_snapshot()` | `pgtrickle` | `` | The stream table must already be registered. |
@@ -82,13 +106,16 @@ See [docs/SQL_REFERENCE.md](SQL_REFERENCE.md) for full signatures and examples.
 | `pgtrickle.sql_stable_name_for_oid()` | `pgtrickle` | `Option<String>` | Returns `NULL` when the relation no longer exists (e.g. |
 | `pgtrickle.st_auto_threshold()` | `pgtrickle` | `Option<f64>` | Returns the per-ST `auto_threshold` if set, otherwise the global `pg_trickle.differential_max_change_ratio` GUC. |
 | `pgtrickle.st_refresh_stats()` | `pgtrickle` | `TableIterator<` | This is the primary monitoring function, exposed as `pgtrickle.st_refresh_stats()`. |
+| `pgtrickle.stream_table_lineage()` | `pgtrickle` | `TableIterator<` | # Example ```sql SELECT * FROM pgtrickle.stream_table_lineage('public.revenue_summary'); ```. |
 | `pgtrickle.stream_table_to_publication()` | `pgtrickle` | `` | Creates a PostgreSQL publication exposing the named stream table so that Kafka Connect, Debezium, and other logical replication subscribers can receive change events without a separate replication slot. |
 | `pgtrickle.subscribe()` | `pgtrickle` | `Result<(), PgTrickleError>` | The subscription is stored in `pgtrickle.pgt_subscriptions` and survives restarts. |
+| `pgtrickle.subscribe_distance()` | `pgtrickle` | `Result<(), PgTrickleError>` | The subscription is stored in `pgtrickle.pgt_distance_subscriptions` and survives restarts. |
 | `pgtrickle.teardown_self_monitoring()` | `pgtrickle` | `` | Safe with partial setups: each table is dropped individually, and missing tables are silently skipped (STAB-5). |
 | `pgtrickle.trigger_inventory()` | `pgtrickle` | `TableIterator<` | Exposed as `pgtrickle.trigger_inventory()`. |
 | `pgtrickle.ungate_source()` | `pgtrickle` | `Result<(), PgTrickleError>` | `source` is the source table name, optionally schema-qualified. |
 | `pgtrickle.unsubscribe()` | `pgtrickle` | `Result<(), PgTrickleError>` | UX-SUB: Remove a NOTIFY subscription for a stream table / channel pair. |
 | `pgtrickle.unsubscribe_distance()` | `pgtrickle` | `Result<(), PgTrickleError>` | VH-2 (v0.48.0): Remove a distance-predicate subscription. |
+| `pgtrickle.validate_query()` | `pgtrickle` | `TableIterator<` | # SQL usage ```sql SELECT * FROM pgtrickle.validate_query(   'SELECT customer_id, COUNT(*) FROM orders GROUP BY customer_id' ); ```. |
 | `pgtrickle.vector_status()` | `pgtrickle` | `TableIterator<` | Returns one row per stream table that has a `post_refresh_action` other than 'none', or that has any ANN-relevant index on its storage table. |
 | `pgtrickle.version()` | `pgtrickle` | `&'static str` |  |
 | `pgtrickle.version_check()` | `pgtrickle` | `String` | Returns a JSON string with library_version, extension_version, pg_version, and a boolean `version_match`. |

--- a/scripts/gen_catalogs.py
+++ b/scripts/gen_catalogs.py
@@ -166,16 +166,25 @@ def extract_sql_functions(src_dir: Path) -> list[dict]:
                 else:
                     break
 
-            # Find the fn signature in the next few lines
+            # Find the fn signature in the next few lines.
+            # Join up to 10 lines so that multi-line argument lists (e.g.
+            # when pgrx::default!() spans multiple lines) are handled by
+            # the single-line regex.
             fn_name = None
             args_str = ""
             ret_str = ""
             for scan in range(idx + 1, min(idx + 10, len(lines))):
-                fm = _FN_SIG_RE.search(lines[scan])
-                if fm:
-                    fn_name = fm.group(1)
-                    args_str = fm.group(2).strip()
-                    ret_str = (fm.group(3) or "").strip().rstrip("{").strip()
+                # Try matching the current line alone first (fast path), then
+                # with up to 9 subsequent lines joined (handles multi-line args).
+                for window in range(1, min(10, len(lines) - scan + 1)):
+                    joined = " ".join(lines[scan : scan + window])
+                    fm = _FN_SIG_RE.search(joined)
+                    if fm:
+                        fn_name = fm.group(1)
+                        args_str = fm.group(2).strip()
+                        ret_str = (fm.group(3) or "").strip().rstrip("{").strip()
+                        break
+                if fn_name:
                     break
 
             if not fn_name:

--- a/sql/archive/pg_trickle--0.48.0.sql
+++ b/sql/archive/pg_trickle--0.48.0.sql
@@ -296,33 +296,6 @@ CREATE UNLOGGED TABLE IF NOT EXISTS pgtrickle.pgt_template_cache (
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:566
-
--- Create event trigger functions with correct RETURNS event_trigger type.
--- pgrx's #[pg_extern] generates RETURNS void, which PostgreSQL rejects for
--- event triggers. We create them manually here with the correct return type.
-CREATE FUNCTION pgtrickle."_on_ddl_end"()
-    RETURNS event_trigger
-    LANGUAGE c
-    AS 'MODULE_PATHNAME', 'pg_trickle_on_ddl_end_wrapper';
-
-CREATE FUNCTION pgtrickle."_on_sql_drop"()
-    RETURNS event_trigger
-    LANGUAGE c
-    AS 'MODULE_PATHNAME', 'pg_trickle_on_sql_drop_wrapper';
-
--- Event trigger: track ALTER TABLE on upstream sources
-CREATE EVENT TRIGGER pg_trickle_ddl_tracker
-    ON ddl_command_end
-    EXECUTE FUNCTION pgtrickle._on_ddl_end();
-
--- Event trigger: track DROP TABLE on upstream sources / ST storage tables
-CREATE EVENT TRIGGER pg_trickle_drop_tracker
-    ON sql_drop
-    EXECUTE FUNCTION pgtrickle._on_sql_drop();
-/* </end connected objects> */
-
-/* <begin connected objects> */
 -- src/lib.rs:986
 
 -- v0.46.0: Slim outbox attachment catalog.
@@ -370,38 +343,30 @@ COMMENT ON TABLE pgtrickle.pgt_distance_subscriptions IS
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:723
+-- src/lib.rs:566
 
-CREATE OR REPLACE FUNCTION pgtrickle."pause_all"()
-RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    UPDATE pgtrickle.pgt_stream_tables
-       SET status = 'PAUSED'
-     WHERE status = 'ACTIVE';
-    RAISE NOTICE 'pg_trickle: all stream tables paused.';
-END;
-$$;
+-- Create event trigger functions with correct RETURNS event_trigger type.
+-- pgrx's #[pg_extern] generates RETURNS void, which PostgreSQL rejects for
+-- event triggers. We create them manually here with the correct return type.
+CREATE FUNCTION pgtrickle."_on_ddl_end"()
+    RETURNS event_trigger
+    LANGUAGE c
+    AS 'MODULE_PATHNAME', 'pg_trickle_on_ddl_end_wrapper';
 
-COMMENT ON FUNCTION pgtrickle."pause_all"() IS
-    'Pause automatic refreshes for every ACTIVE stream table. '
-    'Use pgtrickle.resume_all() to re-activate them.';
+CREATE FUNCTION pgtrickle."_on_sql_drop"()
+    RETURNS event_trigger
+    LANGUAGE c
+    AS 'MODULE_PATHNAME', 'pg_trickle_on_sql_drop_wrapper';
 
-CREATE OR REPLACE FUNCTION pgtrickle."resume_all"()
-RETURNS void
-LANGUAGE plpgsql
-AS $$
-BEGIN
-    UPDATE pgtrickle.pgt_stream_tables
-       SET status = 'ACTIVE'
-     WHERE status = 'PAUSED';
-    RAISE NOTICE 'pg_trickle: all paused stream tables resumed.';
-END;
-$$;
+-- Event trigger: track ALTER TABLE on upstream sources
+CREATE EVENT TRIGGER pg_trickle_ddl_tracker
+    ON ddl_command_end
+    EXECUTE FUNCTION pgtrickle._on_ddl_end();
 
-COMMENT ON FUNCTION pgtrickle."resume_all"() IS
-    'Re-activate all stream tables that were paused with pgtrickle.pause_all().';
+-- Event trigger: track DROP TABLE on upstream sources / ST storage tables
+CREATE EVENT TRIGGER pg_trickle_drop_tracker
+    ON sql_drop
+    EXECUTE FUNCTION pgtrickle._on_sql_drop();
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -437,322 +402,100 @@ WHERE ct.source_placement = 'distributed';
 /* </end connected objects> */
 
 /* <begin connected objects> */
+-- src/lib.rs:723
+
+CREATE OR REPLACE FUNCTION pgtrickle."pause_all"()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE pgtrickle.pgt_stream_tables
+       SET status = 'PAUSED'
+     WHERE status = 'ACTIVE';
+    RAISE NOTICE 'pg_trickle: all stream tables paused.';
+END;
+$$;
+
+COMMENT ON FUNCTION pgtrickle."pause_all"() IS
+    'Pause automatic refreshes for every ACTIVE stream table. '
+    'Use pgtrickle.resume_all() to re-activate them.';
+
+CREATE OR REPLACE FUNCTION pgtrickle."resume_all"()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    UPDATE pgtrickle.pgt_stream_tables
+       SET status = 'ACTIVE'
+     WHERE status = 'PAUSED';
+    RAISE NOTICE 'pg_trickle: all paused stream tables resumed.';
+END;
+$$;
+
+COMMENT ON FUNCTION pgtrickle."resume_all"() IS
+    'Re-activate all stream tables that were paused with pgtrickle.pause_all().';
+/* </end connected objects> */
+
+/* <begin connected objects> */
 -- src/lib.rs:54
 CREATE SCHEMA IF NOT EXISTS pgtrickle; /* pg_trickle::pgtrickle */
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor.rs:893
--- pg_trickle::monitor::st_auto_threshold
-CREATE  FUNCTION pgtrickle."st_auto_threshold"(
-	"name" TEXT /* & str */
-) RETURNS double precision /* Option < f64 > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'st_auto_threshold_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:566
--- pg_trickle::api::self_monitoring::explain_dag
-CREATE  FUNCTION pgtrickle."explain_dag"(
-	"format" TEXT DEFAULT 'mermaid' /* Option < & str > */
-) RETURNS TEXT /* Option < String > */
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_dag_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:407
--- pg_trickle::api::diagnostics::explain_delta
-CREATE  FUNCTION pgtrickle."explain_delta"(
-	"name" TEXT, /* & str */
-	"format" TEXT DEFAULT 'text' /* & str */
-) RETURNS SETOF TEXT /* String */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_delta_text_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1123
--- pg_trickle::api::diagnostics::create_watermark_group
-CREATE  FUNCTION pgtrickle."create_watermark_group"(
-	"group_name" TEXT, /* & str */
-	"sources" TEXT[], /* Vec < String > */
-	"tolerance_secs" double precision DEFAULT 0.0 /* f64 */
-) RETURNS INT /* Result < i32, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_watermark_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:3631
--- pg_trickle::api::alter_stream_table
-CREATE  FUNCTION pgtrickle."alter_stream_table"(
-	"name" TEXT, /* & str */
-	"query" TEXT DEFAULT NULL, /* Option < & str > */
-	"schedule" TEXT DEFAULT NULL, /* Option < & str > */
-	"refresh_mode" TEXT DEFAULT NULL, /* Option < & str > */
-	"status" TEXT DEFAULT NULL, /* Option < & str > */
-	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
-	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
-	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
-	"append_only" bool DEFAULT NULL, /* Option < bool > */
-	"pooler_compatibility_mode" bool DEFAULT NULL, /* Option < bool > */
-	"tier" TEXT DEFAULT NULL, /* Option < & str > */
-	"fuse" TEXT DEFAULT NULL, /* Option < & str > */
-	"fuse_ceiling" bigint DEFAULT NULL, /* Option < i64 > */
-	"fuse_sensitivity" INT DEFAULT NULL, /* Option < i32 > */
-	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
-	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
-	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
-	"post_refresh_action" TEXT DEFAULT NULL, /* Option < & str > */
-	"reindex_drift_threshold" double precision DEFAULT NULL /* Option < f64 > */
-) RETURNS void
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'alter_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:358
--- pg_trickle::api::self_monitoring::self_monitoring_status
-CREATE  FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
-	"st_name" TEXT,  /* String */
-	"exists" bool,  /* bool */
-	"status" TEXT,  /* Option < String > */
-	"refresh_mode" TEXT,  /* Option < String > */
-	"last_refresh_at" TEXT,  /* Option < String > */
-	"total_refreshes" bigint  /* Option < i64 > */
+-- src/api/mod.rs:5507
+-- pg_trickle::api::list_distance_subscriptions
+CREATE  FUNCTION pgtrickle."list_distance_subscriptions"(
+	"p_stream_table" TEXT DEFAULT NULL /* Option < & str > */
+) RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"channel" TEXT,  /* Option < String > */
+	"vector_column" TEXT,  /* Option < String > */
+	"op" TEXT,  /* Option < String > */
+	"threshold" double precision,  /* Option < f64 > */
+	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
 )
-STRICT 
+
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
+AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/helpers.rs:2497
--- pg_trickle::api::helpers::refresh_efficiency
-CREATE  FUNCTION pgtrickle."refresh_efficiency"() RETURNS TABLE (
-	"pgt_schema" TEXT,  /* String */
-	"pgt_name" TEXT,  /* String */
-	"refresh_mode" TEXT,  /* String */
-	"total_refreshes" bigint,  /* i64 */
-	"diff_count" bigint,  /* i64 */
-	"full_count" bigint,  /* i64 */
-	"avg_diff_ms" double precision,  /* Option < f64 > */
-	"avg_full_ms" double precision,  /* Option < f64 > */
-	"avg_change_ratio" double precision,  /* Option < f64 > */
-	"diff_speedup" TEXT,  /* Option < String > */
-	"last_refresh_at" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_efficiency_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/hooks.rs:1077
--- pg_trickle::hooks::pg_trickle_on_sql_drop
--- Skipped due to `#[pgrx(sql = false)]`
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/outbox.rs:266
--- pg_trickle::api::outbox::attach_embedding_outbox
-CREATE  FUNCTION pgtrickle."attach_embedding_outbox"(
-	"p_name" TEXT, /* & str */
-	"p_vector_column" TEXT, /* & str */
-	"p_retention_hours" INT DEFAULT 24, /* i32 */
-	"p_inline_threshold_rows" INT DEFAULT 10000 /* i32 */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'attach_embedding_outbox_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1168
--- pg_trickle::api::diagnostics::watermarks
-CREATE  FUNCTION pgtrickle."watermarks"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"schema_name" TEXT,  /* String */
-	"watermark" timestamp with time zone,  /* TimestampWithTimeZone */
-	"updated_at" timestamp with time zone,  /* TimestampWithTimeZone */
-	"advanced_by" TEXT,  /* Option < String > */
-	"wal_lsn" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'watermarks_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:5370
--- pg_trickle::api::subscribe
-CREATE  FUNCTION pgtrickle."subscribe"(
-	"stream_table" TEXT, /* & str */
-	"channel" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'subscribe_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:491
--- pg_trickle::monitor::st_refresh_stats
-CREATE  FUNCTION pgtrickle."st_refresh_stats"() RETURNS TABLE (
-	"pgt_name" TEXT,  /* String */
-	"pgt_schema" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"refresh_mode" TEXT,  /* String */
-	"is_populated" bool,  /* bool */
-	"total_refreshes" bigint,  /* i64 */
-	"successful_refreshes" bigint,  /* i64 */
-	"failed_refreshes" bigint,  /* i64 */
-	"total_rows_inserted" bigint,  /* i64 */
-	"total_rows_deleted" bigint,  /* i64 */
-	"avg_duration_ms" double precision,  /* f64 */
-	"last_refresh_action" TEXT,  /* Option < String > */
-	"last_refresh_status" TEXT,  /* Option < String > */
-	"last_refresh_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"staleness_secs" double precision,  /* Option < f64 > */
-	"stale" bool,  /* bool */
-	"consecutive_errors" INT,  /* i32 */
-	"schedule" TEXT,  /* Option < String > */
-	"refresh_tier" TEXT,  /* String */
-	"last_error_message" TEXT,  /* Option < String > */
-	"downstream_publication" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'st_refresh_stats_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/hash.rs:54
--- pg_trickle::hash::pg_trickle_hash_multi
-CREATE  FUNCTION pgtrickle."pg_trickle_hash_multi"(
-	"inputs" TEXT[] /* Vec < Option < String > > */
-) RETURNS bigint /* i64 */
-IMMUTABLE STRICT PARALLEL SAFE 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pg_trickle_hash_multi_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/snapshot.rs:550
--- pg_trickle::api::snapshot::drop_snapshot
-CREATE  FUNCTION pgtrickle."drop_snapshot"(
-	"p_snapshot_table" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_snapshot_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:1000
--- pg_trickle::monitor::pgtrickle_refresh_stats
-CREATE  FUNCTION pgtrickle."pgtrickle_refresh_stats"() RETURNS TABLE (
-	"stream_table" TEXT,  /* String */
-	"mode" TEXT,  /* String */
-	"avg_ms" double precision,  /* f64 */
-	"p95_ms" double precision,  /* f64 */
-	"p99_ms" double precision,  /* f64 */
-	"refresh_count" bigint,  /* i64 */
-	"last_refresh_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgtrickle_refresh_stats_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:1627
--- pg_trickle::monitor::check_cdc_health
-CREATE  FUNCTION pgtrickle."check_cdc_health"() RETURNS TABLE (
-	"source_relid" bigint,  /* i64 */
-	"source_table" TEXT,  /* String */
-	"cdc_mode" TEXT,  /* String */
-	"slot_name" TEXT,  /* Option < String > */
-	"lag_bytes" bigint,  /* Option < i64 > */
-	"confirmed_lsn" TEXT,  /* Option < String > */
-	"alert" TEXT,  /* Option < String > */
-	"selective_capture" bool  /* bool */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'check_cdc_health_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2312
--- pg_trickle::api::helpers::convert_buffers_to_unlogged
-CREATE  FUNCTION pgtrickle."convert_buffers_to_unlogged"() RETURNS bigint /* Result < i64, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'convert_buffers_to_unlogged_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/outbox.rs:163
--- pg_trickle::api::outbox::detach_outbox
-CREATE  FUNCTION pgtrickle."detach_outbox"(
-	"p_name" TEXT, /* & str */
-	"p_if_exists" bool DEFAULT false /* bool */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'detach_outbox_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1160
--- pg_trickle::api::diagnostics::drop_watermark_group
-CREATE  FUNCTION pgtrickle."drop_watermark_group"(
-	"group_name" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_watermark_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:912
--- pg_trickle::api::diagnostics::gate_source
-CREATE  FUNCTION pgtrickle."gate_source"(
+-- src/api/diagnostics.rs:935
+-- pg_trickle::api::diagnostics::ungate_source
+CREATE  FUNCTION pgtrickle."ungate_source"(
 	"source" TEXT /* & str */
 ) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'gate_source_wrapper';
+AS 'MODULE_PATHNAME', 'ungate_source_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor.rs:2125
--- pg_trickle::monitor::change_buffer_sizes
-CREATE  FUNCTION pgtrickle."change_buffer_sizes"() RETURNS TABLE (
-	"stream_table" TEXT,  /* String */
-	"source_table" TEXT,  /* String */
-	"source_oid" bigint,  /* i64 */
-	"cdc_mode" TEXT,  /* String */
-	"pending_rows" bigint,  /* i64 */
-	"buffer_bytes" bigint  /* i64 */
-)
-STRICT  
+-- src/api/diagnostics.rs:1377
+-- pg_trickle::api::diagnostics::create_refresh_group
+CREATE  FUNCTION pgtrickle."create_refresh_group"(
+	"group_name" TEXT, /* & str */
+	"members" TEXT[], /* Vec < String > */
+	"isolation" TEXT DEFAULT 'read_committed' /* & str */
+) RETURNS INT /* Result < i32, PgTrickleError > */
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'change_buffer_sizes_wrapper';
+AS 'MODULE_PATHNAME', 'create_refresh_group_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:865
--- pg_trickle::api::create_or_replace_stream_table
-CREATE  FUNCTION pgtrickle."create_or_replace_stream_table"(
+-- src/api/self_monitoring.rs:240
+-- pg_trickle::api::self_monitoring::setup_self_monitoring
+CREATE  FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:635
+-- pg_trickle::api::create_stream_table_if_not_exists
+CREATE  FUNCTION pgtrickle."create_stream_table_if_not_exists"(
 	"name" TEXT, /* & str */
 	"query" TEXT, /* & str */
 	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
@@ -772,345 +515,33 @@ CREATE  FUNCTION pgtrickle."create_or_replace_stream_table"(
 ) RETURNS void
 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_or_replace_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'create_stream_table_if_not_exists_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:748
--- pg_trickle::api::diagnostics::fuse_status
-CREATE  FUNCTION pgtrickle."fuse_status"() RETURNS TABLE (
-	"stream_table" TEXT,  /* String */
-	"fuse_mode" TEXT,  /* String */
-	"fuse_state" TEXT,  /* String */
-	"fuse_ceiling" bigint,  /* Option < i64 > */
-	"effective_ceiling" bigint,  /* Option < i64 > */
-	"fuse_sensitivity" INT,  /* Option < i32 > */
-	"blown_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"blow_reason" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'fuse_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:3261
--- pg_trickle::monitor::parallel_job_status
-CREATE  FUNCTION pgtrickle."parallel_job_status"(
-	"max_age_seconds" INT DEFAULT 300 /* i32 */
-) RETURNS TABLE (
-	"job_id" bigint,  /* i64 */
-	"unit_key" TEXT,  /* String */
-	"unit_kind" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"member_count" INT,  /* i32 */
-	"attempt_no" INT,  /* i32 */
-	"scheduler_pid" INT,  /* i32 */
-	"worker_pid" INT,  /* Option < i32 > */
-	"enqueued_at" timestamp with time zone,  /* TimestampWithTimeZone */
-	"started_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"finished_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"duration_ms" double precision  /* Option < f64 > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'parallel_job_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:296
--- pg_trickle::api::diagnostics::explain_refresh_mode
-CREATE  FUNCTION pgtrickle."explain_refresh_mode"(
+-- src/api/mod.rs:6552
+-- pg_trickle::api::stream_table_lineage
+CREATE  FUNCTION pgtrickle."stream_table_lineage"(
 	"name" TEXT /* & str */
 ) RETURNS TABLE (
-	"configured_mode" TEXT,  /* String */
-	"effective_mode" TEXT,  /* Option < String > */
-	"downgrade_reason" TEXT  /* Option < String > */
+	"output_col" TEXT,  /* Option < String > */
+	"source_table" TEXT,  /* Option < String > */
+	"source_col" TEXT  /* Option < String > */
 )
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_refresh_mode_wrapper';
+AS 'MODULE_PATHNAME', 'stream_table_lineage_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:5381
--- pg_trickle::api::unsubscribe
-CREATE  FUNCTION pgtrickle."unsubscribe"(
-	"stream_table" TEXT, /* & str */
-	"channel" TEXT /* & str */
+-- src/api/diagnostics.rs:1160
+-- pg_trickle::api::diagnostics::drop_watermark_group
+CREATE  FUNCTION pgtrickle."drop_watermark_group"(
+	"group_name" TEXT /* & str */
 ) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'unsubscribe_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/cluster.rs:18
--- pg_trickle::api::cluster::cluster_worker_summary
-CREATE  FUNCTION pgtrickle."cluster_worker_summary"() RETURNS TABLE (
-	"db_oid" bigint,  /* Option < i64 > */
-	"db_name" TEXT,  /* Option < String > */
-	"active_workers" INT,  /* Option < i32 > */
-	"scheduler_pid" INT,  /* Option < i32 > */
-	"scheduler_running" bool,  /* Option < bool > */
-	"total_active_workers" INT  /* Option < i32 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'cluster_worker_summary_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:1366
--- pg_trickle::monitor::explain_diff_sql
-CREATE  FUNCTION pgtrickle."explain_diff_sql"(
-	"name" TEXT /* & str */
-) RETURNS TEXT /* Option < String > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_diff_sql_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:3023
--- pg_trickle::monitor::refresh_timeline
-CREATE  FUNCTION pgtrickle."refresh_timeline"(
-	"max_rows" INT DEFAULT 50 /* i32 */
-) RETURNS TABLE (
-	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
-	"stream_table" TEXT,  /* String */
-	"action" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"rows_inserted" bigint,  /* i64 */
-	"rows_deleted" bigint,  /* i64 */
-	"duration_ms" double precision,  /* Option < f64 > */
-	"error_message" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_timeline_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/diagnostics.rs:767
--- pg_trickle::diagnostics::validate_query
-CREATE  FUNCTION pgtrickle."validate_query"(
-	"query" TEXT /* & str */
-) RETURNS TABLE (
-	"check_name" TEXT,  /* String */
-	"result" TEXT,  /* String */
-	"severity" TEXT  /* String */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'validate_query_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:6372
--- pg_trickle::api::bulk_drop_stream_tables
-CREATE  FUNCTION pgtrickle."bulk_drop_stream_tables"(
-	"names" TEXT[] /* Vec < Option < String > > */
-) RETURNS INT /* i32 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bulk_drop_stream_tables_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:6427
--- pg_trickle::api::exec_stream_ddl
-CREATE  FUNCTION pgtrickle."exec_stream_ddl"(
-	"cmd" TEXT /* & str */
-) RETURNS bool /* bool */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'exec_stream_ddl_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:4455
--- pg_trickle::api::repair_stream_table
-CREATE  FUNCTION pgtrickle."repair_stream_table"(
-	"name" TEXT /* & str */
-) RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'repair_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:3109
--- pg_trickle::monitor::trigger_inventory
-CREATE  FUNCTION pgtrickle."trigger_inventory"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"source_oid" bigint,  /* i64 */
-	"trigger_name" TEXT,  /* String */
-	"trigger_type" TEXT,  /* String */
-	"present" bool,  /* bool */
-	"enabled" bool  /* bool */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'trigger_inventory_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:2876
--- pg_trickle::monitor::health_summary
-CREATE  FUNCTION pgtrickle."health_summary"() RETURNS TABLE (
-	"total_stream_tables" INT,  /* i32 */
-	"active_count" INT,  /* i32 */
-	"error_count" INT,  /* i32 */
-	"suspended_count" INT,  /* i32 */
-	"stale_count" INT,  /* i32 */
-	"reinit_pending" INT,  /* i32 */
-	"max_staleness_seconds" double precision,  /* Option < f64 > */
-	"scheduler_status" TEXT,  /* String */
-	"cache_hit_rate" double precision  /* Option < f64 > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'health_summary_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/diagnostics.rs:570
--- pg_trickle::diagnostics::list_auxiliary_columns
-CREATE  FUNCTION pgtrickle."list_auxiliary_columns"(
-	"name" TEXT /* & str */
-) RETURNS TABLE (
-	"column_name" TEXT,  /* String */
-	"data_type" TEXT,  /* String */
-	"purpose" TEXT  /* String */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_auxiliary_columns_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/ivm.rs:834
--- pg_trickle::ivm::pgt_ivm_apply_delta_enr
-CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta_enr"(
-	"pgt_id" bigint, /* i64 */
-	"source_oid" INT, /* i32 */
-	"has_new" bool, /* bool */
-	"has_old" bool /* bool */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_enr_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1459
--- pg_trickle::api::diagnostics::refresh_groups
-CREATE  FUNCTION pgtrickle."refresh_groups"() RETURNS TABLE (
-	"group_id" INT,  /* i32 */
-	"group_name" TEXT,  /* String */
-	"member_count" INT,  /* i32 */
-	"isolation" TEXT,  /* String */
-	"created_at" timestamp with time zone  /* TimestampWithTimeZone */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_groups_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:935
--- pg_trickle::monitor::slot_health
-CREATE  FUNCTION pgtrickle."slot_health"() RETURNS TABLE (
-	"slot_name" TEXT,  /* String */
-	"source_relid" bigint,  /* i64 */
-	"active" bool,  /* bool */
-	"retained_wal_bytes" bigint,  /* i64 */
-	"wal_status" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'slot_health_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1091
--- pg_trickle::api::diagnostics::advance_watermark
-CREATE  FUNCTION pgtrickle."advance_watermark"(
-	"source" TEXT, /* & str */
-	"watermark" timestamp with time zone /* TimestampWithTimeZone */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'advance_watermark_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1256
--- pg_trickle::api::diagnostics::watermark_status
-CREATE  FUNCTION pgtrickle."watermark_status"() RETURNS TABLE (
-	"group_name" TEXT,  /* String */
-	"min_watermark" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"max_watermark" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"lag_secs" double precision,  /* Option < f64 > */
-	"aligned" bool,  /* bool */
-	"sources_with_watermark" INT,  /* i32 */
-	"sources_total" INT  /* i32 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'watermark_status_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/publication.rs:16
--- pg_trickle::api::publication::stream_table_to_publication
-CREATE  FUNCTION pgtrickle."stream_table_to_publication"(
-	"name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_to_publication_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1377
--- pg_trickle::api::diagnostics::create_refresh_group
-CREATE  FUNCTION pgtrickle."create_refresh_group"(
-	"group_name" TEXT, /* & str */
-	"members" TEXT[], /* Vec < String > */
-	"isolation" TEXT DEFAULT 'read_committed' /* & str */
-) RETURNS INT /* Result < i32, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_refresh_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1508
--- pg_trickle::api::diagnostics::worker_allocation_status
-CREATE  FUNCTION pgtrickle."worker_allocation_status"() RETURNS TABLE (
-	"db_name" TEXT,  /* String */
-	"workers_used" bigint,  /* i64 */
-	"workers_quota" bigint,  /* i64 */
-	"workers_queued" bigint,  /* i64 */
-	"cluster_active" bigint,  /* i64 */
-	"cluster_max" bigint  /* i64 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'worker_allocation_status_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:912
--- pg_trickle::monitor::get_staleness
-CREATE  FUNCTION pgtrickle."get_staleness"(
-	"name" TEXT /* & str */
-) RETURNS double precision /* Option < f64 > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'get_staleness_wrapper';
+AS 'MODULE_PATHNAME', 'drop_watermark_group_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1132,96 +563,28 @@ AS 'MODULE_PATHNAME', 'shared_buffer_stats_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/self_monitoring.rs:305
--- pg_trickle::api::self_monitoring::teardown_self_monitoring
-CREATE  FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:223
--- pg_trickle::api::diagnostics::pgt_scc_status
-CREATE  FUNCTION pgtrickle."pgt_scc_status"() RETURNS TABLE (
-	"scc_id" INT,  /* i32 */
-	"member_count" INT,  /* i32 */
-	"members" TEXT[],  /* Vec < String > */
-	"last_iterations" INT,  /* Option < i32 > */
-	"last_converged_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_scc_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:6241
--- pg_trickle::api::is_drained
-CREATE  FUNCTION pgtrickle."is_drained"() RETURNS bool /* bool */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'is_drained_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:4399
--- pg_trickle::api::resume_stream_table
-CREATE  FUNCTION pgtrickle."resume_stream_table"(
-	"name" TEXT /* & str */
+-- src/api/outbox.rs:82
+-- pg_trickle::api::outbox::attach_outbox
+CREATE  FUNCTION pgtrickle."attach_outbox"(
+	"p_name" TEXT, /* & str */
+	"p_retention_hours" INT DEFAULT 24, /* i32 */
+	"p_inline_threshold_rows" INT DEFAULT 10000 /* i32 */
 ) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'resume_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'attach_outbox_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/hooks.rs:51
--- pg_trickle::hooks::pg_trickle_on_ddl_end
--- Skipped due to `#[pgrx(sql = false)]`
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:4216
--- pg_trickle::api::drop_stream_table
-CREATE  FUNCTION pgtrickle."drop_stream_table"(
-	"name" TEXT, /* & str */
-	"cascade" bool DEFAULT false /* bool */
-) RETURNS void
+-- src/api/mod.rs:6356
+-- pg_trickle::api::bulk_alter_stream_tables
+CREATE  FUNCTION pgtrickle."bulk_alter_stream_tables"(
+	"names" TEXT[], /* Vec < Option < String > > */
+	"params" json /* pgrx :: Json */
+) RETURNS INT /* i32 */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:2557
--- pg_trickle::monitor::health_check
-CREATE  FUNCTION pgtrickle."health_check"() RETURNS TABLE (
-	"check_name" TEXT,  /* String */
-	"severity" TEXT,  /* String */
-	"detail" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'health_check_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1019
--- pg_trickle::api::diagnostics::bootstrap_gate_status
-CREATE  FUNCTION pgtrickle."bootstrap_gate_status"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"schema_name" TEXT,  /* String */
-	"gated" bool,  /* bool */
-	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"gated_by" TEXT,  /* Option < String > */
-	"gate_duration" interval,  /* Option < pgrx :: datum :: Interval > */
-	"affected_stream_tables" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bootstrap_gate_status_fn_wrapper';
+AS 'MODULE_PATHNAME', 'bulk_alter_stream_tables_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1244,23 +607,92 @@ AS 'MODULE_PATHNAME', 'vector_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:8
--- pg_trickle::api::diagnostics::version
-CREATE  FUNCTION pgtrickle."version"() RETURNS TEXT /* & '_ str */
-IMMUTABLE STRICT PARALLEL SAFE 
+-- src/api/mod.rs:5447
+-- pg_trickle::api::subscribe_distance
+CREATE  FUNCTION pgtrickle."subscribe_distance"(
+	"stream_table" TEXT, /* & str */
+	"channel" TEXT, /* & str */
+	"vector_column" TEXT, /* & str */
+	"query_vector" TEXT, /* & str */
+	"op" TEXT, /* & str */
+	"threshold" double precision /* f64 */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'version_wrapper';
+AS 'MODULE_PATHNAME', 'subscribe_distance_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/planner.rs:117
--- pg_trickle::api::planner::recommend_schedule
-CREATE  FUNCTION pgtrickle."recommend_schedule"(
-	"p_name" TEXT /* & str */
-) RETURNS jsonb /* pgrx :: JsonB */
+-- src/hash.rs:54
+-- pg_trickle::hash::pg_trickle_hash_multi
+CREATE  FUNCTION pgtrickle."pg_trickle_hash_multi"(
+	"inputs" TEXT[] /* Vec < Option < String > > */
+) RETURNS bigint /* i64 */
+IMMUTABLE STRICT PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pg_trickle_hash_multi_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:5492
+-- pg_trickle::api::unsubscribe_distance
+CREATE  FUNCTION pgtrickle."unsubscribe_distance"(
+	"stream_table" TEXT, /* & str */
+	"channel" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'recommend_schedule_wrapper';
+AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:4630
+-- pg_trickle::api::refresh_stream_table
+CREATE  FUNCTION pgtrickle."refresh_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'refresh_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:761
+-- requires:
+--   refresh_stream_table
+
+
+CREATE OR REPLACE FUNCTION pgtrickle."refresh_if_stale"(
+    p_name   text,
+    p_max_age interval DEFAULT '5 minutes'::interval
+)
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_last_end timestamp with time zone;
+    v_refreshed boolean := false;
+BEGIN
+    SELECT MAX(end_time)
+      INTO v_last_end
+      FROM pgtrickle.pgt_refresh_history h
+      JOIN pgtrickle.pgt_stream_tables   s USING (pgt_id)
+     WHERE s.pgt_name = p_name
+       AND h.status = 'COMPLETED';
+
+    IF v_last_end IS NULL OR (now() - v_last_end) > p_max_age THEN
+        PERFORM pgtrickle.refresh_stream_table(p_name);
+        v_refreshed := true;
+    END IF;
+
+    RETURN v_refreshed;
+END;
+$$;
+
+COMMENT ON FUNCTION pgtrickle."refresh_if_stale"(text, interval) IS
+    'Refresh the named stream table only when the most recent completed '
+    'refresh is older than max_age.  Returns TRUE when a refresh was '
+    'triggered, FALSE when the table was fresh enough.';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1282,147 +714,6 @@ AS 'MODULE_PATHNAME', 'worker_pool_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:6258
--- pg_trickle::api::cdc_pause_status
-CREATE  FUNCTION pgtrickle."cdc_pause_status"() RETURNS TABLE (
-	"paused" bool,  /* bool */
-	"capture_mode" TEXT,  /* String */
-	"note" TEXT  /* String */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'cdc_pause_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:958
--- pg_trickle::monitor::cache_stats
-CREATE  FUNCTION pgtrickle."cache_stats"() RETURNS TABLE (
-	"l1_hits" bigint,  /* i64 */
-	"l2_hits" bigint,  /* i64 */
-	"misses" bigint,  /* i64 */
-	"evictions" bigint,  /* i64 */
-	"l1_size" INT  /* i32 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'cache_stats_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1447
--- pg_trickle::api::diagnostics::drop_refresh_group
-CREATE  FUNCTION pgtrickle."drop_refresh_group"(
-	"group_name" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_refresh_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:516
--- pg_trickle::api::diagnostics::dedup_stats
-CREATE  FUNCTION pgtrickle."dedup_stats"() RETURNS TABLE (
-	"total_diff_refreshes" bigint,  /* i64 */
-	"dedup_needed" bigint,  /* i64 */
-	"dedup_ratio_pct" double precision  /* f64 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dedup_stats_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:453
--- pg_trickle::api::self_monitoring::scheduler_overhead
-CREATE  FUNCTION pgtrickle."scheduler_overhead"() RETURNS TABLE (
-	"total_refreshes_1h" bigint,  /* i64 */
-	"df_refreshes_1h" bigint,  /* i64 */
-	"df_refresh_fraction" double precision,  /* Option < f64 > */
-	"avg_refresh_ms" double precision,  /* Option < f64 > */
-	"avg_df_refresh_ms" double precision,  /* Option < f64 > */
-	"total_refresh_time_s" double precision,  /* Option < f64 > */
-	"df_refresh_time_s" double precision  /* Option < f64 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'scheduler_overhead_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1599
--- pg_trickle::api::diagnostics::preflight
-CREATE  FUNCTION pgtrickle."preflight"() RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'preflight_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/publication.rs:73
--- pg_trickle::api::publication::drop_stream_table_publication
-CREATE  FUNCTION pgtrickle."drop_stream_table_publication"(
-	"name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_stream_table_publication_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/citus.rs:783
--- pg_trickle::citus::handle_vp_promoted
-CREATE  FUNCTION pgtrickle."handle_vp_promoted"(
-	"payload" TEXT /* & str */
-) RETURNS bool /* bool */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'sql_handle_vp_promoted_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/snapshot.rs:321
--- pg_trickle::api::snapshot::restore_from_snapshot
-CREATE  FUNCTION pgtrickle."restore_from_snapshot"(
-	"p_name" TEXT, /* & str */
-	"p_source" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'restore_from_snapshot_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:1077
--- pg_trickle::monitor::explain_st
-CREATE  FUNCTION pgtrickle."explain_st"(
-	"name" TEXT, /* & str */
-	"with_analyze" bool DEFAULT false /* bool */
-) RETURNS TABLE (
-	"property" TEXT,  /* String */
-	"value" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_st_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:6143
--- pg_trickle::api::view_evolution_status
-CREATE  FUNCTION pgtrickle."view_evolution_status"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"in_shadow_build" bool,  /* Option < bool > */
-	"shadow_table_name" TEXT,  /* Option < String > */
-	"status" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'view_evolution_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
 -- src/api/diagnostics.rs:1221
 -- pg_trickle::api::diagnostics::watermark_groups
 CREATE  FUNCTION pgtrickle."watermark_groups"() RETURNS TABLE (
@@ -1437,318 +728,12 @@ AS 'MODULE_PATHNAME', 'watermark_groups_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:109
--- pg_trickle::api::diagnostics::rebuild_cdc_triggers
-CREATE  FUNCTION pgtrickle."rebuild_cdc_triggers"() RETURNS TEXT /* & '_ str */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'rebuild_cdc_triggers_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:676
--- pg_trickle::api::diagnostics::reset_fuse
-CREATE  FUNCTION pgtrickle."reset_fuse"(
-	"name" TEXT, /* & str */
-	"action" TEXT DEFAULT 'apply' /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'reset_fuse_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/diagnostics.rs:395
--- pg_trickle::diagnostics::diagnose_errors
-CREATE  FUNCTION pgtrickle."diagnose_errors"(
-	"name" TEXT /* & str */
-) RETURNS TABLE (
-	"event_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"error_type" TEXT,  /* String */
-	"error_message" TEXT,  /* String */
-	"remediation" TEXT  /* String */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'diagnose_errors_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/ivm.rs:712
--- pg_trickle::ivm::pgt_ivm_apply_delta
-CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta"(
-	"pgt_id" bigint, /* i64 */
-	"source_oid" INT, /* i32 */
-	"has_new" bool, /* bool */
-	"has_old" bool /* bool */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:154
--- pg_trickle::api::diagnostics::parse_duration_seconds
-CREATE  FUNCTION pgtrickle."parse_duration_seconds"(
-	"input" TEXT /* & str */
-) RETURNS bigint /* Option < i64 > */
+-- src/api/diagnostics.rs:8
+-- pg_trickle::api::diagnostics::version
+CREATE  FUNCTION pgtrickle."version"() RETURNS TEXT /* & '_ str */
 IMMUTABLE STRICT PARALLEL SAFE 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'parse_duration_seconds_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:684
--- requires:
---   parse_duration_seconds
-
-
--- ERG-E: One-row health summary for dashboards and alerting.
-CREATE OR REPLACE VIEW pgtrickle.quick_health AS
-SELECT
-    (SELECT count(*) FROM pgtrickle.pgt_stream_tables)::bigint
-        AS total_stream_tables,
-    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
-     WHERE status = 'ERROR' OR consecutive_errors > 0)::bigint
-        AS error_tables,
-    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
-     WHERE schedule IS NOT NULL
-       AND schedule !~ '[\s@]'
-       AND last_refresh_at IS NOT NULL
-       AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
-           pgtrickle.parse_duration_seconds(schedule))::bigint
-        AS stale_tables,
-    (SELECT count(*) > 0 FROM pg_stat_activity
-     WHERE backend_type = 'pg_trickle scheduler')
-        AS scheduler_running,
-    CASE
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables) = 0 THEN 'EMPTY'
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'SUSPENDED') > 0 THEN 'CRITICAL'
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'ERROR' OR consecutive_errors > 0) > 0 THEN 'WARNING'
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables
-              WHERE schedule IS NOT NULL
-                AND schedule !~ '[\s@]'
-                AND last_refresh_at IS NOT NULL
-                AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
-                    pgtrickle.parse_duration_seconds(schedule)) > 0 THEN 'WARNING'
-        ELSE 'OK'
-    END AS status;
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:511
--- requires:
---   parse_duration_seconds
-
-
--- Status overview view (ERR-1d: last_error_message and last_error_at are
--- included via st.* from pgt_stream_tables)
-CREATE OR REPLACE VIEW pgtrickle.stream_tables_info AS
-SELECT st.*,
-       now() - st.last_refresh_at AS staleness,
-       CASE WHEN st.schedule IS NOT NULL
-                 AND st.schedule !~ '[\s@]'
-            THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
-                 pgtrickle.parse_duration_seconds(st.schedule)
-            ELSE NULL::boolean
-       END AS stale,
-       CASE WHEN st.topk_limit IS NOT NULL THEN TRUE ELSE FALSE END AS is_topk
-FROM pgtrickle.pgt_stream_tables st;
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:596
--- requires:
---   parse_duration_seconds
-
-
--- Convenience view: pg_stat_stream_tables
--- Combines catalog metadata with aggregate refresh statistics.
-CREATE OR REPLACE VIEW pgtrickle.pg_stat_stream_tables AS
-SELECT
-    st.pgt_id,
-    st.pgt_schema,
-    st.pgt_name,
-    st.status,
-    st.refresh_mode,
-    st.is_populated,
-    st.data_timestamp,
-    st.schedule,
-    now() - st.last_refresh_at AS staleness,
-    CASE WHEN st.schedule IS NOT NULL AND st.last_refresh_at IS NOT NULL
-              AND st.schedule !~ '[\s@]'
-         THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
-              pgtrickle.parse_duration_seconds(st.schedule)
-         ELSE NULL::boolean
-    END AS stale,
-    st.consecutive_errors,
-    st.needs_reinit,
-    st.last_refresh_at,
-    COALESCE(stats.total_refreshes, 0) AS total_refreshes,
-    COALESCE(stats.successful_refreshes, 0) AS successful_refreshes,
-    COALESCE(stats.failed_refreshes, 0) AS failed_refreshes,
-    COALESCE(stats.total_rows_inserted, 0) AS total_rows_inserted,
-    COALESCE(stats.total_rows_deleted, 0) AS total_rows_deleted,
-    stats.avg_duration_ms,
-    stats.last_action,
-    stats.last_status,
-    (SELECT array_agg(DISTINCT d.cdc_mode ORDER BY d.cdc_mode)
-     FROM pgtrickle.pgt_dependencies d
-     WHERE d.pgt_id = st.pgt_id AND d.source_type = 'TABLE') AS cdc_modes,
-    st.scc_id,
-    st.last_fixpoint_iterations,
-    st.refresh_tier
-FROM pgtrickle.pgt_stream_tables st
-LEFT JOIN LATERAL (
-    SELECT
-        count(*)::bigint AS total_refreshes,
-        count(*) FILTER (WHERE h.status = 'COMPLETED')::bigint AS successful_refreshes,
-        count(*) FILTER (WHERE h.status = 'FAILED')::bigint AS failed_refreshes,
-        COALESCE(sum(h.rows_inserted), 0)::bigint AS total_rows_inserted,
-        COALESCE(sum(h.rows_deleted), 0)::bigint AS total_rows_deleted,
-        CASE WHEN count(*) FILTER (WHERE h.end_time IS NOT NULL) > 0
-             THEN avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000)
-                  FILTER (WHERE h.end_time IS NOT NULL)
-             ELSE NULL
-        END::float8 AS avg_duration_ms,
-        (SELECT h2.action FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_action,
-        (SELECT h2.status FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_status,
-        (SELECT h2.initiated_by FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_initiated_by,
-        (SELECT h2.freshness_deadline FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS freshness_deadline
-    FROM pgtrickle.pgt_refresh_history h
-    WHERE h.pgt_id = st.pgt_id
-) stats ON true;
-
--- Per-source CDC status view (G5): exposes cdc_mode, slot names, and
--- transition timestamps for every TABLE dependency of a stream table.
-CREATE OR REPLACE VIEW pgtrickle.pgt_cdc_status AS
-SELECT
-    st.pgt_schema,
-    st.pgt_name,
-    d.source_relid,
-    c.relname        AS source_name,
-    n.nspname        AS source_schema,
-    d.cdc_mode,
-    d.slot_name,
-    d.decoder_confirmed_lsn,
-    d.transition_started_at
-FROM pgtrickle.pgt_dependencies d
-JOIN pgtrickle.pgt_stream_tables st ON st.pgt_id = d.pgt_id
-JOIN pg_class c ON c.oid = d.source_relid
-JOIN pg_namespace n ON n.oid = c.relnamespace
-WHERE d.source_type = 'TABLE';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:5657
--- pg_trickle::api::embedding_stream_table
-CREATE  FUNCTION pgtrickle."embedding_stream_table"(
-	"name" TEXT, /* & str */
-	"source_table" TEXT, /* & str */
-	"vector_column" TEXT, /* & str */
-	"extra_columns" TEXT DEFAULT NULL, /* Option < & str > */
-	"refresh_interval" TEXT DEFAULT '1m', /* & str */
-	"index_type" TEXT DEFAULT 'hnsw', /* & str */
-	"dry_run" bool DEFAULT false /* bool */
-) RETURNS TABLE (
-	"action" TEXT  /* Option < String > */
-)
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'embedding_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/snapshot.rs:472
--- pg_trickle::api::snapshot::list_snapshots
-CREATE  FUNCTION pgtrickle."list_snapshots"(
-	"p_name" TEXT /* & str */
-) RETURNS TABLE (
-	"snapshot_table" TEXT,  /* Option < String > */
-	"created_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"row_count" bigint,  /* Option < i64 > */
-	"frontier" jsonb,  /* Option < pgrx :: JsonB > */
-	"size_bytes" bigint  /* Option < i64 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_snapshots_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:819
--- pg_trickle::api::diagnostics::diamond_groups
-CREATE  FUNCTION pgtrickle."diamond_groups"() RETURNS TABLE (
-	"group_id" INT,  /* i32 */
-	"member_name" TEXT,  /* String */
-	"member_schema" TEXT,  /* String */
-	"is_convergence" bool,  /* bool */
-	"epoch" bigint,  /* i64 */
-	"schedule_policy" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'diamond_groups_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:6505
--- pg_trickle::api::stream_table_lineage
-CREATE  FUNCTION pgtrickle."stream_table_lineage"(
-	"name" TEXT /* & str */
-) RETURNS TABLE (
-	"output_col" TEXT,  /* Option < String > */
-	"source_table" TEXT,  /* Option < String > */
-	"source_col" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_lineage_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:2206
--- pg_trickle::monitor::list_sources
-CREATE  FUNCTION pgtrickle."list_sources"(
-	"name" TEXT /* & str */
-) RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"source_oid" bigint,  /* i64 */
-	"source_type" TEXT,  /* String */
-	"cdc_mode" TEXT,  /* String */
-	"columns_used" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_sources_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:5951
--- pg_trickle::api::explain_stream_table
-CREATE  FUNCTION pgtrickle."explain_stream_table"(
-	"name" TEXT /* & str */
-) RETURNS TEXT /* Result < String, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:6309
--- pg_trickle::api::bulk_alter_stream_tables
-CREATE  FUNCTION pgtrickle."bulk_alter_stream_tables"(
-	"names" TEXT[], /* Vec < Option < String > > */
-	"params" json /* pgrx :: Json */
-) RETURNS INT /* i32 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bulk_alter_stream_tables_wrapper';
+AS 'MODULE_PATHNAME', 'version_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1785,68 +770,136 @@ COMMENT ON FUNCTION pgtrickle."stream_table_definition"(text) IS
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor.rs:3414
--- pg_trickle::monitor::wal_source_status
-CREATE  FUNCTION pgtrickle."wal_source_status"() RETURNS TABLE (
-	"source_relid" bigint,  /* i64 */
-	"source_name" TEXT,  /* String */
-	"cdc_mode" TEXT,  /* String */
-	"slot_name" TEXT,  /* Option < String > */
-	"slot_lag_bytes" bigint,  /* i64 */
-	"publication_name" TEXT,  /* Option < String > */
-	"blocked_reason" TEXT,  /* Option < String > */
-	"transition_started_at" TEXT,  /* Option < String > */
-	"decoder_confirmed_lsn" TEXT  /* Option < String > */
+-- src/api/diagnostics.rs:1019
+-- pg_trickle::api::diagnostics::bootstrap_gate_status
+CREATE  FUNCTION pgtrickle."bootstrap_gate_status"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"schema_name" TEXT,  /* String */
+	"gated" bool,  /* bool */
+	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"gated_by" TEXT,  /* Option < String > */
+	"gate_duration" interval,  /* Option < pgrx :: datum :: Interval > */
+	"affected_stream_tables" TEXT  /* Option < String > */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'wal_source_status_wrapper';
+AS 'MODULE_PATHNAME', 'bootstrap_gate_status_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:716
--- pg_trickle::api::bulk_create
-CREATE  FUNCTION pgtrickle."bulk_create"(
-	"definitions" jsonb /* pgrx :: JsonB */
-) RETURNS jsonb /* pgrx :: JsonB */
+-- src/monitor.rs:1627
+-- pg_trickle::monitor::check_cdc_health
+CREATE  FUNCTION pgtrickle."check_cdc_health"() RETURNS TABLE (
+	"source_relid" bigint,  /* i64 */
+	"source_table" TEXT,  /* String */
+	"cdc_mode" TEXT,  /* String */
+	"slot_name" TEXT,  /* Option < String > */
+	"lag_bytes" bigint,  /* Option < i64 > */
+	"confirmed_lsn" TEXT,  /* Option < String > */
+	"alert" TEXT,  /* Option < String > */
+	"selective_capture" bool  /* bool */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'check_cdc_health_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:6249
+-- pg_trickle::api::drain
+CREATE  FUNCTION pgtrickle."drain"(
+	"timeout_s" INT DEFAULT 60 /* i32 */
+) RETURNS bool /* bool */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bulk_create_wrapper';
+AS 'MODULE_PATHNAME', 'drain_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:5492
--- pg_trickle::api::unsubscribe_distance
-CREATE  FUNCTION pgtrickle."unsubscribe_distance"(
-	"stream_table" TEXT, /* & str */
-	"channel" TEXT /* & str */
+-- src/api/diagnostics.rs:516
+-- pg_trickle::api::diagnostics::dedup_stats
+CREATE  FUNCTION pgtrickle."dedup_stats"() RETURNS TABLE (
+	"total_diff_refreshes" bigint,  /* i64 */
+	"dedup_needed" bigint,  /* i64 */
+	"dedup_ratio_pct" double precision  /* f64 */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'dedup_stats_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/ivm.rs:712
+-- pg_trickle::ivm::pgt_ivm_apply_delta
+CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta"(
+	"pgt_id" bigint, /* i64 */
+	"source_oid" INT, /* i32 */
+	"has_new" bool, /* bool */
+	"has_old" bool /* bool */
 ) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
+AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor.rs:785
--- pg_trickle::monitor::get_refresh_history
-CREATE  FUNCTION pgtrickle."get_refresh_history"(
-	"name" TEXT, /* & str */
-	"max_rows" INT DEFAULT 20 /* i32 */
-) RETURNS TABLE (
-	"refresh_id" bigint,  /* i64 */
-	"data_timestamp" timestamp with time zone,  /* TimestampWithTimeZone */
-	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
-	"end_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"action" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"rows_inserted" bigint,  /* i64 */
-	"rows_deleted" bigint,  /* i64 */
-	"duration_ms" double precision,  /* Option < f64 > */
-	"error_message" TEXT  /* Option < String > */
+-- src/api/mod.rs:5396
+-- pg_trickle::api::list_subscriptions
+CREATE  FUNCTION pgtrickle."list_subscriptions"() RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"channel" TEXT,  /* Option < String > */
+	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
 )
-STRICT  
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'get_refresh_history_wrapper';
+AS 'MODULE_PATHNAME', 'list_subscriptions_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/hash.rs:33
+-- pg_trickle::hash::pg_trickle_hash
+CREATE  FUNCTION pgtrickle."pg_trickle_hash"(
+	"input" TEXT /* Option < & str > */
+) RETURNS bigint /* i64 */
+IMMUTABLE PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pg_trickle_hash_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:676
+-- pg_trickle::api::diagnostics::reset_fuse
+CREATE  FUNCTION pgtrickle."reset_fuse"(
+	"name" TEXT, /* & str */
+	"action" TEXT DEFAULT 'apply' /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'reset_fuse_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/publication.rs:126
+-- pg_trickle::api::publication::set_stream_table_sla
+CREATE  FUNCTION pgtrickle."set_stream_table_sla"(
+	"name" TEXT, /* & str */
+	"sla" interval /* Interval */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'set_stream_table_sla_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:4455
+-- pg_trickle::api::repair_stream_table
+CREATE  FUNCTION pgtrickle."repair_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS TEXT /* String */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'repair_stream_table_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1859,48 +912,130 @@ AS 'MODULE_PATHNAME', 'version_check_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/self_monitoring.rs:240
--- pg_trickle::api::self_monitoring::setup_self_monitoring
-CREATE  FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
+-- src/api/mod.rs:6474
+-- pg_trickle::api::exec_stream_ddl
+CREATE  FUNCTION pgtrickle."exec_stream_ddl"(
+	"cmd" TEXT /* & str */
+) RETURNS bool /* bool */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
+AS 'MODULE_PATHNAME', 'exec_stream_ddl_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:5447
--- pg_trickle::api::subscribe_distance
-CREATE  FUNCTION pgtrickle."subscribe_distance"(
-	"stream_table" TEXT, /* & str */
-	"channel" TEXT, /* & str */
-	"vector_column" TEXT, /* & str */
-	"query_vector" TEXT, /* & str */
-	"op" TEXT, /* & str */
-	"threshold" double precision /* f64 */
+-- src/monitor.rs:958
+-- pg_trickle::monitor::cache_stats
+CREATE  FUNCTION pgtrickle."cache_stats"() RETURNS TABLE (
+	"l1_hits" bigint,  /* i64 */
+	"l2_hits" bigint,  /* i64 */
+	"misses" bigint,  /* i64 */
+	"evictions" bigint,  /* i64 */
+	"l1_size" INT  /* i32 */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'cache_stats_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:2557
+-- pg_trickle::monitor::health_check
+CREATE  FUNCTION pgtrickle."health_check"() RETURNS TABLE (
+	"check_name" TEXT,  /* String */
+	"severity" TEXT,  /* String */
+	"detail" TEXT  /* String */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'health_check_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:305
+-- pg_trickle::api::self_monitoring::teardown_self_monitoring
+CREATE  FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/outbox.rs:163
+-- pg_trickle::api::outbox::detach_outbox
+CREATE  FUNCTION pgtrickle."detach_outbox"(
+	"p_name" TEXT, /* & str */
+	"p_if_exists" bool DEFAULT false /* bool */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'detach_outbox_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:6190
+-- pg_trickle::api::view_evolution_status
+CREATE  FUNCTION pgtrickle."view_evolution_status"() RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"in_shadow_build" bool,  /* Option < bool > */
+	"shadow_table_name" TEXT,  /* Option < String > */
+	"status" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'view_evolution_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:935
+-- pg_trickle::monitor::slot_health
+CREATE  FUNCTION pgtrickle."slot_health"() RETURNS TABLE (
+	"slot_name" TEXT,  /* String */
+	"source_relid" bigint,  /* i64 */
+	"active" bool,  /* bool */
+	"retained_wal_bytes" bigint,  /* i64 */
+	"wal_status" TEXT  /* String */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'slot_health_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:912
+-- pg_trickle::api::diagnostics::gate_source
+CREATE  FUNCTION pgtrickle."gate_source"(
+	"source" TEXT /* & str */
 ) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'subscribe_distance_wrapper';
+AS 'MODULE_PATHNAME', 'gate_source_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/helpers.rs:2392
--- pg_trickle::api::helpers::recommend_refresh_mode
-CREATE  FUNCTION pgtrickle."recommend_refresh_mode"(
-	"st_name" TEXT DEFAULT NULL /* Option < String > */
-) RETURNS TABLE (
-	"pgt_schema" TEXT,  /* String */
-	"pgt_name" TEXT,  /* String */
-	"current_mode" TEXT,  /* String */
-	"effective_mode" TEXT,  /* Option < String > */
-	"recommended_mode" TEXT,  /* String */
-	"confidence" TEXT,  /* String */
-	"reason" TEXT,  /* String */
-	"signals" jsonb  /* pgrx :: JsonB */
+-- src/api/planner.rs:186
+-- pg_trickle::api::planner::schedule_recommendations
+CREATE  FUNCTION pgtrickle."schedule_recommendations"() RETURNS TABLE (
+	"name" TEXT,  /* Option < String > */
+	"current_interval_seconds" double precision,  /* Option < f64 > */
+	"recommended_interval_seconds" double precision,  /* Option < f64 > */
+	"delta_pct" double precision,  /* Option < f64 > */
+	"confidence" double precision,  /* Option < f64 > */
+	"reasoning" TEXT  /* Option < String > */
 )
- 
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'recommend_refresh_mode_wrapper';
+AS 'MODULE_PATHNAME', 'schedule_recommendations_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:893
+-- pg_trickle::monitor::st_auto_threshold
+CREATE  FUNCTION pgtrickle."st_auto_threshold"(
+	"name" TEXT /* & str */
+) RETURNS double precision /* Option < f64 > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'st_auto_threshold_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1916,30 +1051,58 @@ AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:958
--- pg_trickle::api::diagnostics::source_gates
-CREATE  FUNCTION pgtrickle."source_gates"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"schema_name" TEXT,  /* String */
-	"gated" bool,  /* bool */
-	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"gated_by" TEXT  /* Option < String > */
+-- src/monitor.rs:3261
+-- pg_trickle::monitor::parallel_job_status
+CREATE  FUNCTION pgtrickle."parallel_job_status"(
+	"max_age_seconds" INT DEFAULT 300 /* i32 */
+) RETURNS TABLE (
+	"job_id" bigint,  /* i64 */
+	"unit_key" TEXT,  /* String */
+	"unit_kind" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"member_count" INT,  /* i32 */
+	"attempt_no" INT,  /* i32 */
+	"scheduler_pid" INT,  /* i32 */
+	"worker_pid" INT,  /* Option < i32 > */
+	"enqueued_at" timestamp with time zone,  /* TimestampWithTimeZone */
+	"started_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"finished_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"duration_ms" double precision  /* Option < f64 > */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'source_gates_fn_wrapper';
+AS 'MODULE_PATHNAME', 'parallel_job_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/hash.rs:33
--- pg_trickle::hash::pg_trickle_hash
-CREATE  FUNCTION pgtrickle."pg_trickle_hash"(
-	"input" TEXT /* Option < & str > */
-) RETURNS bigint /* i64 */
-IMMUTABLE PARALLEL SAFE 
+-- src/citus.rs:103
+-- pg_trickle::citus::source_stable_name
+CREATE  FUNCTION pgtrickle."source_stable_name"(
+	"source_oid" oid /* pg_sys :: Oid */
+) RETURNS TEXT /* Option < String > */
+STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pg_trickle_hash_wrapper';
+AS 'MODULE_PATHNAME', 'sql_stable_name_for_oid_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1447
+-- pg_trickle::api::diagnostics::drop_refresh_group
+CREATE  FUNCTION pgtrickle."drop_refresh_group"(
+	"group_name" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drop_refresh_group_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:61
+-- pg_trickle::api::diagnostics::migrate
+CREATE  FUNCTION pgtrickle."migrate"() RETURNS TEXT /* String */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'migrate_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1966,6 +1129,400 @@ CREATE  FUNCTION pgtrickle."create_stream_table"(
 
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'create_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:748
+-- pg_trickle::api::diagnostics::fuse_status
+CREATE  FUNCTION pgtrickle."fuse_status"() RETURNS TABLE (
+	"stream_table" TEXT,  /* String */
+	"fuse_mode" TEXT,  /* String */
+	"fuse_state" TEXT,  /* String */
+	"fuse_ceiling" bigint,  /* Option < i64 > */
+	"effective_ceiling" bigint,  /* Option < i64 > */
+	"fuse_sensitivity" INT,  /* Option < i32 > */
+	"blown_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"blow_reason" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuse_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1168
+-- pg_trickle::api::diagnostics::watermarks
+CREATE  FUNCTION pgtrickle."watermarks"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"schema_name" TEXT,  /* String */
+	"watermark" timestamp with time zone,  /* TimestampWithTimeZone */
+	"updated_at" timestamp with time zone,  /* TimestampWithTimeZone */
+	"advanced_by" TEXT,  /* Option < String > */
+	"wal_lsn" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'watermarks_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2673
+-- pg_trickle::api::helpers::restore_stream_tables
+CREATE  FUNCTION pgtrickle."restore_stream_tables"() RETURNS VOID /* Result < (), crate :: error :: PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'restore_stream_tables_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:2876
+-- pg_trickle::monitor::health_summary
+CREATE  FUNCTION pgtrickle."health_summary"() RETURNS TABLE (
+	"total_stream_tables" INT,  /* i32 */
+	"active_count" INT,  /* i32 */
+	"error_count" INT,  /* i32 */
+	"suspended_count" INT,  /* i32 */
+	"stale_count" INT,  /* i32 */
+	"reinit_pending" INT,  /* i32 */
+	"max_staleness_seconds" double precision,  /* Option < f64 > */
+	"scheduler_status" TEXT,  /* String */
+	"cache_hit_rate" double precision  /* Option < f64 > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'health_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:912
+-- pg_trickle::monitor::get_staleness
+CREATE  FUNCTION pgtrickle."get_staleness"(
+	"name" TEXT /* & str */
+) RETURNS double precision /* Option < f64 > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'get_staleness_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:3109
+-- pg_trickle::monitor::trigger_inventory
+CREATE  FUNCTION pgtrickle."trigger_inventory"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"source_oid" bigint,  /* i64 */
+	"trigger_name" TEXT,  /* String */
+	"trigger_type" TEXT,  /* String */
+	"present" bool,  /* bool */
+	"enabled" bool  /* bool */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'trigger_inventory_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:472
+-- pg_trickle::api::snapshot::list_snapshots
+CREATE  FUNCTION pgtrickle."list_snapshots"(
+	"p_name" TEXT /* & str */
+) RETURNS TABLE (
+	"snapshot_table" TEXT,  /* Option < String > */
+	"created_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"row_count" bigint,  /* Option < i64 > */
+	"frontier" jsonb,  /* Option < pgrx :: JsonB > */
+	"size_bytes" bigint  /* Option < i64 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_snapshots_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:6419
+-- pg_trickle::api::bulk_drop_stream_tables
+CREATE  FUNCTION pgtrickle."bulk_drop_stream_tables"(
+	"names" TEXT[] /* Vec < Option < String > > */
+) RETURNS INT /* i32 */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bulk_drop_stream_tables_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:95
+-- pg_trickle::api::diagnostics::_signal_launcher_rescan
+CREATE  FUNCTION pgtrickle."_signal_launcher_rescan"() RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', '_signal_launcher_rescan_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1123
+-- pg_trickle::api::diagnostics::create_watermark_group
+CREATE  FUNCTION pgtrickle."create_watermark_group"(
+	"group_name" TEXT, /* & str */
+	"sources" TEXT[], /* Vec < String > */
+	"tolerance_secs" double precision DEFAULT 0.0 /* f64 */
+) RETURNS INT /* Result < i32, PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_watermark_group_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1508
+-- pg_trickle::api::diagnostics::worker_allocation_status
+CREATE  FUNCTION pgtrickle."worker_allocation_status"() RETURNS TABLE (
+	"db_name" TEXT,  /* String */
+	"workers_used" bigint,  /* i64 */
+	"workers_quota" bigint,  /* i64 */
+	"workers_queued" bigint,  /* i64 */
+	"cluster_active" bigint,  /* i64 */
+	"cluster_max" bigint  /* i64 */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'worker_allocation_status_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:819
+-- pg_trickle::api::diagnostics::diamond_groups
+CREATE  FUNCTION pgtrickle."diamond_groups"() RETURNS TABLE (
+	"group_id" INT,  /* i32 */
+	"member_name" TEXT,  /* String */
+	"member_schema" TEXT,  /* String */
+	"is_convergence" bool,  /* bool */
+	"epoch" bigint,  /* i64 */
+	"schedule_policy" TEXT  /* String */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'diamond_groups_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:3631
+-- pg_trickle::api::alter_stream_table
+CREATE  FUNCTION pgtrickle."alter_stream_table"(
+	"name" TEXT, /* & str */
+	"query" TEXT DEFAULT NULL, /* Option < & str > */
+	"schedule" TEXT DEFAULT NULL, /* Option < & str > */
+	"refresh_mode" TEXT DEFAULT NULL, /* Option < & str > */
+	"status" TEXT DEFAULT NULL, /* Option < & str > */
+	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
+	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
+	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
+	"append_only" bool DEFAULT NULL, /* Option < bool > */
+	"pooler_compatibility_mode" bool DEFAULT NULL, /* Option < bool > */
+	"tier" TEXT DEFAULT NULL, /* Option < & str > */
+	"fuse" TEXT DEFAULT NULL, /* Option < & str > */
+	"fuse_ceiling" bigint DEFAULT NULL, /* Option < i64 > */
+	"fuse_sensitivity" INT DEFAULT NULL, /* Option < i32 > */
+	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
+	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
+	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
+	"post_refresh_action" TEXT DEFAULT NULL, /* Option < & str > */
+	"reindex_drift_threshold" double precision DEFAULT NULL /* Option < f64 > */
+) RETURNS void
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'alter_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:865
+-- pg_trickle::api::create_or_replace_stream_table
+CREATE  FUNCTION pgtrickle."create_or_replace_stream_table"(
+	"name" TEXT, /* & str */
+	"query" TEXT, /* & str */
+	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
+	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
+	"initialize" bool DEFAULT true, /* bool */
+	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
+	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
+	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
+	"append_only" bool DEFAULT false, /* bool */
+	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
+	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
+	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
+	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
+	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
+	"temporal" bool DEFAULT false, /* bool */
+	"storage_backend" TEXT DEFAULT NULL /* Option < & str > */
+) RETURNS void
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_or_replace_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/ivm.rs:1160
+-- pg_trickle::ivm::pgt_ivm_handle_truncate
+CREATE  FUNCTION pgtrickle."pgt_ivm_handle_truncate"(
+	"pgt_id" bigint /* i64 */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_ivm_handle_truncate_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/cluster.rs:18
+-- pg_trickle::api::cluster::cluster_worker_summary
+CREATE  FUNCTION pgtrickle."cluster_worker_summary"() RETURNS TABLE (
+	"db_oid" bigint,  /* Option < i64 > */
+	"db_name" TEXT,  /* Option < String > */
+	"active_workers" INT,  /* Option < i32 > */
+	"scheduler_pid" INT,  /* Option < i32 > */
+	"scheduler_running" bool,  /* Option < bool > */
+	"total_active_workers" INT  /* Option < i32 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'cluster_worker_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:566
+-- pg_trickle::api::self_monitoring::explain_dag
+CREATE  FUNCTION pgtrickle."explain_dag"(
+	"format" TEXT DEFAULT 'mermaid' /* Option < & str > */
+) RETURNS TEXT /* Option < String > */
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_dag_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:716
+-- pg_trickle::api::bulk_create
+CREATE  FUNCTION pgtrickle."bulk_create"(
+	"definitions" jsonb /* pgrx :: JsonB */
+) RETURNS jsonb /* pgrx :: JsonB */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bulk_create_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:321
+-- pg_trickle::api::snapshot::restore_from_snapshot
+CREATE  FUNCTION pgtrickle."restore_from_snapshot"(
+	"p_name" TEXT, /* & str */
+	"p_source" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'restore_from_snapshot_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:109
+-- pg_trickle::api::diagnostics::rebuild_cdc_triggers
+CREATE  FUNCTION pgtrickle."rebuild_cdc_triggers"() RETURNS TEXT /* & '_ str */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'rebuild_cdc_triggers_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:163
+-- pg_trickle::api::diagnostics::pgt_status
+CREATE  FUNCTION pgtrickle."pgt_status"() RETURNS TABLE (
+	"name" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"refresh_mode" TEXT,  /* String */
+	"is_populated" bool,  /* bool */
+	"consecutive_errors" INT,  /* i32 */
+	"schedule" TEXT,  /* Option < String > */
+	"data_timestamp" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"staleness" interval,  /* Option < pgrx :: datum :: Interval > */
+	"scc_id" INT  /* Option < i32 > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/outbox.rs:266
+-- pg_trickle::api::outbox::attach_embedding_outbox
+CREATE  FUNCTION pgtrickle."attach_embedding_outbox"(
+	"p_name" TEXT, /* & str */
+	"p_vector_column" TEXT, /* & str */
+	"p_retention_hours" INT DEFAULT 24, /* i32 */
+	"p_inline_threshold_rows" INT DEFAULT 10000 /* i32 */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'attach_embedding_outbox_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/hooks.rs:1077
+-- pg_trickle::hooks::pg_trickle_on_sql_drop
+-- Skipped due to `#[pgrx(sql = false)]`
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/publication.rs:73
+-- pg_trickle::api::publication::drop_stream_table_publication
+CREATE  FUNCTION pgtrickle."drop_stream_table_publication"(
+	"name" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drop_stream_table_publication_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:3023
+-- pg_trickle::monitor::refresh_timeline
+CREATE  FUNCTION pgtrickle."refresh_timeline"(
+	"max_rows" INT DEFAULT 50 /* i32 */
+) RETURNS TABLE (
+	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
+	"stream_table" TEXT,  /* String */
+	"action" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"rows_inserted" bigint,  /* i64 */
+	"rows_deleted" bigint,  /* i64 */
+	"duration_ms" double precision,  /* Option < f64 > */
+	"error_message" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'refresh_timeline_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:395
+-- pg_trickle::diagnostics::diagnose_errors
+CREATE  FUNCTION pgtrickle."diagnose_errors"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"event_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"error_type" TEXT,  /* String */
+	"error_message" TEXT,  /* String */
+	"remediation" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'diagnose_errors_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:4216
+-- pg_trickle::api::drop_stream_table
+CREATE  FUNCTION pgtrickle."drop_stream_table"(
+	"name" TEXT, /* & str */
+	"cascade" bool DEFAULT false /* bool */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drop_stream_table_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2132,307 +1689,52 @@ COMMENT ON FUNCTION pgtrickle."canary_promote"(text) IS
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:6202
--- pg_trickle::api::drain
-CREATE  FUNCTION pgtrickle."drain"(
-	"timeout_s" INT DEFAULT 60 /* i32 */
-) RETURNS bool /* bool */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drain_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:5396
--- pg_trickle::api::list_subscriptions
-CREATE  FUNCTION pgtrickle."list_subscriptions"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"channel" TEXT,  /* Option < String > */
-	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_subscriptions_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:635
--- pg_trickle::api::create_stream_table_if_not_exists
-CREATE  FUNCTION pgtrickle."create_stream_table_if_not_exists"(
-	"name" TEXT, /* & str */
-	"query" TEXT, /* & str */
-	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
-	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
-	"initialize" bool DEFAULT true, /* bool */
-	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
-	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
-	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
-	"append_only" bool DEFAULT false, /* bool */
-	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
-	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
-	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
-	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
-	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
-	"temporal" bool DEFAULT false, /* bool */
-	"storage_backend" TEXT DEFAULT NULL /* Option < & str > */
-) RETURNS void
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_stream_table_if_not_exists_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:5872
--- pg_trickle::api::sla_summary
-CREATE  FUNCTION pgtrickle."sla_summary"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"p50_ms" double precision,  /* Option < f64 > */
-	"p99_ms" double precision,  /* Option < f64 > */
-	"freshness_lag_s" double precision,  /* Option < f64 > */
-	"error_rate" double precision,  /* Option < f64 > */
-	"error_budget_remaining" double precision  /* Option < f64 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'sla_summary_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:4630
--- pg_trickle::api::refresh_stream_table
-CREATE  FUNCTION pgtrickle."refresh_stream_table"(
-	"name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:761
--- requires:
---   refresh_stream_table
-
-
-CREATE OR REPLACE FUNCTION pgtrickle."refresh_if_stale"(
-    p_name   text,
-    p_max_age interval DEFAULT '5 minutes'::interval
-)
-RETURNS boolean
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    v_last_end timestamp with time zone;
-    v_refreshed boolean := false;
-BEGIN
-    SELECT MAX(end_time)
-      INTO v_last_end
-      FROM pgtrickle.pgt_refresh_history h
-      JOIN pgtrickle.pgt_stream_tables   s USING (pgt_id)
-     WHERE s.pgt_name = p_name
-       AND h.status = 'COMPLETED';
-
-    IF v_last_end IS NULL OR (now() - v_last_end) > p_max_age THEN
-        PERFORM pgtrickle.refresh_stream_table(p_name);
-        v_refreshed := true;
-    END IF;
-
-    RETURN v_refreshed;
-END;
-$$;
-
-COMMENT ON FUNCTION pgtrickle."refresh_if_stale"(text, interval) IS
-    'Refresh the named stream table only when the most recent completed '
-    'refresh is older than max_age.  Returns TRUE when a refresh was '
-    'triggered, FALSE when the table was fresh enough.';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/citus.rs:103
--- pg_trickle::citus::source_stable_name
-CREATE  FUNCTION pgtrickle."source_stable_name"(
-	"source_oid" oid /* pg_sys :: Oid */
-) RETURNS TEXT /* Option < String > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'sql_stable_name_for_oid_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/snapshot.rs:212
--- pg_trickle::api::snapshot::snapshot_stream_table
-CREATE  FUNCTION pgtrickle."snapshot_stream_table"(
-	"p_name" TEXT, /* & str */
-	"p_target" TEXT DEFAULT NULL /* Option < & str > */
-) RETURNS TEXT /* String */
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'snapshot_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:163
--- pg_trickle::api::diagnostics::pgt_status
-CREATE  FUNCTION pgtrickle."pgt_status"() RETURNS TABLE (
-	"name" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"refresh_mode" TEXT,  /* String */
-	"is_populated" bool,  /* bool */
-	"consecutive_errors" INT,  /* i32 */
-	"schedule" TEXT,  /* Option < String > */
-	"data_timestamp" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"staleness" interval,  /* Option < pgrx :: datum :: Interval > */
-	"scc_id" INT  /* Option < i32 > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/planner.rs:186
--- pg_trickle::api::planner::schedule_recommendations
-CREATE  FUNCTION pgtrickle."schedule_recommendations"() RETURNS TABLE (
-	"name" TEXT,  /* Option < String > */
-	"current_interval_seconds" double precision,  /* Option < f64 > */
-	"recommended_interval_seconds" double precision,  /* Option < f64 > */
-	"delta_pct" double precision,  /* Option < f64 > */
-	"confidence" double precision,  /* Option < f64 > */
-	"reasoning" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'schedule_recommendations_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/ivm.rs:1160
--- pg_trickle::ivm::pgt_ivm_handle_truncate
-CREATE  FUNCTION pgtrickle."pgt_ivm_handle_truncate"(
-	"pgt_id" bigint /* i64 */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_ivm_handle_truncate_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2673
--- pg_trickle::api::helpers::restore_stream_tables
-CREATE  FUNCTION pgtrickle."restore_stream_tables"() RETURNS VOID /* Result < (), crate :: error :: PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'restore_stream_tables_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:5504
--- pg_trickle::api::list_distance_subscriptions
-CREATE  FUNCTION pgtrickle."list_distance_subscriptions"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"channel" TEXT,  /* Option < String > */
-	"vector_column" TEXT,  /* Option < String > */
-	"op" TEXT,  /* Option < String > */
-	"threshold" double precision,  /* Option < f64 > */
-	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:935
--- pg_trickle::api::diagnostics::ungate_source
-CREATE  FUNCTION pgtrickle."ungate_source"(
-	"source" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ungate_source_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/outbox.rs:82
--- pg_trickle::api::outbox::attach_outbox
-CREATE  FUNCTION pgtrickle."attach_outbox"(
-	"p_name" TEXT, /* & str */
-	"p_retention_hours" INT DEFAULT 24, /* i32 */
-	"p_inline_threshold_rows" INT DEFAULT 10000 /* i32 */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'attach_outbox_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1769
--- pg_trickle::api::diagnostics::clear_caches
-CREATE  FUNCTION pgtrickle."clear_caches"() RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'clear_caches_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:61
--- pg_trickle::api::diagnostics::migrate
-CREATE  FUNCTION pgtrickle."migrate"() RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'migrate_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:95
--- pg_trickle::api::diagnostics::_signal_launcher_rescan
-CREATE  FUNCTION pgtrickle."_signal_launcher_rescan"() RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', '_signal_launcher_rescan_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor.rs:2288
--- pg_trickle::monitor::dependency_tree
-CREATE  FUNCTION pgtrickle."dependency_tree"() RETURNS TABLE (
-	"tree_line" TEXT,  /* String */
-	"node" TEXT,  /* String */
-	"node_type" TEXT,  /* String */
-	"depth" INT,  /* i32 */
+-- src/api/self_monitoring.rs:358
+-- pg_trickle::api::self_monitoring::self_monitoring_status
+CREATE  FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
+	"st_name" TEXT,  /* String */
+	"exists" bool,  /* bool */
 	"status" TEXT,  /* Option < String > */
-	"refresh_mode" TEXT  /* Option < String > */
+	"refresh_mode" TEXT,  /* Option < String > */
+	"last_refresh_at" TEXT,  /* Option < String > */
+	"total_refreshes" bigint  /* Option < i64 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1256
+-- pg_trickle::api::diagnostics::watermark_status
+CREATE  FUNCTION pgtrickle."watermark_status"() RETURNS TABLE (
+	"group_name" TEXT,  /* String */
+	"min_watermark" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"max_watermark" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"lag_secs" double precision,  /* Option < f64 > */
+	"aligned" bool,  /* bool */
+	"sources_with_watermark" INT,  /* i32 */
+	"sources_total" INT  /* i32 */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dependency_tree_wrapper';
+AS 'MODULE_PATHNAME', 'watermark_status_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/publication.rs:126
--- pg_trickle::api::publication::set_stream_table_sla
-CREATE  FUNCTION pgtrickle."set_stream_table_sla"(
-	"name" TEXT, /* & str */
-	"sla" interval /* Interval */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'set_stream_table_sla_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/diagnostics.rs:49
--- pg_trickle::diagnostics::explain_query_rewrite
-CREATE  FUNCTION pgtrickle."explain_query_rewrite"(
-	"query" TEXT /* & str */
-) RETURNS TABLE (
-	"pass_name" TEXT,  /* String */
-	"changed" bool,  /* bool */
-	"sql_after" TEXT  /* Option < String > */
+-- src/monitor.rs:2125
+-- pg_trickle::monitor::change_buffer_sizes
+CREATE  FUNCTION pgtrickle."change_buffer_sizes"() RETURNS TABLE (
+	"stream_table" TEXT,  /* String */
+	"source_table" TEXT,  /* String */
+	"source_oid" bigint,  /* i64 */
+	"cdc_mode" TEXT,  /* String */
+	"pending_rows" bigint,  /* i64 */
+	"buffer_bytes" bigint  /* i64 */
 )
-STRICT 
+STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_query_rewrite_wrapper';
+AS 'MODULE_PATHNAME', 'change_buffer_sizes_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2453,6 +1755,706 @@ CREATE  FUNCTION pgtrickle."metrics_summary"() RETURNS TABLE (
 STRICT 
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'metrics_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:1000
+-- pg_trickle::monitor::pgtrickle_refresh_stats
+CREATE  FUNCTION pgtrickle."pgtrickle_refresh_stats"() RETURNS TABLE (
+	"stream_table" TEXT,  /* String */
+	"mode" TEXT,  /* String */
+	"avg_ms" double precision,  /* f64 */
+	"p95_ms" double precision,  /* f64 */
+	"p99_ms" double precision,  /* f64 */
+	"refresh_count" bigint,  /* i64 */
+	"last_refresh_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgtrickle_refresh_stats_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2497
+-- pg_trickle::api::helpers::refresh_efficiency
+CREATE  FUNCTION pgtrickle."refresh_efficiency"() RETURNS TABLE (
+	"pgt_schema" TEXT,  /* String */
+	"pgt_name" TEXT,  /* String */
+	"refresh_mode" TEXT,  /* String */
+	"total_refreshes" bigint,  /* i64 */
+	"diff_count" bigint,  /* i64 */
+	"full_count" bigint,  /* i64 */
+	"avg_diff_ms" double precision,  /* Option < f64 > */
+	"avg_full_ms" double precision,  /* Option < f64 > */
+	"avg_change_ratio" double precision,  /* Option < f64 > */
+	"diff_speedup" TEXT,  /* Option < String > */
+	"last_refresh_at" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'refresh_efficiency_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:958
+-- pg_trickle::api::diagnostics::source_gates
+CREATE  FUNCTION pgtrickle."source_gates"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"schema_name" TEXT,  /* String */
+	"gated" bool,  /* bool */
+	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"gated_by" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'source_gates_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2312
+-- pg_trickle::api::helpers::convert_buffers_to_unlogged
+CREATE  FUNCTION pgtrickle."convert_buffers_to_unlogged"() RETURNS bigint /* Result < i64, PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'convert_buffers_to_unlogged_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:223
+-- pg_trickle::api::diagnostics::pgt_scc_status
+CREATE  FUNCTION pgtrickle."pgt_scc_status"() RETURNS TABLE (
+	"scc_id" INT,  /* i32 */
+	"member_count" INT,  /* i32 */
+	"members" TEXT[],  /* Vec < String > */
+	"last_iterations" INT,  /* Option < i32 > */
+	"last_converged_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_scc_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1599
+-- pg_trickle::api::diagnostics::preflight
+CREATE  FUNCTION pgtrickle."preflight"() RETURNS TEXT /* String */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'preflight_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:296
+-- pg_trickle::api::diagnostics::explain_refresh_mode
+CREATE  FUNCTION pgtrickle."explain_refresh_mode"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"configured_mode" TEXT,  /* String */
+	"effective_mode" TEXT,  /* Option < String > */
+	"downgrade_reason" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_refresh_mode_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/planner.rs:117
+-- pg_trickle::api::planner::recommend_schedule
+CREATE  FUNCTION pgtrickle."recommend_schedule"(
+	"p_name" TEXT /* & str */
+) RETURNS jsonb /* pgrx :: JsonB */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'recommend_schedule_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:3414
+-- pg_trickle::monitor::wal_source_status
+CREATE  FUNCTION pgtrickle."wal_source_status"() RETURNS TABLE (
+	"source_relid" bigint,  /* i64 */
+	"source_name" TEXT,  /* String */
+	"cdc_mode" TEXT,  /* String */
+	"slot_name" TEXT,  /* Option < String > */
+	"slot_lag_bytes" bigint,  /* i64 */
+	"publication_name" TEXT,  /* Option < String > */
+	"blocked_reason" TEXT,  /* Option < String > */
+	"transition_started_at" TEXT,  /* Option < String > */
+	"decoder_confirmed_lsn" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'wal_source_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:1366
+-- pg_trickle::monitor::explain_diff_sql
+CREATE  FUNCTION pgtrickle."explain_diff_sql"(
+	"name" TEXT /* & str */
+) RETURNS TEXT /* Option < String > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_diff_sql_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:6305
+-- pg_trickle::api::cdc_pause_status
+CREATE  FUNCTION pgtrickle."cdc_pause_status"() RETURNS TABLE (
+	"paused" bool,  /* bool */
+	"capture_mode" TEXT,  /* String */
+	"note" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'cdc_pause_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:5381
+-- pg_trickle::api::unsubscribe
+CREATE  FUNCTION pgtrickle."unsubscribe"(
+	"stream_table" TEXT, /* & str */
+	"channel" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'unsubscribe_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:453
+-- pg_trickle::api::self_monitoring::scheduler_overhead
+CREATE  FUNCTION pgtrickle."scheduler_overhead"() RETURNS TABLE (
+	"total_refreshes_1h" bigint,  /* i64 */
+	"df_refreshes_1h" bigint,  /* i64 */
+	"df_refresh_fraction" double precision,  /* Option < f64 > */
+	"avg_refresh_ms" double precision,  /* Option < f64 > */
+	"avg_df_refresh_ms" double precision,  /* Option < f64 > */
+	"total_refresh_time_s" double precision,  /* Option < f64 > */
+	"df_refresh_time_s" double precision  /* Option < f64 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'scheduler_overhead_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:212
+-- pg_trickle::api::snapshot::snapshot_stream_table
+CREATE  FUNCTION pgtrickle."snapshot_stream_table"(
+	"p_name" TEXT, /* & str */
+	"p_target" TEXT DEFAULT NULL /* Option < & str > */
+) RETURNS TEXT /* String */
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'snapshot_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/hooks.rs:51
+-- pg_trickle::hooks::pg_trickle_on_ddl_end
+-- Skipped due to `#[pgrx(sql = false)]`
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:767
+-- pg_trickle::diagnostics::validate_query
+CREATE  FUNCTION pgtrickle."validate_query"(
+	"query" TEXT /* & str */
+) RETURNS TABLE (
+	"check_name" TEXT,  /* String */
+	"result" TEXT,  /* String */
+	"severity" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'validate_query_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/publication.rs:16
+-- pg_trickle::api::publication::stream_table_to_publication
+CREATE  FUNCTION pgtrickle."stream_table_to_publication"(
+	"name" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'stream_table_to_publication_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:550
+-- pg_trickle::api::snapshot::drop_snapshot
+CREATE  FUNCTION pgtrickle."drop_snapshot"(
+	"p_snapshot_table" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drop_snapshot_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/citus.rs:783
+-- pg_trickle::citus::handle_vp_promoted
+CREATE  FUNCTION pgtrickle."handle_vp_promoted"(
+	"payload" TEXT /* & str */
+) RETURNS bool /* bool */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'sql_handle_vp_promoted_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:2288
+-- pg_trickle::monitor::dependency_tree
+CREATE  FUNCTION pgtrickle."dependency_tree"() RETURNS TABLE (
+	"tree_line" TEXT,  /* String */
+	"node" TEXT,  /* String */
+	"node_type" TEXT,  /* String */
+	"depth" INT,  /* i32 */
+	"status" TEXT,  /* Option < String > */
+	"refresh_mode" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'dependency_tree_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1459
+-- pg_trickle::api::diagnostics::refresh_groups
+CREATE  FUNCTION pgtrickle."refresh_groups"() RETURNS TABLE (
+	"group_id" INT,  /* i32 */
+	"group_name" TEXT,  /* String */
+	"member_count" INT,  /* i32 */
+	"isolation" TEXT,  /* String */
+	"created_at" timestamp with time zone  /* TimestampWithTimeZone */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'refresh_groups_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:2206
+-- pg_trickle::monitor::list_sources
+CREATE  FUNCTION pgtrickle."list_sources"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"source_oid" bigint,  /* i64 */
+	"source_type" TEXT,  /* String */
+	"cdc_mode" TEXT,  /* String */
+	"columns_used" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_sources_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:5370
+-- pg_trickle::api::subscribe
+CREATE  FUNCTION pgtrickle."subscribe"(
+	"stream_table" TEXT, /* & str */
+	"channel" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'subscribe_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:785
+-- pg_trickle::monitor::get_refresh_history
+CREATE  FUNCTION pgtrickle."get_refresh_history"(
+	"name" TEXT, /* & str */
+	"max_rows" INT DEFAULT 20 /* i32 */
+) RETURNS TABLE (
+	"refresh_id" bigint,  /* i64 */
+	"data_timestamp" timestamp with time zone,  /* TimestampWithTimeZone */
+	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
+	"end_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"action" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"rows_inserted" bigint,  /* i64 */
+	"rows_deleted" bigint,  /* i64 */
+	"duration_ms" double precision,  /* Option < f64 > */
+	"error_message" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'get_refresh_history_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:154
+-- pg_trickle::api::diagnostics::parse_duration_seconds
+CREATE  FUNCTION pgtrickle."parse_duration_seconds"(
+	"input" TEXT /* & str */
+) RETURNS bigint /* Option < i64 > */
+IMMUTABLE STRICT PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'parse_duration_seconds_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:511
+-- requires:
+--   parse_duration_seconds
+
+
+-- Status overview view (ERR-1d: last_error_message and last_error_at are
+-- included via st.* from pgt_stream_tables)
+CREATE OR REPLACE VIEW pgtrickle.stream_tables_info AS
+SELECT st.*,
+       now() - st.last_refresh_at AS staleness,
+       CASE WHEN st.schedule IS NOT NULL
+                 AND st.schedule !~ '[\s@]'
+            THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
+                 pgtrickle.parse_duration_seconds(st.schedule)
+            ELSE NULL::boolean
+       END AS stale,
+       CASE WHEN st.topk_limit IS NOT NULL THEN TRUE ELSE FALSE END AS is_topk
+FROM pgtrickle.pgt_stream_tables st;
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:684
+-- requires:
+--   parse_duration_seconds
+
+
+-- ERG-E: One-row health summary for dashboards and alerting.
+CREATE OR REPLACE VIEW pgtrickle.quick_health AS
+SELECT
+    (SELECT count(*) FROM pgtrickle.pgt_stream_tables)::bigint
+        AS total_stream_tables,
+    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
+     WHERE status = 'ERROR' OR consecutive_errors > 0)::bigint
+        AS error_tables,
+    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
+     WHERE schedule IS NOT NULL
+       AND schedule !~ '[\s@]'
+       AND last_refresh_at IS NOT NULL
+       AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
+           pgtrickle.parse_duration_seconds(schedule))::bigint
+        AS stale_tables,
+    (SELECT count(*) > 0 FROM pg_stat_activity
+     WHERE backend_type = 'pg_trickle scheduler')
+        AS scheduler_running,
+    CASE
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables) = 0 THEN 'EMPTY'
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'SUSPENDED') > 0 THEN 'CRITICAL'
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'ERROR' OR consecutive_errors > 0) > 0 THEN 'WARNING'
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables
+              WHERE schedule IS NOT NULL
+                AND schedule !~ '[\s@]'
+                AND last_refresh_at IS NOT NULL
+                AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
+                    pgtrickle.parse_duration_seconds(schedule)) > 0 THEN 'WARNING'
+        ELSE 'OK'
+    END AS status;
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:596
+-- requires:
+--   parse_duration_seconds
+
+
+-- Convenience view: pg_stat_stream_tables
+-- Combines catalog metadata with aggregate refresh statistics.
+CREATE OR REPLACE VIEW pgtrickle.pg_stat_stream_tables AS
+SELECT
+    st.pgt_id,
+    st.pgt_schema,
+    st.pgt_name,
+    st.status,
+    st.refresh_mode,
+    st.is_populated,
+    st.data_timestamp,
+    st.schedule,
+    now() - st.last_refresh_at AS staleness,
+    CASE WHEN st.schedule IS NOT NULL AND st.last_refresh_at IS NOT NULL
+              AND st.schedule !~ '[\s@]'
+         THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
+              pgtrickle.parse_duration_seconds(st.schedule)
+         ELSE NULL::boolean
+    END AS stale,
+    st.consecutive_errors,
+    st.needs_reinit,
+    st.last_refresh_at,
+    COALESCE(stats.total_refreshes, 0) AS total_refreshes,
+    COALESCE(stats.successful_refreshes, 0) AS successful_refreshes,
+    COALESCE(stats.failed_refreshes, 0) AS failed_refreshes,
+    COALESCE(stats.total_rows_inserted, 0) AS total_rows_inserted,
+    COALESCE(stats.total_rows_deleted, 0) AS total_rows_deleted,
+    stats.avg_duration_ms,
+    stats.last_action,
+    stats.last_status,
+    (SELECT array_agg(DISTINCT d.cdc_mode ORDER BY d.cdc_mode)
+     FROM pgtrickle.pgt_dependencies d
+     WHERE d.pgt_id = st.pgt_id AND d.source_type = 'TABLE') AS cdc_modes,
+    st.scc_id,
+    st.last_fixpoint_iterations,
+    st.refresh_tier
+FROM pgtrickle.pgt_stream_tables st
+LEFT JOIN LATERAL (
+    SELECT
+        count(*)::bigint AS total_refreshes,
+        count(*) FILTER (WHERE h.status = 'COMPLETED')::bigint AS successful_refreshes,
+        count(*) FILTER (WHERE h.status = 'FAILED')::bigint AS failed_refreshes,
+        COALESCE(sum(h.rows_inserted), 0)::bigint AS total_rows_inserted,
+        COALESCE(sum(h.rows_deleted), 0)::bigint AS total_rows_deleted,
+        CASE WHEN count(*) FILTER (WHERE h.end_time IS NOT NULL) > 0
+             THEN avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000)
+                  FILTER (WHERE h.end_time IS NOT NULL)
+             ELSE NULL
+        END::float8 AS avg_duration_ms,
+        (SELECT h2.action FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_action,
+        (SELECT h2.status FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_status,
+        (SELECT h2.initiated_by FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_initiated_by,
+        (SELECT h2.freshness_deadline FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS freshness_deadline
+    FROM pgtrickle.pgt_refresh_history h
+    WHERE h.pgt_id = st.pgt_id
+) stats ON true;
+
+-- Per-source CDC status view (G5): exposes cdc_mode, slot names, and
+-- transition timestamps for every TABLE dependency of a stream table.
+CREATE OR REPLACE VIEW pgtrickle.pgt_cdc_status AS
+SELECT
+    st.pgt_schema,
+    st.pgt_name,
+    d.source_relid,
+    c.relname        AS source_name,
+    n.nspname        AS source_schema,
+    d.cdc_mode,
+    d.slot_name,
+    d.decoder_confirmed_lsn,
+    d.transition_started_at
+FROM pgtrickle.pgt_dependencies d
+JOIN pgtrickle.pgt_stream_tables st ON st.pgt_id = d.pgt_id
+JOIN pg_class c ON c.oid = d.source_relid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE d.source_type = 'TABLE';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/ivm.rs:834
+-- pg_trickle::ivm::pgt_ivm_apply_delta_enr
+CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta_enr"(
+	"pgt_id" bigint, /* i64 */
+	"source_oid" INT, /* i32 */
+	"has_new" bool, /* bool */
+	"has_old" bool /* bool */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_enr_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:570
+-- pg_trickle::diagnostics::list_auxiliary_columns
+CREATE  FUNCTION pgtrickle."list_auxiliary_columns"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"column_name" TEXT,  /* String */
+	"data_type" TEXT,  /* String */
+	"purpose" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_auxiliary_columns_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:407
+-- pg_trickle::api::diagnostics::explain_delta
+CREATE  FUNCTION pgtrickle."explain_delta"(
+	"name" TEXT, /* & str */
+	"format" TEXT DEFAULT 'text' /* & str */
+) RETURNS SETOF TEXT /* String */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_delta_text_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:4399
+-- pg_trickle::api::resume_stream_table
+CREATE  FUNCTION pgtrickle."resume_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'resume_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:491
+-- pg_trickle::monitor::st_refresh_stats
+CREATE  FUNCTION pgtrickle."st_refresh_stats"() RETURNS TABLE (
+	"pgt_name" TEXT,  /* String */
+	"pgt_schema" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"refresh_mode" TEXT,  /* String */
+	"is_populated" bool,  /* bool */
+	"total_refreshes" bigint,  /* i64 */
+	"successful_refreshes" bigint,  /* i64 */
+	"failed_refreshes" bigint,  /* i64 */
+	"total_rows_inserted" bigint,  /* i64 */
+	"total_rows_deleted" bigint,  /* i64 */
+	"avg_duration_ms" double precision,  /* f64 */
+	"last_refresh_action" TEXT,  /* Option < String > */
+	"last_refresh_status" TEXT,  /* Option < String > */
+	"last_refresh_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"staleness_secs" double precision,  /* Option < f64 > */
+	"stale" bool,  /* bool */
+	"consecutive_errors" INT,  /* i32 */
+	"schedule" TEXT,  /* Option < String > */
+	"refresh_tier" TEXT,  /* String */
+	"last_error_message" TEXT,  /* Option < String > */
+	"downstream_publication" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'st_refresh_stats_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:5998
+-- pg_trickle::api::explain_stream_table
+CREATE  FUNCTION pgtrickle."explain_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS TEXT /* Result < String, PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1769
+-- pg_trickle::api::diagnostics::clear_caches
+CREATE  FUNCTION pgtrickle."clear_caches"() RETURNS bigint /* i64 */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'clear_caches_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2392
+-- pg_trickle::api::helpers::recommend_refresh_mode
+CREATE  FUNCTION pgtrickle."recommend_refresh_mode"(
+	"st_name" TEXT DEFAULT NULL /* Option < String > */
+) RETURNS TABLE (
+	"pgt_schema" TEXT,  /* String */
+	"pgt_name" TEXT,  /* String */
+	"current_mode" TEXT,  /* String */
+	"effective_mode" TEXT,  /* Option < String > */
+	"recommended_mode" TEXT,  /* String */
+	"confidence" TEXT,  /* String */
+	"reason" TEXT,  /* String */
+	"signals" jsonb  /* pgrx :: JsonB */
+)
+ 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'recommend_refresh_mode_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1091
+-- pg_trickle::api::diagnostics::advance_watermark
+CREATE  FUNCTION pgtrickle."advance_watermark"(
+	"source" TEXT, /* & str */
+	"watermark" timestamp with time zone /* TimestampWithTimeZone */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'advance_watermark_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:5673
+-- pg_trickle::api::embedding_stream_table
+CREATE  FUNCTION pgtrickle."embedding_stream_table"(
+	"name" TEXT, /* & str */
+	"source_table" TEXT, /* & str */
+	"vector_column" TEXT, /* & str */
+	"extra_columns" TEXT DEFAULT NULL, /* Option < & str > */
+	"refresh_interval" TEXT DEFAULT '1m', /* & str */
+	"index_type" TEXT DEFAULT 'hnsw', /* & str */
+	"dry_run" bool DEFAULT false /* bool */
+) RETURNS TABLE (
+	"action" TEXT  /* Option < String > */
+)
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'embedding_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor.rs:1077
+-- pg_trickle::monitor::explain_st
+CREATE  FUNCTION pgtrickle."explain_st"(
+	"name" TEXT, /* & str */
+	"with_analyze" bool DEFAULT false /* bool */
+) RETURNS TABLE (
+	"property" TEXT,  /* String */
+	"value" TEXT  /* String */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_st_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:5919
+-- pg_trickle::api::sla_summary
+CREATE  FUNCTION pgtrickle."sla_summary"() RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"p50_ms" double precision,  /* Option < f64 > */
+	"p99_ms" double precision,  /* Option < f64 > */
+	"freshness_lag_s" double precision,  /* Option < f64 > */
+	"error_rate" double precision,  /* Option < f64 > */
+	"error_budget_remaining" double precision  /* Option < f64 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'sla_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:6288
+-- pg_trickle::api::is_drained
+CREATE  FUNCTION pgtrickle."is_drained"() RETURNS bool /* bool */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'is_drained_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:49
+-- pg_trickle::diagnostics::explain_query_rewrite
+CREATE  FUNCTION pgtrickle."explain_query_rewrite"(
+	"query" TEXT /* & str */
+) RETURNS TABLE (
+	"pass_name" TEXT,  /* String */
+	"changed" bool,  /* bool */
+	"sql_after" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_query_rewrite_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/pg_trickle--0.40.0--0.48.0.sql
+++ b/sql/pg_trickle--0.40.0--0.48.0.sql
@@ -617,7 +617,7 @@ AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
 COMMENT ON FUNCTION pgtrickle."unsubscribe_distance"(TEXT,TEXT) IS
     'VH-2 (v0.48.0): Remove a distance-predicate subscription.';
 
-CREATE FUNCTION pgtrickle."list_distance_subscriptions"()
+CREATE FUNCTION pgtrickle."list_distance_subscriptions"("p_stream_table" TEXT DEFAULT NULL)
 RETURNS TABLE(
     "stream_table"   TEXT,
     "channel"        TEXT,
@@ -629,7 +629,7 @@ RETURNS TABLE(
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
 
-COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"() IS
+COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"(TEXT) IS
     'VH-2 (v0.48.0): List all active distance-predicate subscriptions.';
 
 -- ── Step 4: Register VA-1 embedding_stream_table() ───────────────────────

--- a/sql/pg_trickle--0.41.0--0.48.0.sql
+++ b/sql/pg_trickle--0.41.0--0.48.0.sql
@@ -586,7 +586,7 @@ AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
 COMMENT ON FUNCTION pgtrickle."unsubscribe_distance"(TEXT,TEXT) IS
     'VH-2 (v0.48.0): Remove a distance-predicate subscription.';
 
-CREATE FUNCTION pgtrickle."list_distance_subscriptions"()
+CREATE FUNCTION pgtrickle."list_distance_subscriptions"("p_stream_table" TEXT DEFAULT NULL)
 RETURNS TABLE(
     "stream_table"   TEXT,
     "channel"        TEXT,
@@ -598,7 +598,7 @@ RETURNS TABLE(
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
 
-COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"() IS
+COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"(TEXT) IS
     'VH-2 (v0.48.0): List all active distance-predicate subscriptions.';
 
 -- ── Step 4: Register VA-1 embedding_stream_table() ───────────────────────

--- a/sql/pg_trickle--0.42.0--0.48.0.sql
+++ b/sql/pg_trickle--0.42.0--0.48.0.sql
@@ -562,7 +562,7 @@ AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
 COMMENT ON FUNCTION pgtrickle."unsubscribe_distance"(TEXT,TEXT) IS
     'VH-2 (v0.48.0): Remove a distance-predicate subscription.';
 
-CREATE FUNCTION pgtrickle."list_distance_subscriptions"()
+CREATE FUNCTION pgtrickle."list_distance_subscriptions"("p_stream_table" TEXT DEFAULT NULL)
 RETURNS TABLE(
     "stream_table"   TEXT,
     "channel"        TEXT,
@@ -574,7 +574,7 @@ RETURNS TABLE(
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
 
-COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"() IS
+COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"(TEXT) IS
     'VH-2 (v0.48.0): List all active distance-predicate subscriptions.';
 
 -- ── Step 4: Register VA-1 embedding_stream_table() ───────────────────────

--- a/sql/pg_trickle--0.43.0--0.48.0.sql
+++ b/sql/pg_trickle--0.43.0--0.48.0.sql
@@ -512,7 +512,7 @@ AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
 COMMENT ON FUNCTION pgtrickle."unsubscribe_distance"(TEXT,TEXT) IS
     'VH-2 (v0.48.0): Remove a distance-predicate subscription.';
 
-CREATE FUNCTION pgtrickle."list_distance_subscriptions"()
+CREATE FUNCTION pgtrickle."list_distance_subscriptions"("p_stream_table" TEXT DEFAULT NULL)
 RETURNS TABLE(
     "stream_table"   TEXT,
     "channel"        TEXT,
@@ -524,7 +524,7 @@ RETURNS TABLE(
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
 
-COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"() IS
+COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"(TEXT) IS
     'VH-2 (v0.48.0): List all active distance-predicate subscriptions.';
 
 -- ── Step 4: Register VA-1 embedding_stream_table() ───────────────────────

--- a/sql/pg_trickle--0.44.0--0.48.0.sql
+++ b/sql/pg_trickle--0.44.0--0.48.0.sql
@@ -473,7 +473,7 @@ AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
 COMMENT ON FUNCTION pgtrickle."unsubscribe_distance"(TEXT,TEXT) IS
     'VH-2 (v0.48.0): Remove a distance-predicate subscription.';
 
-CREATE FUNCTION pgtrickle."list_distance_subscriptions"()
+CREATE FUNCTION pgtrickle."list_distance_subscriptions"("p_stream_table" TEXT DEFAULT NULL)
 RETURNS TABLE(
     "stream_table"   TEXT,
     "channel"        TEXT,
@@ -485,7 +485,7 @@ RETURNS TABLE(
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
 
-COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"() IS
+COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"(TEXT) IS
     'VH-2 (v0.48.0): List all active distance-predicate subscriptions.';
 
 -- ── Step 4: Register VA-1 embedding_stream_table() ───────────────────────

--- a/sql/pg_trickle--0.46.0--0.48.0.sql
+++ b/sql/pg_trickle--0.46.0--0.48.0.sql
@@ -184,7 +184,7 @@ AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
 COMMENT ON FUNCTION pgtrickle."unsubscribe_distance"(TEXT,TEXT) IS
     'VH-2 (v0.48.0): Remove a distance-predicate subscription.';
 
-CREATE FUNCTION pgtrickle."list_distance_subscriptions"()
+CREATE FUNCTION pgtrickle."list_distance_subscriptions"("p_stream_table" TEXT DEFAULT NULL)
 RETURNS TABLE(
     "stream_table"   TEXT,
     "channel"        TEXT,
@@ -196,7 +196,7 @@ RETURNS TABLE(
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
 
-COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"() IS
+COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"(TEXT) IS
     'VH-2 (v0.48.0): List all active distance-predicate subscriptions.';
 
 -- ── Step 4: Register VA-1 embedding_stream_table() ───────────────────────

--- a/sql/pg_trickle--0.47.0--0.48.0.sql
+++ b/sql/pg_trickle--0.47.0--0.48.0.sql
@@ -86,7 +86,7 @@ AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
 COMMENT ON FUNCTION pgtrickle."unsubscribe_distance"(TEXT,TEXT) IS
     'VH-2 (v0.48.0): Remove a distance-predicate subscription.';
 
-CREATE FUNCTION pgtrickle."list_distance_subscriptions"()
+CREATE FUNCTION pgtrickle."list_distance_subscriptions"("p_stream_table" TEXT DEFAULT NULL)
 RETURNS TABLE(
     "stream_table"   TEXT,
     "channel"        TEXT,
@@ -98,7 +98,7 @@ RETURNS TABLE(
 LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
 
-COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"() IS
+COMMENT ON FUNCTION pgtrickle."list_distance_subscriptions"(TEXT) IS
     'VH-2 (v0.48.0): List all active distance-predicate subscriptions.';
 
 -- ── Step 4: Register VA-1 embedding_stream_table() ───────────────────────

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5500,9 +5500,14 @@ fn unsubscribe_distance(stream_table: &str, channel: &str) -> Result<(), PgTrick
 }
 
 /// VH-2 (v0.48.0): List all active distance-predicate subscriptions.
+///
+/// When `p_stream_table` is provided (e.g. `'public.ds3_st'`), only
+/// subscriptions for that stream table are returned.  Pass NULL to list all.
 #[allow(clippy::type_complexity)]
 #[pg_extern(schema = "pgtrickle")]
-fn list_distance_subscriptions() -> TableIterator<
+fn list_distance_subscriptions(
+    p_stream_table: pgrx::default!(Option<&str>, "NULL"),
+) -> TableIterator<
     'static,
     (
         name!(stream_table, Option<String>),
@@ -5514,13 +5519,24 @@ fn list_distance_subscriptions() -> TableIterator<
     ),
 > {
     let rows = Spi::connect(|client| {
-        let tup_table = client.select(
-            "SELECT stream_table, channel, vector_column, op, threshold, created_at \
-             FROM pgtrickle.pgt_distance_subscriptions \
-             ORDER BY stream_table, channel",
-            None,
-            &[],
-        )?;
+        let tup_table = if let Some(st) = p_stream_table {
+            client.select(
+                "SELECT stream_table, channel, vector_column, op, threshold, created_at \
+                 FROM pgtrickle.pgt_distance_subscriptions \
+                 WHERE stream_table = $1 \
+                 ORDER BY stream_table, channel",
+                None,
+                &[st.into()],
+            )?
+        } else {
+            client.select(
+                "SELECT stream_table, channel, vector_column, op, threshold, created_at \
+                 FROM pgtrickle.pgt_distance_subscriptions \
+                 ORDER BY stream_table, channel",
+                None,
+                &[],
+            )?
+        };
         let mut result: Vec<(
             Option<String>,
             Option<String>,
@@ -5798,15 +5814,46 @@ fn embedding_stream_table_impl(
         _ => "vector_l2_ops",
     };
 
+    // Look up the source column's format_type (e.g. "vector(2)") so we can
+    // build an explicit cast in the index expression.  pgvector HNSW/IVFFlat
+    // indexes require the column expression to have explicit dimensions; when
+    // pgtrickle creates the stream table it stores only the base type OID
+    // (without type modifier), so the stream table column ends up as `vector`
+    // (no dims).  Using `(col::vector(2))` in the index expression provides
+    // the required dimensions without altering the stream table schema.
+    let src_format_type: Option<String> = Spi::get_one_with_args::<String>(
+        "SELECT format_type(a.atttypid, a.atttypmod) \
+         FROM pg_attribute a \
+         JOIN pg_class c ON c.oid = a.attrelid \
+         JOIN pg_namespace n ON n.oid = c.relnamespace \
+         WHERE n.nspname = $1 AND c.relname = $2 AND a.attname = $3 \
+           AND a.attnum > 0 AND NOT a.attisdropped \
+         LIMIT 1",
+        &[
+            src_schema.as_str().into(),
+            src_tbl.as_str().into(),
+            vector_col.into(),
+        ],
+    )
+    .unwrap_or(None);
+
+    // Use an explicit cast when the source type carries dimension info
+    // (e.g. "vector(2)" — contains a parenthesised modifier).
+    let idx_col_expr = match &src_format_type {
+        Some(fmt) if fmt.contains('(') => {
+            format!("({}::{})", quote_identifier(vector_col), fmt)
+        }
+        _ => quote_identifier(vector_col).to_string(),
+    };
+
     let create_idx_sql = format!(
         "CREATE INDEX IF NOT EXISTS {}_{}_idx ON {}.{} \
-         USING {} ({} {opclass})",
+         USING {} ({idx_col_expr} {opclass})",
         dst_name,
         vector_col,
         quote_identifier(&dst_schema),
         quote_identifier(&dst_name),
         idx_access_method,
-        quote_identifier(vector_col),
     );
 
     let mut actions: Vec<String> = Vec::new();

--- a/src/api/outbox.rs
+++ b/src/api/outbox.rs
@@ -296,7 +296,7 @@ fn attach_embedding_outbox_impl(
          SET embedding_vector_column = $1 \
          WHERE stream_table_oid = (\
            SELECT pgt_id::oid FROM pgtrickle.pgt_stream_tables \
-           WHERE schema_name = $2 AND stream_table_name = $3 \
+           WHERE pgt_schema = $2 AND pgt_name = $3 \
          )",
         &[
             vector_column.into(),

--- a/tests/e2e_upgrade_tests.rs
+++ b/tests/e2e_upgrade_tests.rs
@@ -857,26 +857,32 @@ async fn test_upgrade_schema_additions_from_sql() {
     let mut current = from_version.clone();
     let mut sql_files: Vec<String> = Vec::new();
     while current != to_version {
-        // Find the next step from `current`
-        let pattern = format!("sql/pg_trickle--{}--", current);
-        let mut found = false;
-        for entry in std::fs::read_dir("sql").expect("sql/ directory") {
-            let entry = entry.unwrap();
+        // Find the next step from `current`.
+        // Collect all candidates sorted by name so that when multiple scripts
+        // start from the same version (e.g. 0.41.0→0.47.0 and 0.41.0→0.48.0)
+        // the traversal is deterministic: prefer the smallest next-version hop.
+        let prefix = format!("pg_trickle--{}--", current);
+        let pattern = format!("sql/{prefix}");
+        let mut candidates: Vec<std::fs::DirEntry> = std::fs::read_dir("sql")
+            .expect("sql/ directory")
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let name = e.file_name().to_string_lossy().to_string();
+                name.starts_with(&prefix) && name.ends_with(".sql")
+            })
+            .collect();
+        candidates.sort_by_key(|e| e.file_name());
+        if let Some(entry) = candidates.into_iter().next() {
             let name = entry.file_name().to_string_lossy().to_string();
-            if name.starts_with(&format!("pg_trickle--{}--", current)) && name.ends_with(".sql") {
-                let next = name
-                    .strip_prefix(&format!("pg_trickle--{}--", current))
-                    .unwrap()
-                    .strip_suffix(".sql")
-                    .unwrap()
-                    .to_string();
-                sql_files.push(entry.path().to_string_lossy().to_string());
-                current = next;
-                found = true;
-                break;
-            }
-        }
-        if !found {
+            let next = name
+                .strip_prefix(&prefix)
+                .unwrap()
+                .strip_suffix(".sql")
+                .unwrap()
+                .to_string();
+            sql_files.push(entry.path().to_string_lossy().to_string());
+            current = next;
+        } else {
             panic!(
                 "No upgrade script found for {pattern}*.sql — cannot reach {to_version} from {from_version}"
             );


### PR DESCRIPTION
## Summary

Fixes 3 failing tests in `e2e_pgvector_tests` introduced with v0.48.0 embedding APIs.

## Bugs fixed

### 1. `attach_embedding_outbox` — wrong column names in catalog lookup
**File:** `src/api/outbox.rs`  
The `attach_embedding_outbox_impl` function queried `pgt_stream_tables` using `schema_name` and `stream_table_name`, but the actual column names are `pgt_schema` and `pgt_name`.  
**Error:** `column "schema_name" does not exist`

### 2. `list_distance_subscriptions` — missing filter parameter
**File:** `src/api/mod.rs`  
The function took no arguments, but the test calls it as `list_distance_subscriptions('public.ds3_st')`. Added an optional `p_stream_table TEXT DEFAULT NULL` parameter that filters results when provided.  
**Error:** `function pgtrickle.list_distance_subscriptions(unknown) does not exist`

### 3. `embedding_stre### 3. `embedding_stre### 3. `embedding_stre### 3. `embe co### 3. `embedding_stre### 3. `embedding_stre### 3. `emb's ### 3. `embedding_rea### 3. `embedding_stre### 3. `embedding_stre### 3. `embedding_stre### 3. `embe co#are### 3. `emb. p### 3. `embedding_stre### 3. `embedding_stre### 3. `embedding_stre### 3xed by querying `format_type()` from the source column and injecting an explicit cast (e.g. `(embedding::vector(2))`) into the index DDL.  
**Error:** `column does not have dimensions`

## SQL files updated
- `sql/archive- `sql/archive- `sql/archive- `sql/archive- `srgo - `sql/archive- `sql/archive- `sql/archive- `sql/archive- `ted - `sql/archive- `sql/archiv`- `sql/archive- `sql/archive- `sql/archive- `sql/archive- `srgo - `sql/archive- `sql/archive- `sql/archive- `sql/archive- `ted - `sql/archive- `sql/archiv`- `sql/archive- `sql/archive- `sql/ar16/16 passed ✅
- `check-upgrade-all`: 14/14 upgrade steps pass ✅
- `check-version-sync`: all 10 checks pass ✅