### PR TITLE
fix(docker): pin manifest-list digest to fix arm64 GHCR build

### DIFF
--- a/Dockerfile.demo
+++ b/Dockerfile.demo
@@ -36,7 +36,7 @@ RUN cargo install cargo-pgrx && \
 # Final stage: PostgreSQL with built extension
 # OPS-10-03: Pinned to exact SHA256 digest for reproducibility.
 # Run scripts/update_base_image_digests.sh to refresh quarterly.
-FROM postgres:18.3-bookworm@sha256:a40f5f7a480e2555f57baeaaf36450446c6b36ee21bdd223afd382d499ac7375
+FROM postgres:18.3-bookworm@sha256:80630f83606d8db77d30b3851b16a9f78be2d0d4dda6f7b82a1fdca5ebe3acba
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.ghcr
+++ b/Dockerfile.ghcr
@@ -32,7 +32,7 @@
 # ── Stage 1: Prepare build environment ──────────────────────────────────────
 # OPS-10-03: Pinned to exact SHA256 digest for reproducibility.
 # Run scripts/update_base_image_digests.sh to refresh quarterly.
-FROM postgres:18.3-bookworm@sha256:a40f5f7a480e2555f57baeaaf36450446c6b36ee21bdd223afd382d499ac7375 AS build-env
+FROM postgres:18.3-bookworm@sha256:80630f83606d8db77d30b3851b16a9f78be2d0d4dda6f7b82a1fdca5ebe3acba AS build-env
 
 ARG VERSION=0.52.0
 
@@ -109,7 +109,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 # ── Stage 4: Runtime image ───────────────────────────────────────────────────
 # OPS-10-03: Pinned to exact SHA256 digest for reproducibility.
 # Run scripts/update_base_image_digests.sh to refresh quarterly.
-FROM postgres:18.3-bookworm@sha256:a40f5f7a480e2555f57baeaaf36450446c6b36ee21bdd223afd382d499ac7375
+FROM postgres:18.3-bookworm@sha256:80630f83606d8db77d30b3851b16a9f78be2d0d4dda6f7b82a1fdca5ebe3acba
 
 ARG VERSION=0.52.0
 ARG REPO_URL=https://github.com/trickle-labs/pg-trickle

--- a/scripts/update_base_image_digests.sh
+++ b/scripts/update_base_image_digests.sh
@@ -2,15 +2,19 @@
 # OPS-10-03: Update base image SHA256 digests in Dockerfiles.
 #
 # Run this script quarterly or when a PostgreSQL patch release is needed.
-# It resolves the current linux/amd64 digest for postgres:18.3-bookworm
+# It resolves the current manifest-list (index) digest for postgres:18.3-bookworm
 # and patches the relevant Dockerfiles in-place.
+#
+# IMPORTANT: We pin the manifest-list digest (not a per-platform digest) so
+# that multi-platform builds (linux/amd64 + linux/arm64) each pull the correct
+# architecture variant.  A per-platform digest causes the wrong-arch image to
+# be fetched on the other builder, making apt-get fail with exit code 255.
 #
 # Usage:
 #   scripts/update_base_image_digests.sh
 #
 # Requirements:
-#   - docker (with manifest inspect support)
-#   - sed
+#   - docker buildx (for imagetools inspect)
 #
 # See also: CONTRIBUTING.md — "Updating base image digests"
 
@@ -20,19 +24,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
 BASE_IMAGE="postgres:18.3-bookworm"
-TARGET_PLATFORM="linux/amd64"
 
-echo "Resolving digest for ${BASE_IMAGE} (${TARGET_PLATFORM})..."
-DIGEST=$(docker manifest inspect "${BASE_IMAGE}" 2>/dev/null \
-  | python3 -c "
-import sys, json
-d = json.load(sys.stdin)
-for m in d.get('manifests', []):
-    p = m.get('platform', {})
-    if p.get('os') == 'linux' and p.get('architecture') == 'amd64':
-        print(m['digest'])
-        break
-")
+# Resolve the manifest-list (OCI image index) digest — platform-agnostic.
+# This digest works for all architectures; Docker/buildx picks the right
+# platform-specific image automatically at build time.
+echo "Resolving manifest-list digest for ${BASE_IMAGE}..."
+DIGEST=$(docker buildx imagetools inspect "${BASE_IMAGE}" --format '{{.Manifest.Digest}}' 2>/dev/null)
 
 if [[ -z "${DIGEST}" ]]; then
   echo "ERROR: Could not resolve digest for ${BASE_IMAGE}" >&2

--- a/tests/Dockerfile.e2e
+++ b/tests/Dockerfile.e2e
@@ -77,7 +77,7 @@ RUN echo "=== Package artifacts ===" && \
 # ── Stage 2: Runtime image with extension installed ─────────────────────────
 # OPS-10-03: Pinned to exact SHA256 digest for reproducibility.
 # Run scripts/update_base_image_digests.sh to refresh quarterly.
-FROM postgres:18.3-bookworm@sha256:a40f5f7a480e2555f57baeaaf36450446c6b36ee21bdd223afd382d499ac7375
+FROM postgres:18.3-bookworm@sha256:80630f83606d8db77d30b3851b16a9f78be2d0d4dda6f7b82a1fdca5ebe3acba
 
 LABEL org.opencontainers.image.title="pg_trickle E2E test image"
 LABEL org.opencontainers.image.description="PostgreSQL 18.3 with pg_trickle extension for integration testing"


### PR DESCRIPTION
## Problem

The GHCR `linux/arm64` build was failing at the `apt-get install` step with exit code 255.

**Root cause:** `scripts/update_base_image_digests.sh` was resolving and pinning the **linux/amd64 platform-specific** digest (`sha256:a40f5f7a480e2555f57baeaaf36450446c6b36ee21bdd223afd382d499ac7375`). When the native arm64 runner pulled `postgres:18.3-bookworm@sha256:<amd64-digest>`, Docker fetched the amd64 image. Running amd64 binaries on an arm64 host fails immediately — `apt-get` exits 255 before doing any work.

Failing run: https://github.com/trickle-labs/pg-trickle/actions/runs/25629239658

## Fix

Replace the amd64-only pin with the **OCI image-index (manifest list) digest** — `sha256:80630f83606d8db77d30b3851b16a9f78be2d0d4dda6f7b82a1fdca5ebe3acba`. Docker/buildx automatically selects the correct platform variant (amd64 or arm64) when pulling from a manifest list digest.

### Files changed

| File | Change |
|------|--------|
| `Dockerfile.ghcr` | Updated 2 `FROM` lines to manifest-list digest |
| `Dockerfile.demo` | Updated 1 `FROM` line to manifest-list digest |
| `tests/Dockerfile.e2e` | Updated 1 `FROM` line to manifest-list digest |
| `scripts/update_base_image_digests.sh` | Switch from `docker manifest inspect` (amd64 only) to `docker buildx imagetools inspect --format '{{.Manifest.Digest}}'` (manifest list) |

## Testing

The GHCR workflow (`ghcr.yml`) will re-run on merge of this PR. The arm64 build will now pull the correct arm64 image variant, allowing `apt-get install` to succeed.
