### PR TITLE
roadmap: add v0.49–v0.51 v1.0 readiness arc (test infra, perf/security/ops, Citus chaos)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -105,6 +105,14 @@
 | [v0.47.0](roadmap/v0.47.0.md) | Embedding pipeline infrastructure: post-refresh hooks, drift-based reindex, vector monitoring | ✅ Released | Medium | [Full details](roadmap/v0.47.0.md-full.md) |
 | [v0.48.0](roadmap/v0.48.0.md) | Complete embedding programme: sparse/half-precision vector aggregates, hybrid search, embedding_stream_table() API, per-tenant ANN, embedding outbox | ✅ Released | Large | [Full details](roadmap/v0.48.0.md-full.md) |
 
+### v1.0 Readiness Arc (v0.49.x – v0.51.x)
+
+| Version | Theme | Status | Scope | Full details |
+|---------|-------|--------|-------|--------------|
+| [v0.49.0](roadmap/v0.49.0.md) | Test infrastructure hardening: concurrency synchronization overhaul, 10-module unit test sweep, merge/row_id fuzz targets, DDL-during-refresh E2E, scheduler decomposition, CI smoke breadth | Planned | Large | [Full details](roadmap/v0.49.0.md-full.md) |
+| [v0.50.0](roadmap/v0.50.0.md) | Performance, security & operational hardening: SPI batching in differential refresh, dblink escaping fix, CNPG graceful-drain preStop hook, Docker image digest pinning, invalidation ring observability, deep-join drift monitoring, Prometheus secondary metrics | Planned | Large | [Full details](roadmap/v0.50.0.md-full.md) |
+| [v0.51.0](roadmap/v0.51.0.md) | Citus chaos resilience & documentation truth: chaos test rig (node kill/rebalance/partition), deprecated GUC removal, ARCHITECTURE.md pg_tide boundary, recursive CTE strategy docs, CDC-enabled-flag documentation | Planned | Large | [Full details](roadmap/v0.51.0.md-full.md) |
+
 ### Beyond v1.0
 
 | Version | Theme | Status | Scope | Full details |
@@ -171,6 +179,12 @@ v0.47    ─── Embedding infrastructure: post-refresh actions, drift-based r
     │
 v0.48    ─── Complete embedding programme: sparse vectors, hybrid search, embedding_stream_table(), per-tenant ANN
     │
+v0.49    ─── Test infrastructure hardening: concurrency sync overhaul, 10-module unit sweep, merge fuzz, DDL E2E, scheduler split
+    │
+v0.50    ─── Performance, security & ops hardening: SPI batching, dblink fix, CNPG drain hook, digest pinning, ring observability
+    │
+v0.51    ─── Citus chaos resilience & doc truth: chaos rig, deprecated GUC removal, pg_tide boundary, CTE strategy docs
+    │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```
 
@@ -231,3 +245,71 @@ hybrid search, the ergonomic `embedding_stream_table()` API, per-tenant ANN
 patterns, and outbox-emitted embedding events). v0.46.0 precedes this arc
 with the extraction of `pg_tide` — moving the outbox, inbox, and relay
 subsystems into a standalone extension at `trickle-labs/pg-tide`.
+
+**v0.49.0 through v0.51.0 form the v1.0 readiness arc**, driven by the findings
+in the v0.48.0 overall assessment (plans/PLAN_OVERALL_ASSESSMENT_10.md). The
+assessment confirmed that every P0 correctness issue from prior assessments is
+closed — EC-01 phantom rows, snapshot cache-key weakness, placeholder resolution,
+and WAL transition TOCTOU are all fixed. The project has transitioned from a
+capability problem to a coverage confidence problem. These three releases
+systematically close the remaining gaps across test reliability, performance,
+security hardening, operational polish, and documentation truth before v1.0.
+
+**v0.49.0 targets test infrastructure quality** — the single highest-risk
+category from the v10 assessment. All concurrency tests currently rely on
+`sleep(50ms)` for synchronization, which provides false confidence: tests may
+pass locally while missing real race conditions on slow CI runners or under
+load. This release replaces sleep-based synchronization with `pg_locks`-polling
+patterns throughout `tests/e2e_concurrent_tests.rs`. Alongside, ten source
+modules that have zero `#[cfg(test)]` unit test coverage are systematically
+addressed: `catalog.rs`, `template_cache.rs`, `ivm.rs`, `cdc/polling.rs`,
+`cdc/rebuild.rs`, `diagnostics.rs`, `logging.rs`, `metrics_server.rs`, and
+`otel.rs`. New fuzz targets are added for the refresh merge SQL codegen
+(`src/refresh/merge/`) and row identity tracking (`src/dvm/row_id.rs`) — two
+high-value surfaces with no current fuzz coverage. An E2E test for concurrent
+DDL during active refresh (`ALTER STREAM TABLE` + in-flight refresh) is added.
+The `src/scheduler/mod.rs` monolith (6,700+ lines) is decomposed into focused
+submodule files: scheduling loop, parallel dispatch state, and cost model
+each become separate files. The e2e-smoke CI filter is widened to cover join,
+aggregate, and window operator regressions on every PR, and a consolidated
+`just fuzz-all` recipe is added to the justfile.
+
+**v0.50.0 targets performance, security, and operational hardening.** The
+differential refresh hot path currently makes 3–4 separate SPI round-trips per
+refresh cycle — buffer existence check, change count per source, and table row
+estimate — that are consolidated into a single CTE query, saving 10–15ms per
+multi-source refresh. The CDC trigger SQL generation loop is tightened using
+`String::with_capacity()` to eliminate per-column heap allocations. The
+watermark computation in the scheduler tick is consolidated into a single
+compound query. On the security side, the `src/citus.rs` dblink calls that
+use manual single-quote doubling for escaping are replaced with
+`pg_escape_literal()` SPI calls for defense-in-depth. Operational gaps are
+closed: the CNPG `cluster-production.yaml` gains a preStop lifecycle hook
+that calls `pgtrickle.drain(timeout_s => 120)` before pod termination,
+preventing interrupted in-flight refreshes during rolling upgrades. All Docker
+base images are pinned to SHA256 digests for reproducible builds. The shared
+memory invalidation ring capacity limit (1,024 entries) is documented in
+`docs/CONFIGURATION.md` with a new `pg_trickle_invalidation_ring_overflow`
+Prometheus counter. Two additional Prometheus metrics are added:
+`pg_trickle_dag_cycles_detected` and `pg_trickle_cache_stale_evictions`.
+The deep join chain Part 3 correction threshold GUC and its trade-off
+between SQL complexity and correctness at >6 join tables is documented in the
+configuration reference with an associated soak-test assertion.
+
+**v0.51.0 closes the Citus resilience gap and brings documentation into full
+truth.** The Citus distributed support shipped in v0.32–v0.34 has never had
+a chaos test suite — there are zero tests validating behaviour under node
+failure, shard rebalance, or network partition. This release delivers a
+docker-compose-based chaos rig with three scenarios: coordinator restart,
+worker node kill with automatic reconnect, and rolling shard rebalance during
+active refresh. The deprecated `pg_trickle.event_driven_wake` GUC (non-functional
+since background workers cannot use `LISTEN`) is removed entirely along with
+all associated code paths and the runtime warning it emits. Documentation is
+brought to full truth: `docs/ARCHITECTURE.md` is updated to clearly describe
+the pg_tide boundary after v0.46.0 extraction; `docs/CONFIGURATION.md` gains
+a deprecation header on the removed GUC entry; the recursive CTE strategy
+selection heuristic (semi-naive vs. DRed vs. recomputation fallback) is
+documented for the first time with an example EXPLAIN output; and a note is
+added to `docs/CONFIGURATION.md` clarifying that CDC triggers fire even when
+`pg_trickle.enabled = false` (by design, to keep buffers ready for re-enable).
+

