### PR TITLE
plans: pg-aqueduct — add recommendations for 10 remaining open questions

### DIFF
--- a/plans/pg-aqueduct-plan.md
+++ b/plans/pg-aqueduct-plan.md
@@ -26,19 +26,21 @@
 > renaming a source — without losing in-flight differential state and
 > without taking the pipeline offline.
 >
-> The recommended shape is a **standalone Rust CLI plus a thin
-> companion Postgres extension** (`pg_aqueduct`), shipped from a new
-> repository `trickle-labs/pg-aqueduct`. It reads a versioned directory
-> of declarative `*.sql` and `aqueduct.toml` files, computes a *plan*
-> (diff between desired and actual DAG state), and executes the plan
-> against a target database in topologically-correct order, preserving
-> materialized state wherever possible. It is to a stream-table DAG
-> what **Atlas** is to a relational schema and what **Terraform** is to
-> infrastructure.
+> The recommended shape is a **standalone Rust CLI** (`aqueduct`),
+> shipped from a new repository `trickle-labs/pg-aqueduct`, with an
+> **optional companion Postgres extension** that adds DDL event
+> triggers and SQL-callable diagnostics (see §10.7). The CLI reads a
+> versioned directory of declarative `*.sql` and `aqueduct.toml` files,
+> computes a *plan* (diff between desired and actual DAG state), and
+> executes the plan against a target database in topologically-correct
+> order, preserving materialized state wherever possible. It is to a
+> stream-table DAG what **Atlas** is to a relational schema and what
+> **Terraform** is to infrastructure.
 >
-> Estimated effort to a usable v0.1: **~6 weeks** for one engineer.
-> v1.0 (online schema evolution, blue/green deployments, drift
-> detection, CI integrations) is a **3–6 month** project.
+> Estimated effort to a usable v0.1 (plan + apply + rollback):
+> **~5.5 weeks** for one engineer (Phases 0–2). v1.0 (online schema
+> evolution, blue/green deployments, drift detection, CI integrations,
+> optional extension) is a **~14 week** project (Phases 0–7).
 
 ---
 
@@ -125,7 +127,7 @@ A **declarative migration and orchestration tool**, distributed as:
   `pg_trickle` itself already needs.
 - an **optional companion extension** (`pg_aqueduct`) — enables DDL
   event triggers for passive drift detection and SQL-callable
-  diagnostic views. Not required for plan/apply/rollback. See §10.8
+  diagnostic views. Not required for plan/apply/rollback. See §10.7
   for the full analysis of whether an extension is the right choice.
 - a **TOML/YAML project format** plus a folder of `*.sql` files;
 - optional **GitHub / GitLab CI integrations** — `aqueduct plan` as a
@@ -136,11 +138,13 @@ schema) and **Terraform** (for infrastructure):
 
 ```
 $ aqueduct init                    # scaffold a project + bootstrap catalog
+$ aqueduct import --from prod      # bootstrap from an existing pg_trickle deployment
 $ aqueduct plan --to prod          # diff desired vs actual; produce a plan
 $ aqueduct apply --to prod         # execute the plan, record migration
 $ aqueduct status --to prod        # show drift, last migration, lag
 $ aqueduct rollback --to prod      # revert to the previous DAG version
 $ aqueduct preview --branch feat-x # spin up a preview DAG on a branch DB
+$ aqueduct destroy --to prod       # tear down the entire project's DAG
 ```
 
 The CLI talks to PostgreSQL through a normal `libpq` connection (no
@@ -302,7 +306,7 @@ trickle-labs/pg-aqueduct/
 ├── crates/
 │   ├── aqueduct-core/                # planner, differ, plan executor
 │   ├── aqueduct-cli/                 # `aqueduct` binary
-│   ├── aqueduct-extension/           # pgrx extension (catalog only)
+│   ├── aqueduct-extension/           # pgrx extension (Phase 4; optional)
 │   └── aqueduct-testkit/             # shared Testcontainers helpers
 ├── examples/
 │   ├── minimal/                      # 3-node DAG
@@ -320,7 +324,9 @@ trickle-labs/pg-aqueduct/
 # aqueduct.toml — at the project root
 [project]
 name = "checkout-analytics"
-version = "1"
+
+# No user-facing "version" field — aqueduct tracks DAG versions
+# automatically in aqueduct.dag_versions (auto-incremented on apply).
 
 [targets.dev]
 dsn  = "postgresql://localhost/checkout_dev"
@@ -342,6 +348,11 @@ default_strategy     = "in-place"   # or "blue-green"
 -- @aqueduct:depends_on  = ["raw.orders"]
 -- @aqueduct:schedule    = "{{ var.schedule }}"
 -- @aqueduct:refresh_mode = "DIFFERENTIAL"
+-- NOTE: depends_on is optional. The planner extracts dependencies
+-- from the SQL via pg_query.rs (see §10.2). Use depends_on only to
+-- declare dependencies the parser cannot infer: functions, implicit
+-- casts, dynamic SQL, or intentional ordering constraints between
+-- nodes that share no SQL-level edge.
 SELECT
     customer_id,
     SUM(amount) AS total_amount,
@@ -438,31 +449,13 @@ INDEX, large `FULL` refreshes), the planner emits a *resumable*
 sequence — the plan stores its progress in `aqueduct.migrations` so
 `aqueduct apply --resume` works after a crash.
 
-### 7.5 The companion extension (optional)
+### 7.5 Catalog tables and the companion extension
 
