### PR TITLE
plans: pg-aqueduct — clarify base-table migration scope (two-tier policy)

### DIFF
--- a/plans/pg-aqueduct-plan.md
+++ b/plans/pg-aqueduct-plan.md
@@ -280,7 +280,7 @@ where it is `'wal'`). `pg_aqueduct` owns the substitution.
 | **`pg_trickle`** | Runtime target. `aqueduct` calls its SQL API. |
 | **`pg_tide`** | Sibling — the relay, outbox, inbox. `aqueduct` may manage tide's catalog (relay subscriptions, inbox shapes) under the same migration discipline. |
 | **dbt / dbt-pgtrickle** | Upstream authoring. `aqueduct ingest --from dbt-target` reads dbt's compiled `manifest.json` and produces an `aqueduct` migration. |
-| **Atlas / Liquibase / sqitch** | Sibling — they migrate base-table schemas; `aqueduct` migrates the stream-table DAG. They can run in sequence (`atlas apply && aqueduct apply`). |
+| **Atlas / Liquibase / sqitch** | Complementary — they own general-purpose base-table schema migrations (`CREATE TABLE`, partitioning, index changes). `pg_aqueduct` owns *stream-adjacent* base-table changes — any ALTER to a column that is a source for at least one stream table. For those changes, aqueduct generates and executes the base-table ALTER **and** the downstream stream-table cascade in a single coordinated plan. For standalone base-table migrations, aqueduct can invoke Atlas/sqitch as a pre-step hook. |
 | **Terraform / Pulumi** | Outer — provisions the database; the operator embeds a `terraform_data` resource that calls `aqueduct apply` post-provision. |
 | **CloudNativePG / Patroni** | `aqueduct` understands HA: it locks against the primary, refuses to apply against a standby, and integrates with switchover events. |
 | **GitHub / GitLab Actions** | First-class CI integration: `aqueduct/plan-action`, `aqueduct/apply-action`. |
