### PR TITLE
test: add defining_query_hash to catalog schema stability test

### DIFF
--- a/tests/e2e_upgrade_tests.rs
+++ b/tests/e2e_upgrade_tests.rs
@@ -41,6 +41,7 @@ async fn test_upgrade_catalog_schema_stability() {
         ("created_at", "timestamp with time zone"),
         ("data_timestamp", "timestamp with time zone"),
         ("defining_query", "text"),
+        ("defining_query_hash", "bigint"),
         ("diamond_consistency", "text"),
         ("diamond_schedule_policy", "text"),
         ("downstream_publication_name", "text"),


### PR DESCRIPTION
## Summary

The v0.58.0→0.59.0 migration added a `defining_query_hash BIGINT` column to `pgtrickle.pgt_stream_tables` (PERF-2), but the column was not added to the `expected_columns` list in `test_upgrade_catalog_schema_stability`. This caused the column-count assertion to fail on every E2E run after the v0.59.0 release.

## Changes

- Add `("defining_query_hash", "bigint")` to the expected columns list in `test_upgrade_catalog_schema_stability` (alphabetical order, between `defining_query` and `diamond_consistency`)

## Testing

- `just lint` — passes (no clippy warnings)
- `test_upgrade_catalog_schema_stability` will now match the actual 56-column schema of `pgt_stream_tables` in v0.59.0

## Notes

Fixes CI run #2252 / job 75720883172 (`E2E tests` — `test_upgrade_catalog_schema_stability`).
