### PR TITLE
roadmap: add Report 12 assessment-driven hardening arc (v0.58–v0.61)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -145,6 +145,27 @@ stable release.
 | [v0.56.0](roadmap/v0.56.0.md) | Documentation Foundation: fix GUC_CATALOG corruption, complete ERRORS.md (all 44 variants), correct parallel_refresh_mode default, complete SQL_REFERENCE outbox/inbox, add MENTAL_MODEL.md, LIMITATIONS.md, PERFORMANCE_CHEATSHEET.md | ✅ Released | Large | [Full details](roadmap/v0.56.0.md-full.md) |
 | [v0.57.0](roadmap/v0.57.0.md) | Documentation Excellence: four new tutorials (first dashboard, event sourcing, backfill/migration, security hardening), P2/P3 quality polish, full 83-file consistency sweep | ✅ Released | Large | [Full details](roadmap/v0.57.0.md-full.md) |
 
+### Assessment-Driven Hardening Arc (v0.58.x – v0.61.x)
+
+Driven by the findings in the v0.57.0 overall assessment
+([plans/PLAN_OVERALL_ASSESSMENT_12.md](plans/PLAN_OVERALL_ASSESSMENT_12.md)).
+The assessment found 0 critical, 4 HIGH, 23 MEDIUM, and 20 LOW findings across
+security (ownership bypass in outbox/publication APIs), correctness (recursive-CTE
+depth guard in DIFFERENTIAL mode, multi-column NOT IN + NULL semantics, WAL decoder
+TOCTOU race), performance (per-source SPI fan-out in monitor, merge-template clone
+overhead, WAL decoder allocation patterns), observability (missing CDC-lag
+percentiles, worker queue-depth, WAL decoder queue, refresh-mode ratio counters),
+code quality (scheduler log levels, codegen decomposition, cdc.rs split), and test
+coverage (refresh orchestrator, CDC, hooks, remaining fixed sleeps). This four-release
+arc resolves all findings before v1.0.
+
+| Version | Theme | Status | Scope | Full details |
+|---------|-------|--------|-------|--------------|
+| [v0.58.0](roadmap/v0.58.0.md) | Security & Correctness Hardening: ownership checks for outbox/publication APIs, multi-column NOT IN + NULL fix, recursive CTE depth guard in DIFFERENTIAL mode, WAL decoder TOCTOU advisory lock, DDL hook escalation on SPI failure | Planned | Medium | [Full details](roadmap/v0.58.0.md-full.md) |
+| [v0.59.0](roadmap/v0.59.0.md) | Performance & Observability: batched monitor buffer-growth SPI, query-hash caching, Arc<str> merge templates, WAL decoder Vec pre-allocation, frontier borrow not clone, CDC-lag percentile metrics, worker queue-depth, WAL decoder queue, refresh-mode ratio counters, application_name in BGW, backup/restore docs | Planned | Large | [Full details](roadmap/v0.59.0.md-full.md) |
+| [v0.60.0](roadmap/v0.60.0.md) | Code Quality, Test Coverage & CI: scheduler log levels, codegen decomposition, cdc.rs 4-way split, refresh orchestrator/merge/CDC/hooks unit tests, differential idempotence proptest, sleep removal, WAL OID filter, partition-attach rebuild, path-filtered full E2E on PRs, Dockerfile non-root, codecov module thresholds | Planned | Large | [Full details](roadmap/v0.60.0.md-full.md) |
+| [v0.61.0](roadmap/v0.61.0.md) | DX, Documentation & Final Pre-1.0 Polish: health_check() foreign-owner row, SQL_REFERENCE completeness, snapshot cache secondary equality, cte_counter reset, outbox name collision fix, sublinks.rs decomposition, ctid invariant comment, 3 foundational ADRs, LIMITATIONS.md NOT IN + NULL section, SEARCH/CYCLE clear error, LATERAL+DIFFERENTIAL docs | Planned | Large | [Full details](roadmap/v0.61.0.md-full.md) |
+
 ### Beyond v1.0
 
 | Version | Theme | Status | Scope | Full details |
@@ -229,6 +250,14 @@ v0.56    ─── Documentation Foundation: GUC_CATALOG fix, ERRORS.md complete
     │
 v0.57    ─── Documentation Excellence: 4 new tutorials, P2/P3 polish, full 83-file consistency sweep
     │