--- a/plans/PLAN_OVERALL_ASSESSMENT_10.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT_10.md
@@ -1,0 +1,402 @@
+# pg_trickle — Overall Assessment v10
+
+> Status: Deep gap analysis — static source audit + test mapping
+> Date: 6 May 2026
+> Scope: Full repository (v0.48.0)
+
+## Executive Summary
+
+pg_trickle has matured into a well-engineered, production-ready PostgreSQL
+extension. The most significant finding of this assessment is that the three
+persistent P0 correctness issues raised across v7–v9 assessments — EC-01 join
+phantom rows, snapshot cache-key weakness, and placeholder resolution gaps —
+have all been **resolved**. The DVM engine now uses structural fingerprinting
+(A41-1) for cache keys, includes strict placeholder assertion (A41-2), and
+the EC-01 fix uses proper Part 1a/1b split with R₀/R₁ snapshot strategy. The
+WAL transition TOCTOU vulnerability (v9 COR-03) is fixed via A41-3 eligibility
+re-check. `repair_stream_table()` (v9 FEAT-01) is fully implemented since
+v0.41.
+
+The project's overall health is **strong**. Code quality is excellent
+(clippy::unwrap_used denied in production, 100% SAFETY documentation on unsafe
+blocks, proper error propagation throughout). The remaining risks are
+concentrated in **test coverage gaps** (modules with zero unit tests,
+sleep-based concurrency synchronization) and **operational polish** (CNPG
+graceful drain integration, missing Prometheus metrics for secondary
+subsystems, full E2E not gated on push-to-main).
+
+| ID | Severity | Description |
+|----|----------|-------------|
+| TEST-01 | P1 | Concurrency tests use sleep-based synchronization — flaky on slow CI |
+| CI-01 | P1 | Full E2E + TPC-H not triggered on push-to-main (blind spot) |
+| PERF-01 | P2 | 3–4 SPI round-trips per differential refresh that could be batched |
+| COV-01 | P2 | 10 source modules with zero unit test coverage |
+| OPS-01 | P2 | CNPG preStop hook missing graceful drain call |
+
+## What Has Improved Since v9
+
+| v9 Finding | ID | Status | Evidence |
+|---|---|---|---|
+| DVM snapshot CTE cache keys use only leaf aliases | COR-01 (P0) | **CLOSED** | Structural fingerprinting (A41-1) in `src/dvm/diff.rs:254-430` |
+| LSN/template placeholder resolvers lack assertion | COR-02 (P0) | **CLOSED** | `check_no_remaining_placeholders()` at `src/dvm/mod.rs:248` |
+| WAL transition lacks eligibility recheck at commit | COR-03 (P0) | **CLOSED** | A41-3 TOCTOU fix in `src/wal_decoder.rs:1742-1750` |
+| `repair_stream_table()` not implemented | FEAT-01 (P1) | **CLOSED** | Full 6-step implementation in `src/api/mod.rs:4456-4650` |
+| SQL/GUC generated catalogs broken | DOC-01 (P1) | **CLOSED** | `scripts/gen_catalogs.py` operational with `--check` CI flag |
+| Full E2E not gated on PR | CI-02 (P1) | **PARTIALLY ADDRESSED** | Light E2E runs on PR; full E2E still schedule/dispatch only |
+| EC-01 join phantom rows | C1 (P0) | **CLOSED** | Part 1a/1b split with R₀ strategy in `src/dvm/operators/join.rs:216-447` |
+| WAL backpressure not enforced | C2 | **CLOSED** | Frontier holdback mode (xmin) with `frontier_holdback_warn_seconds` GUC |
+| Event-driven wake documented as active | C3 | **CLOSED** | GUC deprecated, documented as non-functional, default `false` |
+| SQLSTATE classification mostly unwired | C4 | **CLOSED** | `SpiErrorCode(u32, String)` variant + `classify_spi_sqlstate_retryable()` in `src/error.rs` |
+| Citus coordination lacks hardening coverage | C5 | **STILL OPEN** | No chaos tests in repo |
+| `pg_trickle.enabled=false` doesn't fully disable CDC | v7 3.6 | **BY DESIGN** | Triggers still fire (keeps buffers fresh for re-enable); scheduler skips refreshes |
+
+## Methodology
+
+This assessment was conducted via exhaustive static source audit of the v0.48.0
+codebase. The following methodology was applied:
+
+1. **Prior assessment cross-reference**: Read v7, v8, and v9 assessments in full
+   to establish baseline of known issues and verified fixes.
+2. **Architectural documentation review**: Read ARCHITECTURE.md, SQL_REFERENCE.md,
+   CONFIGURATION.md, ROADMAP.md, and AGENTS.md.
+3. **Source code deep-dive**: Direct reading of all DVM operator files
+   (`src/dvm/operators/*.rs`), refresh engine (`src/refresh/merge/`), CDC
+   (`src/cdc.rs`, `src/cdc/*.rs`), WAL decoder (`src/wal_decoder.rs`), DAG
+   (`src/dag.rs`), scheduler (`src/scheduler/mod.rs`), shared memory
+   (`src/shmem.rs`), configuration (`src/config.rs`), error handling
+   (`src/error.rs`), and API layer (`src/api/mod.rs`).
+4. **Test mapping**: Inventory of all E2E test files, unit test modules,
+   fuzz targets, and benchmark files.
+5. **CI validation**: Cross-reference of `.github/workflows/ci.yml` against
+   AGENTS.md trigger table.
+6. **Security scan**: Dynamic SQL construction patterns, unsafe blocks, shared
+   memory bounds, dependency advisories.
+
+Limitations: No runtime verification was performed. Claims about SQL execution
+plans, actual refresh latency, and Prometheus endpoint correctness are based on
+code inspection only, not live measurement.
+
+---
+
+## Dimension 1 — Correctness and Data Integrity
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| COR-10-01 | P2 | `src/dvm/operators/join.rs:436-447` | Part 3 correction term skipped when left-child scan count > GUC threshold (default 5); deep join chains (>6 tables) may accumulate small delta errors over many cycles | Drift in very deep join chains under sustained concurrent changes | Monitor with soak test (G17-SOAK); document threshold trade-off |
+| COR-10-02 | P3 | `src/cdc.rs` (trigger body) | CDC triggers fire regardless of `pg_trickle.enabled` GUC — change buffers grow when extension disabled | Buffer growth during maintenance windows | Document in CONFIGURATION.md as expected behavior |
+
+### Positive Findings
+
+- **EC-01 fix is mathematically rigorous**: Part 1a/1b split with R₀/R₁ snapshot strategy correctly addresses the join-key-update phantom row problem. Hash formula invariant (line 216-225) ensures row_id stability across cycles.
+- **Structural fingerprinting for snapshot cache keys** (A41-1): Recursively encodes operator types, join conditions, predicates, projections, and child fingerprints. Two structurally different subtrees always produce different keys.
+- **Strict placeholder assertion** (A41-2): `check_no_remaining_placeholders()` validates all tokens resolved after substitution. Pattern matching requires uppercase/digits/underscores to avoid false positives.
+- **WAL transition TOCTOU fix** (A41-3): Three-phase protocol with eligibility re-check before committing TRANSITIONING state. Slot is dropped and mode reverts to TRIGGER on failure.
+- **Aggregate invertibility classification**: SUM(CASE WHEN) correctly identified as non-algebraic (DI-8) and falls back to GROUP_RESCAN.
+- **Multiset net-counting for keyless tables**: Proper decompose → aggregate → expand pattern with `generate_series()` expansion.
+- **Metadata reload after lock** (TOCTOU fix): `load_st_by_id()` called after `SELECT ... FOR UPDATE` prevents stale-frontier-based re-processing.
+- **Frontier holdback**: xmin-based probe of `pg_stat_activity` prevents commit-LSN vs. MVCC visibility race.
+
+---
+
+## Dimension 2 — Code Quality and Maintainability
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| CQ-10-01 | P2 | `src/scheduler/mod.rs` (6700+ lines) | Scheduler remains a single-file module despite prior assessment recommendations to split | Harder to navigate; increased merge conflicts on multi-contributor branches | Extract scheduling loop, parallel dispatch, and cost model into separate submodule files |
+| CQ-10-02 | P3 | `src/config.rs:375-400` | Deprecated `event_driven_wake` GUC still registered and emits runtime warning | User confusion; unnecessary code path | Remove GUC registration in next major version; document removal in CHANGELOG |
+| CQ-10-03 | P3 | `src/hooks.rs:192` | `#[allow(dead_code)]` retained for test compatibility | Minor technical debt | Remove or gate behind `#[cfg(test)]` |
+
+### Positive Findings
+
+- **`#![deny(clippy::unwrap_used)]` in non-test code**: Enforced at crate level (`src/lib.rs:22`). Zero unwrap violations in production paths.
+- **100% SAFETY documentation**: Every `unsafe` block has a `// SAFETY:` comment with clear invariant explanation.
+- **Error enum design**: 30+ well-categorized variants in `PgTrickleError`, all with context (table names, OIDs). `is_retryable()` classification with SQLSTATE integration.
+- **SPI discipline**: All `Spi::connect()` calls are short-lived, `name::text` casts applied consistently, `Option` handling for absent rows.
+- **Identifier quoting**: `quote_identifier()` properly escapes double-quotes via replacement.
+
+---
+
+## Dimension 3 — Performance
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| PERF-10-01 | P2 | `src/refresh/merge/mod.rs:440-495` | 3–4 separate SPI round-trips per differential refresh (buffer existence check, change count per source, row estimate) | ~10-15ms overhead per refresh for multi-source STs | Consolidate into single CTE query returning all buffer stats |
+| PERF-10-02 | P3 | `src/cdc.rs:1898-1920` | String allocation per column in trigger SQL generation (`format!()` in loop) | ~2-5ms per trigger rebuild for wide tables | Use `String::with_capacity()` + push_str |
+| PERF-10-03 | P3 | `src/scheduler/mod.rs:970-1040` | Watermark computation issues multiple `pg_current_wal_lsn()` queries per tick | Minor: 1-2ms per tick × 10 ticks/sec at min interval | Combine with xmin probe into single query |
+
+### Positive Findings
+
+- **L0 template cache** (CACHE-1): Saves ~45ms per differential refresh by caching generated delta SQL.
+- **SCAL-1 catalog cache**: Thread-local DAG cache invalidated on version bump. Avoids ~100-150ms catalog reload on unchanged ticks.
+- **Adaptive polling** (DAG-2): Exponential backoff 20ms → 200ms when workers in-flight. No busy-wait — uses PostgreSQL latch mechanism.
+- **Statement-mode triggers**: Single INSERT...SELECT per statement (not per-row), minimizing CDC overhead.
+- **Benchmark suite**: Criterion benchmarks cover DAG construction (500+ STs), delta SQL generation per operator, LSN comparison, and frontier serialization. Regression gate runs on every PR.
+
+---
+
+## Dimension 4 — Scalability
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| SCAL-10-01 | P2 | `src/shmem.rs:37` | Invalidation ring max capacity 1024 entries; on DAG with >1024 simultaneously-invalidated STs, overflow flag triggers full DAG rebuild | Thundering-herd on very large deployments (1000+ STs with bulk DDL) | Document limit; consider dynamic ring sizing or batched invalidation |
+| SCAL-10-02 | P3 | `src/scheduler/mod.rs:1812` | `ParallelDispatchState` rebuilt from scratch on DAG version change | O(n) rebuild cost for n execution units; acceptable for <1000 STs | No action needed currently |
+
+### Positive Findings
+
+- **Three-lock split** (SCAL-3): `PGS_STATE`, `SCHEDULER_META_STATE`, and `TICK_WATERMARK_STATE` reduce contention by allowing watermark reads without holding the DAG lock.
+- **Bounded worker tokens**: Atomic counter with `saturating_sub()` prevents underflow. Reconciliation on crash startup.
+- **SKIP LOCKED job claiming**: Zero deadlock risk in parallel worker dispatch.
+- **DAG bounded recursion**: `resolve_calculated_schedule()` limited to O(|V|) iterations.
+- **Kahn's algorithm for cycle detection**: Linear-time, correct, returns diagnostic cycle path.
+
+---
+
+## Dimension 5 — Feature Gaps
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| FEAT-10-01 | P2 | N/A | Citus distributed coordination has zero chaos/resilience tests | Cannot validate correctness under node failure, rebalance, or network partition | Add docker-compose chaos rig with node kill/reconnect scenarios |
+| FEAT-10-02 | P3 | N/A | No `pg_trickle--uninstall.sql` script | Standard DROP EXTENSION works; no issue for most deployments | Document in FAQ; no implementation needed |
+| FEAT-10-03 | P3 | N/A | Event-driven wake (sub-10ms latency) not achievable via current PostgreSQL backend worker API | Advertised latency improvement requires polling at 100ms+ | Document limitation; explore shmem-based latch signalling for future versions |
+
+### Positive Findings
+
+- **repair_stream_table()**: Complete 6-step repair workflow with advisory locks, CDC frontier reset, trigger/buffer rebuild, and cache invalidation.
+- **Drain mode**: Fully implemented with `drain()`, `is_drained()`, runbook, and 6 E2E proof tests.
+- **Snapshot/PITR**: `snapshot_stream_table()` and `restore_from_snapshot()` with atomic sub-transaction wrapper.
+- **pgvector integration**: Complete embedding programme (v0.47-v0.48) with sparse/half-precision vectors, hybrid search, per-tenant ANN.
+- **Fan-out upgrade paths**: 60 migration files covering v0.1.3→v0.48.0 with skip-version direct jumps tested in CI.
+
+---
+
+## Dimension 6 — Test Coverage and Quality
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| TEST-10-01 | P1 | `tests/e2e_concurrent_tests.rs` | All concurrency tests use `sleep(Duration::from_millis(50))` for synchronization | Flaky on slow CI; no guarantee tasks actually overlap | Replace with `pg_locks` polling or condition-variable pattern |
+| TEST-10-02 | P2 | `src/cdc/polling.rs`, `src/cdc/rebuild.rs`, `src/diagnostics.rs`, `src/template_cache.rs`, `src/ivm.rs`, `src/catalog.rs`, `src/logging.rs`, `src/metrics_server.rs`, `src/otel.rs` | 10 source modules with zero `#[cfg(test)]` unit test blocks | Logic errors in these modules require full E2E to detect | Add focused unit tests for pure-logic functions in each |
+| TEST-10-03 | P2 | `fuzz/` | No fuzz target for refresh merge logic (`src/refresh/merge/`) or row identity tracking (`src/dvm/row_id.rs`) | SQL generation bugs in merge codegen could silently produce incorrect DML | Add fuzz target for merge SQL construction with random change streams |
+| TEST-10-04 | P3 | `tests/e2e_concurrent_tests.rs` | DDL during concurrent refresh not tested (ALTER STREAM TABLE + active refresh) | Unknown behavior under realistic operational scenario | Add E2E test |
+
+### Positive Findings
+
+- **107+ E2E test files**: Comprehensive operator coverage (JOIN, AGG, WINDOW, SUBQUERY, SET operations, LATERAL, recursive CTE).
+- **Differential/full equivalence tests**: `e2e_diff_full_equivalence_tests.rs` exercises INSERT + UPDATE + DELETE across 5+ cycles for inner/left/full joins.
+- **7 fuzz targets**: Parser, CDC payload, DAG, GUC, cron, SQL builder, WAL decoder.
+- **TPC-H integration**: Full TPC-H query suite (Q1-Q22) with cycle-based differential verification.
+- **Property tests**: `e2e_property_tests.rs` for randomized correctness validation.
+- **Benchmark regression gate**: Criterion baseline checked on every PR via `scripts/criterion_regression_check.py`.
+
+---
+
+## Dimension 7 — Security
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| SEC-10-01 | P2 | `src/citus.rs:357-364` | dblink SQL escaping uses manual single-quote doubling instead of `pg_escape_literal()` | Low practical risk (inputs are system-controlled from `pg_dist_node`) but violates defense-in-depth | Replace with `pg_escape_literal()` SPI call |
+| SEC-10-02 | P3 | `deny.toml` | `rand 0.8.5` unsoundness advisory (RUSTSEC-2026-0097) allowed — dev-only via sqlx | No production risk; requires custom logger + specific log feature interaction | Monitor for sqlx 0.9.x upgrade |
+
+### Positive Findings
+
+- **`quote_identifier()` used consistently**: All user-provided identifiers properly double-quote-escaped.
+- **SECURITY DEFINER validation**: Automated CI script (`scripts/check_security_definer.sh`) validates search_path pinning on every commit.
+- **No hardcoded secrets**: Clean scan of source, tests, and CI configuration.
+- **Transaction-scoped advisory locks**: No orphaning risk.
+- **Worker crash recovery**: Comprehensive orphan job detection + token reconciliation at scheduler startup.
+- **Shared memory bounds**: Fixed-capacity ring with `.min()` cap; `saturating_sub()` on atomic counters.
+- **`cargo deny` policy**: Reasonable allow-list with justified advisory exceptions documented inline.
+
+---
+
+## Dimension 8 — Operational and Deployment Readiness
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| OPS-10-01 | P2 | `cnpg/cluster-production.yaml` | No preStop hook calling `pgtrickle.drain()` for graceful shutdown | During rolling upgrades, in-flight refreshes may be interrupted | Add `preStop` lifecycle hook: `psql -c "SELECT pgtrickle.drain(timeout_s => 120)"` |
+| OPS-10-02 | P3 | `monitoring/prometheus/pg_trickle_queries.yml` | No Prometheus metric for DAG cycle detection events or template cache eviction rate | Reduced observability for secondary subsystems | Add `pg_trickle_dag_cycles_detected` and `pg_trickle_cache_evictions` counters |
+| OPS-10-03 | P3 | `Dockerfile.demo`, `Dockerfile.ghcr` | Base image `postgres:18.3-bookworm` not pinned to digest | Floating minor updates could introduce incompatibilities | Pin to SHA256 digest for reproducible builds |
+
+### Positive Findings
+
+- **Complete migration chain**: 60 files, fan-out topology with skip-version direct paths, tested in CI.
+- **Comprehensive monitoring**: 14+ Prometheus metrics, 6 alerting rules covering staleness, errors, suspension, buffer growth, scheduler health, and refresh duration.
+- **CNPG production-ready**: Backup/restore via Barman S3, probes configured, worker budget formula documented, HA with streaming replica.
+- **Drain mode**: Complete with SQL API, GUC controls, E2E tests, and operational runbook.
+- **Docker images**: Three purpose-built images (demo, GHCR distribution, E2E testing) with BuildKit cache optimization for fast iteration.
+
+---
+
+## Dimension 9 — Documentation
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| DOC-10-01 | P3 | `docs/ARCHITECTURE.md` | Still describes outbox/inbox as pg_trickle subsystems despite v0.46.0 extraction to pg_tide | Reader confusion about extension boundary | Add note clarifying pg_tide extraction and integration boundary |
+| DOC-10-02 | P3 | `docs/CONFIGURATION.md` | Deprecated `event_driven_wake` GUC listed without clear deprecation banner | Users may enable expecting latency improvement | Add `⚠️ DEPRECATED` prefix to entry |
+| DOC-10-03 | P3 | `docs/ARCHITECTURE.md` | Recursive CTE strategy selection heuristic (semi-naive vs. DRed vs. recomputation) not documented | Black box for operators trying to debug refresh behavior | Document selection criteria and add EXPLAIN output example |
+
+### Positive Findings
+
+- **CHANGELOG completeness**: All 48 versions documented with feature areas, breaking changes, and upgrade notes.
+- **SQL_REFERENCE accuracy**: 100+ functions documented with signatures, examples, and version annotations. Internal links to `DVM_OPERATORS.md` are valid.
+- **Blog post accuracy**: Checked `immediate-mode-zero-lag.md`, `drain-mode.md`, `migrating-from-pg-ivm.md` — all match current implementation.
+- **INSTALL.md and CONTRIBUTING.md**: Complete onboarding path with toolchain requirements, Docker setup, and test workflow.
+- **gen_catalogs.py**: Operational with `--check` CI flag for drift detection.
+
+---
+
+## Dimension 10 — CI and Developer Experience
+
+| ID | Severity | File:Line | Description | Impact | Recommended Fix |
+|----|----------|-----------|-------------|--------|-----------------|
+| CI-10-01 | P1 | `.github/workflows/ci.yml:317` | Full E2E + TPC-H only run on schedule/dispatch, NOT on push-to-main (AGENTS.md says they should) | Regressions on main branch not caught until nightly run | Add `github.event_name == 'push' && github.ref == 'refs/heads/main'` condition |
+| CI-10-02 | P3 | `.github/workflows/ci.yml` (e2e-smoke) | Smoke filter uses only 4 test name patterns — may miss operator-level regressions on PR | Narrow gate; JOIN/AGG regressions could pass | Expand filter to include join/aggregate/window smoke tests |
+| CI-10-03 | P3 | `justfile` | No `just fuzz-all` recipe for running all fuzz targets; individual targets undocumented | Fuzzing requires manual invocation | Add consolidated fuzz recipe |
+
+### Positive Findings
+
+- **Light E2E on every PR**: `cargo pgrx package` + stock postgres container provides ~570 tests on every PR without Docker image build overhead.
+- **Benchmark regression gate**: Criterion baseline comparison on every PR targeting main.
+- **Windows compile gate** (A46-13): Cross-platform compilation validated on PR.
+- **Pinned Rust toolchain**: Edition 2024, pgrx 0.18.x pinned in Cargo.toml.
+- **Upgrade completeness check**: CI validates migration file chain integrity.
+- **Three-shard parallelism**: Light E2E split across 3 CI runners for faster feedback.
+
+---
+
+## Cross-Cutting Synthesis
+
+The project has transitioned from a **capability problem** (missing features,
+correctness gaps) to a **coverage confidence problem**. The core algorithms
+are mathematically sound and well-implemented. The remaining risks are
+concentrated in:
+
+1. **Test infrastructure quality**: Sleep-based concurrency synchronization
+   provides false confidence. Tests may pass locally but miss real race
+   conditions. This affects both correctness validation and CI reliability.
+
+2. **CI gating asymmetry**: The gap between what runs on PR (light E2E) and
+   what runs on schedule (full E2E + TPC-H) means regressions can land on
+   main undetected for up to 24 hours. Given the project's correctness-first
+   values, this is the highest-leverage CI investment.
+
+3. **Module test coverage**: 10 source modules with zero unit tests represent
+   code that can only be validated through expensive E2E runs. Adding targeted
+   unit tests (especially for `catalog.rs`, `template_cache.rs`, and
+   `cdc/rebuild.rs`) would catch bugs faster and cheaper.
+
+The single highest-return investment would be **running full E2E on push-to-main**.
+The ~20 minute cost is justified by the correctness standard the project
+demands.
+
+---
+
+## Prioritised Action Plan
+
+```
+[P1] TEST-10-01 — Replace sleep-based sync in concurrency tests with pg_locks polling — Effort: S
+[P1] CI-10-01   — Enable full E2E + TPC-H on push-to-main — Effort: XS
+[P2] PERF-10-01 — Batch SPI round-trips in differential refresh entry point — Effort: S
+[P2] COV-10-02  — Add unit tests for 10 uncovered modules — Effort: M
+[P2] TEST-10-03 — Add fuzz target for refresh merge SQL generation — Effort: S
+[P2] FEAT-10-01 — Create Citus chaos test rig with node kill/rebalance — Effort: L
+[P2] OPS-10-01  — Add CNPG preStop hook for graceful drain — Effort: XS
+[P2] SEC-10-01  — Replace manual dblink escaping with pg_escape_literal() — Effort: XS
+[P2] SCAL-10-01 — Document invalidation ring limit; add overflow metric — Effort: XS
+[P2] CQ-10-01   — Split scheduler/mod.rs into submodule files — Effort: M
+[P3] DOC-10-01  — Clarify pg_tide extraction in ARCHITECTURE.md — Effort: XS
+[P3] DOC-10-02  — Add deprecation banner to event_driven_wake GUC docs — Effort: XS
+[P3] DOC-10-03  — Document recursive CTE strategy selection heuristic — Effort: S
+[P3] CI-10-02   — Expand e2e-smoke filter to include operator tests — Effort: XS
+[P3] CI-10-03   — Add consolidated fuzz recipe to justfile — Effort: XS
+[P3] OPS-10-02  — Add DAG cycle and cache eviction Prometheus metrics — Effort: S
+[P3] OPS-10-03  — Pin Docker base images to SHA256 digest — Effort: XS
+[P3] CQ-10-02   — Remove deprecated event_driven_wake GUC in next major — Effort: XS
+[P3] PERF-10-02 — Optimize CDC trigger string building — Effort: XS
+[P3] COR-10-02  — Document CDC-fires-when-disabled behavior — Effort: XS
+```
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Concurrency bug lands on main undetected (sleep-based tests pass locally but miss race) | Medium | High — silent data corruption | Fix TEST-10-01; enable full E2E on push |
+| Citus deployment hits node-failure scenario with no test coverage | Low | High — data divergence across distributed nodes | Implement chaos test rig (FEAT-10-01) |
+| Deep join chain (>6 tables) accumulates delta drift over many cycles | Low | Medium — gradual aggregate inaccuracy | Monitor via G17-SOAK; tune Part 3 threshold GUC |
+| Invalidation ring overflow under bulk DDL (>1024 STs) | Very Low | Medium — thundering-herd full DAG rebuild | Document limit; add overflow Prometheus counter |
+| CNPG rolling upgrade interrupts in-flight refresh | Medium | Low — triggers full refresh on restart (safe but slow) | Add preStop drain hook (OPS-10-01) |
+| Nightly regression goes unnoticed for 24h (full E2E only on schedule) | Medium | Medium — broken main for a day | CI-10-01: gate on push |
+
+---
+
+## Appendix — Files Analysed
+
+```
+.github/workflows/ci.yml
+benches/diff_operators.rs
+benches/pgvector_bench.rs
+benches/refresh_bench.rs
+benches/scheduler_bench.rs
+CHANGELOG.md
+cnpg/cluster-production.yaml
+CONTRIBUTING.md
+Cargo.toml
+deny.toml
+Dockerfile.demo
+Dockerfile.ghcr
+docs/ARCHITECTURE.md
+docs/CONFIGURATION.md
+docs/SQL_REFERENCE.md
+INSTALL.md
+justfile
+monitoring/prometheus/alerts.yml
+monitoring/prometheus/pg_trickle_queries.yml
+monitoring/README.md
+pg_trickle.control
+plans/PLAN_OVERALL_ASSESSMENT_7.md
+plans/PLAN_OVERALL_ASSESSMENT_8.md
+plans/PLAN_OVERALL_ASSESSMENT_9.md
+ROADMAP.md
+scripts/gen_catalogs.py
+sql/pg_trickle--0.41.0--0.48.0.sql
+sql/pg_trickle--0.47.0--0.48.0.sql
+src/api/helpers.rs
+src/api/mod.rs
+src/api/snapshot.rs
+src/catalog.rs
+src/cdc.rs
+src/cdc/polling.rs
+src/cdc/rebuild.rs
+src/citus.rs
+src/config.rs
+src/dag.rs
+src/dvm/diff.rs
+src/dvm/mod.rs
+src/dvm/operators/aggregate.rs
+src/dvm/operators/filter.rs
+src/dvm/operators/join.rs
+src/dvm/operators/scan.rs
+src/dvm/parser/mod.rs
+src/dvm/parser/rewrites.rs
+src/dvm/parser/types.rs
+src/dvm/parser/validation.rs
+src/dvm/row_id.rs
+src/error.rs
+src/hooks.rs
+src/ivm.rs
+src/lib.rs
+src/refresh/merge/mod.rs
+src/refresh/tests.rs
+src/scheduler/mod.rs
+src/scheduler/pool.rs
+src/shmem.rs
+src/template_cache.rs
+src/wal_decoder.rs
+tests/Dockerfile.e2e
+tests/e2e_concurrent_tests.rs
+tests/e2e_diff_full_equivalence_tests.rs
+tests/e2e_drain_mode_tests.rs
+tests/e2e_repair_tests.rs
+tests/e2e_tpch_tests.rs
+```

