### PR TITLE
feat(skills): add grill-me productivity skill

### DIFF
--- a/.github/skills/grill-me/SKILL.md
+++ b/.github/skills/grill-me/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of
+this plan until we reach a shared understanding. Walk down each branch of the
+design tree, resolving dependencies between decisions one-by-one. For each question,
+provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a
+question can be answered by exploring the codebase, explore the codebase instead.

--- a/.github/skills/grill-me/SKILL.md
+++ b/.github/skills/grill-me/SKILL.md
@@ -3,12 +3,8 @@ name: grill-me
 description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
 ---
 
-Interview me relentlessly about every aspect of
-this plan until we reach a shared understanding. Walk down each branch of the
-design tree, resolving dependencies between decisions one-by-one. For each question,
-provide your recommended answer.
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
 
 Ask the questions one at a time.
 
-If a
-question can be answered by exploring the codebase, explore the codebase instead.
+If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION
## Summary

Add the `grill-me` productivity skill to the project, enabling relentless interviewing of plans and designs to reach shared understanding. This skill walks through decision trees systematically, resolving dependencies one-by-one.

## Changes

- Added `.github/skills/grill-me/SKILL.md` with the skill definition
- Integrates the skill from mattpocock/skills repository
- Enables use of "grill-me" skill invocation for design stress-testing

## Testing

No tests required — this is a skill configuration file used by Copilot.

## Notes

The skill is now available for use via Copilot's skill system and can be invoked when planning or stress-testing designs and decisions.