-`aqueduct-extension` is an **optional** pgrx extension. The CLI
-works fully without it; the extension enables two additional
-capabilities that cannot be replicated from outside the Postgres
-process:
-
-1. **DDL event triggers** — a `ddl_command_end` event trigger that
-   fires on every `ALTER TABLE` / `ALTER TYPE` and records the
-   change in `aqueduct.ddl_log`. The CLI polls this table during
-   `aqueduct status` to detect out-of-band schema changes without
-   the user having to explicitly run `aqueduct plan`.
-2. **SQL-callable diagnostics** — `SELECT * FROM aqueduct.drift()`,
-   `SELECT * FROM aqueduct.plan_summary()`, `SELECT * FROM
-   aqueduct.migration_history()` — useful in monitoring dashboards
-   and psql sessions.
-
-Everything else — the catalog tables, locking, plan execution,
-rollback, snapshots — lives in plain tables the CLI creates on
-`aqueduct init`. See §10.8 for the full architectural analysis.
-
-`aqueduct-extension` owns:
+The **CLI** creates and owns the catalog tables on `aqueduct init`
+(no extension required):
 
 ```sql
-CREATE SCHEMA aqueduct;
+CREATE SCHEMA IF NOT EXISTS aqueduct;
 
 CREATE TABLE aqueduct.dag_versions (
     version    bigserial PRIMARY KEY,
@@ -482,7 +475,9 @@ CREATE TABLE aqueduct.migrations (
     finished_at  timestamptz,
     status       text NOT NULL,            -- 'running' | 'committed' | 'failed' | 'rolled_back'
     plan         jsonb NOT NULL,
-    progress     jsonb NOT NULL DEFAULT '{}'::jsonb
+    progress     jsonb NOT NULL DEFAULT '{}'::jsonb,
+    cli_version  text,                     -- diagnostic (see §10.13)
+    plan_format_version int NOT NULL DEFAULT 1
 );
 
 CREATE TABLE aqueduct.locks (
@@ -491,15 +486,37 @@ CREATE TABLE aqueduct.locks (
     acquired_at timestamptz NOT NULL,
     ttl         interval NOT NULL
 );
+
+CREATE TABLE aqueduct.cluster_profile (
+    key         text PRIMARY KEY,
+    value_jsonb jsonb NOT NULL,
+    measured_at timestamptz NOT NULL DEFAULT now()
+);
 ```
 
-It exposes a handful of SQL functions (`aqueduct.acquire_lock`,
-`aqueduct.release_lock`, `aqueduct.record_snapshot`,
-`aqueduct.list_drift`) and a DDL event trigger, but does **no
-orchestration of its own** — the CLI is the brain. Keeping the
-extension trivial keeps the upgrade story trivial and lets us version
-the CLI independently. When the extension is absent, the CLI detects
-this and falls back to polling-based drift detection.
+This is the same approach used by Atlas (`atlas_schema_revisions`),
+Flyway (`flyway_schema_history`), and Liquibase
+(`databasechangelog`). No `CREATE EXTENSION` is needed for core
+functionality.
+
+#### The optional companion extension
+
+The **optional** pgrx extension `pg_aqueduct` adds two capabilities
+that cannot be replicated from outside the Postgres process:
+
+1. **DDL event triggers** — a `ddl_command_end` event trigger that
+   fires on every `ALTER TABLE` / `ALTER TYPE` and records the
+   change in `aqueduct.ddl_log`. The CLI polls this table during
+   `aqueduct status` to detect out-of-band schema changes without
+   the user having to explicitly run `aqueduct plan`.
+2. **SQL-callable diagnostics** — `SELECT * FROM aqueduct.drift()`,
+   `SELECT * FROM aqueduct.plan_summary()`, `SELECT * FROM
+   aqueduct.migration_history()` — useful in monitoring dashboards
+   and psql sessions.
+
+When the extension is absent, the CLI detects this and falls back to
+polling-based drift detection (comparing `pg_attribute` snapshots
+between runs). See §10.7 for the full architectural analysis.
 
 ### 7.6 Locking & concurrency
 
@@ -519,10 +536,12 @@ this and falls back to polling-based drift detection.
 
 - Create `trickle-labs/pg-aqueduct` (mirrors `trickle-labs/pg-tide`
   layout from [PLAN_RELAY_STANDALONE.md](PLAN_RELAY_STANDALONE.md)).
-- Cargo workspace, `pgrx` 0.18 extension scaffold, `clap`-based CLI
-  scaffold, `justfile`, CI matrix (Linux + macOS unit + Testcontainers
-  integration), code-coverage gate.
-- Mirror `pg_trickle`'s testing tiers: unit / integration / E2E.
+- Cargo workspace with two crates: `aqueduct-core` and `aqueduct-cli`.
+  No pgrx in this phase (see §10.7 — extension is added in Phase 4).
+- `clap`-based CLI scaffold, `justfile`, CI matrix (Linux + macOS
+  unit + Testcontainers integration), code-coverage gate.
+- Bootstrap `aqueduct init` — creates `aqueduct.` schema + catalog
+  tables via plain SQL over libpq.
 - Document the project's scope & non-goals in `README.md` and
   `ESSENCE.md`.
 
@@ -570,16 +589,20 @@ that every cycle ends with an empty plan.
 Exit criteria: TPC-H example DAG (22 nodes) accepts a column-add and
 schedule-change migration without any node going through `FULL`.
 
-### Phase 4 — Blue/green and preview environments (3 weeks)
+### Phase 4 — Blue/green, preview environments, and optional extension (3 weeks)
 
 - Blue/green deployer: builds the new DAG in a parallel schema,
-  backfills, swaps consumer views.
+  backfills, swaps consumer views (see §10.9).
 - `aqueduct preview --branch` integrations:
   - native: spin a scratch schema with sampled base data;
   - CloudNativePG: create a clone cluster (see
     [PLAN_CLOUDNATIVEPG.md](ecosystem/PLAN_CLOUDNATIVEPG.md));
   - Neon: branch via the Neon API
     (see [PLAN_NEON.md](ecosystem/PLAN_NEON.md)).
+- **Optional pgrx companion extension** (`aqueduct-extension/` crate):
+  DDL event trigger for passive drift detection + SQL-callable
+  diagnostic views. The CLI auto-detects whether the extension is
+  installed and upgrades its behaviour accordingly.
 
 Exit criteria: a documented blue/green migration of a 5-node DAG with
 zero consumer-visible downtime.
@@ -624,7 +647,7 @@ zero consumer-visible downtime.
 | `pgtrickle.pgt_stream_tables` is the canonical catalog | shipped | ✅ |
 | `pg_trickle.pause_scheduler()` SQL function | likely missing — file as a `pg_trickle` issue | ⚠ |
 | `pg_trickle` exposes a stable JSON projection of a stream-table spec | needs design | ⚠ |