--- a/roadmap/v0.49.0.md
+++ b/roadmap/v0.49.0.md
@@ -1,0 +1,127 @@
+# v0.49.0 — Test Infrastructure Hardening
+
+> **Theme:** Replace false-confidence tests with provably-correct synchronization;
+> fill the unit-test and fuzz coverage gaps identified in the v10 overall
+> assessment; decompose the scheduler monolith.
+
+## Why This Release
+
+The v10 overall assessment found that pg_trickle's core algorithms are
+mathematically sound — all P0 correctness issues are closed. The remaining
+risk is concentrated in **coverage confidence**: tests that look correct but
+cannot actually detect the failures they were written to catch, and source
+modules that can only be validated through expensive E2E runs because they
+have zero unit test coverage.
+
+This release fixes the test foundation so that every subsequent hardening
+investment lands on solid ground.
+
+## Deliverables
+
+### TEST-10-01 — Concurrency Test Synchronization Overhaul
+
+All tests in `tests/e2e_concurrent_tests.rs` currently use
+`tokio::time::sleep(Duration::from_millis(50))` to simulate overlap between
+concurrent operations. This is unreliable: on a loaded CI runner the 50ms
+window may not be enough, and there is no guarantee the spawned tasks are
+actually executing concurrently.
+
+Replace with `pg_locks`-polling loops that wait until the target transaction
+is actually visible in `pg_locks` before proceeding. Add a timeout with a
+clear failure message so flakiness becomes a named error rather than a silent
+pass.
+
+Affected tests:
+- `test_pb1_concurrent_refresh_skip_locked_no_corruption`
+- `test_concurrent_inserts_during_refresh`
+- `test_concurrent_refresh_and_drop`
+- `test_concurrent_refresh_multiple_sts_same_source`
+
+### TEST-10-02 — 10-Module Unit Test Sweep
+
+Add `#[cfg(test)]` modules with focused unit tests for pure-logic functions
+in every module that currently has zero test coverage:
+
+| Module | Key logic to test |
+|--------|-------------------|
+| `src/catalog.rs` | ST lookup, OID resolution, metadata serialization |
+| `src/template_cache.rs` | Cache hit/miss/eviction logic, hash key derivation |
+| `src/ivm.rs` | Lock mode selection for given operator trees |
+| `src/cdc/polling.rs` | LSN range splitting, synthetic slot naming |
+| `src/cdc/rebuild.rs` | Trigger body SQL generation, reserved column mapping |
+| `src/diagnostics.rs` | Status field population, staleness calculation |
+| `src/logging.rs` | Log-level routing, message formatting |
+| `src/metrics_server.rs` | Metric serialization format |
+| `src/otel.rs` | Span creation, attribute propagation |
+
+### TEST-10-03 — Fuzz Targets for Merge Codegen and Row Identity
+
+Add two new `libFuzzer` fuzz targets:
+
+1. **`fuzz/merge_sql_fuzz.rs`** — generates random change streams (random
+   insert/update/delete counts, random column types, random key cardinalities)
+   and feeds them into the full merge SQL construction pipeline
+   (`src/refresh/merge/`). Validates that the generated SQL is valid UTF-8,
+   does not contain unresolved placeholders, and round-trips through a
+   PostgreSQL parse-only check.
+
+2. **`fuzz/row_id_fuzz.rs`** — generates random operator trees with random
+   source schemas and feeds them into the row identity tracking logic
+   (`src/dvm/row_id.rs`). Validates that the keyed/keyless classification is
+   deterministic and that generated row-id expressions are syntactically valid.
+
+Both targets are added to the nightly fuzz workflow.
+
+### TEST-10-04 — DDL During Concurrent Refresh E2E Test
+
+Add `test_ddl_during_concurrent_refresh` to `tests/e2e_concurrent_tests.rs`.
+This test:
+1. Creates a stream table and populates it.
+2. Starts a long-running refresh in a background task.
+3. Concurrently issues `ALTER STREAM TABLE ... SET query = '...'`.
+4. Verifies that either:
+   - The DDL completes and the next refresh uses the new query, or
+   - The DDL is blocked until the refresh completes (no torn state).
+5. Runs three refresh cycles to confirm the stream table remains correct.
+
+### CI-10-02 — Expand e2e-Smoke Filter
+
+The current PR smoke test filter matches only 4 test name patterns
+(`smoke`, `basic`, `create_stream_table`, `health_check`). An operator-level
+regression in JOIN or AGG handling would pass this gate undetected.
+
+Expand the filter to also match:
+- `test_.*join.*` — inner/left/full join correctness
+- `test_.*aggregate.*` — aggregate differential correctness
+- `test_.*window.*` — window function correctness
+- `test_.*subquery.*` — correlated subquery correctness
+
+### CI-10-03 — Consolidated Fuzz Recipe
+
+Add `just fuzz-all` to the `justfile` that runs all fuzz targets in sequence
+with a configurable corpus duration (default 60s each). Document the available
+fuzz targets and their corpus locations in `CONTRIBUTING.md`.
+
+### CQ-10-01 — Scheduler Module Decomposition
+
+`src/scheduler/mod.rs` is 6,700+ lines — the largest single file in the
+codebase and a source of high merge-conflict risk. Extract into focused
+submodules:
+
+| New file | Content |
+|----------|---------|
+| `src/scheduler/loop.rs` | Main scheduling loop, tick logic, SIGTERM handling |
+| `src/scheduler/dispatch.rs` | Parallel dispatch state, worker claiming, orphan reaping |
+| `src/scheduler/cost.rs` | (already exists — ensure complete) |
+| `src/scheduler/watermark.rs` | Tick watermark computation, xmin holdback, frontier advance |
+
+`mod.rs` becomes a thin re-export facade. All existing public API is
+preserved with no behaviour change.
+
+## Testing
+
+- `just test-unit` — all new unit tests pass
+- `just test-integration` — concurrency tests pass with `pg_locks`-polling sync
+- `just test-light-e2e` — smoke filter expansion catches more regressions
+- `cargo fuzz run merge_sql_fuzz -- -max_total_time=60` — no crashes
+- `cargo fuzz run row_id_fuzz -- -max_total_time=60` — no crashes