@@ -346,6 +346,28 @@ FROM raw.orders
 GROUP BY customer_id;
 ```
 
+Base tables that are *sources* for stream tables may also be declared
+in the migrations directory, so that `aqueduct plan` can compute the
+full impact of a base-table change on the downstream DAG:
+
+```sql
+-- migrations/sources/orders.sql
+-- @aqueduct:kind = source
+-- @aqueduct:owned = false    -- aqueduct tracks schema but does not create the table
+CREATE TABLE raw.orders (
+    id          bigint PRIMARY KEY,
+    customer_id bigint NOT NULL,
+    amount      numeric(12,2) NOT NULL,
+    created_at  timestamptz NOT NULL DEFAULT now()
+);
+```
+
+`owned = false` (the default for sources) means `aqueduct apply` will
+never `CREATE` or `DROP` the base table — it only reads its schema to
+compute stream-table cascade plans. `owned = true` tells aqueduct it
+may emit base-table DDL as part of a coordinated migration (useful for
+full GitOps environments where the entire schema lives in one repo).
+
 The format is intentionally simple — a folder of SQL files with
 front-matter directives — so that diffs in PRs are readable and so
 that interop with dbt-compiled artefacts is trivial.
@@ -361,9 +383,22 @@ that interop with dbt-compiled artefacts is trivial.
 3. **Recorded history** — read `aqueduct.dag_versions` to know the
    *intended* current state (which may diverge from actual = drift).
 
-The differ is a structural diff over the DAG (nodes, edges, SQL ASTs,
-schedules, refresh modes, cdc modes). Each delta is classified into
-one of four migration kinds:
+The differ operates over three layers simultaneously:
+
+1. **Source layer** — base tables and views that the stream-table DAG
+   reads from. For `owned = false` sources, aqueduct tracks schema
+   changes from `pg_attribute` and uses them for impact analysis only.
+   For `owned = true` sources, it also generates base-table DDL.
+2. **Stream-table DAG** — the nodes and edges managed by `pg_trickle`.
+3. **Consumer layer** (v1.1+) — materialized views, API views, or
+   export connectors that read from stream tables.
+
+Changes at layer 1 cascade into layer 2 automatically. The key
+classification question is: *does this source-layer change affect any
+column referenced in a stream-table query?* If yes, aqueduct owns the
+full cascade plan. If no, it delegates to Atlas/sqitch/Liquibase.
+
+Each stream-table delta is classified into one of four migration kinds:
 
 | Class | Example | Cost |
 |---|---|---|
@@ -611,12 +646,32 @@ Multi-tenant Postgres (one cluster, many independent projects) needs a
 project-scoped lock, which §7.5 already provides — but the operator
 ergonomics need work.
 
-### 10.5 What about non-stream-table objects?
+### 10.5 Base-table migrations and non-stream-table objects
 
-Functions, types, indexes, GUCs that are part of the same logical
-deploy. Recommendation: **defer to Atlas/Liquibase/sqitch** for
-general schema, and let `aqueduct apply` invoke them as a pre-step
-hook. Do not build a generic schema migration tool.
+`pg_aqueduct` takes a two-tier stance:
+
+**Tier 1 — stream-adjacent base-table changes** (a column that appears
+in at least one stream-table query): `pg_aqueduct` owns the entire
+operation. It generates the base-table ALTER, computes the cascade
+impact on the downstream DAG, classifies each affected stream-table
+node (free / in-place / rebuild / blue-green), and executes the full
+sequence as a single resumable plan. This is non-negotiable: allowing
+two separate tools to split this coordination reintroduces the §1.3
+problem (silently broken queries).
+
+**Tier 2 — standalone base-table objects** (new tables, non-referenced
+columns, indexes, partitioning, types, GUCs): delegate to
+Atlas/Liquibase/sqitch. `aqueduct apply` can invoke a user-supplied
+pre/post hook that runs the delegate tool, then proceeds with its own
+stream-table plan. Do not build a general-purpose schema migration
+tool — that would be competing with Atlas on Atlas's home turf.
+
+The boundary between tier 1 and tier 2 is determined automatically by
+the query parser: if `pg_query.rs` can prove that a column is
+unreferenced in any stream-table query, aqueduct defers; otherwise it
+classifies it as tier 1. The `--tier1-only` flag restricts the apply
+run to stream-adjacent changes only, for teams that want to keep
+base-table DDL in Atlas regardless.
 
 ### 10.6 Naming
 
@@ -638,7 +693,10 @@ vendored copy and add a CI job that diffs the two.
 
 ## 11. Non-Goals (v1.0)
 
-- A general-purpose schema migration tool. Use Atlas or sqitch.
+- A general-purpose schema migration tool. `pg_aqueduct` manages
+  stream-adjacent base-table changes (§10.5 Tier 1) but defers
+  standalone DDL (non-referenced columns, new tables, indexes,
+  partitioning, types) to Atlas or sqitch.
 - A query authoring environment. Use dbt, Hex, or psql.
 - A monitoring / alerting product. Use `pg_trickle`'s monitoring views
   + Grafana.

--- a/plans/pg-aqueduct-plan.md
+++ b/plans/pg-aqueduct-plan.md
@@ -119,10 +119,14 @@ sample of base data) are unsupported.
 
 A **declarative migration and orchestration tool**, distributed as:
 
-- a **Rust CLI binary** (`aqueduct`) — the primary user surface;
-- a thin **Postgres extension** (`pg_aqueduct`) — owns its own catalog
-  (`aqueduct.migrations`, `aqueduct.locks`, `aqueduct.snapshots`,
-  `aqueduct.dag_versions`);
+- a **Rust CLI binary** (`aqueduct`) — the primary user surface and
+  the mandatory component. Works against any Postgres cluster that
+  has `pg_trickle` installed. No superuser required beyond what
+  `pg_trickle` itself already needs.
+- an **optional companion extension** (`pg_aqueduct`) — enables DDL
+  event triggers for passive drift detection and SQL-callable
+  diagnostic views. Not required for plan/apply/rollback. See §10.8
+  for the full analysis of whether an extension is the right choice.
 - a **TOML/YAML project format** plus a folder of `*.sql` files;
 - optional **GitHub / GitLab CI integrations** — `aqueduct plan` as a
   PR check, just like `terraform plan`.
@@ -131,7 +135,7 @@ The user-facing model is intentionally close to **Atlas** (for SQL
 schema) and **Terraform** (for infrastructure):
 
 ```