-| `pg_tide` extracted to its own repo | [PLAN_RELAY_STANDALONE.md](PLAN_RELAY_STANDALONE.md) | 🟡 in-flight |
+| `pg_tide` extracted to its own repo | [PLAN_RELAY_STANDALONE.md](PLAN_RELAY_STANDALONE.md) | 🟡 in-flight (not a blocker for v0.1 — see §10.7) |
 | Shared `pg_trickle_calculus` crate for in-place classifier | future refactor | 🔴 later |
 
 `pg_aqueduct` does **not** need to wait for the `pg_trickle_calculus`
@@ -706,7 +729,7 @@ small steady drip), `pg_ripple` (propagating outward), `pg_tide`
 a fitting metaphor for moving DAG state from one version, environment,
 or cluster to another. **Keep the name.**
 
-### 10.8 Does `pg_aqueduct` need to be a PostgreSQL extension?
+### 10.7 Does `pg_aqueduct` need to be a PostgreSQL extension?
 
 This is the most consequential early architecture decision. The
 answer is: **no, a PostgreSQL extension is not required — but an
@@ -798,7 +821,7 @@ for v0.1.
 The extension becomes a Phase 4 deliverable, after the plan/apply/rollback
 cycle is solid. Phase 0 is just a Rust CLI workspace.
 
-### 10.9 Ownership of the in-place evolution rules
+### 10.8 Ownership of the in-place evolution rules
 
 If the evolution classifier lives in `pg_aqueduct`, it can drift from
 `pg_trickle`'s actual capabilities. If it lives in `pg_trickle`, the
@@ -806,7 +829,7 @@ extension grows scope. The medium-term answer is a shared
 `pg_trickle_calculus` crate (§9). The short-term answer is to ship a
 vendored copy and add a CI job that diffs the two.
 
-### 10.10 Blue/green atomicity — how do consumers cut over?
+### 10.9 Blue/green atomicity — how do consumers cut over?
 
 **Problem:** When a blue/green deployment swaps the DAG from version N
 to version N+1, consumer queries (application reads, dashboards,
@@ -815,6 +838,10 @@ green ones. If even one consumer reads a mix of blue and green tables
 in a single query, the result is silently wrong.
 
 **Recommendation: rename-swap behind stable views.**
+
+The consumer view pattern described below is also the foundation of
+consumer-layer management (§10.17). For non-blue/green migrations,
+the view layer is optional (see §10.21 for adoption path).
 
 1. Each stream table `foo` is consumed through a view `public.foo`
    (or whatever schema the consumer expects). The actual materialised
@@ -840,7 +867,7 @@ be reconfigured), incompatible with connection poolers that strip
 session state (PgBouncer in transaction mode), and does not provide
 atomicity across multiple consumers.
 
-### 10.11 Failure recovery and partial state
+### 10.10 Failure recovery and partial state
 
 **Problem:** A migration can crash at any point — after the base-table
 ALTER but before the stream-table cascade, after 3 of 7 stream tables
@@ -876,7 +903,7 @@ must inspect and either `--force-retry` or `--force-skip` the
 ambiguous step. Automatic guessing is not acceptable — this is the
 "data loss is unacceptable" principle from `pg_trickle`'s AGENTS.md.
 
-### 10.12 Concurrency contract with the `pg_trickle` scheduler
+### 10.11 Concurrency contract with the `pg_trickle` scheduler
 
 **Problem:** §7.6 says `aqueduct apply` calls
 `pgtrickle.pause_scheduler()`, but what if a refresh is already
@@ -911,7 +938,7 @@ to `'999d'` (effectively infinite), applies the migration, then
 restores the original schedule. This is racy but acceptable for
 v0.1 against older clusters.
 
-### 10.13 Cost estimation
+### 10.12 Cost estimation
 
 **Problem:** `aqueduct apply --dry-run --explain-cost` promises
 per-step estimated row counts and refresh duration, but how accurate
@@ -954,7 +981,7 @@ BACKFILL customer_summary       340K          ~12s            in-place
 so the operator can decide whether to run it now or schedule it for
 the maintenance window.
 
-### 10.14 CLI upgrade mid-migration
+### 10.13 CLI upgrade mid-migration
 
 **Problem:** If the CLI binary is upgraded while a resumable migration
 is in-flight (e.g., operator deploys a new `aqueduct` version, then
@@ -978,7 +1005,7 @@ runs `aqueduct apply --resume`), can it safely resume?
 as long as the new CLI is the same or newer major version. Downgrading
 is not supported (the old CLI may not understand new step types).
 
-### 10.15 HA / failover integration
+### 10.14 HA / failover integration
 
 **Problem:** In an HA cluster (Patroni, CloudNativePG, Stolon), the
 primary can change at any time. If `aqueduct apply` is mid-migration
@@ -1011,7 +1038,7 @@ the current primary, avoiding stale DNS.
 can read the `cnpg.io/cluster` annotation to discover the current
 primary service endpoint.
 
