### PR TITLE
fix(ci): split citus-init from --wait in citus chaos cluster startup

### DIFF
--- a/.github/workflows/stability-tests.yml
+++ b/.github/workflows/stability-tests.yml
@@ -68,7 +68,15 @@ jobs:
         uses: ./.github/actions/setup-pgrx
 
       - name: Spin up Citus chaos cluster
-        run: docker compose -f docker/docker-compose.citus.yml up -d --wait
+        run: |
+          # Start persistent services and wait for them to be healthy.
+          # citus-init is excluded here because it exits after completion and
+          # docker compose --wait treats any exited container as failure.
+          docker compose -f docker/docker-compose.citus.yml up -d --wait \
+            coordinator worker-0 worker-1 worker-2
+          # Run the one-shot init container in the foreground; it waits for
+          # healthy deps via depends_on and exits 0 on success.
+          docker compose -f docker/docker-compose.citus.yml up citus-init
         timeout-minutes: 5
 
       - name: Build E2E Docker image


### PR DESCRIPTION
## Problem

`docker compose up -d --wait` treats **any exited container as a failure**, including one-shot init containers that exit successfully. The `citus-init` service registers workers with the coordinator then exits with code 0. This caused the *Spin up Citus chaos cluster* step to report exit code 1 immediately after `citus-init` completed, blocking all subsequent chaos tests.

Stability-tests run [#55](https://github.com/trickle-labs/pg-trickle/actions/runs/25654485411):
```
container citus-init exited (0)
##[error]Process completed with exit code 1.
```

## Fix

Split the startup into two calls:
1. `docker compose up -d --wait coordinator worker-0 worker-1 worker-2` — starts the four persistent services and blocks until all healthchecks pass.
2. `docker compose 2. `docker compose 2. `docker compose 2. `docker compose 2. `docker compose 2. `docker compose 2. `docker compose 2. `docker compose 2. `docker compose 2. `docker compose 2. `docker compose 2. `docker compose 2. `docker come` invocations.