-$ aqueduct init                    # scaffold a project
+$ aqueduct init                    # scaffold a project + bootstrap catalog
 $ aqueduct plan --to prod          # diff desired vs actual; produce a plan
 $ aqueduct apply --to prod         # execute the plan, record migration
 $ aqueduct status --to prod        # show drift, last migration, lag
@@ -140,9 +144,9 @@ $ aqueduct preview --branch feat-x # spin up a preview DAG on a branch DB
 ```
 
 The CLI talks to PostgreSQL through a normal `libpq` connection (no
-custom protocol). The companion extension is required only for the
-*online* migration features (§4.4); the basic plan/apply loop works
-against any cluster that has `pg_trickle` installed.
+custom protocol). `aqueduct init` bootstraps the `aqueduct.` catalog
+schema directly (plain tables, no extension needed) — the same
+approach used by Atlas, Flyway, and Liquibase.
 
 ---
 
@@ -434,9 +438,28 @@ INDEX, large `FULL` refreshes), the planner emits a *resumable*
 sequence — the plan stores its progress in `aqueduct.migrations` so
 `aqueduct apply --resume` works after a crash.
 
-### 7.5 The companion extension
+### 7.5 The companion extension (optional)
 
-`aqueduct-extension` is a small pgrx extension that owns:
+`aqueduct-extension` is an **optional** pgrx extension. The CLI
+works fully without it; the extension enables two additional
+capabilities that cannot be replicated from outside the Postgres
+process:
+
+1. **DDL event triggers** — a `ddl_command_end` event trigger that
+   fires on every `ALTER TABLE` / `ALTER TYPE` and records the
+   change in `aqueduct.ddl_log`. The CLI polls this table during
+   `aqueduct status` to detect out-of-band schema changes without
+   the user having to explicitly run `aqueduct plan`.
+2. **SQL-callable diagnostics** — `SELECT * FROM aqueduct.drift()`,
+   `SELECT * FROM aqueduct.plan_summary()`, `SELECT * FROM
+   aqueduct.migration_history()` — useful in monitoring dashboards
+   and psql sessions.
+
+Everything else — the catalog tables, locking, plan execution,
+rollback, snapshots — lives in plain tables the CLI creates on
+`aqueduct init`. See §10.8 for the full architectural analysis.
+
+`aqueduct-extension` owns:
 
 ```sql
 CREATE SCHEMA aqueduct;
@@ -472,9 +495,11 @@ CREATE TABLE aqueduct.locks (
 
 It exposes a handful of SQL functions (`aqueduct.acquire_lock`,
 `aqueduct.release_lock`, `aqueduct.record_snapshot`,
-`aqueduct.list_drift`) but does **no orchestration of its own** — the
-CLI is the brain. Keeping the extension trivial keeps the upgrade
-story trivial and lets us version the CLI freely.
+`aqueduct.list_drift`) and a DDL event trigger, but does **no
+orchestration of its own** — the CLI is the brain. Keeping the
+extension trivial keeps the upgrade story trivial and lets us version
+the CLI independently. When the extension is absent, the CLI detects
+this and falls back to polling-based drift detection.
 
 ### 7.6 Locking & concurrency
 
@@ -681,7 +706,99 @@ small steady drip), `pg_ripple` (propagating outward), `pg_tide`
 a fitting metaphor for moving DAG state from one version, environment,
 or cluster to another. **Keep the name.**
 
