### PR TITLE
fix(test): respect outer deadline in settle_auto_invariants inner retry

### DIFF
--- a/tests/e2e_dag_autorefresh_tests.rs
+++ b/tests/e2e_dag_autorefresh_tests.rs
@@ -540,8 +540,15 @@ async fn settle_auto_invariants(
             return;
         }
         // Wait for another scheduler cycle (l1 is the leaf and must process
-        // CDC before l2/l3 can be correct).
-        wait_for_refresh_cycle(db, "prop_auto_l1", Duration::from_secs(15)).await;
+        // CDC before l2/l3 can be correct).  Cap the inner wait at the
+        // remaining time so the outer deadline is always respected (important
+        // for slow coverage / instrumented builds where 15 s may expire).
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining < Duration::from_millis(500) {
+            assert_st_query_invariants(db, &AUTO_INVARIANTS, seed, cycle, step).await;
+            return;
+        }
+        wait_for_refresh_cycle(db, "prop_auto_l1", remaining.min(Duration::from_secs(30))).await;
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes a spurious panic in `test_prop_autorefresh_no_spurious_changes` that
caused coverage run #383 to fail with exit code 101.

The root cause is that the inner `wait_for_refresh_cycle(prop_auto_l1, 15s)`
call in `settle_auto_invariants` used a **hardcoded 15-second timeout**
independent of the outer 90-second deadline. In slow environments (coverage-
instrumented builds, loaded CI runners) the scheduler can take longer than
15 seconds for a single refresh cycle, causing a panic even though plenty of
outer deadline remained.

## Changes

- `tests/e2e_dag_autorefresh_tests.rs` — `settle_auto_invariants`:
  - Compute `remaining = deadline − now()` before each inner retry.
  - Cap the inner `wait_for_refresh_cycle` timeout at `min(remaining, 30s)`
    so the inner wait always respects the outer deadline.
  - Add an early-exit guard: if `remaining < 500 ms`, skip straight to the
    assertion rather than entering `wait_for_refresh_cycle` with near-zero
    time left.

## Root cause analysis

```
Timed out waiting for scheduler refresh of 'prop_auto_l1'
(initial last_refresh_at = 2026-05-08 07:57:09.977564+00)
```

The panic site is `wait_for_refresh_cycle` at line 67. The outer deadline was
90 seconds, but the inner call used an independent 15-second window. In the
coverage build the instrumented scheduler binary is slower, so the single 15s
window expired before the next `last_refresh_at` tick appeared.

## Testing

- `just lint` — passes
- The fix is a pure timeout/deadline plumbing change with no logic change to
  the invariant checks. The coverage workflow itself will re-verify on the
  next manual or scheduled run.