+v0.58    ─── Security & correctness hardening: ownership checks (outbox/publication APIs), NOT IN + NULL fix, recursive CTE depth guard, WAL decoder TOCTOU lock, DDL hook escalation
+    │
+v0.59    ─── Performance & observability: batched monitor SPI, query-hash cache, Arc<str> templates, WAL decoder Vec pre-alloc, CDC-lag percentiles, worker queue metrics, app_name BGW, backup docs
+    │
+v0.60    ─── Code quality, test coverage & CI: cdc.rs split, codegen decompose, refresh/CDC/hooks unit tests, idempotence proptest, sleep removal, WAL OID filter, partition-attach rebuild, path-filtered E2E on PRs
+    │
+v0.61    ─── DX, docs & pre-1.0 polish: health_check foreign-owner row, SQL_REFERENCE complete, snapshot secondary equality, cte_counter reset, outbox name fix, sublinks decompose, 3 ADRs, LATERAL docs
+    │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```
 
@@ -298,6 +327,19 @@ and WAL transition TOCTOU are all fixed. The project has transitioned from a
 capability problem to a coverage confidence problem. These three releases
 systematically close the remaining gaps across test reliability, performance,
 security hardening, operational polish, and documentation truth before v1.0.
+
+**v0.58.0 through v0.61.0 form the final assessment-driven hardening arc before
+v1.0**, driven by the findings in the v0.57.0 overall assessment
+(plans/PLAN_OVERALL_ASSESSMENT_12.md). The assessment found 0 critical findings,
+4 HIGH severity issues (ownership-check bypass in the outbox and publication APIs,
+recursive-CTE depth guard not applied in DIFFERENTIAL mode, multi-column NOT IN
+with NULL row semantics, and per-source SPI fan-out in the monitor health check),
+plus 23 MEDIUM and 20 LOW items spanning performance, observability, code quality,
+test coverage, and documentation. v0.58.0 closes all HIGH findings as a hard gate.
+v0.59.0 eliminates the performance and observability gaps. v0.60.0 completes the
+code quality and test coverage sweep. v0.61.0 delivers the final developer-experience
+and documentation polish, closing the last remaining items so that v1.0 is a clean,
+fully verified stable release.
 
 **v0.49.0 targets test infrastructure quality** — the single highest-risk
 category from the v10 assessment. All concurrency tests currently rely on

--- a/plans/PLAN_OVERALL_ASSESSMENT_12.md
+++ b/plans/PLAN_OVERALL_ASSESSMENT_12.md
@@ -1,0 +1,854 @@
+# pg_trickle Overall Assessment — Report 12
+
+> Status: Deep gap analysis — static source audit + test mapping
+> Date: 2026-05-12
+> Scope: Full repository (v0.57.0)
+> Prior reports: 11 (v0.51), 10 (v0.49), 9 (v0.48), 8, 7, 3, 2, 1
+
+---
+
+## Executive Summary
+
+pg_trickle has continued to mature substantially since Report 11 (v0.51.0).
+The v0.52–v0.57 releases closed almost every actionable finding from the
+prior audit: the Aho-Corasick placeholder resolver replaced the O(n²) string
+replacement (P-1), thread-local volatility caches eliminated per-call SPI
+round-trips (P-2), `DiffContext` allocations were made lazy (P-3), the
+snapshot fingerprint gained a two-level pointer-identity cache (P-4),
+`Expr::to_sql()` now writes into a pre-allocated buffer (P-5), view
+inlining caches relkind lookups (P-6), MERGE template LRU is now O(1) via
+the `lru` crate (P-8), `diff_node()` enforces depth and CTE-count limits
+(C-7/R-7), upstream ST frontier validation prevents the "0/0" silent fallback
+(C-4), diamond detection is now O(V+E) via precomputed ancestor sets (S-1),
+the invalidation ring capacity is configurable up to 4 096 (S-2), every
+scheduler and parser sub-module gained `#[cfg(test)]` coverage (T-2..T-6),
+the NOTIFY payload pipeline switched to `serde_json` (SEC-6), and `api/mod.rs`
+and `monitor.rs` were decomposed into focused sub-modules (Q-2/Q-3). This is
+an unusually disciplined burn-down of an assessment backlog and demonstrates
+the project's commitment to closing audit findings.
+
+That said, this audit surfaces **four genuinely concerning issues** that
+deserve attention before the v1.0 cut. (1) Two of the newer SQL-callable
+APIs — `attach_outbox()` / `detach_outbox()` / `attach_embedding_outbox()` in
+[src/api/outbox.rs](src/api/outbox.rs) and `stream_table_to_publication()` /
+`drop_stream_table_publication()` in [src/api/publication.rs](src/api/publication.rs)
+— are missing the `check_stream_table_ownership()` call that all other
+mutating APIs use. Any role with `EXECUTE` on the pgtrickle schema can publish
+another user's stream table over logical replication or hijack its delta
+stream into a pg_tide outbox. This is a clear privilege-escalation gap that
+prior audits did not catch because these APIs were added in v0.46 and v0.48.
+(2) The recursive-CTE depth guard introduced for IMMEDIATE mode in
+[src/dvm/operators/recursive_cte.rs](src/dvm/operators/recursive_cte.rs#L670)
+is not applied to DIFFERENTIAL mode, leaving open a pathological-loop vector
+that the new `diff_node()` depth guard only partially compensates for. (3)
+The multi-column `IN` rewrite shipped in v0.55 (M-5) does not handle row
+constructors containing `NULL` correctly under `NOT IN`. (4) The monitor's
+per-source buffer-growth check
+([src/monitor/mod.rs](src/monitor/mod.rs#L1515)) still issues one
+`SELECT count(*)` per source instead of using the batched
+`UNION ALL` pattern already proven in the scheduler — this is an N×ticks
+SPI amplifier on busy clusters.
+
+The remaining findings are incremental quality work: WAL-decoder TOCTOU race
+between slot eligibility check and `poll_wal_changes()`, missing CDC-lag and
+worker-utilisation percentile metrics, `application_name` not set on BGW
+connections, several large functions in `src/refresh/codegen.rs` and
+`src/cdc.rs` that warrant extraction, a handful of fixed `sleep()` calls in
+E2E tests, and documentation gaps around `pg_dump`/`pg_restore` of the
+`pgtrickle` and `pgtrickle_changes` schemas. None of these are release
+blockers individually, but together they form a polished v1.0 sprint
+backlog.
+
+**Top five risks (priority order):**
+
+1. 🟠 **HIGH — `attach_outbox()` / publication APIs lack ownership checks**
+   (S-1, S-3). Add `check_stream_table_ownership()` before these run.
+2. 🟠 **HIGH — Recursive CTE depth guard absent in DIFFERENTIAL mode**
+   (C-2). Apply the existing guard uniformly.
+3. 🟠 **HIGH — Multi-column `NOT IN` rewrite + `NULL` rows** (C-1). Either
+   detect the NULL case and fall back, or emit an `UnsupportedFeature`.
+4. 🟠 **HIGH — Per-source SPI fan-out in monitor health check** (P-1).
+   Batch buffer-count queries the same way the scheduler already does.
+5. 🟡 **MEDIUM — WAL-decoder slot eligibility TOCTOU race** (C-3). Hold an
+   advisory lock or check eligibility inside the same SPI transaction that
+   consumes from the slot.
+
+Overall, the project is in **excellent** shape — one of the cleanest
+PostgreSQL extension codebases I have audited at this stage of maturity.
+The findings below are calibrated against a "world-class v1.0" bar, not a
+"functional pre-1.0" bar.
+
+---
+
+## Severity Legend
+
+- 🔴 CRITICAL — data loss, security breach, crash, or correctness bug
+- 🟠 HIGH — significant performance regression, scalability blocker, or
+  missing core feature
+- 🟡 MEDIUM — code quality, ergonomics, observability, or test coverage gap
+- 🟢 LOW — polish, documentation, minor improvement
+
+---
+
+## Summary Table
+
+| ID    | Severity | Area              | Title                                                                  | Status |
+|-------|----------|-------------------|------------------------------------------------------------------------|--------|
+| C-1   | 🟠 HIGH  | Correctness       | Multi-column `NOT IN` rewrite missing NULL row handling                | NEW |
+| C-2   | 🟠 HIGH  | Correctness       | Recursive CTE depth guard not applied in DIFFERENTIAL mode             | NEW |
+| C-3   | 🟡 MED   | Correctness       | WAL decoder TOCTOU between slot eligibility and `poll_wal_changes()`   | NEW |
+| C-4   | 🟡 MED   | Correctness       | Compact-buffer advisory-lock failure returns `Ok(0)` silently          | NEW |
+| C-5   | 🟡 MED   | Correctness       | WAL decoder filters by qualified name string instead of OID            | NEW |
+| C-6   | 🟡 MED   | Correctness       | Publication-rebuild check misses "table becomes a partition of" case   | NEW |
+| C-7   | 🟢 LOW   | Correctness       | EC01-2 phantom cleanup uses raw `ctid` (HOT-update fragile)            | NEW |
+| C-8   | 🟢 LOW   | Correctness       | Snapshot cache key is 64-bit hash with no secondary equality           | PERSISTENT (C-10 R11) |
+| C-9   | 🟢 LOW   | Correctness       | `DiffContext::cte_counter` never resets across `differentiate()` calls | PERSISTENT (C-8 R11) |
+| S-1   | 🟠 HIGH  | Security          | `attach_outbox()` / `detach_outbox()` / `attach_embedding_outbox()` lack ownership check | NEW |
+| S-2   | 🟠 HIGH  | Security          | `stream_table_to_publication()` / `drop_stream_table_publication()` lack ownership check | NEW |
+| S-3   | 🟡 MED   | Security          | DDL hook silently swallows SPI errors and skips reinit marking         | NEW |
+| S-4   | 🟡 MED   | Security          | `buffer_qualified_name_for_oid()` does not quote schema identifier     | NEW |
+| S-5   | 🟢 LOW   | Security          | Outbox-name truncation can collide on long ST names                    | NEW |
+| P-1   | 🟠 HIGH  | Performance       | Monitor buffer-growth check issues one SPI per source                  | NEW |
+| P-2   | 🟡 MED   | Performance       | `defining_query_hash` recomputed per refresh; should be cached on meta | NEW |
+| P-3   | 🟡 MED   | Performance       | MERGE template cache hit path clones 8 large `String` fields           | NEW |
+| P-4   | 🟡 MED   | Performance       | Two separate cache borrows in `cached_non_monotonic` / `cached_is_deduplicated` | NEW |
+| P-5   | 🟡 MED   | Performance       | WAL-decoder UPDATE path allocates 5 `Vec<String>` per row              | NEW |
+| P-6   | 🟡 MED   | Performance       | Per-upstream `frontier.clone()` in `has_stream_table_source_changes()` | NEW |
+| P-7   | 🟢 LOW   | Performance       | Diamond detection still allocates intersection vectors per pair        | NEW |
+| Q-1   | 🟡 MED   | Quality           | Scheduler workers mix `log!` and `warning!` levels inconsistently      | NEW |
+| Q-2   | 🟡 MED   | Quality           | `src/refresh/codegen.rs` contains multiple 200+-line functions         | NEW |
+| Q-3   | 🟡 MED   | Quality           | `src/cdc.rs` is 3 383 lines (refactor candidate after monitor split)   | NEW |
+| Q-4   | 🟢 LOW   | Quality           | `src/dvm/parser/sublinks.rs` is 7 065 lines (largest non-test file)    | NEW |
+| Q-5   | 🟢 LOW   | Quality           | Test code in `lateral_subquery.rs` uses brittle `split().nth(1).unwrap_or("")` | NEW |
+| T-1   | 🟡 MED   | Test coverage     | `src/refresh/orchestrator.rs` and `src/refresh/merge/*.rs` lack unit tests | NEW |
+| T-2   | 🟡 MED   | Test coverage     | `src/cdc.rs`, `src/cdc/polling.rs`, `src/cdc/rebuild.rs` lack pure-logic unit tests | PERSISTENT (T-5 R11) |
+| T-3   | 🟡 MED   | Test coverage     | `src/hooks.rs` DDL classification has no unit tests                    | NEW |
+| T-4   | 🟢 LOW   | Test coverage     | ~50 fixed `tokio::time::sleep()` calls remain across `tests/`          | PARTIAL (T-9 R11) |
+| T-5   | 🟢 LOW   | Test coverage     | No proptest target asserts differential idempotence under partition reordering | NEW |
+| E-1   | 🟡 MED   | Ergonomics        | `pgtrickle.health_check()` does not surface "publication owned by other user" | NEW |
+| E-2   | 🟢 LOW   | Ergonomics        | `SQL_REFERENCE.md` lists 40+ functions but source has 100+ `#[pg_extern]` | NEW |
+| O-1   | 🟡 MED   | Observability     | No CDC-lag percentile metrics (p50/p95/p99)                            | NEW |
+| O-2   | 🟡 MED   | Observability     | No parallel-worker queue-depth / idle-time metric                      | NEW |
+| O-3   | 🟡 MED   | Observability     | No WAL-decoder pending-record / queue-depth metric                     | NEW |
+| O-4   | 🟡 MED   | Observability     | No refresh-mode (DIFFERENTIAL vs FULL) ratio metric per ST             | NEW |
+| O-5   | 🟡 MED   | Observability     | BGW connections do not set `application_name` on `Spi::connect()`      | NEW |
+| O-6   | 🟢 LOW   | Observability     | `INSTALL.md` does not document required `pg_dump --schema` flags       | NEW |
+| CI-1  | 🟡 MED   | CI/CD             | Full E2E + TPC-H still skipped on PRs; ~24 h feedback loop on `main`   | PERSISTENT (B-2 R11) |
+| CI-2  | 🟢 LOW   | CI/CD             | `tests/Dockerfile.e2e` runs as root inside the postgres image          | NEW |
+| CI-3  | 🟢 LOW   | CI/CD             | `codecov.yml` excludes `cdc.rs` / `hooks.rs` / `wal_decoder.rs` from the patch gate | NEW |
+| F-1   | 🟡 MED   | Features          | LATERAL + DIFFERENTIAL on outer-applied subqueries underspecified in docs | NEW |
+| F-2   | 🟢 LOW   | Features          | SQL:2023 `SEARCH` / `CYCLE` clauses still unsupported (no error message in some paths) | PERSISTENT (F-2 R11) |
+| F-3   | 🟢 LOW   | Features          | `auto_explain` integration still missing                               | PERSISTENT (F-3 R11) |
+| F-4   | 🟢 LOW   | Features          | No `pg_partman` integration; pg_trickle-managed partition pruning manual | PERSISTENT (F-4 R11) |
+| D-1   | 🟢 LOW   | Documentation     | ADRs in `plans/adrs/PLAN_ADRS.md` are still in PROPOSED status         | NEW |
+| D-2   | 🟢 LOW   | Documentation     | `docs/LIMITATIONS.md` does not mention multi-column `NOT IN` with NULLs | NEW |
+
+Total findings: **47** (4 HIGH, 23 MEDIUM, 20 LOW; 0 CRITICAL).
+
+---
+
+## What Has Improved Since Report 11
+
+| R11 ID | Title                                              | Status in v0.57.0 | Evidence |
+|--------|----------------------------------------------------|-------------------|----------|
+| C-1    | `filter.rs expect()` in HAVING path                 | ✅ Fixed v0.52    | CHANGELOG `## [0.52.0]` C-1 |
+| C-2    | Placeholder regex matches user identifiers          | ✅ Documented v0.55 | M-7 reserved-prefix docs |
+| C-4    | ST source frontier defaults to "0/0"                | ✅ Fixed v0.54    | `PgTrickleError::StSourceFrontierMissing` |
+| C-6    | `sqlstate_to_string()` boundary tests               | ⏳ Open (not addressed) | — |
+| C-7    | `diff_node()` has no depth limit                    | ✅ Fixed v0.54    | `max_parse_depth` enforced; `DiffDepthExceeded` |
+| C-10   | Snapshot cache key collision risk                   | ⏳ Open (re-raised as C-8 here) | — |
+| Q-2    | `api/mod.rs` is 7 600+ lines                        | ✅ Split v0.55 (M-2) | `src/api/{create,alter,refresh_ops,…}` |
+| Q-3    | `monitor.rs` is 4 000+ lines                        | ✅ Split v0.55 (M-3) | `src/monitor/{alert,health,tree,mod}.rs` |
+| Q-6    | GUC defaults lack rationale comments                | ✅ Fixed v0.55 (M-8) | inline rationale across `config.rs` |
+| P-1    | Placeholder resolution O(n²)                        | ✅ Fixed v0.52    | `aho-corasick` single-pass |
+| P-2    | Function volatility lookups uncached                | ✅ Fixed v0.52    | thread-local `HashMap` cache |
+| P-3    | DiffContext over-allocates HashMaps                 | ✅ Fixed v0.52    | lazy `Option<HashMap>` |
+| P-4    | Snapshot fingerprint traverses full tree            | ✅ Fixed v0.54    | two-level cache |
+| P-5    | `Expr::to_sql()` allocates per call                 | ✅ Fixed v0.54    | `to_sql_into(&mut String)` visitor |
+| P-6    | View inlining re-parses per iteration               | ✅ Fixed v0.54    | relkind cache through call chain |
+| P-7    | Operator volatility lookup complex SPI              | ✅ Fixed v0.52    | unified thread-local cache |
+| P-8    | Template cache LRU eviction O(N)                    | ✅ Fixed v0.52    | `lru::LruCache` |
+| S-1    | Diamond detection O(V²)                             | ✅ Fixed v0.54    | `compute_all_ancestors()` |
+| S-2    | Shmem ring buffer fixed at 1024                     | ✅ Fixed v0.55 (M-1) | max raised to 4 096, GUC default 1 024 |
+| SEC-6  | NOTIFY JSON manual escaping                         | ✅ Fixed v0.55 (M-4) | `serde_json::json!` |
+| T-2    | `dag.rs` no unit tests                              | ✅ Fixed v0.53    | proptests + unit tests added |
+| T-3    | `config.rs` no unit tests                           | ✅ Fixed v0.53    | — |
+| T-4    | `scheduler/` no unit tests                          | ✅ Fixed v0.53    | dispatch/pool/cost/tier/watermark/citus/scheduler_loop tested |
+| T-5    | `cdc.rs` no unit tests                              | ⏳ Still minimal (re-raised as T-2 here) | only 1 `#[cfg(test)]` block |
+| T-6    | DVM parser pure-function tests                      | ✅ Fixed v0.53    | sublinks/parser tests added |
+| T-9    | Long timeouts in buffer-growth tests                | ✅ Fixed v0.53 (T-8) | adaptive polling |
+| R-7    | No OOM protection in DiffContext                    | ✅ Fixed v0.54    | `max_diff_ctes` cap |
+| F-1    | Multi-column IN not supported                       | ✅ Fixed v0.55 (M-5) — but NULL edge case re-raised here as C-1 |
+| O-4    | Missing DVM parser perf metrics                     | ✅ Fixed v0.55 (M-6) | `pg_trickle_dvm_parse_ms`, `pg_trickle_delta_query_size_bytes` |
+| B-8    | Coverage not gated in PRs                           | ⏳ Partial — codecov uploaded but not blocking (M-9 v0.55) |
+
+Closure rate from Report 11: **23 of 30 actionable findings fixed in
+six minor releases** — exemplary. Three remain open (C-6 sqlstate tests,
+C-10/C-8 cache key, B-8 coverage gating), four were superseded by deeper
+or different issues raised here (F-1 → C-1 NULL edge case; T-5 still open
+as T-2 here).
+
+---
+
+## Area 1: Correctness & Bugs
+
+### Finding C-1: Multi-column `NOT IN` Rewrite Missing NULL Row Handling
+**Severity:** 🟠 HIGH — NEW
+**Location:** [src/dvm/parser/sublinks.rs](src/dvm/parser/sublinks.rs) (multi-column `IN`/`NOT IN` rewrite added in v0.55 M-5; row-expr extraction near line 1000)
+**Description:** The v0.55 rewrite of `(a, b) IN (SELECT x, y FROM …)` into a
+semi-join with `a = x AND b = y` (and the matching anti-join for `NOT IN`)
+relies on the equality being TRUE/FALSE-valued. With `NULL` rows, however,
+SQL's `(NULL, 5) IN (SELECT …)` returns UNKNOWN if no row matches the
+non-NULL components, while the rewritten AND-chain in a SemiJoin can still
+yield rows because `NULL = NULL` is UNKNOWN, not FALSE. For `NOT IN`, the
+issue is more dangerous: `(NULL, …) NOT IN (…)` must produce UNKNOWN (and
+hence reject the row), but anti-join semantics will keep rows whose
+correlation predicate evaluates to UNKNOWN, producing extra rows in the
+stream table.
+**Impact:** Silently incorrect `NOT IN` results for rows containing NULLs
+in any IN-list component — the textbook IVM trap.
+**Recommendation:** Either (a) detect `NULL`/non-strict expressions in the
+row constructor and the subquery's target list and skip the rewrite, or
+(b) inject `IS NOT NULL` guards on every column on both sides of the
+generated anti-join, matching PostgreSQL's executor semantics for
+`NOT IN`. Add proptest cases that fuzz row constructors with NULLs and
+compare against `REFRESH MATERIALIZED VIEW`.
+
+### Finding C-2: Recursive-CTE Depth Guard Not Applied in DIFFERENTIAL Mode
+**Severity:** 🟠 HIGH — NEW
+**Location:** [src/dvm/operators/recursive_cte.rs](src/dvm/operators/recursive_cte.rs#L670)
+**Description:** The depth guard is gated on `DeltaSource::TransitionTable`
+(IMMEDIATE mode); for `DeltaSource::ChangeBuffer` (DIFFERENTIAL mode) the
+guard is `None`. The `diff_node()` depth cap (v0.54 C-7) protects against
+operator-tree recursion but does not bound the *recursive CTE's* iteration
+depth at execution time. A pathological self-referencing recursive CTE in
+DIFFERENTIAL mode can therefore loop until WAL/temp-buffer limits trip.
+**Evidence:**
+```rust
+let max_depth = if matches!(ctx.delta_source, DeltaSource::TransitionTable { .. }) {
+    crate::config::pg_trickle_ivm_recursive_max_depth()
+} else {
+    None
+};
+```
+**Impact:** Backend OOM/long-running query on adversarial recursive
+definitions in DIFFERENTIAL mode.
+**Recommendation:** Apply `ivm_recursive_max_depth` to both modes.
+
+### Finding C-3: WAL Decoder TOCTOU Between Slot Eligibility and Consumption
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/wal_decoder.rs](src/wal_decoder.rs#L260-L300)
+**Description:** `is_slot_suitable_for_wal_transition()` and the subsequent
+`poll_wal_changes()` are separate calls; between them a concurrent
+`pg_drop_replication_slot()` (e.g., from an admin or from the EC-20 fallback
+path) can invalidate the slot. The error path falls back to triggers, but
+the brief race can miss changes if eligibility passes after a slot was
+recreated with a different `restart_lsn`.
+**Impact:** Rare CDC-gap risk on slot churn.
+**Recommendation:** Hold `pg_advisory_xact_lock` keyed on slot OID across
+both calls, or merge eligibility into the same SPI transaction as
+consumption.
+
+### Finding C-4: Compact-Buffer Advisory-Lock Failure Returns `Ok(0)`
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/cdc.rs](src/cdc.rs#L942-L1030)
+**Description:** When `pg_try_advisory_xact_lock()` fails, the compactor
+returns `Ok(0)`, indistinguishable from "no rows needed compaction". A
+persistent lock contention scenario thus hides itself from operators.
+**Impact:** Change buffers can grow unbounded without visible signal.
+**Recommendation:** Return `enum CompactionResult { Done(i64), Contended,
+SkippedDisabled }`, log at `debug!` on contention, and expose a
+shmem counter `pg_trickle_cdc_compact_contended_total`.
+
+### Finding C-5: WAL Decoder Filters by Qualified-Name String Instead of OID
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/wal_decoder.rs](src/wal_decoder.rs) (table-name filter
+section ~L550–L600)
+**Description:** The decoder compares `test_decoding`'s
+schema-qualified table names by string equality. Edge cases (search_path,
+case-sensitive quoted names, partition routing where the child arrives
+instead of the root) can cause false negatives.
+**Impact:** Silently dropped CDC rows in partitioned setups.
+**Recommendation:** Resolve every decoded row to an OID via
+`to_regclass()` once per cycle and key the filter on OID; fall back to
+text matching only if OID lookup fails.
+
+### Finding C-6: Publication-Rebuild Check Misses "Table Becomes Partition of"
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/wal_decoder.rs](src/wal_decoder.rs#L3350-L3383)
+(`check_if_publication_needs_rebuild()`)
+**Description:** The check examines the source `relkind` to detect when a
+plain table is converted to a partitioned root. It does *not* detect the
+inverse — when a previously-standalone table is attached as a partition of
+some other parent. After such an `ALTER TABLE ATTACH PARTITION`, changes
+arrive with the parent's name and the existing publication silently filters
+them out.
+**Impact:** Stream tables that depend on a partition can freeze after
+attach without an error.
+**Recommendation:** Additionally check
+`SELECT EXISTS (SELECT 1 FROM pg_inherits WHERE inhrelid = $1)` and
+rebuild the publication when this transitions from false to true.
+
+### Finding C-7: EC01-2 Phantom Cleanup Uses Raw `ctid`
+**Severity:** 🟢 LOW — NEW
+**Location:** [src/refresh/phd1.rs](src/refresh/phd1.rs#L180-L220)
+**Description:** Cross-cycle phantom reconciliation deletes by `ctid`
+captured from a CTE earlier in the same transaction. PostgreSQL guarantees
+`ctid` stability within a snapshot, so this is technically safe inside one
+transaction; however, the comment block does not state the invariant
+explicitly, and any future refactor that splits the operation across
+transactions would silently break.
+**Impact:** Footgun for future maintainers; current code is correct.
+**Recommendation:** Add a `// INVARIANT: ctid is captured and consumed in
+the same snapshot; do not split across subtransactions` comment, and
+prefer the stream table's row identity columns (`__pgt_row_id`) where
+they are available.
+
+### Finding C-8: 64-bit `DefaultHasher` Snapshot Cache Key
+**Severity:** 🟢 LOW — PERSISTENT (R11 C-10)
+**Location:** [src/dvm/diff.rs](src/dvm/diff.rs#L233-L280)
+**Description:** The structural fingerprint is still a single 64-bit
+hash. Even at billions of refreshes, the birthday-bound collision
+probability is negligible but non-zero, and a collision produces silently
+wrong SQL.
+**Recommendation:** Cheap defence-in-depth: store the rendered fingerprint
+*string* alongside the hash and compare both on cache hit.
+
+### Finding C-9: `DiffContext::cte_counter` Never Resets
+**Severity:** 🟢 LOW — PERSISTENT (R11 C-8)
+**Location:** [src/dvm/diff.rs](src/dvm/diff.rs#L598)
+**Recommendation:** Reset to 0 at the top of each `differentiate()` call.
+
+---
+
+## Area 2: Performance & Scalability
+
+### Finding P-1: Monitor Buffer-Growth Check Issues One SPI per Source
+**Severity:** 🟠 HIGH — NEW
+**Location:** [src/monitor/mod.rs](src/monitor/mod.rs#L1515-L1530)
+**Description:** Inside the health-check loop, every CDC source gets its
+own `SELECT count(*)::bigint FROM pgtrickle_changes.changes_<oid>` SPI
+call. With 100 CDC-enabled sources on a 10 Hz monitor tick this is 1 000
+SPI round-trips per second, dwarfing the rest of the refresh path.
+**Recommendation:** Batch into a single SPI:
+```sql
+SELECT * FROM (VALUES (oid1, (SELECT count(*) FROM changes_oid1)::bigint),
+                       (oid2, (SELECT count(*) FROM changes_oid2)::bigint),
+                       …) v(source_oid, pending);
+```
+or use `pg_class.reltuples` for an approximate first-pass filter and only
+COUNT(*) on plausibly-over-threshold buffers.
+
+### Finding P-2: `defining_query_hash` Recomputed Per Refresh
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/refresh/merge/mod.rs](src/refresh/merge/mod.rs#L1342-L1360)
+**Description:** On every refresh entry, the merge-cache lookup hashes the
+full defining query (`DefaultHasher`) and compares against the cached
+hash. The query is immutable between CREATE/ALTER, so the hash can be
+computed once at catalog write and cached in `StreamTableMeta`.
+**Recommendation:** Add `defining_query_hash: i64` to
+`pgtrickle.pgt_stream_tables`, populate on insert/update, and pass through
+to the cache lookup.
+
+### Finding P-3: Merge-Template Cache Hits Clone Eight `String` Fields
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/refresh/merge/mod.rs](src/refresh/merge/mod.rs#L1350-L1430)
+**Description:** On a cache hit, the full `CachedMergeTemplate` is
+`.clone()`d to produce an executable plan. The struct holds eight
+multi-kilobyte template strings; under a 1 000 refresh/s load this dwarfs
+the cache itself.
+**Recommendation:** Wrap each template `String` in `Arc<String>` (or
+`Arc<str>`); cloning then becomes an atomic increment. Alternatively,
+restructure the plan to borrow from the cache entry by lifetime.
+
+### Finding P-4: Two Separate `MERGE_TEMPLATE_CACHE.with()` Borrows
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/refresh/merge/mod.rs](src/refresh/merge/mod.rs#L874-L892)
+**Description:** `cached_non_monotonic` and `cached_is_deduplicated` each
+acquire their own `RefCell::borrow()` and `LruCache::get()`. The second
+call also marks the entry as recently used, distorting LRU ordering.
+**Recommendation:** Single borrow, extract both flags into a small tuple.
+
+### Finding P-5: WAL-Decoder UPDATE Path Allocates Five `Vec<String>` per Row
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/wal_decoder.rs](src/wal_decoder.rs#L781-L870)
+**Description:** Builds `col_names`, `placeholders`, `param_values`,
+`col_names_u`, `d_all_params`, `i_all_params`, with `to_string()` calls
+inside loops. At sustained 10 k UPDATE/s with 50-column rows this is a
+multi-MB/s allocator burn rate.
+**Recommendation:** Reuse a per-call `Vec` pool (or `Vec::with_capacity`
+keyed off column count) and switch to `write!` into a pre-allocated
+`String`.
+
+### Finding P-6: `frontier.clone()` per Upstream Source-Change Probe
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/scheduler/mod.rs](src/scheduler/mod.rs#L2200-L2235)
+**Description:** `has_stream_table_source_changes()` clones the entire
+`Frontier` for every upstream check. The struct contains a HashMap keyed
+on upstream `pgt_id`; cloning costs scale with both fan-in and frontier
+density.
+**Recommendation:** Borrow via `st.frontier.as_ref().unwrap_or(&FRONTIER_EMPTY)`.
+
+### Finding P-7: Diamond Detection Still Allocates Intersection Vectors
+**Severity:** 🟢 LOW — NEW
+**Location:** [src/dag.rs](src/dag.rs#L750-L800)
+**Description:** Even after S-1's O(V+E) ancestor-set precomputation, the
+pair-wise intersection still uses `.intersection().copied().collect()`
+into a temporary `Vec`. For dense fan-in nodes this is a small but
+measurable allocation per pair.
+**Recommendation:** Iterate via `intersection()` lazily and break on the
+first shared node, or short-circuit using bitset representation if the
+node count is small.
+
+---
+
+## Area 3: Security
+
+### Finding S-1: `attach_outbox()` / `detach_outbox()` / `attach_embedding_outbox()` Skip Ownership Checks
+**Severity:** 🟠 HIGH — NEW
+**Location:** [src/api/outbox.rs](src/api/outbox.rs#L92-L153),
+[src/api/outbox.rs](src/api/outbox.rs#L168-L260),
+[src/api/outbox.rs](src/api/outbox.rs#L282-L420)
+**Description:** Every other mutating API (`alter_stream_table`,
+`drop_stream_table`, `pause_stream_table`, `resume_stream_table`, …) calls
+`check_stream_table_ownership()` (or equivalent) before proceeding. The
+outbox attach/detach functions do not. Any role with `EXECUTE` on the
+`pgtrickle` schema can therefore attach a pg_tide outbox to a stream
+table owned by another role and observe (or modify, depending on outbox
+configuration) its change stream.
+**Evidence:** No `check_stream_table_ownership` or `verify_st_owner`
+call appears in `attach_outbox_impl` (line 92), `detach_outbox_impl`
+(line 168), or `attach_embedding_outbox_impl` (line 282).
+**Impact:** Direct privilege-escalation / data-exfiltration vector once
+the pg_tide extension is co-installed.
+**Recommendation:** Insert the standard ownership check immediately after
+`StreamTableMeta::get_by_name()` in all three functions.
+
+### Finding S-2: `stream_table_to_publication()` and `drop_stream_table_publication()` Skip Ownership Checks
+**Severity:** 🟠 HIGH — NEW
+**Location:** [src/api/publication.rs](src/api/publication.rs#L22-L72),
+[src/api/publication.rs](src/api/publication.rs#L79-L120)
+**Description:** Same gap as S-1 but with consequences specific to
+logical replication: a non-owner can create a publication exposing the
+stream table's storage to any subscriber, or drop an owner's publication
+out from under them.
+**Evidence:** No ownership check between `StreamTableMeta::get_by_name()`
+and `CREATE PUBLICATION` / `DROP PUBLICATION IF EXISTS`.
+**Impact:** Privilege escalation / denial of service against logical
+replication subscribers.
+**Recommendation:** Identical fix to S-1.
+
+### Finding S-3: DDL Hook Silently Swallows SPI Errors and Skips Reinit Marking
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/hooks.rs](src/hooks.rs#L200-L260)
+**Description:** When `find_view_downstream_pgt_ids()` fails (transient
+SPI error, catalog corruption, concurrent DDL), `handle_alter_table()`
+emits a `warning!()` and returns. The downstream stream tables that
+needed `needs_reinit = true` therefore never get marked.
+**Impact:** Schema changes can silently produce stale stream tables.
+**Recommendation:** On SPI failure, retry once, then escalate to an
+`error!()` so the original DDL fails — better to block the schema change
+than to corrupt downstream state.
+
+### Finding S-4: `buffer_qualified_name_for_oid()` Does Not Quote Schema
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/cdc.rs](src/cdc.rs#L100-L160)
+**Description:** Returns `format!("{change_schema}.{base}")` without
+quoting `change_schema`. The default `pgtrickle_changes` is safe, but the
+schema name is a GUC and quoted-identifier schemas (e.g.
+`"my schema"`) would break the SQL. While not a direct injection vector
+(the GUC is superuser-only), it is an unnecessary footgun.
+**Recommendation:** Use the existing `sql_builder::qualified()` helper,
+or `pg_catalog.quote_ident()` via SPI.
+
+### Finding S-5: Outbox Name Truncation Can Collide
+**Severity:** 🟢 LOW — NEW
+**Location:** [src/api/outbox.rs](src/api/outbox.rs#L27-L35)
+**Description:** `outbox_table_name_for()` truncates to 63 chars without
+disambiguation. Two ST names that differ only after the 56-character mark
+produce identical outbox names.
+**Recommendation:** When truncation occurs, append the first 8 hex chars
+of `blake3(st_name)`.
+
+---
+
+## Area 4: Code Quality & Maintainability
+
+### Finding Q-1: Scheduler Workers Mix `log!` and `warning!` Levels Inconsistently
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/scheduler/dispatch.rs](src/scheduler/dispatch.rs#L100-L250)
+**Description:** Routine state transitions log at `log!` (DEBUG)
+alongside `warning!` for recoverable failures. Operators running at
+`log_min_messages = warning` see warnings but never see "started parallel
+dispatch", and operators at `log_min_messages = debug1` see both plus
+log spam from elsewhere.
+**Recommendation:** Standardise on `info!` for routine state transitions,
+`warning!` for recoverable failures, `error!` for fatal events.
+
+### Finding Q-2: `src/refresh/codegen.rs` Has Multiple 200+-Line Functions
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/refresh/codegen.rs](src/refresh/codegen.rs)
+**Description:** `build_bypass_capture_sql`, `capture_diff_to_table`, and
+the MERGE-template builders mix conditionals with SQL building. Hard to
+review.
+**Recommendation:** Extract `build_cte_predicate()`,
+`build_merge_join_condition()`, `build_content_hash_column()` into a
+`refresh/sql_fragments.rs` helper module.
+
+### Finding Q-3: `src/cdc.rs` is 3 383 Lines
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/cdc.rs](src/cdc.rs)
+**Description:** After the v0.55 monitor/api decomposition, `cdc.rs` is
+now the third-largest non-test file. Trigger generation, buffer
+management, compaction, and partition-promotion all live here.
+**Recommendation:** Split into `cdc/triggers.rs`, `cdc/buffer.rs`,
+`cdc/compact.rs`, `cdc/partition.rs` following the v0.55 monitor pattern.
+
+### Finding Q-4: `src/dvm/parser/sublinks.rs` is 7 065 Lines
+**Severity:** 🟢 LOW — NEW
+**Location:** [src/dvm/parser/sublinks.rs](src/dvm/parser/sublinks.rs)
+**Description:** Largest non-test file in the project. Despite logical
+sectioning, the file mixes EXISTS, NOT EXISTS, scalar sublink hoisting,
+multi-column IN, HAVING rewriting, and aggregate classification.
+**Recommendation:** Decompose into `sublinks/{exists,scalar,in_list,
+having,aggregates}.rs`.
+
+### Finding Q-5: Test Code Uses Brittle `split().nth(1).unwrap_or("")`
+**Severity:** 🟢 LOW — NEW
+**Location:** [src/dvm/operators/lateral_subquery.rs](src/dvm/operators/lateral_subquery.rs#L1159)
+**Description:** Test assertions that look for a substring after a CTE
+name fall back to empty string on mismatch, making the assertion silently
+vacuous if CTE naming changes.
+**Recommendation:** Use `splitn(2, …)` and assert
+`parts.len() == 2`.
+
+---
+
+## Area 5: Test Coverage
+
+### Finding T-1: Refresh Orchestrator and Merge Sub-Modules Lack Unit Tests
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/refresh/orchestrator.rs](src/refresh/orchestrator.rs),
+[src/refresh/merge/mod.rs](src/refresh/merge/mod.rs),
+[src/refresh/merge/{insert,update,delete,columns,conflict}.rs](src/refresh/merge/)
+**Description:** Two `#[cfg(test)]` blocks across the refresh tree; the
+cost-model state machine and merge-template caching paths rely on E2E
+coverage.
+**Recommendation:** Add unit tests for: cost-model transitions (cold
+start → diff-preferred → full-preferred → diff-recovery), template-cache
+LRU eviction under thrash, and merge-SQL builders for the
+`columns.rs`/`conflict.rs` pure helpers.
+
+### Finding T-2: CDC Pure-Logic Functions Still Lack Unit Tests
+**Severity:** 🟡 MEDIUM — PERSISTENT (R11 T-5)
+**Location:** [src/cdc.rs](src/cdc.rs), [src/cdc/polling.rs](src/cdc/polling.rs),
+[src/cdc/rebuild.rs](src/cdc/rebuild.rs)
+**Description:** `cb_col_name`, `buffer_base_name_for_oid`,
+`build_changed_cols_bitmask_expr`, `should_promote_to_partitioned`,
+`classify_holdback`, and similar helpers are pure functions and would
+unit-test cleanly.
+**Recommendation:** Mirror the v0.53 scheduler-test sweep.
+
+### Finding T-3: `src/hooks.rs` DDL Classification Lacks Unit Tests
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/hooks.rs](src/hooks.rs)
+**Description:** DDL command kind classification, the `DdlCommandKind`
+enum dispatch, and the schema-change-impact decision logic are all
+pure functions but only exercised via E2E.
+**Recommendation:** Add table-driven tests for each `DdlCommandKind`
+variant against representative `ObjectAddress`/`identity` inputs.
+
+### Finding T-4: ~50 Fixed `tokio::time::sleep()` Calls Remain
+**Severity:** 🟢 LOW — PARTIAL (R11 T-9 partially closed)
+**Location:** [tests/e2e_quota_tests.rs](tests/e2e_quota_tests.rs#L236),
+[tests/e2e_bgworker_tests.rs](tests/e2e_bgworker_tests.rs#L108),
+[tests/e2e_wal_cdc_tests.rs](tests/e2e_wal_cdc_tests.rs#L80), …
+**Recommendation:** Continue the v0.53 pattern: replace fixed sleeps with
+`wait_for_*` polling helpers in `tests/common/mod.rs`.
+
+### Finding T-5: No Proptest for Differential Idempotence Under Partition Reorder
+**Severity:** 🟢 LOW — NEW
+**Description:** The existing proptest suite covers Z-set algebra and
+DAG invariants but does not assert that a refresh cycle with the same
+inputs produces the same result regardless of partition-ingest order.
+**Recommendation:** Add a proptest that randomises partition write order
+and asserts equal stream-table contents post-refresh.
+
+---
+
+## Module Coverage Matrix
+
+| Module                              | Unit `#[cfg(test)]` | Integration | E2E | Proptest |
+|-------------------------------------|---------------------|-------------|-----|----------|
+| `src/dag.rs`                        | ✅ (v0.53)          | ✅          | ✅  | ✅       |
+| `src/config.rs`                     | ✅ (v0.53)          | ✅          | ✅  | —        |
+| `src/scheduler/*.rs` (8 files)      | ✅ (v0.53)          | ✅          | ✅  | —        |
+| `src/dvm/parser/*.rs`               | ✅ (v0.53)          | ✅          | ✅  | ✅       |
+| `src/dvm/operators/*.rs`            | ✅                  | ✅          | ✅  | ✅       |
+| `src/dvm/diff.rs`                   | ✅                  | ✅          | ✅  | ✅       |
+| `src/refresh/orchestrator.rs`       | ❌                  | ✅          | ✅  | —        |
+| `src/refresh/merge/*.rs`            | ⚠️ minimal          | ✅          | ✅  | —        |
+| `src/refresh/codegen.rs`            | ⚠️ minimal          | ✅          | ✅  | —        |
+| `src/refresh/phd1.rs`               | ⚠️ minimal          | ✅          | ✅  | —        |
+| `src/cdc.rs`                        | ❌                  | ✅          | ✅  | —        |
+| `src/cdc/polling.rs`                | ❌                  | ✅          | ✅  | —        |
+| `src/cdc/rebuild.rs`                | ❌                  | ✅          | ✅  | —        |
+| `src/wal_decoder.rs`                | ⚠️ minimal          | ✅          | ✅  | ✅       |
+| `src/hooks.rs`                      | ❌                  | ✅          | ✅  | —        |
+| `src/shmem.rs`                      | ⚠️ minimal          | ✅          | ✅  | —        |
+| `src/hash.rs`                       | ✅                  | —           | —   | —        |
+| `src/sql_builder.rs`                | ✅                  | —           | —   | —        |
+| `src/monitor/*.rs`                  | ⚠️ minimal          | ✅          | ✅  | —        |
+| `src/api/*.rs`                      | ✅ (per-module)     | ✅          | ✅  | —        |
+| `src/error.rs`                      | ✅                  | —           | —   | —        |
+| `src/diagnostics.rs`                | ❌                  | ✅          | ✅  | —        |
+| `src/metrics_server.rs`             | ✅                  | —           | —   | —        |
+
+---
+
+## Area 6: Ergonomics & Developer Experience
+
+### Finding E-1: `health_check()` Does Not Surface Foreign-Owned Publications/Outboxes
+**Severity:** 🟡 MEDIUM — NEW
+**Description:** If S-1/S-2 are exploited (a non-owner attaches an
+outbox/publication), the owner has no signal in `health_check()`. The
+8-check matrix does not include "Are any pgtrickle artefacts attached to
+this ST owned by a different role?"
+**Recommendation:** Add a `attachment_owner_check` row that lists pg_tide
+outboxes and downstream publications and flags mismatches.
+
+### Finding E-2: SQL_REFERENCE.md Function Inventory Is Incomplete
+**Severity:** 🟢 LOW — NEW
+**Description:** `grep -rn '#\[pg_extern' src/ | wc -l` reports ~100+
+exported functions; `docs/SQL_REFERENCE.md` lists ~40. Internal helpers
+(`recommend_refresh_mode`, `refresh_efficiency`, `reliability_counters`)
+are reachable from SQL but undocumented.
+**Recommendation:** Either annotate internal `#[pg_extern]` functions
+with `@internal` comments and exclude them from the doc generator, or
+document them in a new "Internal / advanced diagnostics" section.
+
+---
+
+## Area 7: Observability & Operations
+
+### Finding O-1: No CDC-Lag Percentile Metrics
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/shmem.rs](src/shmem.rs), [src/monitor/mod.rs](src/monitor/mod.rs)
+**Description:** `pg_trickle_frontier_holdback_lsn` is a single scalar.
+SREs need p50/p95/p99 of "how stale is my data right now" across stream
+tables.
+**Recommendation:** Add a HDR-histogram (or a simple `[t-1m, t-5m, t-15m]`
+ring buffer) in shmem and expose `pg_trickle_cdc_lag_p{50,95,99}_seconds`.
+
+### Finding O-2: No Parallel-Worker Queue-Depth / Idle-Time Metrics
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/scheduler/pool.rs](src/scheduler/pool.rs)
+**Recommendation:** Add `pg_trickle_parallel_queue_depth` and
+`pg_trickle_worker_idle_time_seconds_total` counters.
+
+### Finding O-3: No WAL-Decoder Pending-Record Metric
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/wal_decoder.rs](src/wal_decoder.rs)
+**Description:** Without a queue-depth metric, a stalled decoder is
+invisible until the replication slot runs out of WAL.
+**Recommendation:** Expose `pg_trickle_wal_decoder_pending_records`.
+
+### Finding O-4: No Refresh-Mode Ratio Metric per ST
+**Severity:** 🟡 MEDIUM — NEW
+**Description:** Operators cannot tell whether the cost model is keeping
+queries on the DIFFERENTIAL hot path.
+**Recommendation:** Add
+`pg_trickle_refresh_mode_total{mode="differential"|"full",pgt=…}`
+counters.
+
+### Finding O-5: `application_name` Not Set on BGW Connections
+**Severity:** 🟡 MEDIUM — NEW
+**Location:** [src/scheduler/mod.rs](src/scheduler/mod.rs)
+**Description:** `pg_stat_activity` shows BGW backends with the worker
+name only; queries cannot be attributed to scheduler vs dispatcher vs
+pool worker without correlating PIDs.
+**Recommendation:** Call `SET application_name = 'pg_trickle_<role>'`
+right after `Spi::connect()` in each BGW.
+
+### Finding O-6: `INSTALL.md` Does Not Document `pg_dump --schema` Requirements
+**Severity:** 🟢 LOW — NEW
+**Description:** A naive `pg_dump db > dump.sql` will include user data
+but skip the `pgtrickle` and `pgtrickle_changes` schemas if not
+explicitly listed. Restoration without the catalog is a data-loss event
+masquerading as success.
+**Recommendation:** Add a "Backup & Restore" section to INSTALL.md
+listing the required flags and link to the same content from
+`docs/RUNBOOK_DRAIN.md`.
+
+---
+
+## Area 8: CI/CD & Infrastructure
+
+### Finding CI-1: Full E2E + TPC-H Still Skipped on PRs
+**Severity:** 🟡 MEDIUM — PERSISTENT (R11 B-2)
+**Description:** PRs only run light E2E; full E2E and TPC-H gate
+push-to-main and scheduled runs. Regressions to differential correctness
+have up to a 24 h detection window for changes that affect only the
+full-E2E paths.
+**Recommendation:** Either (a) add a path-filtered trigger that runs
+full E2E on PRs touching `src/dvm/`, `src/refresh/`, or `src/cdc/`, or
+(b) shard the full E2E to fit inside the existing 45-min PR budget.
+
+### Finding CI-2: `tests/Dockerfile.e2e` Runs as Root
+**Severity:** 🟢 LOW — NEW
+**Location:** [tests/Dockerfile.e2e](tests/Dockerfile.e2e)
+**Description:** The image inherits from `postgres:18.3-bookworm`
+(pinned by digest, good) but does not switch to the `postgres` user
+before the `CMD`. Test containers run as root.
+**Recommendation:** Add `USER postgres` before the final `CMD`.
+
+### Finding CI-3: `codecov.yml` Excludes Critical Modules from Patch Gate
+**Severity:** 🟢 LOW — NEW
+**Location:** [codecov.yml](codecov.yml)
+**Description:** `cdc.rs`, `hooks.rs`, and `wal_decoder.rs` are excluded
+from the 70 % patch coverage gate. These are the most safety-critical
+modules in the project.
+**Recommendation:** Add a per-file threshold (50 % for cdc/hooks, 40 %
+for wal_decoder) instead of a blanket exclusion.
+
+---
+
+## Area 9: Missing Features & Roadmap Gaps
+
+### Finding F-1: LATERAL + DIFFERENTIAL on Outer-Applied Subqueries Underspecified
+**Severity:** 🟡 MEDIUM — NEW
+**Description:** `src/dvm/operators/lateral_subquery.rs` supports LATERAL
+SRFs and basic LATERAL joins. However the interaction with outer joins
+that *contain* a LATERAL on the right side (the EC-01 phantom-row
+pattern) is documented neither in `docs/DVM_OPERATORS.md` nor in
+`docs/LIMITATIONS.md`.
+**Recommendation:** Document the precise supported subset and the
+fallback policy.
+
+### Finding F-2: SQL:2023 `SEARCH` / `CYCLE` Clauses Silently Drop
+**Severity:** 🟢 LOW — PERSISTENT (R11 F-2)
+**Description:** No explicit error from the parser; the query may be
+accepted and the clause silently ignored.
+**Recommendation:** Detect during parse, raise `UnsupportedFeature`.
+
+### Finding F-3: `auto_explain` Integration Missing
+**Severity:** 🟢 LOW — PERSISTENT (R11 F-3)
+**Recommendation:** Roadmap item.
+
+### Finding F-4: No `pg_partman` Integration
+**Severity:** 🟢 LOW — PERSISTENT (R11 F-4)
+**Recommendation:** Roadmap item.
+
+---
+
+## Roadmap Coverage Matrix
+
+| ROADMAP item / planned feature             | Status in v0.57.0 | Notes |
+|--------------------------------------------|-------------------|-------|
+| Trigger-based CDC (statement & row)        | ✅ Implemented    | `src/cdc.rs` |
+| WAL-based CDC (logical replication)        | ✅ Implemented    | `src/wal_decoder.rs`; partition gap in C-6 |
+| Differential refresh for joins (inner/outer/full/lateral) | ✅ Implemented | `src/dvm/operators/{join,outer_join,full_join,lateral_subquery}.rs` |
+| Differential refresh for aggregates        | ✅ Implemented    | `src/dvm/operators/aggregate.rs` |
+| Differential refresh for recursive CTEs    | ⚠️ Partial        | 5 strategies, but depth guard missing in DIFF (C-2) |
+| Multi-column IN / NOT IN                   | ⚠️ Partial        | v0.55 M-5; NULL edge case (C-1) |
+| GROUPING SETS / CUBE / ROLLUP              | ✅ Implemented    | up to 64 branches |
+| Window functions (9 supported)             | ✅ Implemented    | `src/dvm/operators/window.rs` |
+| dbt adapter                                | ✅ Production     | `dbt-pgtrickle/` |
+| pg_tide outbox / inbox / relay integration | ✅ Production     | but ownership bypass (S-1) |
+| Downstream logical-replication publishing  | ✅ Implemented    | but ownership bypass (S-2) |
+| Parameterised stream tables                | ❌ Not implemented | blog post only |
+| Online schema evolution (ADD/DROP COLUMN)  | ⚠️ Partial        | needs explicit doc of unsupported ALTER TYPE cases |
+| SEARCH / CYCLE for recursive CTEs          | ❌ Not implemented | F-2 |
+| auto_explain integration                   | ❌ Not implemented | F-3 |
+| pg_partman integration                     | ❌ Not implemented | F-4 |
+| pgtrickle-relay (standalone binary)        | ⚠️ Prototype      | `pgtrickle-relay/`; needs production-readiness gate |
+| Citus distributed support                  | ✅ Implemented + chaos-tested | v0.51 CHAOS-5/6/7 |
+| Drain mode & CNPG preStop                  | ✅ Implemented    | OPS-10-01 |
+| Prometheus metrics server                  | ✅ Implemented    | observability gaps in O-1..O-4 |
+
+---
+
+## Area 10: Documentation
+
+### Finding D-1: ADRs Are Still PROPOSED
+**Severity:** 🟢 LOW — NEW
+**Location:** [plans/adrs/PLAN_ADRS.md](plans/adrs/PLAN_ADRS.md)
+**Description:** The ADR framework is described, but no individual ADR
+(`ADR-001 trigger-based CDC rationale`, `ADR-002 Z-set vs multiset`,
+`ADR-003 differential correctness invariants`) has been written.
+**Recommendation:** Write 3–5 foundational ADRs before v1.0.
+
+### Finding D-2: `LIMITATIONS.md` Misses Multi-Column `NOT IN` With NULLs
+**Severity:** 🟢 LOW — NEW
+**Description:** Tied to C-1. Even if C-1 is fixed by a fall-back path,
+the limitation should be documented.
+
+---
+
+## Recommended Action Plan
+
+Top 15 actions in priority order. Owner hint: **R** = Rust, **S** = SQL,
+**D** = docs, **C** = CI/build. Effort: **S** ≤ 1 day, **M** ≤ 3 days,
+**L** ≤ 1 week, **XL** > 1 week.
+
+| # | Finding | Action                                                                       | Owner | Effort |
+|---|---------|------------------------------------------------------------------------------|-------|--------|
+| 1 | S-1, S-2 | Add `check_stream_table_ownership()` to outbox + publication APIs            | R+S   | S      |
+| 2 | C-2     | Apply `ivm_recursive_max_depth` guard in DIFFERENTIAL mode                    | R     | S      |
+| 3 | C-1     | Detect NULLs in multi-column `IN`/`NOT IN` row constructors; fall back/error  | R     | M      |
+| 4 | P-1     | Batch monitor buffer-growth check into a single SPI                           | R     | S      |
+| 5 | C-3     | Hold advisory lock across WAL-slot eligibility + consumption                  | R     | M      |
+| 6 | C-5, C-6 | Switch WAL-decoder name filter to OID-based; add partition-attach rebuild   | R     | M      |
+| 7 | T-1     | Add unit tests for refresh orchestrator and merge sub-modules                 | R     | M      |
+| 8 | O-1..O-4 | Add CDC-lag percentiles, worker queue depth, WAL decoder queue, refresh-mode counters | R | M |
+| 9 | O-5     | `SET application_name` in every BGW connection                                | R     | S      |
+| 10 | S-3    | Fail DDL on hook SPI error; do not silently skip reinit marking               | R     | S      |
+| 11 | P-2, P-3 | Cache `defining_query_hash` on `StreamTableMeta`; `Arc<str>` for templates  | R     | M      |
+| 12 | T-2, T-3 | CDC + hooks pure-logic unit-test sweep mirroring v0.53                      | R     | M      |
+| 13 | CI-1   | Path-filtered full-E2E job on PRs touching DVM/refresh/CDC                    | C     | S      |
+| 14 | E-1    | `health_check()` row for foreign-owned publications/outboxes                  | R+S   | S      |
+| 15 | D-1    | Write 3 foundational ADRs (CDC choice, Z-set algebra, EC-01 invariants)       | D     | M      |
+
+---
+
+## Appendix: Persistent Open Findings Tracker
+
+Findings raised in prior reports that remain open after this audit
+(excluding those superseded by new, narrower findings):
+
+| Original ID | Report | Current Status | Re-raised as |
+|-------------|--------|----------------|--------------|
+| C-6 (sqlstate boundary tests) | R11   | Open | Carried forward (no new finding) |
+| C-10 (snapshot cache 64-bit key) | R11   | Open | C-8 |
+| C-8 (cte_counter reset)       | R11   | Open | C-9 |
+| T-5 (cdc.rs unit tests)       | R11   | Open | T-2 |
+| T-9 (sleep-based sync)        | R11   | Partial | T-4 |
+| B-2 (PR gate length / full E2E coverage) | R11 | Open | CI-1 |
+| B-8 (coverage not gated)      | R11   | Partial (upload added, not blocking) | CI-3 (different framing) |
+| F-2 (SEARCH/CYCLE)            | R11   | Open | F-2 |
+| F-3 (auto_explain)            | R11   | Open | F-3 |
+| F-4 (pg_partman)              | R11   | Open | F-4 |
+
+---
+
+## Metrics
+
+- **Total findings:** 47 (4 HIGH, 23 MEDIUM, 20 LOW; 0 CRITICAL)
+- **New findings:** 36
+- **Persistent open from R11:** 10 (3 re-raised verbatim, 7 re-framed)
+- **Closed since R11:** 23 of 30 actionable items — outstanding burn-down
+- **Cargo version audited:** 0.57.0
+- **Source files audited:** ~90 `.rs` files
+- **Source LOC:** ~124 000
+- **Largest files:** `dvm/parser/sublinks.rs` 7 065; `dvm/parser/rewrites.rs`
+  6 146; `dvm/operators/aggregate.rs` 5 761; `dvm/parser/mod.rs` 5 593;
+  `scheduler/mod.rs` 4 693; `dag.rs` 4 542; `config.rs` 4 475;
+  `api/mod.rs` 4 197 (post-decomposition)
+- **Test files:** 145 `tests/*.rs` (excludes inline `#[cfg(test)]`)
+- **CI workflow files:** 24
+
+The project's trajectory is excellent. With the 15-item action plan above
+executed, **v1.0 is a credible release target**. The two HIGH security
+findings (S-1, S-2) are small code changes and should ship in v0.58.0
+along with the recursive-CTE depth guard fix (C-2) and the multi-column
+NOT-IN NULL handling (C-1).

--- a/roadmap/v0.58.0.md
+++ b/roadmap/v0.58.0.md
@@ -1,0 +1,68 @@
+# v0.58.0 — Security & Correctness Hardening
+
+> **Full details:** [v0.58.0.md-full.md](v0.58.0.md-full.md)
+
+## What's New
+
+v0.58.0 is the first release of the Assessment-Driven Hardening Arc, driven
+by the findings in the v0.57.0 overall assessment
+([plans/PLAN_OVERALL_ASSESSMENT_12.md](../plans/PLAN_OVERALL_ASSESSMENT_12.md)).
+It addresses all HIGH-severity security and correctness findings before any
+feature work resumes.
+
+### SEC-1/2: Ownership Checks for Outbox and Publication APIs (S-1, S-2)
+
+`attach_outbox()`, `detach_outbox()`, `attach_embedding_outbox()`,
+`stream_table_to_publication()`, and `drop_stream_table_publication()` now call
+`check_stream_table_ownership()` immediately after resolving the stream table
+metadata — the same guard used by every other mutating API.  Previously, any
+role with `EXECUTE` on the `pgtrickle` schema could attach a pg_tide outbox
+or create a logical-replication publication for a stream table owned by a
+different role.
+
+### COR-1: Multi-Column NOT IN + NULL Row Handling (C-1)
+
+The v0.55.0 multi-column `IN` rewrite now correctly handles `NULL` elements
+in the row constructor and `NULL`-producing columns in the subquery's target
+list.  When any left-side element is a `NULL` constant, or when the rewrite
+would produce an anti-join that cannot faithfully represent `NOT IN` semantics
+(SQL UNKNOWN propagation), the DVM parser falls back to the original
+subquery-based execution path and emits a diagnostic note.
+
+### COR-2: Recursive-CTE Depth Guard in DIFFERENTIAL Mode (C-2)
+
+The `ivm_recursive_max_depth` GUC is now applied consistently to both
+DIFFERENTIAL (`ChangeBuffer`) and IMMEDIATE (`TransitionTable`) modes.
+Previously only IMMEDIATE mode enforced the depth limit; a pathological
+recursive CTE definition in DIFFERENTIAL mode could loop until WAL or
+temp-buffer limits were exceeded.
+
+### COR-3: WAL Decoder TOCTOU Advisory Lock (C-3)
+
+`is_slot_suitable_for_wal_transition()` and `poll_wal_changes()` are now
+executed inside the same SPI transaction, holding a `pg_advisory_xact_lock`
+keyed on the slot OID.  This eliminates the race window where a concurrent
+`pg_drop_replication_slot()` could invalidate the slot between the eligibility
+check and the first WAL consumption.
+
+### COR-4: Compact-Buffer Lock Contention Is Now Observable (C-4)
+
+`compact_change_buffer()` no longer returns `Ok(0)` when it fails to acquire
+the advisory lock.  It now returns `CompactionResult::Contended`, increments
+a new shared-memory counter `pg_trickle_cdc_compact_contended_total`, and
+logs at `debug!` level.  The counter is exposed via the Prometheus `/metrics`
+endpoint so operators can detect persistent contention.
+
+### SEC-3: DDL Hook Escalates on SPI Failure (S-3)
+
+`handle_alter_table()` in `src/hooks.rs` no longer silently returns when
+`find_view_downstream_pgt_ids()` fails with an SPI error.  It now retries
+once and, on repeated failure, raises an `error!()` so the originating DDL
+statement itself fails with a clear message.  This prevents a catalog-query
+outage from leaving downstream stream tables invisibly stale.
+
+### SEC-4: Schema Identifier Quoted in CDC Buffer Names (S-4)
+
+`buffer_qualified_name_for_oid()` now uses `sql_builder::qualified()` instead
+of `format!("{change_schema}.{base}")`, ensuring the schema identifier is
+properly quoted and safe against unusual schema names.

--- a/roadmap/v0.58.0.md-full.md
+++ b/roadmap/v0.58.0.md-full.md
@@ -1,0 +1,171 @@
+# v0.58.0 — Security & Correctness Hardening (Full Details)
+
+> **Summary:** [v0.58.0.md](v0.58.0.md)
+> **Assessment source:** [plans/PLAN_OVERALL_ASSESSMENT_12.md](../plans/PLAN_OVERALL_ASSESSMENT_12.md)
+> **Findings addressed:** S-1, S-2, S-3, S-4, C-1, C-2, C-3, C-4
+
+This release addresses all HIGH-severity findings from the v0.57.0 overall
+assessment (Report 12).  No new SQL API surface is added.  Every change is a
+targeted security fix, correctness fix, or correctness-observable improvement
+to an existing code path.
+
+---
+
+## Security Fixes
+
+### SEC-1: attach_outbox() / detach_outbox() / attach_embedding_outbox() Ownership Check
+
+**Assessment finding:** S-1 (HIGH)
+**Files:** `src/api/outbox.rs` — `attach_outbox_impl`, `detach_outbox_impl`,
+`attach_embedding_outbox_impl`
+
+The three outbox management functions are missing the `check_stream_table_ownership()`
+call that all other mutating APIs (`alter_stream_table`, `drop_stream_table`,
+`pause_stream_table`, `resume_stream_table`) use as a hard gate.
+
+**Before:** Any role with `EXECUTE` on the `pgtrickle` schema could attach a
+`pg_tide` outbox to a stream table owned by a different role and thereby
+observe or modify its change stream.
+
+**After:** `check_stream_table_ownership()` is called immediately after
+`StreamTableMeta::get_by_name()` in all three functions.  A non-owner
+receives `PgTrickleError::NotStreamTableOwner` with a descriptive message.
+
+### SEC-2: stream_table_to_publication() / drop_stream_table_publication() Ownership Check
+
+**Assessment finding:** S-2 (HIGH)
+**File:** `src/api/publication.rs` — `stream_table_to_publication_impl`,
+`drop_stream_table_publication_impl`
+
+Same gap as SEC-1 but for the logical-replication publication API.  A
+non-owner could issue `CREATE PUBLICATION` over another user's stream table,
+exposing its storage to arbitrary subscribers.
+
+**After:** Same fix as SEC-1 applied to both publication functions.
+
+### SEC-3: DDL Hook Escalates Instead of Silently Returning on SPI Error
+
+**Assessment finding:** S-3 (MEDIUM)
+**File:** `src/hooks.rs` — `handle_alter_table`
+
+When `find_view_downstream_pgt_ids()` encounters an SPI error (e.g., during
+catalog contention or a concurrent DROP EXTENSION), the handler now:
+1. Retries the query once with a fresh `Spi::connect()`.
+2. If the retry also fails, raises `pgrx::error!()` with the message
+   `"pg_trickle: DDL hook could not inspect dependencies — schema change blocked to prevent inconsistent state"`.
+
+This ensures that an upstream ALTER TABLE that would invalidate stream tables
+does not proceed silently when catalog inspection fails.
+
+### SEC-4: Schema Identifier Quoted in CDC Buffer Name Construction
+
+**Assessment finding:** S-4 (MEDIUM)
+**File:** `src/cdc.rs` — `buffer_qualified_name_for_oid`
+
+**Before:**
+```rust
+format!("{change_schema}.{base}")
+```
+
+**After:**
+```rust
+sql_builder::qualified(change_schema, &base)
+```
+
+The `change_schema` value is now properly quoted using the centralised
+`sql_builder` API, preventing malformed SQL if an unusual schema name
+(spaces, mixed case, special characters) is used.
+
+---
+
+## Correctness Fixes
+
+### COR-1: Multi-Column NOT IN Rewrite — NULL Row Safety
+
+**Assessment finding:** C-1 (HIGH)
+**File:** `src/dvm/parser/sublinks.rs` — multi-column IN/NOT IN rewrite path
+
+The v0.55.0 multi-column IN rewrite converts `(a, b) IN (SELECT x, y …)` to
+a SemiJoin and `NOT IN` to an AntiJoin.  For `NOT IN`, SQL mandates that any
+`NULL` value on either side of the correlation predicate produces UNKNOWN,
+which means the outer row must be excluded.  AntiJoin semantics differ: a
+correlation predicate that evaluates to UNKNOWN keeps the row.
+
+**Fix:** Before generating the AntiJoin rewrite for `NOT IN`, the parser now:
+1. Inspects whether any element of the left-side row constructor is a `NULL`
+   constant expression (`IS_NULL_CONST`).
+2. Inspects whether any column in the subquery's target list is nullable
+   (non-strict expression or explicitly `NULL`).
+3. If either condition is detected, the rewrite is skipped and the original
+   subquery-based execution path is used instead, with a diagnostic
+   `NOTICE`-level message:
+   ```
+   NOTICE: pg_trickle: multi-column NOT IN with nullable elements cannot be
+   rewritten to an anti-join; falling back to subquery-based delta computation.
+   ```
+
+`docs/LIMITATIONS.md` gains a new subsection documenting this behaviour.
+
+### COR-2: Recursive CTE Depth Guard Applied in DIFFERENTIAL Mode
+
+**Assessment finding:** C-2 (HIGH)
+**File:** `src/dvm/operators/recursive_cte.rs` — strategy selection
+
+**Before:**
+```rust
+let max_depth = if matches!(ctx.delta_source, DeltaSource::TransitionTable { .. }) {
+    crate::config::pg_trickle_ivm_recursive_max_depth()
+} else {
+    None  // no guard in DIFFERENTIAL mode
+};
+```
+
+**After:**
+```rust
+let max_depth = crate::config::pg_trickle_ivm_recursive_max_depth();
+```
+
+The guard is now unconditional and consistent across both modes.  When
+`max_depth` is reached in DIFFERENTIAL mode, the recursive CTE falls back
+to the `FullRescan` strategy with a `warning!()` logged.
+
+### COR-3: WAL Decoder Slot Eligibility — Advisory Lock
+
+**Assessment finding:** C-3 (MEDIUM)
+**File:** `src/wal_decoder.rs`
+
+A new `pg_advisory_xact_lock` keyed on `BIGINT(slot_oid)` is acquired before
+calling `is_slot_suitable_for_wal_transition()` and released after
+`poll_wal_changes()` returns.  The lock acquisition is done via:
+```sql
+SELECT pg_advisory_xact_lock($1::bigint)
+```
+Any concurrent session attempting to drop the replication slot will block on
+the same lock, serialising the eligibility check and consumption into an
+atomic unit.
+
+### COR-4: Compact-Buffer Contention Is Observable
+
+**Assessment finding:** C-4 (MEDIUM)
+**File:** `src/cdc.rs` — `compact_change_buffer_inner`
+
+**Before:** returned `Ok(0)` on `pg_try_advisory_xact_lock` failure,
+indistinguishable from "no rows to compact".
+
+**After:** returns `Ok(CompactionResult::Contended)`.  The caller in the
+scheduler logs at `debug!` level and increments
+`pg_trickle_cdc_compact_contended_total` (a new `PgAtomic<u64>` in
+`src/shmem.rs`).  The Prometheus endpoint exposes this counter so operators
+can detect persistent lock contention via alerting.
+
+---
+
+## Upgrade Notes
+
+No SQL schema changes.  No `ALTER EXTENSION` migration is required.
+
+After upgrading, owners of stream tables who had previously used
+`attach_outbox` or `stream_table_to_publication` should verify that the
+operations complete as expected under the new ownership checks.  Non-owner
+callers will now receive `ERROR: not stream table owner` instead of silently
+succeeding.

--- a/roadmap/v0.59.0.md
+++ b/roadmap/v0.59.0.md
@@ -1,0 +1,114 @@
+# v0.59.0 — Performance & Observability
+
+> **Full details:** [v0.59.0.md-full.md](v0.59.0.md-full.md)
+
+## What's New
+
+v0.59.0 closes the MEDIUM-severity performance and observability gaps
+identified in the v0.57.0 overall assessment
+([plans/PLAN_OVERALL_ASSESSMENT_12.md](../plans/PLAN_OVERALL_ASSESSMENT_12.md)).
+It eliminates several hot-path allocations and SPI fan-outs, and adds the
+Prometheus metrics that SREs need to operate stream tables confidently in
+production.
+
+### PERF-1: Batched Monitor Buffer-Growth Check (P-1)
+
+The health-check loop in `src/monitor/health.rs` previously issued one
+`SELECT count(*)` SPI call per CDC-enabled source table.  On a cluster with
+100 CDC sources at a 10 Hz monitor tick, this produced ~1 000 SPI round-trips
+per second.  The check is now batched into a single SPI query using a
+`VALUES` lateral union, reducing the cost from O(N × ticks) to O(ticks).
+
+### PERF-2: Query Hash Cached on StreamTableMeta (P-2)
+
+`defining_query_hash` is computed once at CREATE/ALTER time and stored in
+`pgtrickle.pgt_stream_tables`.  The per-refresh hash computation
+(`DefaultHasher` over the full query string) is eliminated.  The SQL upgrade
+script adds the new column and backfills it for all existing stream tables.
+
+### PERF-3: Arc<str> Merge Template Strings (P-3)
+
+The eight SQL template strings inside `CachedMergeTemplate` are now stored
+as `Arc<str>`.  Cache-hit clones become cheap atomic reference-count
+increments instead of multi-kilobyte `memcpy` operations.
+
+### PERF-4: Single MERGE_TEMPLATE_CACHE Borrow per Refresh (P-4)
+
+`cached_non_monotonic` and `cached_is_deduplicated` are now extracted in a
+single `RefCell::borrow()` call, preventing the second borrow from distorting
+LRU ordering and halving the number of cache-lock acquisitions per refresh.
+
+### PERF-5: WAL Decoder UPDATE Path Vec Pre-allocation (P-5)
+
+The WAL-decoder UPDATE handler now calls `Vec::with_capacity(num_columns)`
+before the column loop and uses `write!` into a single pre-allocated `String`
+for placeholder construction, eliminating the five separate `Vec<String>`
+allocations (plus multiple `to_string()` calls) per UPDATE row.
+
+### PERF-6: Frontier Borrow Instead of Clone (P-6)
+
+`has_stream_table_source_changes()` now borrows `st.frontier` via
+`as_ref().unwrap_or(&Frontier::EMPTY)` instead of cloning the entire
+`Frontier` struct (which contains a `HashMap` of upstream LSN entries) on
+every upstream-change probe.
+
+### PERF-7: Diamond Detection — Lazy Intersection (P-7)
+
+The pair-wise branch-ancestor intersection in `detect_diamonds()` now uses a
+lazy `intersection()` iterator that short-circuits on the first shared node,
+avoiding the `collect()` into a temporary `Vec` for every branch pair.
+
+### OBS-1: CDC Lag Percentile Metrics (O-1)
+
+Three new Prometheus gauges expose CDC-lag distribution across all live
+stream tables:
+
+- `pg_trickle_cdc_lag_p50_seconds` — median lag
+- `pg_trickle_cdc_lag_p95_seconds` — 95th percentile lag
+- `pg_trickle_cdc_lag_p99_seconds` — 99th percentile lag
+
+Percentiles are computed from a rolling 15-minute sample window stored in
+shared memory and updated on every frontier advance.
+
+### OBS-2: Parallel Worker Queue-Depth and Idle-Time Metrics (O-2)
+
+Two new Prometheus counters expose parallel worker utilisation:
+
+- `pg_trickle_parallel_queue_depth` — number of refresh jobs waiting for a
+  worker
+- `pg_trickle_worker_idle_time_seconds_total` — cumulative time workers have
+  spent waiting for work
+
+### OBS-3: WAL Decoder Pending-Record Metric (O-3)
+
+`pg_trickle_wal_decoder_pending_records` exposes the number of logical
+replication records buffered but not yet written to the CDC change buffer.
+A persistent non-zero value indicates the decoder is falling behind and
+allows operators to alert before the replication slot runs out of WAL.
+
+### OBS-4: Refresh-Mode Ratio Metric per Stream Table (O-4)
+
+Two new Prometheus counters track mode selection per stream table:
+
+- `pg_trickle_refresh_mode_total{mode="differential",pgt_id="…"}` — count of
+  DIFFERENTIAL refresh cycles
+- `pg_trickle_refresh_mode_total{mode="full",pgt_id="…"}` — count of FULL
+  refresh cycles
+
+These counters let operators verify that the adaptive cost model is keeping
+queries on the differential hot path and detect unexpected fallback patterns.
+
+### OBS-5: Background Worker application_name Tagging (O-5)
+
+All background worker connections now call
+`SET application_name = 'pg_trickle_<role>'` immediately after connecting.
+Scheduler, dispatcher, pool worker, and WAL decoder processes are now
+individually identifiable in `pg_stat_activity`, `pg_stat_bgwriter`, and
+`pg_locks`.
+
+### OBS-6: Backup & Restore Documentation (O-6)
+
+`INSTALL.md` gains a new "Backup & Restore" section documenting the required
+`pg_dump` flags to include both the `pgtrickle` catalog schema and the
+`pgtrickle_changes` change-buffer schema.  The section also covers
+post-restore validation using `pgtrickle.health_check()`.

--- a/roadmap/v0.59.0.md-full.md
+++ b/roadmap/v0.59.0.md-full.md
@@ -1,0 +1,229 @@
+# v0.59.0 — Performance & Observability (Full Details)
+
+> **Summary:** [v0.59.0.md](v0.59.0.md)
+> **Assessment source:** [plans/PLAN_OVERALL_ASSESSMENT_12.md](../plans/PLAN_OVERALL_ASSESSMENT_12.md)
+> **Findings addressed:** P-1, P-2, P-3, P-4, P-5, P-6, P-7, O-1, O-2, O-3, O-4, O-5, O-6
+
+---
+
+## Performance Improvements
+
+### PERF-1: Batched Monitor Buffer-Growth Check
+
+**Assessment finding:** P-1 (HIGH)
+**File:** `src/monitor/health.rs`
+
+**Before:** The per-ST health check loop called `SELECT count(*)::bigint FROM
+pgtrickle_changes.changes_{oid}` for each CDC-enabled source, producing
+O(N × monitor_ticks) SPI round-trips per second.  On a cluster with 100
+sources at 10 Hz, this was ~1 000 SPI calls/sec.
+
+**After:** A single SPI query fans out across all CDC-enabled sources using a
+`VALUES` lateral union and a subquery per buffer table.  The query returns one
+row per source with its pending-row count.  The monitor loop then applies the
+threshold test in Rust without further SPI calls.
+
+Approximate overhead reduction: from ~100 SPI calls per health-check cycle to
+1 SPI call.
+
+### PERF-2: Query Hash Cached on Catalog Row
+
+**Assessment finding:** P-2 (MEDIUM)
+**Files:** `src/refresh/merge/mod.rs`, `src/catalog.rs`,
+`sql/pg_trickle--{prev}--0.59.0.sql`
+
+A new `defining_query_hash BIGINT NOT NULL DEFAULT 0` column is added to
+`pgtrickle.pgt_stream_tables`.  The hash is computed during `CREATE STREAM
+TABLE` / `ALTER STREAM TABLE QUERY` and stored persistently.  The per-refresh
+`DefaultHasher` computation over the full query string is removed.
+
+The SQL upgrade script (`sql/pg_trickle--0.58.0--0.59.0.sql`) adds the column
+and backfills it for all existing rows:
+```sql
+ALTER TABLE pgtrickle.pgt_stream_tables ADD COLUMN IF NOT EXISTS
+    defining_query_hash BIGINT NOT NULL DEFAULT 0;
+UPDATE pgtrickle.pgt_stream_tables
+    SET defining_query_hash = hashtextextended(defining_query, 0)::bigint;
+```
+
+### PERF-3: Arc<str> Merge Template Strings
+
+**Assessment finding:** P-3 (MEDIUM)
+**File:** `src/refresh/merge/mod.rs`
+
+`CachedMergeTemplate` holds eight SQL template strings.  Under a 1 000
+refresh/s workload, cloning the struct on each cache hit produced ~60 MB/s of
+string allocation.
+
+The eight template fields are changed from `String` to `Arc<str>`.  A clone
+of the struct becomes O(1) (8 atomic reference-count increments) regardless
+of template size.
+
+### PERF-4: Single MERGE_TEMPLATE_CACHE Borrow
+
+**Assessment finding:** P-4 (MEDIUM)
+**File:** `src/refresh/merge/mod.rs`
+
+Two separate `MERGE_TEMPLATE_CACHE.with(|cache| { cache.borrow().get(…) })`
+calls — one for `cached_non_monotonic`, one for `cached_is_deduplicated` —
+were each marking the same LRU entry as recently used.  They are merged into
+a single borrow that extracts both flags atomically:
+```rust
+let (non_monotonic, is_deduplicated) = MERGE_TEMPLATE_CACHE.with(|cache| {
+    cache.borrow().peek(&st.pgt_id)
+        .map(|e| (e.is_all_algebraic, e.is_deduplicated))
+        .unwrap_or((false, false))
+});
+```
+`peek()` is used to avoid spurious LRU promotion during read-only inspection.
+
+### PERF-5: WAL Decoder UPDATE Vec Pre-allocation
+
+**Assessment finding:** P-5 (MEDIUM)
+**File:** `src/wal_decoder.rs`
+
+The UPDATE handler previously allocated 5 separate `Vec<String>` objects per
+row (column names for DELETE part, column names for INSERT part, placeholder
+lists, parameter arrays) plus multiple `to_string()` calls per column.
+
+After the fix:
+- A single `Vec::with_capacity(num_columns)` is allocated for column names at
+  the top of the function.
+- Placeholder strings are written into a pre-allocated `String` with
+  `write!(buf, "${}",  n)`.
+- The separate D+I parameter vectors share a `Vec::with_capacity(2 * num_columns)`
+  allocation.
+
+Estimated reduction: 5× fewer heap allocations per UPDATE row.
+
+### PERF-6: Frontier Borrow in Source-Change Probe
+
+**Assessment finding:** P-6 (MEDIUM)
+**File:** `src/scheduler/mod.rs`
+
+`has_stream_table_source_changes()` previously called
+`st.frontier.clone().unwrap_or_default()`, producing a full `Frontier`
+clone (a `HashMap<i64, FrontierEntry>`) for every upstream-dependency probe.
+
+**After:**
+```rust
+let frontier = st.frontier.as_ref().unwrap_or(&Frontier::EMPTY);
+```
+A new `Frontier::EMPTY` static provides a zero-allocation default.
+
+### PERF-7: Diamond Detection Lazy Intersection
+
+**Assessment finding:** P-7 (LOW)
+**File:** `src/dag.rs`
+
+Branch ancestor intersection now uses `HashSet::intersection()` as a lazy
+iterator that breaks on the first shared node, avoiding the `collect()` into
+a temporary `Vec` for every branch pair.  Branches with no shared ancestors
+(the common case) exit without any allocation.
+
+---
+
+## Observability Improvements
+
+### OBS-1: CDC Lag Percentile Metrics
+
+**Assessment finding:** O-1 (MEDIUM)
+**Files:** `src/shmem.rs`, `src/monitor/mod.rs`, `monitoring/prometheus/pg_trickle_queries.yml`
+
+A rolling 15-minute reservoir sampler is added to shared memory, recording the
+age (in seconds) of each frontier advancement.  The sampler uses a 256-slot
+fixed-size circular buffer per worker that is reduced to percentiles on metric
+scrape.
+
+New Prometheus gauges:
+- `pg_trickle_cdc_lag_p50_seconds`
+- `pg_trickle_cdc_lag_p95_seconds`
+- `pg_trickle_cdc_lag_p99_seconds`
+
+### OBS-2: Parallel Worker Utilisation Metrics
+
+**Assessment finding:** O-2 (MEDIUM)
+**Files:** `src/scheduler/pool.rs`, `src/shmem.rs`
+
+Two new shared-memory atomics:
+- `PARALLEL_QUEUE_DEPTH` (`PgAtomic<u64>`) — incremented when a job is
+  enqueued, decremented when a worker picks it up.
+- `WORKER_IDLE_MS_TOTAL` (`PgAtomic<u64>`) — cumulative milliseconds
+  workers have spent in the idle wait loop.
+
+Both are exposed at the `/metrics` endpoint.
+
+### OBS-3: WAL Decoder Pending-Record Metric
+
+**Assessment finding:** O-3 (MEDIUM)
+**File:** `src/wal_decoder.rs`
+
+After each poll cycle, the WAL decoder writes the number of buffered-but-not-yet-
+written records to a new `WAL_DECODER_PENDING_RECORDS` shmem atomic.  The
+Prometheus endpoint reads and resets this counter on each scrape, exposing
+it as `pg_trickle_wal_decoder_pending_records`.
+
+Alerting recommendation added to `monitoring/prometheus/pg_trickle_alerts.yml`:
+fire if `pg_trickle_wal_decoder_pending_records > 10000` for 5 minutes.
+
+### OBS-4: Refresh-Mode Ratio Counters
+
+**Assessment finding:** O-4 (MEDIUM)
+**Files:** `src/refresh/orchestrator.rs`, `src/shmem.rs`
+
+Two counter arrays (one per stream table, keyed by `pgt_id`) track the
+cumulative count of DIFFERENTIAL and FULL refresh cycles.  Both are exposed
+at the `/metrics` endpoint with a `pgt_id` label.  The
+`postgres_exporter`-compatible queries block in
+`monitoring/prometheus/pg_trickle_queries.yml` is updated.
+
+### OBS-5: application_name in Background Workers
+
+**Assessment finding:** O-5 (MEDIUM)
+**File:** `src/scheduler/mod.rs`, `src/scheduler/scheduler_loop.rs`,
+`src/scheduler/pool.rs`, `src/scheduler/dispatch.rs`, `src/wal_decoder.rs`
+
+Each background-worker role now executes:
+```sql
+SET application_name = 'pg_trickle_<role>'
+```
+immediately after its first `Spi::connect()`.  Role names:
+- `pg_trickle_launcher` — database discovery loop
+- `pg_trickle_scheduler` — per-database scheduler
+- `pg_trickle_pool_N` — parallel refresh workers (N = worker index)
+- `pg_trickle_dispatcher` — parallel refresh DAG dispatcher
+- `pg_trickle_wal_decoder` — WAL / logical replication poller
+
+### OBS-6: Backup & Restore Documentation
+
+**Assessment finding:** O-6 (LOW)
+**File:** `INSTALL.md`
+
+New "Backup & Restore" section added at the end of the installation guide.
+Key content:
+
+```bash
+# Include both schemas when dumping a pg_trickle-enabled database:
+pg_dump --schema=public --schema=pgtrickle --schema=pgtrickle_changes \
+        mydb > mydb_backup.sql
+
+# After restore, validate catalog integrity:
+psql mydb -c "SELECT * FROM pgtrickle.health_check();"
+```
+
+The section also notes that change-buffer tables (`pgtrickle_changes.*`) are
+per-OID and that OID assignment may differ after restore, so `pg_trickle_repair_stream_table()`
+should be run on each stream table immediately after restore.
+
+---
+
+## Upgrade Notes
+
+The SQL upgrade script `sql/pg_trickle--0.58.0--0.59.0.sql` adds one column
+to `pgtrickle.pgt_stream_tables`:
+```sql
+ALTER TABLE pgtrickle.pgt_stream_tables
+    ADD COLUMN IF NOT EXISTS defining_query_hash BIGINT NOT NULL DEFAULT 0;
+```
+The column is backfilled automatically.  No existing stream tables need to be
+recreated.

--- a/roadmap/v0.60.0.md
+++ b/roadmap/v0.60.0.md
@@ -1,0 +1,120 @@
+# v0.60.0 — Code Quality, Test Coverage & CI
+
+> **Full details:** [v0.60.0.md-full.md](v0.60.0.md-full.md)
+
+## What's New
+
+v0.60.0 is the third release of the Assessment-Driven Hardening Arc, closing
+the code quality, test coverage, correctness, and CI/CD gaps identified in the
+v0.57.0 overall assessment
+([plans/PLAN_OVERALL_ASSESSMENT_12.md](../plans/PLAN_OVERALL_ASSESSMENT_12.md)).
+
+### QUAL-1: Scheduler Log Level Standardisation (Q-1)
+
+All `log!()` calls in `src/scheduler/dispatch.rs`, `pool.rs`, and
+`scheduler_loop.rs` that represent routine state transitions (start dispatch,
+acquire execution lock, worker registered) are upgraded to `info!()`.
+`warning!()` remains reserved for recoverable errors.  `error!()` is used for
+events that require operator attention.  Operators running at the default
+`log_min_messages = warning` now see warnings and above with no extra noise;
+operators at `log_min_messages = info` get clean, structured progress output.
+
+### QUAL-2: refresh/codegen.rs Function Decomposition (Q-2)
+
+Three functions exceeding 200 lines (`build_bypass_capture_sql`,
+`capture_diff_to_table`, and the primary MERGE template builder) are
+extracted into a new `src/refresh/sql_fragments.rs` helper module containing
+named single-purpose builders: `build_cte_predicate()`,
+`build_merge_join_condition()`, `build_content_hash_column()`, and
+`build_delta_target_list()`.
+
+### QUAL-3: src/cdc.rs Module Decomposition (Q-3)
+
+`src/cdc.rs` (3 383 lines) is split into four focused sub-modules, mirroring
+the v0.55.0 monitor decomposition:
+
+- `cdc/triggers.rs` — trigger creation, trigger SQL builders, column-name
+  escaping, statement vs row mode logic
+- `cdc/buffer.rs` — change-buffer DDL, compaction, buffer naming helpers
+- `cdc/compact.rs` — compaction scheduling, lock-acquisition helpers,
+  `CompactionResult` enum
+- `cdc/partition.rs` — partition-promotion detection, `should_promote_to_partitioned`
+
+`cdc/mod.rs` retains public SQL-callable functions and re-exports.
+
+### TEST-1: Refresh Orchestrator and Merge Sub-Module Unit Tests (T-1)
+
+New `#[cfg(test)]` blocks cover the pure-logic paths in:
+
+- `src/refresh/orchestrator.rs` — cost-model state machine transitions (cold
+  start → diff-preferred → full-preferred → diff-recovery), threshold
+  boundary values, and the adaptive scoring formula.
+- `src/refresh/merge/columns.rs` and `conflict.rs` — column-list builders and
+  conflict-resolution SQL generation.
+- `src/refresh/codegen.rs` — new `sql_fragments.rs` helpers each have table-
+  driven unit tests.
+
+### TEST-2: CDC Pure-Logic Unit Tests (T-2)
+
+`src/cdc/triggers.rs` and `src/cdc/buffer.rs` gain `#[cfg(test)]` blocks
+testing: `cb_col_name()` (reserved-name escaping), `buffer_base_name_for_oid()`
+(OID formatting), `build_changed_cols_bitmask_expr()` (column-bitmask SQL
+generation), and `should_promote_to_partitioned()` (partition-promotion
+classification).
+
+### TEST-3: DDL Hook Classification Unit Tests (T-3)
+
+`src/hooks.rs` gains a `#[cfg(test)]` block with table-driven tests for
+each `DdlCommandKind` variant.  Tests cover: ADD COLUMN on a tracked table,
+DROP COLUMN, ALTER COLUMN TYPE, RENAME TABLE, CREATE INDEX, and commands on
+untracked tables.
+
+### TEST-4: Fixed Sleep Replacement (T-4)
+
+Remaining `tokio::time::sleep()` calls in `tests/e2e_quota_tests.rs`,
+`tests/e2e_bgworker_tests.rs`, and `tests/e2e_wal_cdc_tests.rs` are replaced
+with `wait_for_*` polling helpers from `tests/common/mod.rs`, continuing the
+programme started in v0.53.0.
+
+### TEST-5: Differential Idempotence Proptest (T-5)
+
+A new `proptest!` block in `src/dvm/diff.rs` asserts that refreshing a stream
+table twice with the same source rows (written in randomised partition order)
+produces identical output.  This validates the idempotence invariant of the
+differential engine under arbitrary ingest ordering.
+
+### COR-5: WAL Decoder OID-Based Table Filter (C-5)
+
+The WAL decoder's change-routing filter is changed from string equality on
+qualified names to OID equality.  On each poll cycle, the decoder resolves
+each tracked source table to its OID via `to_regclass()` and compares against
+the decoded row's relation OID (available in the `pg_logical_slot_changes`
+record).  Text-name matching is retained only as a fallback when OID lookup
+fails.
+
+### COR-6: Publication Rebuild Detects Partition-Attach (C-6)
+
+`check_if_publication_needs_rebuild()` now also detects when a source table
+transitions from a standalone table to a partition of another table (i.e.,
+when `pg_inherits.inhrelid = source_oid` becomes true).  When this transition
+is detected, the WAL publication is rebuilt with `publish_via_partition_root =
+true` and the stream table is marked for reinit.
+
+### CI-1: Path-Filtered Full E2E on PRs (CI-1)
+
+`.github/workflows/ci.yml` gains a new `full-e2e-on-dvm-change` job that
+runs the full E2E test suite (stock test image, no TPC-H) when a PR modifies
+any file under `src/dvm/`, `src/refresh/`, or `src/cdc/`.  This reduces the
+worst-case detection window for DVM regressions from ~24 hours to within the
+PR merge gate.
+
+### CI-2: Dockerfile.e2e Non-Root User (CI-2)
+
+`tests/Dockerfile.e2e` adds `USER postgres` before the final `CMD`, so test
+containers run as the `postgres` system user instead of root.
+
+### CI-3: Codecov Threshold for Safety-Critical Modules (CI-3)
+
+`codecov.yml` adds per-path coverage thresholds for modules previously
+excluded from the patch gate: `src/cdc/**` (50%), `src/hooks.rs` (40%),
+`src/wal_decoder.rs` (40%).

--- a/roadmap/v0.60.0.md-full.md
+++ b/roadmap/v0.60.0.md-full.md
@@ -1,0 +1,267 @@
+# v0.60.0 — Code Quality, Test Coverage & CI (Full Details)
+
+> **Summary:** [v0.60.0.md](v0.60.0.md)
+> **Assessment source:** [plans/PLAN_OVERALL_ASSESSMENT_12.md](../plans/PLAN_OVERALL_ASSESSMENT_12.md)
+> **Findings addressed:** Q-1, Q-2, Q-3, T-1, T-2, T-3, T-4, T-5, C-5, C-6, CI-1, CI-2, CI-3
+
+---
+
+## Code Quality
+
+### QUAL-1: Scheduler Log Level Standardisation
+
+**Assessment finding:** Q-1 (MEDIUM)
+**Files:** `src/scheduler/dispatch.rs`, `src/scheduler/pool.rs`,
+`src/scheduler/scheduler_loop.rs`
+
+Prior to this release, routine scheduler events (worker registration, lock
+acquisition, dispatch start) were logged at `log!()` (DEBUG5 in PostgreSQL
+terms), invisible at the default `log_min_messages = warning`.  Recoverable
+failures also used `warning!()`, making it hard to distinguish between
+"expected noise" and "something an operator should act on".
+
+After this release, the convention is:
+- `info!()` — normal state transitions and progress (scheduler start, dispatch
+  complete, worker pool size changes).
+- `warning!()` — recoverable failures that do not stop the scheduler
+  (e.g., a worker failed to acquire a lock and will retry).
+- `error!()` — failures requiring operator attention (e.g., the scheduler
+  cannot reconnect after 3 retries).
+
+The change affects ~40 log call sites across the three files.
+
+### QUAL-2: refresh/codegen.rs Decomposition
+
+**Assessment finding:** Q-2 (MEDIUM)
+**Files:** `src/refresh/codegen.rs` → `src/refresh/sql_fragments.rs`
+(new), `src/refresh/codegen.rs` (reduced)
+
+The new `sql_fragments.rs` module contains:
+
+```rust
+// Builds the WHERE predicate that restricts a CTE scan to the delta window.
+pub(crate) fn build_cte_predicate(lsn_col: &str, prev_lsn: &str, new_lsn: &str) -> String
+
+// Builds the ON clause for a MERGE statement.
+pub(crate) fn build_merge_join_condition(key_cols: &[&str]) -> String
+
+// Builds the MD5 content-hash column expression for deduplication.
+pub(crate) fn build_content_hash_column(data_cols: &[&str]) -> String
+
+// Builds the MERGE WHEN MATCHED / NOT MATCHED target lists.
+pub(crate) fn build_delta_target_list(
+    action: MergeAction,
+    cols: &[ColumnSpec],
+) -> String
+```
+
+Each function has a dedicated unit-test block verifying its output against
+expected SQL strings for common and edge-case inputs (empty column lists,
+columns with reserved characters, single-key tables).
+
+### QUAL-3: src/cdc.rs Module Decomposition
+
+**Assessment finding:** Q-3 (MEDIUM)
+
+The 3 383-line `src/cdc.rs` is split into:
+
+| New module | Contents | ~LOC |
+|------------|----------|-------|
+| `src/cdc/triggers.rs` | Trigger creation/drop SQL builders, column-name escaping (`cb_col_name`), statement vs row mode, trigger function SQL | ~900 |
+| `src/cdc/buffer.rs` | Change-buffer DDL, `buffer_base_name_for_oid`, `buffer_qualified_name_for_oid`, buffer initialisation | ~600 |
+| `src/cdc/compact.rs` | Compaction scheduling, `pg_try_advisory_xact_lock` wrapper, `CompactionResult` enum, holdback classification | ~400 |
+| `src/cdc/partition.rs` | `should_promote_to_partitioned`, partition-promotion logic, `check_if_publication_needs_rebuild` | ~300 |
+| `src/cdc/mod.rs` | Public SQL-callable functions, re-exports, shared constants | ~400 |
+
+No public API changes.
+
+---
+
+## Test Coverage
+
+### TEST-1: Refresh Orchestrator and Merge Unit Tests
+
+**Assessment finding:** T-1 (MEDIUM)
+
+New `#[cfg(test)]` modules added to:
+
+**`src/refresh/orchestrator.rs`** (12 tests):
+- `test_cost_model_cold_start_requires_minimum_observations` — asserts mode is
+  not activated until ≥ 3 DIFFERENTIAL + 1 FULL observations.
+- `test_cost_model_prefers_differential_when_change_ratio_low` — change ratio
+  below `differential_max_change_ratio` → DIFFERENTIAL preferred.
+- `test_cost_model_prefers_full_when_change_ratio_high` — change ratio above
+  threshold → FULL preferred.
+- `test_cost_model_recovery_after_consecutive_errors` — after N consecutive
+  errors the mode resets to cold-start.
+- `test_orchestrator_adaptive_score_boundary_values` — verifies the ±0.15
+  dead-zone does not flip the mode on noisy data.
+
+**`src/refresh/merge/columns.rs`** (8 tests):
+- Column-list builder for various schema shapes (all-nullable, mixed types,
+  empty list, single column).
+
+**`src/refresh/codegen.rs`** → deferred to `sql_fragments.rs` tests (see QUAL-2).
+
+### TEST-2: CDC Pure-Logic Unit Tests
+
+**Assessment finding:** T-2 (MEDIUM)
+
+New `#[cfg(test)]` modules added to `src/cdc/triggers.rs` and
+`src/cdc/buffer.rs`:
+
+- `test_cb_col_name_escapes_reserved_pgt_prefix` — `__pgt_action` →
+  `__usr___pgt_action`
+- `test_cb_col_name_passes_through_normal_name` — `order_id` → `order_id`
+- `test_buffer_base_name_for_oid` — OID 12345 → `changes_12345`
+- `test_build_changed_cols_bitmask_expr_single_col` — single column → correct
+  bitmask expression
+- `test_build_changed_cols_bitmask_expr_empty` — no columns → `0::bit(1)`
+- `test_should_promote_to_partitioned_false_for_regular` — `relkind = 'r'` →
+  no promotion
+- `test_should_promote_to_partitioned_true_for_partitioned` — `relkind = 'p'`
+  → promote
+
+### TEST-3: DDL Hook Classification Unit Tests
+
+**Assessment finding:** T-3 (MEDIUM)
+**File:** `src/hooks.rs`
+
+New `#[cfg(test)]` block with 14 table-driven tests covering:
+
+| Input | Expected outcome |
+|-------|-----------------|
+| `ALTER TABLE ADD COLUMN` on tracked table | `DdlCommandKind::AddColumn` → mark needs_reinit |
+| `ALTER TABLE DROP COLUMN` on tracked table | `DdlCommandKind::DropColumn` → mark needs_reinit |
+| `ALTER TABLE ALTER COLUMN TYPE` | `DdlCommandKind::AlterColumnType` → mark needs_reinit |
+| `ALTER TABLE RENAME TO` | `DdlCommandKind::RenameTable` → mark needs_reinit |
+| `CREATE INDEX` | `DdlCommandKind::CreateIndex` → no-op |
+| Any DDL on untracked table | no-op |
+| DDL on `pgtrickle.*` internal table | no-op |
+
+### TEST-4: Remaining Fixed Sleep Replacement
+
+**Assessment finding:** T-4 (LOW)
+
+Fixed sleeps replaced with `wait_for_*` polling helpers in:
+- `tests/e2e_quota_tests.rs` (3 sleeps)
+- `tests/e2e_bgworker_tests.rs` (4 sleeps)
+- `tests/e2e_wal_cdc_tests.rs` (2 sleeps)
+- `tests/e2e_immediate_tests.rs` (1 sleep)
+
+Total sleeps eliminated: 10.  The `wait_for_auto_refresh`,
+`wait_for_condition`, and `wait_for_row_count` helpers in
+`tests/common/mod.rs` cover all cases.
+
+### TEST-5: Differential Idempotence Proptest
+
+**Assessment finding:** T-5 (LOW)
+**File:** `src/dvm/diff.rs`
+
+New `proptest!` block:
+
+```
+Given: randomly-generated sequence of INSERT/UPDATE/DELETE rows partitioned
+       into two batches in random order
+When: batch 1 is applied and the stream table is refreshed,
+      then batch 2 is applied and the stream table is refreshed
+Then: the stream table contents equal the result of applying all rows in
+      any order followed by a single refresh
+```
+
+This tests the idempotence and commutativity of the Z-set delta engine under
+arbitrary ingest ordering.
+
+---
+
+## Correctness
+
+### COR-5: WAL Decoder OID-Based Table Filter
+
+**Assessment finding:** C-5 (MEDIUM)
+**File:** `src/wal_decoder.rs`
+
+The `should_include_change()` filter previously compared the decoded table
+name (from `test_decoding` output) against the tracked source table's
+qualified name using string equality.  This was fragile for:
+- Partition routing (child arrives instead of root)
+- Search-path-sensitive unqualified names
+- Case-sensitive quoted identifiers
+
+After this fix, the decoder resolves each tracked source table's OID via
+`to_regclass()` once at the start of each poll cycle and compares relation
+OIDs numerically.  String matching is retained only as a fallback for
+`test_decoding`-format output that does not carry a relation OID.
+
+### COR-6: Publication Rebuild Detects Table-Becomes-Partition
+
+**Assessment finding:** C-6 (MEDIUM)
+**File:** `src/cdc/partition.rs` — `check_if_publication_needs_rebuild`
+
+`check_if_publication_needs_rebuild()` now checks:
+1. Has `relkind` changed from `'r'` (regular) to `'p'` (partitioned root)?
+   (Existing check.)
+2. Has the source OID appeared in `pg_inherits.inhrelid`?  (New check.)
+
+When condition 2 is detected, the function rebuilds the publication with
+`publish_via_partition_root = true` and marks the stream table for
+reinitialisation, preventing the silent CDC freeze that otherwise occurs when
+a plain table is converted to a partition of another parent.
+
+---
+
+## CI/CD
+
+### CI-1: Path-Filtered Full E2E on PRs
+
+**Assessment finding:** CI-1 (MEDIUM)
+**File:** `.github/workflows/ci.yml`
+
+New job `full-e2e-on-dvm-change`:
+```yaml
+if: |
+  github.event_name == 'pull_request' &&
+  contains(github.event.pull_request.changed_files, 'src/dvm/') ||
+  contains(github.event.pull_request.changed_files, 'src/refresh/') ||
+  contains(github.event.pull_request.changed_files, 'src/cdc/')
+```
+
+Uses the `docker/build-push-action` cache and the existing
+`test-full-e2e` recipe.  Estimated additional PR gate time: 20 minutes,
+triggered only when the above paths change.
+
+### CI-2: Dockerfile.e2e Non-Root User
+
+**Assessment finding:** CI-2 (LOW)
+**File:** `tests/Dockerfile.e2e`
+
+Added before `CMD`:
+```dockerfile
+USER postgres
+```
+
+All test containers now run as the unprivileged `postgres` OS user.
+
+### CI-3: Codecov Per-Module Thresholds
+
+**Assessment finding:** CI-3 (LOW)
+**File:** `codecov.yml`
+
+New per-path coverage gates (patch coverage):
+```yaml
+coverage:
+  status:
+    patch:
+      src/cdc/:
+        target: 50%
+      src/hooks.rs:
+        target: 40%
+      src/wal_decoder.rs:
+        target: 40%
+```
+
+---
+
+## Upgrade Notes
+
+No SQL schema changes.  No `ALTER EXTENSION` migration is required.

--- a/roadmap/v0.61.0.md
+++ b/roadmap/v0.61.0.md
@@ -1,0 +1,113 @@
+# v0.61.0 — DX, Documentation & Final Pre-1.0 Polish
+
+> **Full details:** [v0.61.0.md-full.md](v0.61.0.md-full.md)
+
+## What's New
+
+v0.61.0 closes the remaining low-severity findings from the v0.57.0 overall
+assessment and delivers the developer-experience and documentation improvements
+needed before the v1.0 stable label.  After this release every finding in
+Report 12 is resolved and the project is ready for the v1.0 release gate.
+
+### DX-1: health_check() Detects Foreign-Owned Attachments (E-1)
+
+`pgtrickle.health_check()` gains an `attachment_owner_check` row.  It lists
+all pg_tide outboxes and downstream publications attached to stream tables
+where the attachment was made by a role other than the stream table owner.
+This catches the residual exposure from the pre-v0.58.0 ownership-check gap
+and flags it clearly for operators performing post-upgrade audits.
+
+### DX-2: SQL_REFERENCE.md Completeness Audit (E-2)
+
+`docs/SQL_REFERENCE.md` is reconciled against the full list of
+`#[pg_extern]` symbols in the compiled extension.  Every function not
+intended for direct user use is annotated with `@internal` in the source and
+excluded from the reference.  Functions in `src/api/metrics_ext.rs`,
+`src/api/self_monitoring.rs`, and `src/api/planner.rs` that are useful for
+operators are promoted to documented entries with signatures, return types,
+and worked examples.
+
+### COR-7: ctid Invariant Comment in phd1.rs (C-7)
+
+The EC01-2 phantom-cleanup code in `src/refresh/phd1.rs` that relies on
+`ctid` stability gains an explicit `// INVARIANT:` comment documenting that
+the `ctid` is captured and consumed within the same snapshot and must not be
+split across subtransaction boundaries.
+
+### COR-8: Snapshot Cache Key Secondary Equality Check (C-8)
+
+The 64-bit `DefaultHasher` snapshot cache now stores the rendered fingerprint
+string alongside the hash.  On a cache hit, the string is compared before the
+cached CTE is reused.  Hash collisions — astronomically rare but silent if
+they occur — now produce a cache miss rather than wrong SQL.
+
+### COR-9: DiffContext cte_counter Reset per differentiate() (C-9)
+
+`DiffContext::cte_counter` is reset to 0 at the start of each
+`differentiate()` call.  CTE names now start from `__pgt_cte_scan_1` in
+every differentiation, keeping generated SQL compact and deterministic.
+
+### SEC-5: Outbox Name Collision Prevention (S-5)
+
+`outbox_table_name_for()` now appends an 8-character hex suffix derived from
+`blake3(st_name)` when truncation to 63 characters would otherwise occur.
+Two stream tables whose names differ only after the 56-character mark now
+produce distinct outbox names.
+
+### QUAL-4: sublinks.rs Decomposition Plan (Q-4)
+
+`src/dvm/parser/sublinks.rs` (7 065 lines) is split into focused sub-modules:
+
+- `dvm/parser/sublinks/exists.rs` — EXISTS / NOT EXISTS extraction
+- `dvm/parser/sublinks/scalar.rs` — scalar sublink hoisting
+- `dvm/parser/sublinks/in_list.rs` — IN / NOT IN rewrite (including
+  multi-column and NULL-safety fixes)
+- `dvm/parser/sublinks/having.rs` — HAVING-clause aggregate rewrites
+
+`dvm/parser/sublinks/mod.rs` re-exports all public functions.
+
+### QUAL-5: Brittle split().nth() Test Pattern Fixed (Q-5)
+
+Tests in `src/dvm/operators/lateral_subquery.rs` that split generated SQL by
+a magic CTE-name string are rewritten to use `splitn(2, marker)` with an
+explicit assertion that the split produced two parts.  A mismatch now fails
+loudly rather than silently passing with an empty assertion.
+
+### DOC-1: Three Foundational ADRs (D-1)
+
+The ADR framework in `plans/adrs/PLAN_ADRS.md` transitions from PROPOSED to
+ACTIVE with the addition of three foundational Architecture Decision Records:
+
+- **ADR-001: Trigger-Based CDC over Logical Replication** — documents why
+  row-level `AFTER` triggers were chosen over logical replication slots for
+  the default CDC path (single-transaction atomicity, no slot management
+  overhead, simpler failure modes) and when WAL-based CDC is appropriate.
+- **ADR-002: Z-Set / Multiset Formalism for IVM** — documents the choice of
+  Z-sets (signed integer multiplicities) as the algebraic foundation for the
+  differential engine, why true multisets were insufficient (negative
+  multiplicities needed for deletes), and the implications for operator
+  correctness.
+- **ADR-003: EC-01 Join-Correctness Invariant** — documents the R₀
+  snapshot-splitting fix and the cross-cycle phantom-reconciliation invariant,
+  specifying the exact conditions under which `phd1.rs` must run and what
+  invariants it guarantees.
+
+### DOC-2: LIMITATIONS.md — Multi-Column NOT IN with NULLs (D-2)
+
+`docs/LIMITATIONS.md` gains a new subsection "Multi-column NOT IN with
+nullable columns" that explains when the rewrite falls back to subquery-based
+execution, why the fallback is necessary, and how users can avoid the
+performance impact (add `IS NOT NULL` predicates on each column).
+
+### FEAT-1: SEARCH / CYCLE Clause — Clear UnsupportedFeature Error (F-2)
+
+Queries using SQL:2023 `SEARCH BREADTH FIRST` or `CYCLE` clauses in recursive
+CTEs now produce a clean `UnsupportedFeature` error with a descriptive message
+instead of being silently ignored or producing a cryptic parse error.
+
+### FEAT-2: LATERAL + DIFFERENTIAL Interaction Documented (F-1)
+
+`docs/DVM_OPERATORS.md` and `docs/LIMITATIONS.md` gain new sections
+documenting the exact supported subset of LATERAL in DIFFERENTIAL mode:
+which LATERAL patterns are fully differentiable, which fall back to FULL
+refresh, and which produce a clear `UnsupportedFeature` error.

--- a/roadmap/v0.61.0.md-full.md
+++ b/roadmap/v0.61.0.md-full.md
@@ -1,0 +1,263 @@
+# v0.61.0 — DX, Documentation & Final Pre-1.0 Polish (Full Details)
+
+> **Summary:** [v0.61.0.md](v0.61.0.md)
+> **Assessment source:** [plans/PLAN_OVERALL_ASSESSMENT_12.md](../plans/PLAN_OVERALL_ASSESSMENT_12.md)
+> **Findings addressed:** E-1, E-2, C-7, C-8, C-9, S-5, Q-4, Q-5, D-1, D-2, F-1, F-2
+
+---
+
+## Developer Experience
+
+### DX-1: health_check() Foreign-Owned Attachment Detection
+
+**Assessment finding:** E-1 (MEDIUM)
+**File:** `src/api/diagnostics.rs`, `src/monitor/health.rs`
+
+The 8-check `health_check()` matrix gains a ninth check:
+`attachment_owner_check`.
+
+**Logic:** For every stream table, query `pgtrickle.pgt_outbox_config` and
+the downstream publication catalogue to find any attachment where the
+attaching role differs from the stream table owner.  The result set includes:
+`pgt_name`, `attachment_type` (`outbox` or `publication`), `attached_by`,
+`owned_by`.
+
+**Output row example:**
+```
+check_name         | attachment_owner_check
+status             | WARNING
+detail             | ST "public.orders" has an outbox attached by role "analyst" but owned by "app_owner"
+action_required    | Review outbox created by non-owner; consider re-attaching as owner or granting explicit permissions
+```
+
+This check is most useful immediately after upgrading from a version below
+v0.58.0 to audit any pre-existing ownership mismatches.
+
+### DX-2: SQL_REFERENCE.md Completeness Reconciliation
+
+**Assessment finding:** E-2 (LOW)
+**File:** `docs/SQL_REFERENCE.md`, `src/api/*.rs`
+
+A new `scripts/gen_sql_reference.py` script compares `#[pg_extern]` symbols
+in the source with entries in `docs/SQL_REFERENCE.md` and produces a diff.
+
+Functions categorised as internal API:
+- Functions in `src/api/metrics_ext.rs` that are DBA-facing but not in the
+  reference are promoted to a new "Advanced Diagnostics" section.
+- Functions intended only for internal use (e.g., `__pgt_trigger_fn_*`) are
+  annotated with `#[pg_extern(sql = "")]` so they produce no SQL declaration
+  and do not appear in `\df pgtrickle.*` output.
+
+The script is wired into CI as a check step: adding a new `#[pg_extern]`
+without updating the reference fails the linting job.
+
+---
+
+## Correctness Hardening
+
+### COR-7: ctid Invariant Comment in phd1.rs
+
+**Assessment finding:** C-7 (LOW)
+**File:** `src/refresh/phd1.rs` (~line 180)
+
+Added:
+```rust
+// INVARIANT: The `ctid` values captured by the preceding CTE are stable
+// within this transaction's snapshot (no concurrent VACUUM or HOT chain
+// updates).  Do NOT split this DELETE into a separate transaction or
+// sub-transaction — if the snapshot isolation guarantee is lost, use
+// __pgt_row_id-based deletion instead.
+```
+
+### COR-8: Snapshot Cache Key Secondary Equality Check
+
+**Assessment finding:** C-8 (LOW)
+**File:** `src/dvm/diff.rs`
+
+The `SnapshotCacheEntry` struct gains a `fingerprint: String` field alongside
+`hash: u64`.  When `get_or_register_snapshot_cte()` finds a hash hit, it also
+compares `fingerprint` strings.  On mismatch (collision), the cached entry is
+evicted, a shmem counter `pg_trickle_snapshot_cache_collisions_total` is
+incremented, and the new CTE is registered.
+
+```rust
+struct SnapshotCacheEntry {
+    hash: u64,
+    fingerprint: String,   // NEW
+    cte_name: String,
+}
+```
+
+### COR-9: DiffContext cte_counter Reset
+
+**Assessment finding:** C-9 (LOW)
+**File:** `src/dvm/diff.rs` — `differentiate()` entry point
+
+```rust
+pub fn differentiate(&mut self, op: &OpTree, …) -> Result<String> {
+    self.cte_counter = 0;  // NEW: reset per differentiation call
+    self.diff_node(op, …)
+}
+```
+
+---
+
+## Security
+
+### SEC-5: Outbox Name Collision Prevention
+
+**Assessment finding:** S-5 (LOW)
+**File:** `src/api/outbox.rs` — `outbox_table_name_for`
+
+**Before:**
+```rust
+raw.chars().take(63).collect()
+```
+
+**After:**
+```rust
+if raw.len() <= 63 {
+    raw
+} else {
+    let hash = blake3::hash(st_name.as_bytes());
+    let suffix = &hex::encode(hash.as_bytes())[..8];
+    format!("{}_{}", &raw[..54], suffix)
+}
+```
+
+The `blake3` crate is already a dependency via `src/hash.rs`.
+
+---
+
+## Code Quality
+
+### QUAL-4: src/dvm/parser/sublinks.rs Decomposition
+
+**Assessment finding:** Q-4 (LOW)
+
+The 7 065-line `src/dvm/parser/sublinks.rs` is split into five focused modules:
+
+```
+src/dvm/parser/
+├── sublinks/
+│   ├── mod.rs          (public re-exports, ~200 lines)
+│   ├── exists.rs       (EXISTS/NOT EXISTS → SemiJoin/AntiJoin, ~800 lines)
+│   ├── scalar.rs       (scalar SubLink hoisting, ~600 lines)
+│   ├── in_list.rs      (IN/NOT IN → SemiJoin/AntiJoin, multi-column, NULL-safety, ~1400 lines)
+│   └── having.rs       (HAVING aggregate rewrites, ~400 lines)
+```
+
+Each sub-module retains the full existing test coverage from its predecessor.
+
+### QUAL-5: Brittle split().nth() Test Pattern Fixed
+
+**Assessment finding:** Q-5 (LOW)
+**File:** `src/dvm/operators/lateral_subquery.rs`
+
+**Before:**
+```rust
+let inner_branch = sql.split("lat_sq_changed").nth(1).unwrap_or("");
+// assertion on inner_branch — silently vacuous if split fails
+```
+
+**After:**
+```rust
+let parts: Vec<&str> = sql.splitn(2, "lat_sq_changed").collect();
+assert_eq!(parts.len(), 2, "expected 'lat_sq_changed' marker in generated SQL");
+let inner_branch = parts[1];
+```
+
+---
+
+## Documentation
+
+### DOC-1: Three Foundational ADRs
+
+**Assessment finding:** D-1 (LOW)
+**Files:** `plans/adrs/ADR-001.md`, `plans/adrs/ADR-002.md`,
+`plans/adrs/ADR-003.md`, `plans/adrs/PLAN_ADRS.md` (updated to ACTIVE)
+
+**ADR-001: Trigger-Based CDC over Logical Replication** covers:
+- Decision: default CDC path uses `AFTER` row/statement triggers.
+- Rationale: single-transaction atomicity (change captured and committed
+  atomically with source write), no replication slot lifecycle management,
+  simpler failure modes (no slot lag accumulation).
+- Trade-offs acknowledged: higher write amplification vs. logical replication;
+  mitigation via statement-level triggers.
+- WAL-based CDC as the opt-in alternative for minimal write overhead.
+
+**ADR-002: Z-Set / Multiset Formalism** covers:
+- Decision: differential engine uses Z-sets (signed integer multiplicities).
+- Rationale: SQL deletes require negative multiplicities; true multisets
+  (non-negative only) cannot represent "undo" operations.
+- Implications for operator correctness: all 22 operator files must maintain
+  the invariant that the sum of multiplicities for any given row is either 0
+  (row absent) or 1 (row present) after each refresh cycle.
+
+**ADR-003: EC-01 Join-Correctness Invariant** covers:
+- The phantom-row problem in outer-join delta rules.
+- The R₀ snapshot-splitting fix (v0.38.0).
+- The cross-cycle reconciliation invariant (phd1.rs).
+- Conditions under which the PHD1 pass must run and the guarantees it provides.
+
+### DOC-2: LIMITATIONS.md — Multi-Column NOT IN with Nullable Columns
+
+**Assessment finding:** D-2 (LOW)
+**File:** `docs/LIMITATIONS.md`
+
+New subsection "Multi-column NOT IN with nullable columns":
+
+> When using `(col1, col2) NOT IN (SELECT ...)` and any of `col1`, `col2`, or
+> the subquery's corresponding output columns can be `NULL`, the DVM parser
+> cannot safely rewrite to an anti-join.  The delta is instead computed via
+> subquery-based execution, which is correct but slower.
+>
+> To restore anti-join performance, add explicit `IS NOT NULL` predicates:
+> ```sql
+> WHERE col1 IS NOT NULL AND col2 IS NOT NULL
+> AND (col1, col2) NOT IN (SELECT x, y FROM t WHERE x IS NOT NULL AND y IS NOT NULL)
+> ```
+
+---
+
+## Features
+
+### FEAT-1: SEARCH / CYCLE Clause — Clear Error
+
+**Assessment finding:** F-2 (LOW)
+**File:** `src/dvm/parser/mod.rs`
+
+Added detection for `WITH RECURSIVE … SEARCH BREADTH FIRST BY …` and
+`… CYCLE … SET … USING …` clauses during DVM parsing.  When detected:
+
+```
+ERROR: pg_trickle: SEARCH and CYCLE clauses are not yet supported in
+differential mode (planned for v1.1.0).
+HINT: Remove the SEARCH/CYCLE clause from the recursive CTE definition, or use
+REFRESH MODE FULL if the query requires it.
+```
+
+### FEAT-2: LATERAL + DIFFERENTIAL Documentation
+
+**Assessment finding:** F-1 (MEDIUM)
+**Files:** `docs/DVM_OPERATORS.md`, `docs/LIMITATIONS.md`
+
+New section "LATERAL Joins and DIFFERENTIAL Mode":
+
+| LATERAL pattern | DIFFERENTIAL support |
+|-----------------|---------------------|
+| `LATERAL` SRF (set-returning function) | ✅ Full support |
+| `LATERAL` subquery with simple filter | ✅ Full support |
+| `LEFT JOIN LATERAL` with outer-applied subquery | ⚠️ Supported; uses R₀ snapshot for outer side (EC-01 semantics) |
+| `LATERAL` with correlated aggregate over LEFT source | ❌ Falls back to FULL; UnsupportedFeature hint |
+| `LATERAL` referencing a volatile SRF | ❌ FULL only (volatility check at parse time) |
+
+---
+
+## Upgrade Notes
+
+No SQL schema changes.  No `ALTER EXTENSION` migration is required.
+
+After upgrading, run `SELECT * FROM pgtrickle.health_check()` to check the new
+`attachment_owner_check` row.  If it reports `WARNING`, review any pre-v0.58.0
+outbox or publication attachments that were created by non-owners.


### PR DESCRIPTION
## Summary

Adds the `plans/PLAN_OVERALL_ASSESSMENT_12.md` deep audit report (Report 12,
v0.57.0 scope) and translates every finding into four new ROADMAP.md versions
(v0.58.0–v0.61.0), forming the **Assessment-Driven Hardening Arc** that resolves
all 47 findings before the v1.0 stable release.

The assessment identified 0 CRITICAL, 4 HIGH, 23 MEDIUM, and 20 LOW findings.
The four releases address them in priority order, with v0.58.0 acting as a hard
security-and-correctness gate.

## Changes

**`plans/PLAN_OVERALL_ASSESSMENT_12.md`** — new overall assessment report

- 854-line audit covering 10 areas (correctness, performance, security, quality,
  tests, ergonomics, observability, CI/CD, features, docs)
- "What Has Improved Since Report 11" table — 23 of 30 R11 findings confirmed
  closed in v0.52–v0.57
- Module coverage matrix, roadmap coverage matrix, 15-item action plan, and
  persistent open findings tracker

**`ROADMAP.md`** — new section and diagram entries

- New section **"Assessment-Driven Hardening Arc (v0.58.x – v0.61.x)"** placed
  between the Documentation Excellence Arc and "Beyond v1.0"
- Updated ASCII diagram with four new entries (v0.58–v0.61)
- New narrative paragraph explaining the arc rationale and inter-release dependency

**New roadmap detail files (8 files)**

| Version | Theme | Key findings addressed |
|---------|-------|------------------------|
| `roadmap/v0.58.0.md[‑full.md]` | Security & Correctness Hardening | S-1, S-2 (ownership bypass in outbox/publication APIs); C-1 (NOT IN + NULL); C-2 (recursive CTE depth guard); C-3 (WAL TOCTOU); S-3, S-4, C-4 |
| `roadmap/v0.59.0.md[‑full.md]` | Performance & Observability | P-1..P-7 (batched monitor SPI, query-hash cache, Arc<str> templates, WAL Vec pre-alloc, frontier borrow); O-1..O-6 (CDC-lag percentiles, worker queue depth, WAL decoder queue, refresh-mode ratio, app_name BGW, pg_dump docs) |
| `roadmap/v0.60.0.md[‑full.md]` | Code Quality, Tests & CI | Q-1..Q-3 (scheduler logs, codegen decompose, cdc.rs 4-way split); T-1..T-5 (refresh/CDC/hooks unit tests, idempotence proptest, sleep removal); C-5, C-6 (WAL OID filter, partition-attach rebuild); CI-1..CI-3 (path-filtered E2E, Dockerfile non-root, codecov thresholds) |
| `roadmap/v0.61.0.md[‑full.md]` | DX, Docs & Final Polish | E-1, E-2 (health_check foreign-owner row, SQL_REFERENCE completeness); C-7..C-9, S-5 (ctid comment, snapshot secondary hash, cte_counter reset, outbox name collision); Q-4, Q-5 (sublinks decompose, brittle test fix); D-1, D-2 (3 ADRs, LIMITATIONS.md); F-1, F-2 (LATERAL docs, SEARCH/CYCLE error) |

## Testing

This PR adds only documentation and planning artefacts — no Rust source files or
SQL schema files are modified. No runtime tests are required. The linting jobs
(link-check, markdown-lint) should pass; the upgrade-completeness check is
unaffected since no SQL migration scripts are added.

## Notes

- v0.58.0 is the **only release in this arc that should be treated as a hard
  gate before any further feature work**. The HIGH-severity findings (S-1, S-2
  ownership bypass) are small code changes that should ship immediately.
- The v0.61.0 work-items (LOW severity) are pre-1.0 polish; they can be
  reordered with v1.0 if scheduling pressure requires it.
- F-3 (auto_explain) and F-4 (pg_partman) remain in the existing v1.1.0 and
  v1.2.0 roadmap entries and are not duplicated here.