-### 10.7 Ownership of the in-place evolution rules
+### 10.8 Does `pg_aqueduct` need to be a PostgreSQL extension?
+
+This is the most consequential early architecture decision. The
+answer is: **no, a PostgreSQL extension is not required — but an
+optional one buys meaningful capabilities**.
+
+#### Four possible approaches
+
+**A — Pure CLI, no extension (Atlas model)**
+
+The CLI bootstraps its own catalog (`aqueduct.` schema + plain
+tables) on first `aqueduct init`, exactly like Atlas, Flyway, and
+Liquibase manage `schema_migrations`. All locking uses PostgreSQL
+advisory locks or row locks. No `CREATE EXTENSION` required.
+
+| Pros | Cons |
+|---|---|
+| Works on RDS, Azure Database, Supabase, Neon, any managed Postgres where installing custom extensions is restricted or requires a support ticket | No DDL event triggers — can't passively observe out-of-band schema changes; must poll |
+| Single artifact to install and version — just the CLI binary | No SQL-callable diagnostics (no `SELECT * FROM aqueduct.drift()`) |
+| No pgrx build pipeline | No `\dx` visibility; catalog tables look like application tables |
+| No superuser required beyond what `pg_trickle` already needs | Cannot intercept `ALTER TABLE` automatically |
+| Fastest possible adoption path | |
+
+**B — CLI + optional companion extension (recommended)**
+
+The CLI works fully without the extension (option A). Installing
+`pg_aqueduct` additionally enables DDL event triggers and SQL-callable
+diagnostic views — a progressive-enhancement model. The CLI detects
+whether the extension is present and upgrades its behavior
+accordingly. This is the approach reflected in §7.5.
+
+| Pros | Cons |
+|---|---|
+| Maximum compatibility — works on every managed Postgres | Two artifacts to version; CLI must handle both code paths |
+| DDL event triggers available for teams that can install the extension | Extension availability on managed services is uneven |
+| SQL-callable diagnostics for dashboards and psql power users | pgrx build dependency adds CI complexity |
+| Clean `DROP EXTENSION CASCADE` for full uninstall | |
+| Progressive adoption: start with CLI, add extension when needed | |
+
+**C — Extension required for online features (original plan §7.5)**
+
+The extension is required for any *online* migration (in-place,
+blue/green). Without it, only rebuild-class migrations are available.
+
+| Pros | Cons |
+|---|---|
+| Clean capability boundary | Blocks adoption on managed services for the most valuable feature class |
+| Simpler CLI code (no fallback path) | Managed Postgres users would be limited to the weakest migration mode — perverse incentive |
+
+**D — Full extension, no separate CLI**
+
+All orchestration lives inside the Postgres process — background
+workers, shared memory, `pg_trickle`-style `pgtrickle.create_stream_table()`
+API. This is the model `pg_trickle` itself follows.
+
+| Pros | Cons |
+|---|---|
+| Deep Postgres integration | No file I/O, no git integration, no PR checks — all the things that make a migration tool useful |
+| One `CREATE EXTENSION` installs everything | Conflates runtime and migration tooling (see §4 for why this was rejected for `pg_trickle` itself) |
+
+#### Recommendation: Option B
+
+**Ship a pure CLI first. Make the extension optional from day one.**
+
+The core insight is that all the genuinely unique value of
+`pg_aqueduct` — the DAG differ, topological plan, cascade classifier,
+resumable executor, GitOps integration, CI checks — lives in the
+CLI binary and requires nothing but `libpq`. The extension only
+adds two capabilities that cannot be replicated from outside the
+process: DDL event triggers and SQL-callable views. Both are
+conveniences, not correctness requirements.
+
+Shipping option A first (pure CLI, no extension) means:
+- `pg_aqueduct` works on day one against every cloud Postgres
+  (RDS, Supabase, Neon, Azure, AlloyDB, CloudNativePG, Citus);
+- there is no pgrx build in the `pg_aqueduct` repository for v0.1
+  (dramatic CI simplification, especially for macOS cross-compile);
+- the extension can be added in Phase 4 as an enhancement, not
+  a prerequisite.
+
+The only things that *genuinely* require the extension:
+- Passive DDL drift detection (event trigger on `ALTER TABLE`)
+- SQL-callable diagnostic views exposed to dashboards / `psql`
+
+Both of these are useful-but-not-required for the core plan/apply
+cycle. Polling-based drift detection is a perfectly adequate fallback
+for v0.1.
+
+**Revised §8 Phase 0 note:** drop the pgrx scaffold from Phase 0.
+The extension becomes a Phase 4 deliverable, after the plan/apply/rollback
+cycle is solid. Phase 0 is just a Rust CLI workspace.
+
+### 10.9 Ownership of the in-place evolution rules
 
 If the evolution classifier lives in `pg_aqueduct`, it can drift from
 `pg_trickle`'s actual capabilities. If it lives in `pg_trickle`, the
