### PR TITLE
ci: cache builder image in GHCR to prevent upgrade-e2e timeout

### DIFF
--- a/.github/workflows/builder-image.yml
+++ b/.github/workflows/builder-image.yml
@@ -1,0 +1,63 @@
+# =============================================================================
+# Builder Image Workflow
+#
+# Builds and publishes the pg_trickle_builder:pg18 image to GHCR so that
+# E2E CI jobs can pull it instead of rebuilding from scratch each run.
+# Without this cache the builder step (Rust + cargo-pgrx + pgrx init) takes
+# ~30–60 min on a cold GitHub Actions runner, causing upgrade-e2e-tests to
+# time out at the 60-minute job limit.
+#
+# Triggers:
+#   - Push to main when Dockerfile.builder changes
+#   - Weekly on Sunday 02:00 UTC (keep base images fresh / catch bit-rot)
+#   - Manual dispatch
+#
+# The published image is pulled by CI jobs that call build_e2e_image.sh via
+# a "Pull builder image from GHCR" step added to e2e-smoke, e2e-tests, and
+# upgrade-e2e-tests jobs.  If the GHCR image is unavailable (e.g. on the
+# very first run), those jobs fall back to building the builder locally.
+# =============================================================================
+name: Builder Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tests/Dockerfile.builder'
+      - '.github/workflows/builder-image.yml'
+  schedule:
+    - cron: '0 2 * * 0'  # Weekly Sunday 02:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-builder-image:
+    name: Build and push builder image to GHCR
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push builder image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: tests/Dockerfile.builder
+          push: true
+          tags: ghcr.io/grove/pg-trickle/builder:pg18
+          # Registry-backed layer cache so repeated runs only rebuild changed layers.
+          cache-from: type=registry,ref=ghcr.io/grove/pg-trickle/builder:cache
+          cache-to: type=registry,ref=ghcr.io/grove/pg-trickle/builder:cache,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,24 @@ jobs:
             docker save postgres:18.3 --output /tmp/docker-images/postgres-18.3.tar
           fi
 
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull builder image from GHCR
+        run: |
+          # Pull the pre-built builder image to avoid a ~30–60 min local build.
+          # Falls back to building locally if the GHCR image is unavailable.
+          if docker pull ghcr.io/grove/pg-trickle/builder:pg18 2>/dev/null; then
+            docker tag ghcr.io/grove/pg-trickle/builder:pg18 pg_trickle_builder:pg18
+            echo "Builder image pulled from GHCR — skipping local build"
+          else
+            echo "::warning::Builder image not in GHCR (first run?). Will build locally."
+          fi
+
       - name: Build E2E Docker image
         run: ./tests/build_e2e_image.sh
 
@@ -309,6 +327,24 @@ jobs:
             docker pull postgres:18.3
             mkdir -p /tmp/docker-images
             docker save postgres:18.3 --output /tmp/docker-images/postgres-18.3.tar
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull builder image from GHCR
+        run: |
+          # Pull the pre-built builder image to avoid a ~30–60 min local build.
+          # Falls back to building locally if the GHCR image is unavailable.
+          if docker pull ghcr.io/grove/pg-trickle/builder:pg18 2>/dev/null; then
+            docker tag ghcr.io/grove/pg-trickle/builder:pg18 pg_trickle_builder:pg18
+            echo "Builder image pulled from GHCR — skipping local build"
+          else
+            echo "::warning::Builder image not in GHCR (first run?). Will build locally."
           fi
 
       - name: Build E2E Docker image
@@ -543,6 +579,24 @@ jobs:
 
       - name: Setup pgrx environment
         uses: ./.github/actions/setup-pgrx
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull builder image from GHCR
+        run: |
+          # Pull the pre-built builder image to avoid a ~30–60 min local build.
+          # Falls back to building locally if the GHCR image is unavailable.
+          if docker pull ghcr.io/grove/pg-trickle/builder:pg18 2>/dev/null; then
+            docker tag ghcr.io/grove/pg-trickle/builder:pg18 pg_trickle_builder:pg18
+            echo "Builder image pulled from GHCR — skipping local build"
+          else
+            echo "::warning::Builder image not in GHCR (first run?). Will build locally."
+          fi
 
       - name: Build E2E Docker image
         run: ./tests/build_e2e_image.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,6 +545,13 @@ jobs:
       - uses: actions/checkout@v5
       - id: pairs
         run: |
+          # v0.47.0 upgrade support policy: only test upgrades from v0.40.0+.
+          # Scripts for older versions remain in sql/ for PostgreSQL chain
+          # compatibility but are no longer E2E tested. The archive
+          # oldest→current chain is omitted for the same reason.
+          SUPPORT_CUTOFF="0.40.0"
+          # Returns 0 if version $1 >= $2 (sort -V for correctness).
+          version_ge() { printf '%s\n%s' "$2" "$1" | sort -V -C; }
           current_version=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
           items='['
           first=true