--- a/roadmap/v0.50.0.md
+++ b/roadmap/v0.50.0.md
@@ -1,0 +1,170 @@
+# v0.50.0 — Performance, Security & Operational Hardening
+
+> **Theme:** Remove the last known performance inefficiencies in the differential
+> refresh hot path; close the security defense-in-depth gaps; make the
+> operational stack world-class with CNPG graceful drain, digest-pinned images,
+> and complete Prometheus observability.
+
+## Why This Release
+
+With test infrastructure solid after v0.49.0, this release addresses three
+orthogonal but equally concrete improvement areas identified in the v10
+assessment: measurable performance overhead in the refresh hot path, a
+defense-in-depth security gap in Citus dblink escaping, and a cluster of
+operational polish items (CNPG lifecycle, Docker reproducibility, Prometheus
+coverage) that individually are small but together compose the operational
+story for production users.
+
+## Deliverables
+
+### PERF-10-01 — SPI Batching in Differential Refresh Entry Point
+
+The function `execute_differential_refresh()` in `src/refresh/merge/mod.rs`
+currently makes 3–4 separate SPI round-trips before executing the merge:
+
+1. Per-source: `to_regclass()` existence check for each change buffer table
+2. Per-source: `COUNT(*)` from each change buffer (delta fraction check)
+3. Per-source: `reltuples` from `pg_class` (row estimate for cost model)
+
+Consolidate into a single CTE query that returns all three values per source
+OID in one round-trip:
+
+```sql
+WITH buf AS (
+  SELECT
+    o.oid,
+    to_regclass(format('pgtrickle_changes.changes_%s', o.oid)) IS NOT NULL AS exists,
+    COALESCE((SELECT count(*) FROM pgtrickle_changes.changes_ || o.oid::text), 0) AS change_count,
+    COALESCE(c.reltuples, 0) AS est_rows
+  FROM unnest($1::oid[]) AS o(oid)
+  LEFT JOIN pg_class c ON c.oid = o.oid
+)
+SELECT * FROM buf
+```
+
+**Expected impact**: Saves 10–15ms per refresh cycle for stream tables with
+multiple source tables. At 10 refreshes/second this is 100–150ms/second of
+SPI overhead eliminated.
+
+### PERF-10-02 — CDC Trigger String Building Optimization
+
+`build_stmt_trigger_fn_sql()` in `src/cdc.rs` uses per-column `format!()`
+calls collected into a `Vec<String>` and then joined. For a 50-column table
+this allocates 50 intermediate strings.
+
+Replace with a single `String::with_capacity()` buffer with direct `push_str()`
+appends. Benchmark before/after with a 100-column table trigger rebuild.
+
+### PERF-10-03 — Watermark Computation Query Consolidation
+
+The scheduler tick watermark computation issues several independent queries:
+`pg_current_wal_lsn()`, `pg_stat_activity` xmin probe, and `pg_prepared_xacts`
+check. Combine these into a single compound SELECT that returns all values in
+one round-trip, reducing per-tick overhead by ~2ms at the 100ms minimum
+scheduler interval.
+
+### SEC-10-01 — Replace Manual dblink Escaping
+
+`src/citus.rs` lines 357–364 and 650–682 escape SQL strings for dblink calls
+using manual `connstr.replace('\'', "''")`. While the inputs are
+system-controlled (values sourced from `pg_dist_node`), this violates
+defense-in-depth and is flagged by semgrep rules.
+
+Replace with `pg_escape_literal()` via SPI for connection string values and
+`pg_escape_identifier()` for identifiers. Add a comment documenting why
+parameterized queries are not available for dblink calls.
+
+### OPS-10-01 — CNPG preStop Lifecycle Hook
+
+`cnpg/cluster-production.yaml` has no preStop hook. When a CNPG-managed
+pod is terminated (rolling upgrade, scale-down, eviction), in-flight refresh
+workers are killed mid-execution. The stream tables are safe (they reinitialize
+on next startup) but the full refresh adds latency after the upgrade.
+
+Add a preStop lifecycle hook:
+
+```yaml
+lifecycle:
+  preStop:
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - psql -U postgres -c "SELECT pgtrickle.drain(timeout_s => 120)" || true
+```
+
+The `|| true` ensures the pod terminates even if the database is unavailable.
+Document this in `docs/RUNBOOK_DRAIN.md` under a new "Kubernetes rolling
+upgrade" section.
+
+### OPS-10-02 — Prometheus Secondary Metrics
+
+Add three metrics that are currently absent from `monitoring/prometheus/pg_trickle_queries.yml`:
+
+1. **`pg_trickle_invalidation_ring_overflows_total`** — Counter incremented
+   in `push_invalidation()` when the ring is full. Surfaced from the existing
+   `INVALIDATION_RING_OVERFLOWS` atomic. Alert threshold: > 0 in a 5-minute
+   window (indicates deployment with >1024 simultaneously-DDL'd STs).
+
+2. **`pg_trickle_dag_cycles_detected_total`** — Counter incremented when
+   `check_for_cycles()` returns `Err(CycleDetected(...))`. This event should
+   never occur in steady state; alerting at any non-zero value is appropriate.
+
+3. **`pg_trickle_template_cache_stale_evictions_total`** — Counter for L0
+   template cache entries evicted because `defining_query_hash` mismatched.
+   A spike here indicates rapid upstream schema change and may predict
+   GROUP_RESCAN fallback storms.
+
+### OPS-10-03 — Docker Base Image Digest Pinning
+
+Pin all Dockerfile base images to exact SHA256 digests:
+
+- `Dockerfile.demo`: `postgres:18.3-bookworm@sha256:<digest>`
+- `Dockerfile.ghcr`: same
+- `tests/Dockerfile.e2e`: same
+
+Add a `scripts/update_base_image_digests.sh` script that resolves current
+digests via `docker manifest inspect` and patches the Dockerfiles. Run this
+script quarterly or when a PostgreSQL patch release is needed. Document the
+process in `CONTRIBUTING.md`.
+
+### SCAL-10-01 — Invalidation Ring Limit Documentation and Observability
+
+The shared memory invalidation ring has a hard ceiling of 1,024 entries
+(`INVALIDATION_RING_MAX_CAPACITY`). When more than 1,024 stream tables are
+simultaneously invalidated (e.g. during bulk DDL), the overflow flag triggers
+a full DAG rebuild rather than incremental invalidation.
+
+Add to `docs/CONFIGURATION.md`:
+- A note under `pg_trickle.invalidation_ring_capacity` documenting the
+  1,024-entry ceiling and the overflow behaviour.
+- Guidance for deployments with 1,000+ stream tables: prefer staged DDL
+  operations or increase `invalidation_ring_capacity`.
+
+Wire the new `pg_trickle_invalidation_ring_overflows_total` counter (see
+OPS-10-02) into the monitoring README with an example alert rule.
+
+### COR-10-01 — Deep Join Chain Threshold Documentation
+
+The Part 3 correction term in `src/dvm/operators/join.rs` (lines 436–447)
+is skipped when the left-child scan count exceeds a GUC threshold (default 5).
+For join chains deeper than 6 tables this may cause small delta drift over
+many concurrent-change cycles.
+
+Add to `docs/CONFIGURATION.md` under a new "Deep Join Chain Tuning" section:
+- Description of the Part 3 threshold trade-off (SQL complexity vs. delta
+  correctness at depth).
+- The GUC name and default value.
+- Recommendation: leave at default for ≤6-table joins; raise for deep chains
+  with sustained concurrent updates; verify with G17-SOAK.
+
+## Testing
+
+- `just test-unit` — passes
+- `just test-integration` — passes
+- `just test-light-e2e` — passes; differential refresh latency benchmarks
+  show improvement for multi-source STs
+- `just bench` — Criterion reports no regression; merge codegen bench shows
+  improvement for wide tables
+- CNPG drain hook: verified by extending `tests/e2e_drain_mode_tests.rs` with
+  a simulated SIGTERM scenario

--- a/roadmap/v0.51.0.md
+++ b/roadmap/v0.51.0.md
@@ -1,0 +1,171 @@
+# v0.51.0 — Citus Chaos Resilience & Documentation Truth
+
+> **Theme:** Prove that the Citus distributed integration survives real failure
+> scenarios; remove the deprecated event_driven_wake dead weight; bring every
+> piece of documentation into full alignment with the implemented code.
+
+## Why This Release
+
+Citus distributed support has been shipping since v0.32.0 but has never had
+a chaos or resilience test suite. There are zero tests validating behaviour
+under node failure, shard rebalance, or network partition — scenarios that
+production deployments encounter routinely. This is the highest remaining
+test coverage risk in the project.
+
+Simultaneously, several documentation items have drifted: the pg_tide
+extraction boundary is not clearly described in the architecture doc, the
+deprecated `event_driven_wake` GUC still clutters configuration docs and
+emits runtime warnings, and the recursive CTE strategy selection logic is a
+complete black box for operators debugging refresh behaviour.
+
+This release closes all of these together as the final gate before v1.0.
+
+## Deliverables
+
+### FEAT-10-01 — Citus Chaos Test Rig
+
+Build a docker-compose-based chaos test rig for Citus distributed scenarios
+in `tests/e2e_citus_chaos_tests.rs`. The rig requires:
+
+- `docker/docker-compose.citus.yml` — 1 coordinator + 3 worker nodes
+- Utility functions in `tests/common/citus_chaos.rs` for injecting failures
+
+**Three chaos scenarios (all mandatory for release):**
+
+**Scenario 1: Coordinator restart during active refresh**
+1. Create a distributed stream table across 3 workers.
+2. Start a refresh cycle.
+3. Restart the coordinator container mid-refresh.
+4. Verify the refresh retries and completes correctly on reconnect.
+5. Run 5 subsequent refresh cycles; assert no phantom rows or missing rows.
+
+**Scenario 2: Worker node kill with shard redistribution**
+1. Create distributed source tables with data distributed across 3 workers.
+2. Kill one worker container.
+3. Trigger a shard rebalance (`SELECT rebalance_table_shards()`).
+4. Verify the stream table refreshes correctly after rebalance completes.
+5. Assert CDC change buffers are consistent post-recovery.
+
+**Scenario 3: Network partition simulation**
+1. Use `docker network disconnect` to isolate one worker.
+2. Insert rows on the remaining workers.
+3. Reconnect the isolated worker.
+4. Verify the stream table converges to the correct state within 3 refresh
+   cycles with no data loss.
+
+The chaos tests are added to `stability-tests.yml` (not to `ci.yml` PR gate)
+and run nightly alongside the existing G17-SOAK and G17-MDB tests.
+
+### CQ-10-02 — Remove Deprecated event_driven_wake GUC
+
+The `pg_trickle.event_driven_wake` GUC has been non-functional since
+PostgreSQL background workers cannot use `LISTEN`/`NOTIFY`. It has been
+deprecated with default `false` since v0.39.0. It still emits a runtime
+WARNING when set to `true` and adds dead code paths.
+
+Remove entirely:
+- GUC registration in `src/config.rs` (lines 375–419)
+- Runtime warning emission in `src/scheduler/mod.rs` (lines 2557–2563)
+- `event_driven = false` stub in scheduling logic
+- `docs/CONFIGURATION.md` entry (replace with a migration note pointing to
+  the `scheduler_interval_ms` + `wake_debounce_ms` alternatives)
+
+Add to `CHANGELOG.md` under a **Breaking Changes** heading for v0.51.0:
+> `pg_trickle.event_driven_wake` has been removed. This GUC had no effect
+> since v0.39.0. Remove it from `postgresql.conf` to avoid an unknown GUC
+> warning on upgrade.
+
+Add SQL migration step that ignores the removed GUC gracefully:
+```sql
+-- v0.51: event_driven_wake removed; no data change needed
+```
+
+### DOC-10-01 — ARCHITECTURE.md pg_tide Boundary
+
+`docs/ARCHITECTURE.md` still describes outbox, inbox, and the relay binary as
+pg_trickle subsystems. Since v0.46.0 these have been extracted to
+`trickle-labs/pg-tide`.
+
+Add a new **§ pg_tide Integration** section to ARCHITECTURE.md that:
+- Explains the v0.46.0 extraction decision (focused extension boundary,
+  separate release cadence for event messaging).
+- Describes what remains in pg_trickle: `attach_outbox()` integration hook,
+  change buffer subscription for pg_tide consumers.
+- Describes what lives in pg_tide: `enable_outbox()`, `poll_outbox()`,
+  consumer groups, claim-check mode, the relay binary.
+- Links to the pg_tide repository for full API documentation.
+
+Remove the `src/api/outbox.rs` and `src/api/inbox.rs` references from the
+module layout diagram and replace with the integration boundary description.
+
+### DOC-10-02 — Configuration Deprecation and Removal Banners
+
+`docs/CONFIGURATION.md` lists deprecated GUCs without clear visual markers.
+After the removal of `event_driven_wake`, audit all remaining deprecated
+GUC entries and add consistent formatting:
+
+- **Removed in v0.51.0**: `event_driven_wake` — add a migration note.
+- **Deprecated (accepted, ignored)**: `merge_planner_hints`, `user_triggers='on'`
+  — add `> ⚠️ **Deprecated** — accepted for backwards compatibility but has
+  no effect. Will be removed in a future major version.` callout.
+
+### DOC-10-03 — Recursive CTE Strategy Selection Heuristic
+
+`docs/ARCHITECTURE.md` mentions three recursive CTE strategies (semi-naive,
+DRed, recomputation fallback) but does not document the selection heuristic.
+This is a black box for operators debugging slow or incorrect recursive-view
+refreshes.
+
+Add a new **§ Recursive CTE Strategy Selection** subsection under the DVM
+Engine section:
+
+1. **Selection criteria**:
+   - Tier 1 (inline expansion): CTE referenced once, non-recursive → expand
+     inline into the query; no differential overhead.
+   - Tier 2 (shared delta): CTE referenced 2+ times, non-recursive → single
+     delta computation shared across all reference sites.
+   - Tier 3a (semi-naive): CTE is recursive with monotone operators only
+     (UNION ALL, no NOT EXISTS / aggregation) → semi-naive evaluation with
+     frontier-bounded delta.
+   - Tier 3b (DRed): CTE is recursive with non-monotone operators, base
+     tables have primary keys → DRed (Deletion Propagation in Recursive
+     Datalog) delta.
+   - Tier 3c (recomputation): CTE is recursive with non-monotone operators,
+     no primary keys, or cycle in dependency graph → full recomputation.
+
+2. **Observability**: Document that `explain_stream_table(st_name)` returns
+   a `recursive_cte_strategy` field showing which tier was selected and why.
+
+3. **Example EXPLAIN output**: Show a concrete example for a recursive
+   hierarchical closure query demonstrating Tier 3a (semi-naive) selection.
+
+### COR-10-02 — Document CDC-Fires-When-Disabled Behavior
+
+`pg_trickle.enabled = false` stops the scheduler from dispatching refreshes
+but CDC triggers continue to fire and write to change buffers. This is by
+design (keeps buffers ready for immediate use when re-enabled) but is
+undocumented and surprises operators who expect `enabled = false` to be a
+complete quiet mode.
+
+Add to `docs/CONFIGURATION.md` under `pg_trickle.enabled`:
+
+> **Note on CDC triggers**: Setting `enabled = false` stops the scheduler from
+> refreshing stream tables but does **not** disable CDC trigger execution.
+> Change buffers continue to accumulate. This is intentional: when the extension
+> is re-enabled, stream tables can refresh immediately from the buffered changes
+> rather than performing a full table scan.
+>
+> To fully quiesce CDC overhead during extended maintenance, use
+> `pgtrickle.drain()` before disabling, then `DROP TRIGGER` the CDC triggers
+> manually and recreate them via `pgtrickle.repair_stream_table()` when
+> re-enabling.
+
+## Testing
+
+- `just test-unit` — passes; deprecated GUC code paths fully removed
+- `just test-integration` — passes
+- `just test-light-e2e` — passes
+- `just test-soak` — G17-SOAK still green after `event_driven_wake` removal
+- Citus chaos rig: `just test-citus-chaos` (new recipe) — all three scenarios
+  pass: coordinator restart, worker kill + rebalance, network partition
+- Documentation: `scripts/gen_catalogs.py --check` passes with updated GUC list


### PR DESCRIPTION
## Summary

Adds the v1.0 readiness arc (v0.49–v0.51) to the roadmap, driven by every
finding in the v10 overall assessment (`plans/PLAN_OVERALL_ASSESSMENT_10.md`).

The v10 assessment confirmed that all prior P0 correctness issues are closed
(EC-01 phantom rows, snapshot cache-key weakness, placeholder resolution, WAL
transition TOCTOU). The project has transitioned from a capability problem to
a **coverage confidence problem**. These three large-scope releases
systematically address every remaining gap before v1.0.

## Changes

### ROADMAP.md

- New section **v1.0 Readiness Arc (v0.49.x – v0.51.x)** inserted between
  the Embedding Programme and the existing Beyond v1.0 table.
- Three new rows added: v0.49.0, v0.50.0, v0.51.0 (all `Planned / Large`).
- Diagram updated with v0.49–v0.51 nodes.
- Narrative paragraph added explaining the arc and each release's purpose.

### roadmap/v0.49.0.md (new)

**Test Infrastructure Hardening** — all test coverage and CI gaps from assessment:

- TEST-10-01: Replace sleep-based concurrency sync with `pg_locks` polling
- TEST-10-02: Unit test sweep for 10 zero-coverage modules (catalog, template_cache, ivm, cdc/polling, cdc/rebuild, diagnostics, logging, metrics_server, otel)
- TEST-10-03: Fuzz targets for refresh merge SQL codegen and row identity tracking
- TEST-10-04: DDL-during-concurrent-refresh E2E test
- CI-10-02: Expand e2e-smoke filter to cover join/aggregate/window regressions
- CI-10-03: Consolidated `just fuzz-all` recipe
- CQ-10-01: Decompose `scheduler/mod.rs` (6700+ lines) into loop / dispatch / watermark submodules

### roadmap/v0.50.0.md (new)

**Performance, Security & Operational Hardening** — all perf, security, and ops gaps:

- PERF-10-01: Batch 3–4 SPI round-trips in `execute_differential_refresh()` into one CTE (saves 10–15ms/refresh)
- PERF-10-02: CDC trigger string building via `String::with_capacity()`
- PERF-10-03: Watermark computation query consolidation
- SEC-10-01: Replace manual dblink escaping with `pg_escape_literal()`
- OPS-10-01: CNPG preStop lifecycle hook for graceful drain during rolling upgrades
- OPS-10-02: Three new Prometheus metrics — invalidation ring overflows, DAG cycles detected, template cache stale evictions
- OPS-10-03: Docker base image digest pinning for reproducible builds
- SCAL-10-01: Document 1024-entry invalidation ring ceiling in configuration reference
- COR-10-01: Deep join chain threshold documentation and soak-test assertion

### roadmap/v0.51.0.md (new)

**Citus Chaos Resilience & Documentation Truth** — Citus hardening and all doc gaps:

- FEAT-10-01: Citus chaos test rig — coordinator restart, worker kill + rebalance, network partition
- CQ-10-02: Remove deprecated `event_driven_wake` GUC and all dead code paths
- DOC-10-01: ARCHITECTURE.md pg_tide boundary description (v0.46 extraction)
- DOC-10-02: Deprecation banners for all deprecated GUCs in CONFIGURATION.md
- DOC-10-03: Recursive CTE strategy selection heuristic with EXPLAIN output example
- COR-10-02: Document CDC-fires-when-disabled behavior in CONFIGURATION.md

### plans/PLAN_OVERALL_ASSESSMENT_10.md (new)

Full v10 overall assessment report (static source audit of v0.48.0).

## Testing

No code changes in this PR — roadmap and documentation only.

- All new roadmap detail files are well-formed Markdown.
- ROADMAP.md table and diagram updated consistently.
- Assessment report provides the traceability link from every finding to its
  corresponding roadmap item.

## Notes

The CI-10-01 finding (enable full E2E on push-to-main) was intentionally
excluded from the roadmap per the author's request — it is a workflow
configuration change that can be applied independently of a release.