@@ -711,12 +828,17 @@ vendored copy and add a CI job that diffs the two.
 ## 12. Recommendation
 
 Open the `trickle-labs/pg-aqueduct` repository now, but keep the work
-**unfunded** until two upstream items ship:
+**unfunded** until one upstream item ships:
 
-1. The `pg_tide` extraction lands and we have a known-good template
-   for "small companion extension + Rust binary".
-2. `pg_trickle` exposes a JSON-stable projection of a stream-table
+1. `pg_trickle` exposes a JSON-stable projection of a stream-table
    spec (small change, useful regardless).
+
+Note: **the `pg_tide` extraction is no longer a prerequisite** for
+`pg_aqueduct` v0.1. Per §10.8, the v0.1 CLI has no pgrx component —
+it is a pure Rust binary that bootstraps its own catalog over libpq,
+like Atlas. The pgrx companion extension arrives in Phase 4 and can
+borrow patterns from `pg_tide` at that point. Unblocking one item
+(JSON spec projection) instead of two cuts the lead time significantly.
 
 In the meantime, this document plus a stub README in the new
 repository is sufficient to:


### PR DESCRIPTION
## Summary

Follows on from #803 (merged). Updates [plans/pg-aqueduct-plan.md](plans/pg-aqueduct-plan.md) to answer the question: **should `pg_aqueduct` support migration of base tables as well as stream tables?**

Short answer: **yes, but only for stream-adjacent changes.**

## What changed

### §10.5 — Base-table migration scope (rewritten)

Replaces the one-liner "use Atlas" with a two-tier policy:

| Tier | Scope | Ownership |
|---|---|---|
| **1** | Any column/table referenced in a stream-table query | `pg_aqueduct` owns the full operation: base-table ALTER + stream-table cascade in a single resumable plan |
| **2** | Standalone DDL (non-referenced columns, new tables, indexes, partitioning, types) | Delegate to Atlas/Liquibase/sqitch via a pre/post hook |

Tier 1 is non-negotiable: allowing two separate tools to split this coordination reintroduces the §1.3 problem (`pg_aqueduct` was designed to solve). The boundary is determined automatically by the query parser — if a column is provably unreferenced in any stream-table query, aqueduct defers; otherwise it takes ownership. A `--tier1-only` flag lets teams keep base-table DDL in Atlas while using aqueduct only for the stream cascade.

### §7.2 — Project file format extended

Source tables that the DAG reads from can now be declared in the migrations directory:

```sql
-- migrations/sources/orders.sql
-- @aqueduct:kind = source
-- @aqueduct:owned = false   -- track schema, no DDL
CREATE TABLE raw.orders ( … );
```

`owned = false` (default): aqueduct reads the live schema from `pg_attribute` for impact analysis but never emits `CREATE`/`DROP`. `owned = true`: aqueduct may emit base-table DDL as part of a full GitOps setup.

### §7.3 — Three-layer differ

The differ description is updated to reflect the three-layer model: source layer → stream-table DAG → consumer layer. Changes at the source layer cascade into the DAG automatically; the classifier determines whether `pg_aqueduct` owns the change or delegates it.

### §6 & §11 — Atlas relationship and non-goals updated accordingly