@@ -553,14 +560,13 @@ jobs:
             from=${base#pg_trickle--}
             to=${from#*--}
             from=${from%%--*}
+            # Skip pairs whose from-version predates the support cutoff.
+            if ! version_ge "$from" "$SUPPORT_CUTOFF"; then
+              continue
+            fi
             if [ "$first" = true ]; then first=false; else items="$items,"; fi
             items="$items{\"from\":\"$from\",\"to\":\"$to\"}"
           done
-          # Add full chain: oldest archive → current version
-          oldest=$(ls sql/archive/pg_trickle--*.sql | sed 's/.*--\(.*\)\.sql/\1/' | sort -V | head -1)
-          if [ "$oldest" != "$current_version" ]; then
-            items="$items,{\"from\":\"$oldest\",\"to\":\"$current_version\"}"
-          fi
           items="$items]"
           echo "matrix={\"include\":$items}" >> "$GITHUB_OUTPUT"
           echo "Discovered upgrade pairs: $items"

--- a/tests/build_e2e_image.sh
+++ b/tests/build_e2e_image.sh
@@ -22,7 +22,12 @@ set -euo pipefail
 
 IMAGE_NAME="pg_trickle_e2e"
 IMAGE_TAG="latest"
-BUILDER_IMAGE="pg_trickle_builder:pg18"
+# Allow CI (or a developer) to override the builder image via the environment.
+# In CI the "Pull builder image from GHCR" step pulls the pre-built image and
+# tags it as pg_trickle_builder:pg18 so this default is found immediately.
+# To point directly at GHCR without a retag step:
+#   BUILDER_IMAGE=ghcr.io/grove/pg-trickle/builder:pg18 ./tests/build_e2e_image.sh
+BUILDER_IMAGE="${BUILDER_IMAGE:-pg_trickle_builder:pg18}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 


### PR DESCRIPTION
## Summary

Two related CI problems caused the `upgrade-e2e-tests` matrix to time out and waste runner hours:

1. **Builder image rebuilt from scratch on every runner** — the `pg_trickle_builder:pg18` image (Rust + cargo-pgrx + pgrx init) was rebuilt on every cold runner, taking 30–60 min and hitting the 60-minute `timeout-minutes`. Confirmed by the job start/cancel timestamps on run [25400788153](https://github.com/grove/pg-trickle/actions/runs/25400788153).

2. **Matrix included pre-0.40.0 pairs** — the `upgrade-e2e-prepare` job was iterating all 56 upgrade SQL scripts from v0.1.3 onward, generating ~57 matrix jobs. The v0.47.0 upgrade support policy (CHANGELOG) says upgrades are only supported **from v0.40.0 or later**, and the `upgrade-check` job already applied this cutoff — but `upgrade-e2e-prepare` did not.

## Changes

### Fix 1 — GHCR-backed builder image cache

- **New: `.github/workflows/builder-image.yml`** — builds and pushes `ghcr.io/grove/pg-trickle/builder:pg18` to GHCR. Triggers on changes to `Dockerfile.builder`, the weekly Sunday schedule, or manual dispatch. Uses registry-backed BuildKit layer cache for fast incremental rebuilds.

- **`ci.yml`** — adds "Log in to GHCR" + "Pull builder image from GHCR" steps before `./tests/build_e2e_image.sh` in `e2e-smoke`, `e2e-tests`, and `upgrade-e2e-tests`. Falls back gracefully to a local build if the GHCR image is unavailable (e.g. first run before the workflow has ever published).

- **`tests/build_e2e_image.sh`** — `BUILDER_IMAGE` is now overridable via environment variable (default unchanged).

### Fix 2 — Apply v0.40.0 support cutoff to upgrade-e2e matrix

- **`ci.yml` (`upgrade-e2e-prepare` job)** — applies the same `SUPPORT_CUTOFF="0.40.0"` filter already used by `upgrade-check`. Matrix shrinks from **57 → 14 pairs** (v0.40.0 through v0.48.0 only). The archive oldest→current chain (v0.1.3 → current) is also removed.

## Testing

- Simulated filtered matrix locally: 14 pairs remain (0.40.0–0.48.0 range), all expected.
- Local build unchanged — `just build-e2e-image` continues to work as before.
- GHCR fallback verified: if `docker pull` returns non-zero, `build_e2e_image.sh` builds locally.

## Notes

- **First run**: `builder-image.yml` must complete before the GHCR image is available. The very first upgrade-e2e run after merge will still fall back to a local build; all runs after that will be fast.
- The `packages: write` permission is scoped to `builder-image.yml` only.
- Pre-0.40.0 upgrade scripts remain in `sql/` for PostgreSQL chain compatibility — they are not deleted, just excluded from E2E testing.
