### PR TITLE
ci: remove redundant TPC-H nightly gate job

### DIFF
--- a/.github/workflows/tpch-nightly.yml
+++ b/.github/workflows/tpch-nightly.yml
@@ -83,17 +83,3 @@ jobs:
             cargo nextest run --profile ci --test e2e_tpch_tests \
               --run-ignored all --no-capture
           fi
-
-  # ── Final gate ────────────────────────────────────────────────────────
-  check:
-    name: TPC-H nightly gate
-    runs-on: ubuntu-latest
-    needs: [tpch-nightly]
-    if: always()
-    steps:
-      - name: Fail if any TPC-H job failed
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: |
-          echo "One or more TPC-H nightly jobs failed:"
-          echo "  tpch-nightly: ${{ needs.tpch-nightly.result }}"
-          exit 1


### PR DESCRIPTION
## Summary

TPC-H Nightly run #22 (2026-05-06) reported failure even though both SF-1 and
SF-10 tests passed. The GitHub Actions annotations showed:

> "The job was not acquired by Runner of type hosted even after multiple attempts"
> "TPC-H Nightly Internal server error. Correlation ID: 86d43f19-…"

The gate job (`TPC-H nightly gate`) was cancelled before any steps ran due to a
transient GitHub infrastructure issue — runner availability was exhausted after
the 90-minute matrix run. The gate itself is redundant: GitHub Actions already
marks the overall workflow as failed whenever any matrix job fails (with
`fail-fast: false`, each job is still independently failure-tracked). Requiring
a third `ubuntu-latest` runner just to echo a pass/fail message adds an
unnecessary dependency on runner availability in a high-contention window.

## Changes

- Removed the `check` / `TPC-H nightly gate` job from `tpch-nightly.yml`
- No other workflow logic changed; the matrix (`tpch-nightly`) already drives
  the correct pass/fail signal for both SF-1 and SF-10

## Testing

- Verified both SF-1 and SF-10 jobs in run #22 passed independently
- The workflow now has exactly 2 jobs; workflow succeeds iff both pass

## Notes

Fixes: https://github.com/grove/pg-trickle/actions/runs/25422509264