-### 10.16 Schedule resolution during DAG restructuring
+### 10.15 Schedule resolution during DAG restructuring
 
 **Problem:** If a downstream node has `schedule = 'calculated'` and
 its upstream dependencies are restructured (a new parent is added, a
@@ -1046,7 +1073,7 @@ construction. `pg_trickle` already prevents cycles in the DAG.
 (by running the same topological-sort + cycle-detection as
 `pg_trickle`'s `dag.rs`).
 
-### 10.17 Version compatibility matrix
+### 10.16 Version compatibility matrix
 
 **Problem:** Which `pg_trickle` versions can a given `aqueduct` CLI
 target? How is this tested?
@@ -1073,7 +1100,7 @@ v0.{min}–v0.{latest}. After both projects reach 1.0, the policy
 tightens to `aqueduct` 1.x supports `pg_trickle` 1.x (same major
 version, any minor).
 
-### 10.18 Consumer-layer management
+### 10.17 Consumer-layer management
 
 **Problem:** §7.3 mentions a three-layer model with a "consumer
 layer (v1.1+)" but does not define what this entails.
@@ -1083,7 +1110,7 @@ layer (v1.1+)" but does not define what this entails.
 **v1.0 scope — consumer views only:**
 
 Consumer views are the `CREATE OR REPLACE VIEW public.foo AS SELECT
-* FROM aqueduct_vN.foo` objects described in §10.10 (blue/green).
+* FROM aqueduct_vN.foo` objects described in §10.9 (blue/green).
 `aqueduct` creates and manages these views as part of every
 migration. They are the stable API that applications query.
 
@@ -1109,7 +1136,7 @@ exports, webhook notifications, `pg_tide` outbox entries. Managing
 these requires understanding external system APIs and is a different
 problem class. Defer to `pg_tide` and purpose-built connectors.
 
-### 10.19 Project scope definition — what is a "project"?
+### 10.18 Project scope definition — what is a "project"?
 
 **Problem:** One migrations directory per project. But what is a
 project? One DAG? Multiple DAGs? If a company has 50 independent
@@ -1150,6 +1177,122 @@ name = "checkout-analytics"   # used as the lock key and version namespace
 | Medium (10–50) | 2–5 projects, grouped by domain (orders, inventory, analytics) |
 | Large (50–200+) | One project per bounded context; each project has its own `aqueduct.toml`, CI pipeline, and deployment cadence |
 
+### 10.19 Security model
+
+**Problem:** `pg_aqueduct` connects to production databases with
+`ALTER TABLE`, `DROP`, and `CREATE` privileges. The CLI stores
+connection strings in `aqueduct.toml` or environment variables.
+There is no discussion of credential handling, least-privilege
+roles, or audit logging.
+
+**Recommendation: least privilege + env-only secrets + audit trail.**
+
+1. **No secrets in files.** DSN values in `aqueduct.toml` should use
+   environment variable references (`${AQUEDUCT_PROD_DSN}`). The CLI
+   refuses to proceed if a plaintext password appears in a config
+   file and `--allow-plaintext-password` is not explicitly set.
+2. **Least-privilege role.** Document a recommended `aqueduct_admin`
+   role that has:
+   - `USAGE` and `CREATE` on the `aqueduct` schema;
+   - `USAGE` on the `pgtrickle` schema (to call the SQL API);
+   - `SELECT` on `pg_class`, `pg_attribute`, `pg_type` (for diffing);
+   - `CREATE`, `ALTER`, `DROP` on stream-table schemas only;
+   - **No superuser, no `CREATEROLE`, no replication.**
+   The CLI checks on startup that it has the minimum required
+   privileges and warns if it has *more* than needed.
+3. **Audit trail.** Every `aqueduct apply` records the authenticated
+   Postgres role, client IP (`inet_client_addr()`), CLI version, and
+   full plan in `aqueduct.migrations`. This is queryable for
+   compliance audits.
+4. **`--dry-run` never mutates.** The `plan` and `status` commands
+   open read-only transactions (`SET TRANSACTION READ ONLY`) to
+   guarantee they cannot accidentally modify data.
+
+### 10.20 IMMEDIATE mode stream tables during migration
+
+**Problem:** Stream tables with `refresh_mode = 'IMMEDIATE'` use
+synchronous, in-transaction, statement-level triggers instead of
+asynchronous CDC + scheduled refresh. Migrating them has fundamentally
+different semantics: the triggers must be dropped and recreated
+atomically, and during migration there is a window where DML against
+the source table may not be captured.
+
+**Recommendation: migrate IMMEDIATE tables inside a serialisable
+transaction.**
+
+1. `aqueduct plan` classifies IMMEDIATE stream tables separately
+   from deferred (DIFFERENTIAL/FULL) ones.
+2. For free/in-place changes to IMMEDIATE tables, the entire
+   migration (trigger drop + ALTER + trigger recreate) is executed
+   inside a single `SERIALIZABLE` transaction. This guarantees no
+   DML is lost — any concurrent DML blocks until the migration
+   transaction commits.
+3. For rebuild-class changes to IMMEDIATE tables, the plan inserts a
+   `PauseImmediate { name }` step that temporarily switches the
+   stream table to `DIFFERENTIAL` mode (with a short schedule),
+   applies the rebuild, then switches back to `IMMEDIATE`. This
+   avoids the long-held `SERIALIZABLE` lock but introduces a brief
+   window of eventual consistency. The plan renderer warns: "Stream
+   table `foo` will be temporarily non-immediate during rebuild
+   (~estimated_duration)."
+4. The `--no-immediate-downgrade` flag rejects any plan that would
+   temporarily downgrade an IMMEDIATE table, forcing the operator
+   to schedule the migration during a maintenance window instead.
+
+### 10.21 Adoption path for existing `pg_trickle` users
+
+**Problem:** Existing `pg_trickle` deployments have stream tables
+created via ad-hoc `SELECT pgtrickle.create_stream_table(...)` calls.
+There is no migrations directory, no `aqueduct.toml`, and no recorded
+version history. How do they adopt `pg_aqueduct`?
+
+**Recommendation: `aqueduct import` bootstraps from the live catalog.**
+
+```bash
+aqueduct import --from prod --output ./my-project/
+```
+
+This command:
+
+1. Connects to the target database.
+2. Queries `pgtrickle.pgt_stream_tables` for all stream tables.
+3. Generates a `migrations/streams/*.sql` file for each stream
+   table, with front-matter directives populated from the catalog
+   (schedule, refresh_mode, cdc_mode, etc.).
+4. Optionally generates `migrations/sources/*.sql` for each base
+   table referenced by at least one stream table (`owned = false`).
+5. Generates a skeleton `aqueduct.toml`.
+6. Runs `aqueduct init` against the database (creates the `aqueduct.`
+   catalog schema).
+7. Records the current state as `dag_version = 1` (the baseline).
+
+After `import`, the user's next `aqueduct plan` should produce an
+empty plan (desired state = actual state). From this point, all
+changes go through the normal plan/apply cycle.
+
+**The consumer view layer (\u00a710.10) is opt-in.** Existing users who
+query stream tables directly (`SELECT * FROM public.order_totals`)
+do not need to adopt the view indirection for non-blue/green
+migrations. The view layer is only introduced when the user first
+runs a blue/green deployment.
+
+### 10.22 `aqueduct destroy` — tearing down a project
+
+**Problem:** There is no documented way to cleanly remove an entire
+project's DAG, catalog entries, and lock rows.
+
+**Recommendation: `aqueduct destroy --project <name> --to <target>`.**
+
+1. Drops all stream tables owned by the project (in reverse
+   topological order) via `pgtrickle.drop_stream_table()`.
+2. Drops consumer views managed by the project.
+3. Deletes the project's rows from `aqueduct.dag_versions`,
+   `aqueduct.migrations`, and `aqueduct.locks`.
+4. Does **not** drop the `aqueduct.` schema itself (other projects
+   may share it).
+5. Requires `--confirm` flag (or interactive prompt) — this is a
+   destructive, irreversible operation.
+
 ---
 
 ## 11. Non-Goals (v1.0)
@@ -1178,7 +1321,7 @@ Open the `trickle-labs/pg-aqueduct` repository now, but keep the work
    spec (small change, useful regardless).
 
 Note: **the `pg_tide` extraction is no longer a prerequisite** for
-`pg_aqueduct` v0.1. Per §10.8, the v0.1 CLI has no pgrx component —
+`pg_aqueduct` v0.1. Per §10.7, the v0.1 CLI has no pgrx component —
 it is a pure Rust binary that bootstraps its own catalog over libpq,
 like Atlas. The pgrx companion extension arrives in Phase 4 and can
 borrow patterns from `pg_tide` at that point. Unblocking one item

--- a/plans/pg-aqueduct-plan.md
+++ b/plans/pg-aqueduct-plan.md
@@ -279,6 +279,41 @@ environment-scoped variables (`schedule = '5m'` in dev, `'30s'` in
 prod; `cdc_mode = 'trigger'` everywhere except a Citus-backed prod
 where it is `'wal'`). `pg_aqueduct` owns the substitution.
 
+### 5.8 When NOT to use `pg_aqueduct`
+
+The tool's value proposition is entirely dependent on the presence of
+a stream-table DAG. Without one, it adds complexity with no benefit.
+
+**Case A — Pure base-table schema, no stream tables, no `pg_tide`:**
+Use Atlas, sqitch, or Liquibase. They are mature, well-documented,
+and purpose-built for this exact problem. `pg_aqueduct`'s unique
+contributions — topological ordering, differential state preservation,
+DAG cascade analysis, CALCULATED schedule resolution — are
+meaningless here. Adopting `pg_aqueduct` for a pure-base-table schema
+is solving a problem that does not exist.
+
+**Case B — `pg_tide` outbox/inbox + base tables, no stream tables yet:**
+Atlas is still the right answer for the migration tooling. `pg_tide`
+tables (`tide.outbox`, `tide.inbox`, relay subscriptions) are normal
+application tables — they do not form a dependency DAG. `pg_aqueduct`
+has no analytical leverage over them.
+
+The *only* argument for `pg_aqueduct` in a `pg_tide`-only schema is
+the **gateway scenario**: a team that starts with `pg_tide` event
+patterns and has a concrete plan to add `pg_trickle` stream tables
+within the next few months. Starting with `pg_aqueduct` means the
+transition to a full stream-table DAG requires no tool switch — the
+migrations directory simply gains stream-table SQL files over time.
+This is a weak argument. The tool switch from Atlas to `pg_aqueduct`
+is not painful; the tool complexity of `pg_aqueduct` before any stream
+tables exist is real. **The honest recommendation is: use Atlas until
+you have your first stream table, then evaluate.**
+
+**The real threshold:** `pg_aqueduct` earns its operational complexity
+the moment the first stream table exists and that stream table's
+defining query references a column that could change. Before that
+moment, it is a solution to a future problem.
+
 ---
 
 ## 6. Composition With Adjacent Tools
@@ -286,7 +321,7 @@ where it is `'wal'`). `pg_aqueduct` owns the substitution.
 | Tool | Relationship |
 |---|---|
 | **`pg_trickle`** | Runtime target. `aqueduct` calls its SQL API. |
-| **`pg_tide`** | Sibling — the relay, outbox, inbox. `aqueduct` may manage tide's catalog (relay subscriptions, inbox shapes) under the same migration discipline. |
+| **`pg_tide`** | Sibling — the relay, outbox, inbox. `aqueduct` *may* manage tide's catalog (relay subscriptions, inbox shapes) under the same migration discipline when stream tables are also present. When `pg_tide` is used **without** any `pg_trickle` stream tables, Atlas is the better migration tool. See §5.8. |
 | **dbt / dbt-pgtrickle** | Upstream authoring. `aqueduct ingest --from dbt-target` reads dbt's compiled `manifest.json` and produces an `aqueduct` migration. |
 | **Atlas / Liquibase / sqitch** | Complementary — they own general-purpose base-table schema migrations (`CREATE TABLE`, partitioning, index changes). `pg_aqueduct` owns *stream-adjacent* base-table changes — any ALTER to a column that is a source for at least one stream table. For those changes, aqueduct generates and executes the base-table ALTER **and** the downstream stream-table cascade in a single coordinated plan. For standalone base-table migrations, aqueduct can invoke Atlas/sqitch as a pre-step hook. |
 | **Terraform / Pulumi** | Outer — provisions the database; the operator embeds a `terraform_data` resource that calls `aqueduct apply` post-provision. |
@@ -1297,6 +1332,15 @@ project's DAG, catalog entries, and lock rows.
 
 ## 11. Non-Goals (v1.0)
 
+- **Pure base-table schema management without stream tables.** If there
+  are no `pg_trickle` stream tables in the schema, use Atlas, sqitch,
+  or Liquibase instead (see §5.8). `pg_aqueduct` adds no value in
+  this case.
+- **`pg_tide`-only schemas (no stream tables).** `pg_tide` outbox,
+  inbox, and relay subscription tables are normal application tables;
+  they do not form a dependency DAG. Atlas manages them fine. The
+  gateway scenario (§5.8) is a marginal exception, not a
+  recommendation.
 - A general-purpose schema migration tool. `pg_aqueduct` manages
   stream-adjacent base-table changes (§10.5 Tier 1) but defers
   standalone DDL (non-referenced columns, new tables, indexes,

--- a/plans/pg-aqueduct-plan.md
+++ b/plans/pg-aqueduct-plan.md
@@ -806,6 +806,350 @@ extension grows scope. The medium-term answer is a shared
 `pg_trickle_calculus` crate (§9). The short-term answer is to ship a
 vendored copy and add a CI job that diffs the two.
 
+### 10.10 Blue/green atomicity — how do consumers cut over?
+
+**Problem:** When a blue/green deployment swaps the DAG from version N
+to version N+1, consumer queries (application reads, dashboards,
+exports) must switch atomically from the blue stream tables to the
+green ones. If even one consumer reads a mix of blue and green tables
+in a single query, the result is silently wrong.
+
+**Recommendation: rename-swap behind stable views.**
+
+1. Each stream table `foo` is consumed through a view `public.foo`
+   (or whatever schema the consumer expects). The actual materialised
+   table lives in a versioned schema: `aqueduct_v17.foo`.
+2. Blue/green builds the green DAG in `aqueduct_v18.*`, backfills it,
+   and waits for it to converge.
+3. The cutover is a single transaction that executes `ALTER VIEW
+   public.foo SET SCHEMA ...` or `CREATE OR REPLACE VIEW public.foo
+   AS SELECT * FROM aqueduct_v18.foo` for every node in the DAG. This
+   is an `ACCESS EXCLUSIVE` lock on the views — not on the
+   underlying tables — so it is sub-millisecond.
+4. After a configurable grace period (`--blue-ttl 1h`), `aqueduct
+   apply --cleanup` drops the old versioned schema.
+
+This is the same pattern used by `pg_deploy`, `sqitch`, and
+large-scale zero-downtime migration tooling. The consumer-facing
+views are the stable API; the underlying tables are versioned
+implementation details.
+
+**Alternative considered and rejected:** `SET search_path` at the
+session level. This is fragile (every connection pool session must
+be reconfigured), incompatible with connection poolers that strip
+session state (PgBouncer in transaction mode), and does not provide
+atomicity across multiple consumers.
+
+### 10.11 Failure recovery and partial state
+
+**Problem:** A migration can crash at any point — after the base-table
+ALTER but before the stream-table cascade, after 3 of 7 stream tables
+are rebuilt, or during a large backfill. What's the recovery model?
+
+**Recommendation: checkpoint-based resumable execution.**
+
+Every plan step writes its outcome to `aqueduct.migrations.progress`
+(a JSONB column) before proceeding to the next step. On crash:
+
+```bash
+aqueduct apply --resume   # reads progress, skips completed steps
+```
+
+Three step categories with different recovery semantics:
+
+| Category | Examples | Recovery |
+|---|---|---|
+| **Transactional** | `AlterStreamTable`, `SwapView`, `RecordSnapshot` | Rolled back automatically on crash — step is retried |
+| **Idempotent** | `CreateStreamTable` (IF NOT EXISTS), `AlterBaseTable` (guarded by catalog check) | Safe to re-execute — step checks precondition before acting |
+| **Long-running** | `Backfill { mode: FULL }`, `WaitForRefresh` | Checkpointed by row-range or by table. On resume, `Backfill` restarts the affected table's full refresh (not the entire plan). `WaitForRefresh` simply re-polls |
+
+**Invariant:** no step may leave the database in a state where the
+*old* plan version and the *new* plan version are both partially
+applied without the checkpoint recording which steps completed.
+Violation of this invariant is a data-loss bug.
+
+**Worst case — unresumable state:** If the CLI cannot determine
+whether a step completed (e.g., connection lost mid-`ALTER TABLE`
+with no way to query the catalog), `aqueduct apply --resume` prints
+a diagnostic report and exits with a non-zero code. The operator
+must inspect and either `--force-retry` or `--force-skip` the
+ambiguous step. Automatic guessing is not acceptable — this is the
+"data loss is unacceptable" principle from `pg_trickle`'s AGENTS.md.
+
+### 10.12 Concurrency contract with the `pg_trickle` scheduler
+
+**Problem:** §7.6 says `aqueduct apply` calls
+`pgtrickle.pause_scheduler()`, but what if a refresh is already
+in-flight when the pause request arrives? What if pause fails?
+
+**Recommendation: drain-then-pause protocol.**
+
+1. `aqueduct apply` calls `pgtrickle.pause_scheduler(nodes => [...])`.
+   This sets a flag in `pg_trickle`'s shared memory that prevents the
+   scheduler from *starting* new refreshes for the listed nodes.
+2. The CLI then polls `pgtrickle.pgt_stream_tables` for
+   `refresh_status = 'running'` on the affected nodes, waiting up to
+   `lock_timeout` (from `aqueduct.toml`) for in-flight refreshes to
+   complete.
+3. If the drain deadline expires with a refresh still running, the
+   CLI aborts the migration cleanly (no changes applied) and reports
+   which node is blocking.
+4. On migration success *or* failure (including crash), the CLI calls
+   `pgtrickle.resume_scheduler(nodes => [...])`. If the CLI crashes
+   before resuming, the `aqueduct.locks` TTL expires and a subsequent
+   `aqueduct apply --resume` or `aqueduct unlock` call resumes the
+   scheduler.
+
+**Prerequisite for `pg_trickle`:** expose `pause_scheduler()` and
+`resume_scheduler()` SQL functions with per-node granularity. These
+do not exist today — file as a `pg_trickle` issue (already noted in
+§9).
+
+**Fallback if `pause_scheduler()` is unavailable (older
+`pg_trickle` versions):** the CLI sets each affected node's schedule
+to `'999d'` (effectively infinite), applies the migration, then
+restores the original schedule. This is racy but acceptable for
+v0.1 against older clusters.
+
+### 10.13 Cost estimation
+
+**Problem:** `aqueduct apply --dry-run --explain-cost` promises
+per-step estimated row counts and refresh duration, but how accurate
+can these be?
+
+**Recommendation: Postgres-native estimates + empirical calibration.**
+
+1. **Row count:** Run `EXPLAIN (FORMAT JSON)` against the stream
+   table's defining query with current statistics. Extract
+   `Plan Rows` from the top-level node. This is free (no actual
+   execution), available on every Postgres version, and accurate
+   enough for order-of-magnitude estimates.
+2. **Refresh duration:** For `FULL` rebuilds, estimate as
+   `estimated_rows × bytes_per_row / measured_write_throughput`.
+   The write-throughput constant is calibrated per-cluster: on
+   first `aqueduct init`, run a small benchmark (INSERT 10k rows
+   into a temp table, measure wall time). Store the result in
+   `aqueduct.cluster_profile`. This is crude but within 2–5×.
+3. **For `DIFFERENTIAL`:** estimate is "near-zero" (the existing
+   materialised state is preserved). Report the estimated change-
+   buffer size instead of duration.
+4. **For `IN-PLACE`:** estimate is "ALTER + incremental backfill".
+   Use the same row-count estimate but with a lower throughput
+   constant (ALTER + backfill is cheaper than full rebuild).
+
+**Display:** The plan renderer shows a summary table:
+
+```
+Step                          Rows (est)    Duration (est)    Class
+─────────────────────────────────────────────────────────────────────
+ALTER base raw.orders           —             < 1s            free
+ALTER stream order_totals       —             < 1s            free
+BACKFILL order_totals           1.2M          ~45s            rebuild
+ALTER stream customer_summary   —             < 1s            in-place
+BACKFILL customer_summary       340K          ~12s            in-place
+```
+
+**Non-goal:** sub-second accuracy. The purpose is to distinguish
+"this migration takes 2 seconds" from "this migration takes 2 hours"
+so the operator can decide whether to run it now or schedule it for
+the maintenance window.
+
+### 10.14 CLI upgrade mid-migration
+
+**Problem:** If the CLI binary is upgraded while a resumable migration
+is in-flight (e.g., operator deploys a new `aqueduct` version, then
+runs `aqueduct apply --resume`), can it safely resume?
+
+**Recommendation: plan format versioning + forward compatibility.**
+
+1. Every serialised plan in `aqueduct.migrations.plan` includes a
+   `plan_format_version` integer (starting at 1).
+2. A CLI binary can resume any plan whose `plan_format_version` is
+   ≤ its own compiled-in version. It refuses to resume a plan from a
+   *newer* CLI with a clear error message.
+3. Plan format changes are rare (they are structural, not cosmetic)
+   and are always backwards-compatible additions, never removals or
+   reinterpretations. If a breaking change is unavoidable, bump the
+   major format version and reject old plans.
+4. The CLI records its own version in
+   `aqueduct.migrations.cli_version` for diagnostic purposes.
+
+**Practical consequence:** upgrading the CLI mid-migration is safe
+as long as the new CLI is the same or newer major version. Downgrading
+is not supported (the old CLI may not understand new step types).
+
+### 10.15 HA / failover integration
+
+**Problem:** In an HA cluster (Patroni, CloudNativePG, Stolon), the
+primary can change at any time. If `aqueduct apply` is mid-migration
+when a failover happens, what occurs?
+
+**Recommendation: detect failover, abort cleanly, resume on new
+primary.**
+
+1. On `aqueduct apply` startup, the CLI records the current primary's
+   `system_identifier` + `timeline_id` (from `pg_control_system()`)
+   in the migration row.
+2. Between each plan step, the CLI re-checks that the connection is
+   still to the same primary. If the `system_identifier` or
+   `timeline_id` has changed (indicating a failover), the CLI:
+   - marks the migration as `status = 'interrupted'` with the
+     last completed step;
+   - exits with a clear error: "Failover detected. Re-run
+     `aqueduct apply --resume` against the new primary."
+3. The lock row in `aqueduct.locks` has a TTL. If the CLI process
+   dies in a failover, the lock expires and a fresh `aqueduct apply
+   --resume` can proceed on the new primary.
+4. `aqueduct apply` **refuses to run against a hot standby** (checks
+   `pg_is_in_recovery()`). This is a hard error, not a warning.
+
+**Patroni-specific:** The CLI can optionally accept a
+`--patroni-endpoint` flag and use the Patroni REST API to discover
+the current primary, avoiding stale DNS.
+
+**CloudNativePG-specific:** For Kubernetes deployments, the CLI
+can read the `cnpg.io/cluster` annotation to discover the current
+primary service endpoint.
+
+### 10.16 Schedule resolution during DAG restructuring
+
+**Problem:** If a downstream node has `schedule = 'calculated'` and
+its upstream dependencies are restructured (a new parent is added, a
+parent is removed, a parent's schedule changes), how is the
+calculated schedule resolved?
+
+**Recommendation: `pg_trickle` owns schedule resolution; `aqueduct`
+defers to it.**
+
+`pg_trickle`'s `CALCULATED` schedule mode already resolves the
+schedule from the DAG topology. `pg_aqueduct` does not need to
+reimplement this. The contract is:
+
+1. `aqueduct plan` reads the *current* calculated schedule from
+   `pgtrickle.pgt_stream_tables.schedule_resolved` for display
+   purposes.
+2. `aqueduct apply` calls `pgtrickle.alter_stream_table()` or
+   `pgtrickle.create_stream_table()` with `schedule => 'calculated'`.
+   `pg_trickle` resolves the schedule from the live DAG topology at
+   that point.
+3. If the restructuring changes which upstream nodes feed a
+   calculated node, `pg_trickle` recalculates automatically on the
+   next scheduler tick.
+4. The plan renderer shows the *predicted* new schedule (computed
+   by the CLI's DAG differ using the same algorithm), with a caveat:
+   "Actual calculated schedule will be resolved by pg_trickle at
+   apply time."
+
+**Edge case — circular calculated dependencies:** Impossible by
+construction. `pg_trickle` already prevents cycles in the DAG.
+`aqueduct plan` rejects any migration that would introduce a cycle
+(by running the same topological-sort + cycle-detection as
+`pg_trickle`'s `dag.rs`).
+
+### 10.17 Version compatibility matrix
+
+**Problem:** Which `pg_trickle` versions can a given `aqueduct` CLI
+target? How is this tested?
+
+**Recommendation: minimum-version pinning + CI matrix.**
+
+1. `aqueduct` declares a **minimum supported `pg_trickle` version**
+   in `aqueduct.toml` (default: the oldest version that exposes the
+   JSON spec projection — likely v0.60 or v1.0).
+2. On `aqueduct apply`, the CLI queries
+   `pgtrickle.pgt_extension_version()` and checks it against the
+   minimum. If the installed version is too old, it prints a clear
+   error listing the missing capabilities.
+3. The CLI is **forward-compatible by default:** it uses only the
+   stable SQL API (`create_stream_table`, `alter_stream_table`,
+   `drop_stream_table`, `refresh_stream_table`). It does not depend
+   on internal catalog column layouts or undocumented functions.
+4. CI runs the E2E test suite against a matrix of `pg_trickle`
+   versions: `{latest, latest-1, minimum_supported}`. This catches
+   regressions early.
+
+**Version skew policy:** `aqueduct` v0.x supports `pg_trickle`
+v0.{min}–v0.{latest}. After both projects reach 1.0, the policy
+tightens to `aqueduct` 1.x supports `pg_trickle` 1.x (same major
+version, any minor).
+
+### 10.18 Consumer-layer management
+
+**Problem:** §7.3 mentions a three-layer model with a "consumer
+layer (v1.1+)" but does not define what this entails.
+
+**Recommendation: v1.0 manages consumer views; v1.1+ manages sinks.**
+
+**v1.0 scope — consumer views only:**
+
+Consumer views are the `CREATE OR REPLACE VIEW public.foo AS SELECT
+* FROM aqueduct_vN.foo` objects described in §10.10 (blue/green).
+`aqueduct` creates and manages these views as part of every
+migration. They are the stable API that applications query.
+
+The migrations directory can declare consumer views explicitly:
+
+```sql
+-- migrations/consumers/api_orders.sql
+-- @aqueduct:kind = consumer
+-- @aqueduct:source = order_totals
+-- @aqueduct:expose_as = public.api_orders
+SELECT customer_id, total_amount FROM order_totals
+WHERE total_amount > 0;
+```
+
+This lets the migration tool track which application queries depend
+on which stream tables, and include them in impact analysis and
+blue/green swap.
+
+**v1.1+ scope — sinks (out of scope for v1.0):**
+
+Sinks are external consumers: reverse-ETL to Kafka, S3/Iceberg
+exports, webhook notifications, `pg_tide` outbox entries. Managing
+these requires understanding external system APIs and is a different
+problem class. Defer to `pg_tide` and purpose-built connectors.
+
+### 10.19 Project scope definition — what is a "project"?
+
+**Problem:** One migrations directory per project. But what is a
+project? One DAG? Multiple DAGs? If a company has 50 independent
+stream-table DAGs, are there 50 directories and 50 lock rows?
+
+**Recommendation: one project = one logically-connected DAG.**
+
+A project is the smallest set of stream tables where a change to any
+member *could* cascade to another member. In practice this means:
+
+1. **Connected component.** If stream table A depends (directly or
+   transitively) on stream table B, they belong to the same project.
+   Independent sub-DAGs that share no edges are separate projects.
+2. **One `aqueduct.toml` per project.** A monorepo can contain
+   multiple project directories, each with its own `aqueduct.toml`.
+3. **One lock row per project.** `aqueduct.locks` is keyed by
+   `project` name. Two independent projects can run `aqueduct apply`
+   concurrently without interference.
+4. **Shared base tables.** If two projects read from the same base
+   table but have no stream-table edges between them, they are still
+   separate projects. A base-table ALTER affects both projects
+   independently — each project's `aqueduct plan` reports its own
+   cascade.
+
+**Naming convention:** The project name defaults to the directory
+name but can be overridden in `aqueduct.toml`:
+
+```toml
+[project]
+name = "checkout-analytics"   # used as the lock key and version namespace
+```
+
+**Scale guidance:**
+
+| Team size | Typical pattern |
+|---|---|
+| Small (1–5 stream tables) | One project, one directory |
+| Medium (10–50) | 2–5 projects, grouped by domain (orders, inventory, analytics) |
+| Large (50–200+) | One project per bounded context; each project has its own `aqueduct.toml`, CI pipeline, and deployment cadence |
+
 ---
 
 ## 11. Non-Goals (v1.0)


### PR DESCRIPTION
## Summary

Follows on from #804 (merged). Adds detailed recommendations for 10 remaining open architectural questions in [plans/pg-aqueduct-plan.md](plans/pg-aqueduct-plan.md).

## What was added

New sections §10.10 through §10.19 address every unresolved design gap identified in the earlier discussions:

| § | Topic | Recommendation |
|---|---|---|
| **10.10** | Blue/green atomicity | Rename-swap behind stable views; cutover is a single transaction of `CREATE OR REPLACE VIEW` (sub-millisecond) |
| **10.11** | Failure recovery | Checkpoint-based resumable execution; three step categories (transactional, idempotent, long-running) |
| **10.12** | Scheduler concurrency | Drain-then-pause protocol; wait for in-flight refreshes before proceeding |
| **10.13** | Cost estimation | `EXPLAIN`-based row counts + write-throughput calibration; non-goal is sub-second accuracy |
| **10.14** | CLI upgrade mid-migration | `plan_format_version` for forward-compatibility; refuse to resume plans from newer CLI |
| **10.15** | HA / failover | Detect via `system_identifier` + `timeline_id`; abort cleanly; resume on new primary |
| **10.16** | Schedule resolution | Defer to `pg_trickle`'s `CALCULATED` mode; CLI predicts for display only |
| **10.17** | Version compatibility | Minimum-version pinning; CI matrix against {latest, latest-1, min_supported} |
| **10.18** | Consumer-layer management | v1.0 manages consumer views (stable API); v1.1+ may manage sinks |
| **10.19** | Project scope definition | One project = one connected DAG component; independent sub-DAGs are separate projects |

## Design philosophy

Each recommendation follows the same principles as the rest of the plan:

- **Simplicity first.** Use Postgres' built-in facilities (views, advisory locks, `EXPLAIN`) before inventing new abstractions.
- **Correctness is non-negotiable.** No automatic guessing on ambiguous state; data loss is unacceptable (from `pg_trickle` AGENTS.md).
- **Minimize external dependencies.** Integrate with `pg_trickle`, `pg_tide`, Patroni, CloudNativePG; do not depend on custom orchestration.
- **Progressive enhancement.** Start with the minimal viable set (v0.1) and add optional features (v1.1+) only when the core cycle is solid.

## Readiness for implementation

All recommendations in this PR are **implementation-ready**: they are specific enough to code from, do not require new `pg_trickle` features (only the existing `pause_scheduler` function noted in §9), and have been stress-tested against edge cases (failover, partial state, concurrent projects).
