### PR TITLE
roadmap: add v0.62.0 and v0.63.0 — Scheduler Throughput Arc

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,6 +166,19 @@ arc resolves all findings before v1.0.
 | [v0.60.0](roadmap/v0.60.0.md) | Code Quality, Test Coverage & CI: scheduler log levels, codegen decomposition, cdc.rs 4-way split, refresh orchestrator/merge/CDC/hooks unit tests, differential idempotence proptest, sleep removal, WAL OID filter, partition-attach rebuild, path-filtered full E2E on PRs, Dockerfile non-root, codecov module thresholds | Planned | Large | [Full details](roadmap/v0.60.0.md-full.md) |
 | [v0.61.0](roadmap/v0.61.0.md) | DX, Documentation & Final Pre-1.0 Polish: health_check() foreign-owner row, SQL_REFERENCE completeness, snapshot cache secondary equality, cte_counter reset, outbox name collision fix, sublinks.rs decomposition, ctid invariant comment, 3 foundational ADRs, LIMITATIONS.md NOT IN + NULL section, SEARCH/CYCLE clear error, LATERAL+DIFFERENTIAL docs | Planned | Large | [Full details](roadmap/v0.61.0.md-full.md) |
 
+### Scheduler Throughput Arc (v0.62.x – v0.63.x)
+
+Two releases targeting scheduler throughput: eliminating redundant change-buffer
+scans via fan-out, adding the `pause_scheduler` / `resume_scheduler` /
+`stream_table_spec` SQL API required by the planned `pg_aqueduct` migration tool
+([plans/pg-aqueduct-plan.md](plans/pg-aqueduct-plan.md)), and implementing
+fused CTE refresh to reduce per-tick statement overhead for multi-node DAGs.
+
+| Version | Theme | Status | Scope | Full details |
+|---------|-------|--------|-------|--------------|
+| [v0.62.0](roadmap/v0.62.0.md) | Scheduler throughput: change-buffer fan-out (O(N)→O(1) scans for multi-consumer DAGs), `pause_scheduler` / `resume_scheduler` per-node SQL functions, `stream_table_spec(oid)` stable JSON projection | Planned | Medium | [Full details](roadmap/v0.62.0.md-full.md) |
+| [v0.63.0](roadmap/v0.63.0.md) | Fused multi-node refresh: CTE-chain composition of per-node delta SQL in a single statement, correctness property test, benchmark regression gate (≥ 20 % wall-time reduction on TPC-H 22-node DAG) | Planned | Large | [Full details](roadmap/v0.63.0.md-full.md) |
+
 ### Beyond v1.0
 
 | Version | Theme | Status | Scope | Full details |
@@ -257,6 +270,10 @@ v0.59    ─── Performance & observability: batched monitor SPI, query-hash 
 v0.60    ─── Code quality, test coverage & CI: cdc.rs split, codegen decompose, refresh/CDC/hooks unit tests, idempotence proptest, sleep removal, WAL OID filter, partition-attach rebuild, path-filtered E2E on PRs
     │
 v0.61    ─── DX, docs & pre-1.0 polish: health_check foreign-owner row, SQL_REFERENCE complete, snapshot secondary equality, cte_counter reset, outbox name fix, sublinks decompose, 3 ADRs, LATERAL docs
+    │
+v0.62    ─── Scheduler throughput: change-buffer fan-out (O(N)→O(1)), pause/resume_scheduler SQL API, stream_table_spec() stable JSON projection
+    │
+v0.63    ─── Fused multi-node refresh: CTE-chain composition across ready nodes, ≥ 20 % wall-time reduction on TPC-H 22-node DAG
     │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```

--- a/plans/pg-aqueduct-plan.md
+++ b/plans/pg-aqueduct-plan.md
@@ -967,6 +967,146 @@ events are emitted periodically. The `apply` command also sets
 `aqueduct/<project>/<migration_id>` so that in-flight migrations
 are visible in `pg_stat_activity`.
 
+### 7.7 Pluggable executor architecture
+
+The planner (differ, classifier, plan renderer) is **target-system-agnostic**.
+It operates on abstract `StreamTableSpec` values and emits abstract `Plan`
+step sequences. All target-system knowledge lives in a thin `StreamExecutor`
+trait implementation that the planner calls at apply time. This boundary is
+designed explicitly so that `pg_aqueduct` can serve IVM systems beyond
+`pg_trickle` without restructuring any of the planning logic.
+
+#### The `StreamExecutor` trait
+
+```rust
+/// Implemented once per target system (pg_trickle, RisingWave, Materialize,
+/// Feldera, Snowflake, …). The planner is parameterised over this trait.
+pub trait StreamExecutor: Send + Sync {
+    // ── Lifecycle ──────────────────────────────────────────────────────────
+
+    /// Create a new stream table / materialized view on the target system.
+    fn create(
+        &self,
+        spec: &StreamTableSpec,
+        conn: &dyn ExecutorConnection,
+    ) -> Result<(), ExecutorError>;
+
+    /// Apply an alteration to an existing stream table.
+    fn alter(
+        &self,
+        name: &QualifiedName,
+        change: &AlterChange,
+        conn: &dyn ExecutorConnection,
+    ) -> Result<(), ExecutorError>;
+
+    /// Drop a stream table. `cascade` drops dependent objects.
+    fn drop(
+        &self,
+        name: &QualifiedName,
+        cascade: bool,
+        conn: &dyn ExecutorConnection,
+    ) -> Result<(), ExecutorError>;
+
+    // ── Refresh ────────────────────────────────────────────────────────────
+
+    /// Trigger an explicit refresh of a single stream table.
+    fn refresh(
+        &self,
+        name: &QualifiedName,
+        mode: RefreshMode,
+        conn: &dyn ExecutorConnection,
+    ) -> Result<(), ExecutorError>;
+
+    // ── Scheduler ─────────────────────────────────────────────────────────
+
+    /// Pause the refresh scheduler for the given nodes.
+    /// On systems that have no scheduler concept, may be a no-op.
+    fn pause_scheduler(
+        &self,
+        nodes: &[QualifiedName],
+        conn: &dyn ExecutorConnection,
+    ) -> Result<(), ExecutorError>;
+
+    /// Resume the refresh scheduler for the given nodes.
+    fn resume_scheduler(
+        &self,
+        nodes: &[QualifiedName],
+        conn: &dyn ExecutorConnection,
+    ) -> Result<(), ExecutorError>;
+
+    // ── State introspection ────────────────────────────────────────────────
+
+    /// Read the live state of all stream tables managed by this project.
+    /// Used by the planner differ to build the "actual" side of the diff.
+    fn live_state(
+        &self,
+        conn: &dyn ExecutorConnection,
+    ) -> Result<Vec<StreamTableState>, ExecutorError>;
+
+    // ── Capability advertisement ───────────────────────────────────────────
+
+    /// Return the set of IVM capabilities this executor supports.
+    /// The planner uses this to gate migration classes it may emit
+    /// (e.g., it will not emit `PauseImmediate` for a system that lacks
+    /// IMMEDIATE mode, nor `ManageWalSlot` for a system without WAL CDC).
+    fn capabilities(&self) -> ExecutorCapabilities;
+}
+
+/// A bitmask of IVM capabilities exposed to the planner.
+bitflags! {
+    pub struct ExecutorCapabilities: u32 {
+        const DIFFERENTIAL_REFRESH   = 0b0000_0001;
+        const FULL_REFRESH           = 0b0000_0010;
+        const IMMEDIATE_MODE         = 0b0000_0100;
+        const TRIGGER_CDC            = 0b0000_1000;
+        const WAL_CDC                = 0b0001_0000;
+        const PAUSE_RESUME_SCHEDULER = 0b0010_0000;
+        const DIAMOND_CONSISTENCY    = 0b0100_0000;
+        const BLUE_GREEN_DEPLOY      = 0b1000_0000;
+    }
+}
+```
+
+The `ExecutorConnection` trait abstracts the network transport:
+`libpq`-style connections for PostgreSQL-wire-compatible targets (pg_trickle,
+RisingWave, Materialize); HTTP REST for Feldera; Snowflake connector for
+Snowflake. The planner never calls the connection directly — only the executor
+does.
+
+#### Crate layout for multi-executor support
+
+```
+aqueduct-core/
+└── src/
+    ├── executor/
+    │   ├── mod.rs            # StreamExecutor trait + ExecutorCapabilities
+    │   ├── connection.rs     # ExecutorConnection trait + libpq impl
+    │   ├── pg_trickle.rs     # built-in executor (v0.1)
+    │   ├── risingwave.rs     # RisingWave executor (future)
+    │   ├── materialize.rs    # Materialize executor (future)
+    │   ├── feldera.rs        # Feldera executor (future; HTTP REST)
+    │   └── snowflake.rs      # Snowflake Dynamic Tables executor (future)
+    ├── planner/              # DAG differ, classifier, plan builder
+    ├── renderer/             # human-readable + JSON + Markdown output
+    └── catalog/              # aqueduct.* catalog access
+```
+
+The executor is selected at runtime from the `[executor]` block in
+`aqueduct.toml`:
+
+```toml
+[executor]
+kind = "pg_trickle"    # pg_trickle | risingwave | materialize | feldera | snowflake
+# executor-specific settings follow:
+# [executor.feldera]
+# api_base_url = "https://my-feldera.example.com"
+# pipeline_name = "checkout-analytics"
+```
+
+`kind = "pg_trickle"` is the default and requires no additional keys — it
+targets the PostgreSQL cluster at the active `[targets.<name>]` DSN. See
+§10.24 for per-system capability matrices and connection details.
+
 ---
 
 ## 8. Implementation Plan
@@ -1206,8 +1346,23 @@ If `pg_aqueduct` is too tightly coupled to `pg_trickle`, it can never
 serve `pg_ivm`, Materialize, RisingWave, or future `pg_trickle` forks.
 The recommended posture: **the planner is generic, the executor is
 pluggable**. v0.1 ships only the `pg_trickle` executor; the trait
-boundary is designed so a `pg_ivm` executor can be added later without
-restructuring the planner.
+boundary (§7.7) is designed so additional executors can be added later
+without restructuring any planning logic.
+
+The hottest near-term candidates for non-`pg_trickle` executors are:
+
+| System | IVM paradigm | Protocol | Realistic timeline |
+|---|---|---|---|
+| **RisingWave** | Streaming SQL; always-on incremental MV | PostgreSQL wire | After v0.1 GA |
+| **Feldera** | Differential dataflow; pipeline-scoped | HTTP REST | After v0.1 GA |
+| **Materialize** | Streaming SQL; differential dataflow | PostgreSQL wire | After v0.1 GA |
+| **Snowflake** | Dynamic Tables; automatic incr/full | Snowflake connector | After v1.0 GA |
+
+These are **not** in scope for v0.1 or v1.0. They are design constraints that
+informed the trait boundary in §7.7 — the executor interface must be expressive
+enough that each of these systems can be implemented cleanly. See §10.24 for
+detailed capability matrices, connection models, and known gaps for each
+candidate system.
 
 ### 10.2 SQL parsing
 
@@ -1963,6 +2118,372 @@ wants to interrupt it). The command:
    scheduler).
 3. Prints a summary of what it released so the operator can verify
    the correct lock was removed.
+
+### 10.24 Pluggable executor profiles — RisingWave, Feldera, Materialize, Snowflake
+
+This section profiles each of the four hot-candidate executor targets listed in
+§10.1. It documents the SQL/API mapping, capability gaps, and open design
+questions for each system. None of these executors will be implemented before
+v1.0 — but they must not require a redesign of the §7.7 trait to land cleanly.
+
+#### 10.24.1 RisingWave
+
+**What it is.** A cloud-native streaming SQL database with full PostgreSQL
+wire-protocol compatibility. Stream tables are modelled as `CREATE MATERIALIZED
+VIEW` and refreshed continuously in a streaming fashion — there is no
+explicit refresh schedule; data propagates as upstream sources change.
+
+**SQL mapping.**
+
+| `pg_trickle` concept | RisingWave equivalent |
+|---|---|
+| `create_stream_table(name, query, refresh_mode='DIFFERENTIAL')` | `CREATE MATERIALIZED VIEW name AS query` |
+| `alter_stream_table(name, schedule=>...)` | No direct equivalent — refresh is always event-driven; schedule becomes a no-op or maps to connector's fetch interval |
+| `drop_stream_table(name)` | `DROP MATERIALIZED VIEW name` |
+| `refresh_stream_table(name)` | Not needed — refresh is continuous; emit a warning if called |
+| `pause_scheduler(nodes)` | `ALTER MATERIALIZED VIEW name SET STREAMING_PAUSE_FREQUENCY = MAX` (if supported) or suspend the upstream source |
+| `resume_scheduler(nodes)` | `ALTER MATERIALIZED VIEW name SET STREAMING_PAUSE_FREQUENCY = DEFAULT` |
+| CDC mode `'trigger'` | N/A — RisingWave has its own source connectors (PostgreSQL CDC via `CREATE SOURCE`) |
+| IMMEDIATE mode | N/A — RisingWave is always streaming; no synchronous within-transaction semantics |
+
+**Capabilities.**
+
+```
+DIFFERENTIAL_REFRESH   ✅  (always-on, continuous)
+FULL_REFRESH           ✅  (via REFRESH MATERIALIZED VIEW if supported)
+IMMEDIATE_MODE         ❌  (no synchronous in-transaction refresh)
+TRIGGER_CDC            ❌  (uses source connectors, not row-level triggers)
+WAL_CDC                ✅  (PostgreSQL CDC source via logical decoding)
+PAUSE_RESUME_SCHEDULER ⚠   (partial — depends on source connector)
+DIAMOND_CONSISTENCY    ❌  (eventual consistency across views)
+BLUE_GREEN_DEPLOY      ✅  (schema-swap pattern applies)
+```
+
+**Connection.** Standard PostgreSQL wire protocol over TLS. The
+`ExecutorConnection` libpq implementation works without modification.
+
+**Key gaps and open questions.**
+
+1. **Schedule semantics.** `pg_trickle` schedules are meaningful
+   (`30s`, `CALCULATED`). RisingWave has no schedule — refresh is
+   driven by upstream data arrival. The `aqueduct.toml` `schedule` key
+   should be silently ignored (with a linter warning) for RisingWave
+   targets, or mapped to the source connector's `scan.startup.mode` /
+   checkpoint interval for batch sources.
+2. **Source declarations.** RisingWave needs explicit `CREATE SOURCE`
+   DDL before any MV can reference a Kafka topic or upstream Postgres
+   table. The executor must translate `@aqueduct:kind = source` +
+   connector metadata into `CREATE SOURCE` calls. A new front-matter
+   directive `@aqueduct:source_connector` is likely needed.
+3. **`aqueduct import` from an existing RisingWave deployment.** Query
+   `rw_catalog.rw_materialized_views` (the RisingWave equivalent of
+   `pgtrickle.pgt_stream_tables`) to reconstruct the migrations
+   directory.
+4. **Blue/green schema-swap.** RisingWave supports schemas. The
+   rename-swap pattern from §10.10 applies directly.
+5. **No `pg_trickle` extension required.** The RisingWave executor
+   does not call any `pgtrickle.*` function. The `aqueduct` catalog
+   (`aqueduct.*` plain tables) is still created on the RisingWave
+   cluster directly.
+
+---
+
+#### 10.24.2 Feldera
+
+**What it is.** A standalone incremental computation engine built on
+differential dataflow (the same mathematical foundation as `pg_trickle`'s
+DVM). Users define SQL programs; Feldera compiles them into pipelines and
+executes them continuously. Unlike pg_trickle and RisingWave, Feldera is
+**not** a PostgreSQL extension or a PostgreSQL-wire-compatible server —
+its primary interface is a **REST API** over HTTP(S).
+
+**API mapping.**
+
+Feldera's unit of deployment is a *pipeline* (a compiled SQL program
+containing all views and sources). Unlike `pg_trickle`, you cannot add a
+single view to a running pipeline without recompiling the entire program.
+This fundamental difference means the executor must manage the whole DAG as
+a single Feldera pipeline artifact rather than issuing per-view SQL calls.
+
+| `pg_trickle` concept | Feldera equivalent |
+|---|---|
+| Create a stream table | Add a `CREATE VIEW` to the pipeline SQL program + `PUT /v0/pipelines/{name}` to redeploy |
+| Alter a stream table | Modify the pipeline SQL + redeploy |
+| Drop a stream table | Remove from pipeline SQL + redeploy |
+| Refresh (differential) | Continuous — no explicit refresh; data flows in from input connectors |
+| pause_scheduler | `POST /v0/pipelines/{name}/pause` |
+| resume_scheduler | `POST /v0/pipelines/{name}/start` |
+| live_state | `GET /v0/pipelines/{name}/views` |
+
+**Capabilities.**
+
+```
+DIFFERENTIAL_REFRESH   ✅  (Feldera is differential dataflow natively)
+FULL_REFRESH           ✅  (reset pipeline + replay inputs)
+IMMEDIATE_MODE         ❌  (no synchronous within-transaction semantics)
+TRIGGER_CDC            ❌  (uses REST input connectors)
+WAL_CDC                ⚠   (PostgreSQL input connector uses logical decoding)
+PAUSE_RESUME_SCHEDULER ✅  (pipeline-level pause/start via REST)
+DIAMOND_CONSISTENCY    ✅  (Feldera's differential dataflow handles diamonds correctly)
+BLUE_GREEN_DEPLOY      ⚠   (can run two pipelines in parallel; no atomic view-swap)
+```
+
+**Connection.** HTTP REST via `reqwest` (async). The `ExecutorConnection`
+trait needs a second implementation: `FelderaConnection { base_url, api_key }`.
+No `libpq`. This is the largest structural departure from the built-in
+executor.
+
+**Key gaps and open questions.**
+
+1. **Pipeline recompile on every change.** Each `create`, `alter`, or `drop`
+   requires redeploying the entire pipeline (compile + restart). For large
+   DAGs this can take seconds to minutes. The executor must batch all plan
+   steps that affect the SQL program into a single pipeline redeploy rather
+   than issuing per-step deploys.
+   
+   Concretely: the plan executor for Feldera runs a pre-pass that groups all
+   `CreateStreamTable`, `AlterStreamTable`, and `DropStreamTable` steps,
+   synthesises the new combined SQL program, and issues a single `PUT
+   /v0/pipelines/{name}` + stop + start cycle. `Free` steps (schedule,
+   refresh-mode metadata) that Feldera does not model are recorded only in
+   `aqueduct.dag_versions`.
+
+2. **No per-view schema.** Feldera's SQL program does not use PostgreSQL
+   schemas — all views are flat within a pipeline namespace. The `schema`
+   qualifier in `QualifiedName` must be mapped to a pipeline name + view
+   name pair, or the executor must enforce that all stream tables in a
+   Feldera target live in the same schema (mapped 1:1 to the pipeline).
+
+3. **`aqueduct import` from Feldera.** Use `GET /v0/pipelines/{name}` to
+   retrieve the program SQL, then parse it with `pg_query.rs` to reconstruct
+   `StreamTableSpec` values.
+
+4. **No `aqueduct` catalog on Feldera itself.** Feldera is not a general-purpose
+   relational store. The `aqueduct.*` catalog tables must live in a separate
+   PostgreSQL instance (or a SQLite file for local dev). The `aqueduct.toml`
+   requires a `catalog_dsn` key when `executor.kind = "feldera"`:
+   ```toml
+   [executor]
+   kind = "feldera"
+   [executor.feldera]
+   api_base_url   = "https://my-feldera.example.com"
+   pipeline_name  = "checkout-analytics"
+   catalog_dsn    = "${AQUEDUCT_CATALOG_DSN}"   # PostgreSQL/SQLite for aqueduct.* tables
+   ```
+
+5. **Blue/green.** Feldera supports running multiple named pipelines
+   simultaneously. Blue/green can be approximated by creating a second
+   pipeline (`checkout-analytics-green`) and swapping consumer input
+   connectors, but there is no atomic view-swap equivalent. This is a
+   known limitation for v0.1 Feldera support.
+
+---
+
+#### 10.24.3 Materialize
+
+**What it is.** A streaming SQL database built on differential dataflow
+(Timely Dataflow), with a PostgreSQL wire protocol interface. Stream tables
+map naturally to `CREATE MATERIALIZED VIEW`. Materialize is the closest
+conceptual peer to `pg_trickle` among the four candidates: it performs the
+same differential dataflow computation, exposes a PostgreSQL-compatible SQL
+interface, and is deployed as a managed cloud service.
+
+**SQL mapping.**
+
+| `pg_trickle` concept | Materialize equivalent |
+|---|---|
+| `create_stream_table(name, query, refresh_mode='DIFFERENTIAL')` | `CREATE MATERIALIZED VIEW name IN CLUSTER compute_cluster AS query` |
+| `alter_stream_table(name, schedule=>...)` | No schedule — refresh is always event-driven |
+| `drop_stream_table(name)` | `DROP MATERIALIZED VIEW name` |
+| `refresh_stream_table(name, mode=>'FULL')` | `REFRESH MATERIALIZED VIEW name` (if supported) |
+| `pause_scheduler` | No direct equivalent; can drop and recreate the source connection to halt ingestion |
+| `resume_scheduler` | Restore source connection |
+| CDC mode `'trigger'` | N/A — Materialize uses `CREATE SOURCE` (PostgreSQL CDC, Kafka, etc.) |
+| IMMEDIATE mode | N/A — always streaming |
+| `CLUSTER` resource assignment | Materialize-specific; maps to `@aqueduct:cluster` front-matter directive |
+
+**Capabilities.**
+
+```
+DIFFERENTIAL_REFRESH   ✅  (always-on differential dataflow)
+FULL_REFRESH           ⚠   (REFRESH MV exists but is rarely needed)
+IMMEDIATE_MODE         ❌  (no synchronous in-transaction refresh)
+TRIGGER_CDC            ❌  (uses source connectors)
+WAL_CDC                ✅  (PostgreSQL source via logical replication)
+PAUSE_RESUME_SCHEDULER ❌  (no per-view pause; would require source manipulation)
+DIAMOND_CONSISTENCY    ✅  (differential dataflow handles diamonds)
+BLUE_GREEN_DEPLOY      ✅  (schema-swap pattern applies; schemas are first-class)
+```
+
+**Connection.** PostgreSQL wire protocol. The libpq `ExecutorConnection`
+works without modification, subject to Materialize's dialect differences
+(no `pg_trickle` extension functions; no `pgtrickle.*` schema).
+
+**Key gaps and open questions.**
+
+1. **`CLUSTER` assignment.** Materialize separates compute clusters from
+   storage. Each MV must be assigned to a cluster. The executor needs a new
+   front-matter directive `@aqueduct:cluster = "compute_default"` and a
+   corresponding `aqueduct.toml` section:
+   ```toml
+   [executor.materialize]
+   default_cluster = "compute_default"
+   ```
+   The planner passes `cluster` to the executor as a `StreamTableSpec` field
+   with a sensible default.
+
+2. **No `pgtrickle.*` schema.** `live_state` must query Materialize's system
+   catalog (`mz_catalog.mz_materialized_views`) instead of
+   `pgtrickle.pgt_stream_tables`. The `aqueduct import` path needs a
+   Materialize-specific catalog reader.
+
+3. **`aqueduct` catalog placement.** Materialize supports `CREATE TABLE` for
+   append-only storage. The `aqueduct.*` tables can be created on a
+   Materialize cluster directly — but they must be plain tables, not
+   materialized views, and Materialize's transaction semantics for plain
+   tables differ from PostgreSQL's. The safest approach is to store the
+   `aqueduct.*` catalog on a companion PostgreSQL instance (same pattern as
+   Feldera §10.24.2) and use Materialize only for stream-table DDL.
+   Alternatively, if the Materialize deployment also includes a PostgreSQL
+   source cluster that hosts the base tables, the `aqueduct.*` catalog can
+   live there.
+
+4. **`pause_scheduler` gap.** Materialize does not expose per-view
+   pause/resume. The executor implements `pause_scheduler` as a no-op +
+   warning: "Materialize does not support per-view scheduling pauses; the
+   migration proceeds without pausing refresh." This is acceptable because
+   Materialize's refresh is event-driven (not scheduler-based), so there is
+   no scheduler to race with.
+
+5. **Permission model.** Materialize uses a role-based model similar to
+   PostgreSQL but with some differences (e.g., `USAGE` on clusters, object
+   ownership model). The `aqueduct_admin` role guidance from §10.20 needs
+   a Materialize-specific variant.
+
+---
+
+#### 10.24.4 Snowflake Dynamic Tables
+
+**What it is.** Snowflake's native incremental computation primitive,
+introduced in 2023. A Dynamic Table is declared with a `TARGET_LAG` that
+specifies how far behind the source data the table is allowed to be.
+Snowflake automatically chooses between incremental and full refresh based
+on the query plan. Dynamic Tables use a proprietary SQL dialect and a
+proprietary connection protocol (Snowflake JDBC/ODBC/connector) — there
+is no PostgreSQL wire compatibility.
+
+**SQL mapping.**
+
+| `pg_trickle` concept | Snowflake Dynamic Table equivalent |
+|---|---|
+| `create_stream_table(name, query, schedule=>'30s')` | `CREATE OR REPLACE DYNAMIC TABLE name TARGET_LAG = '30 seconds' WAREHOUSE = compute_wh AS query` |
+| `alter_stream_table(name, schedule=>'1m')` | `ALTER DYNAMIC TABLE name SET TARGET_LAG = '1 minute'` |
+| `drop_stream_table(name)` | `DROP DYNAMIC TABLE name` |
+| `refresh_stream_table(name, mode=>'FULL')` | `ALTER DYNAMIC TABLE name REFRESH` |
+| `refresh_stream_table(name, mode=>'DIFFERENTIAL')` | No explicit call needed — happens automatically at the next `TARGET_LAG` tick |
+| `pause_scheduler(nodes)` | `ALTER DYNAMIC TABLE name SUSPEND` |
+| `resume_scheduler(nodes)` | `ALTER DYNAMIC TABLE name RESUME` |
+| CDC mode (any) | N/A — Snowflake manages its own change tracking internally; no external CDC |
+| IMMEDIATE mode | N/A — Snowflake always refreshes asynchronously |
+| `refresh_mode = 'DIFFERENTIAL'` | Mapped to `INITIALIZE = ON_CREATE REFRESH_MODE = INCREMENTAL` (Snowflake chooses automatically) |
+| `refresh_mode = 'FULL'` | `REFRESH_MODE = FULL` |
+
+**Capabilities.**
+
+```
+DIFFERENTIAL_REFRESH   ✅  (INCREMENTAL mode; Snowflake decides per-run)
+FULL_REFRESH           ✅  (FULL mode or ALTER DYNAMIC TABLE ... REFRESH)
+IMMEDIATE_MODE         ❌  (always asynchronous)
+TRIGGER_CDC            ❌  (Snowflake handles change tracking internally)
+WAL_CDC                ❌  (not applicable outside PostgreSQL)
+PAUSE_RESUME_SCHEDULER ✅  (ALTER DYNAMIC TABLE ... SUSPEND / RESUME)
+DIAMOND_CONSISTENCY    ⚠   (Snowflake guarantees consistency within a pipeline
+                            topology but does not expose per-group atomicity)
+BLUE_GREEN_DEPLOY      ✅  (schema-swap or `SWAP WITH` DDL if available)
+```
+
+**Connection.** Snowflake connector for Rust (`snowflake-api` crate or
+`arrow-odbc` + Snowflake ODBC DSN). A new `SnowflakeConnection` implementation
+of `ExecutorConnection` is required. This is the most complex connection
+variant because Snowflake uses OAuth/key-pair authentication, not a plain
+password, and the connector is not `libpq`-compatible.
+
+**Key gaps and open questions.**
+
+1. **WAREHOUSE assignment.** Every Dynamic Table requires a `WAREHOUSE`
+   (compute resource). The executor needs a new front-matter directive
+   `@aqueduct:warehouse = "compute_wh"` and a `aqueduct.toml` default:
+   ```toml
+   [executor.snowflake]
+   default_warehouse = "compute_wh"
+   account           = "${SNOWFLAKE_ACCOUNT}"
+   user              = "${SNOWFLAKE_USER}"
+   private_key_path  = "${SNOWFLAKE_PRIVATE_KEY_PATH}"
+   ```
+
+2. **`TARGET_LAG` mapping.** `pg_trickle`'s `schedule` is a duration string
+   (`30s`, `1m`, `5m`). Snowflake's `TARGET_LAG` uses the same unit family.
+   Direct conversion is safe. `CALCULATED` schedule mode has no Snowflake
+   equivalent — the executor must resolve `CALCULATED` to a concrete duration
+   before emitting DDL (the planner already computes the resolved schedule
+   from the DAG topology for display; the executor uses this resolved value).
+   A linter warning is emitted if any node uses `CALCULATED` on a Snowflake
+   target.
+
+3. **`aqueduct` catalog placement.** The `aqueduct.*` catalog tables can be
+   created as regular Snowflake tables in a dedicated schema. Snowflake
+   supports `INSERT`, `UPDATE`, `SELECT FOR UPDATE` semantics (via `MERGE`)
+   — the catalog operations in §7.5 can be adapted. The `aqueduct.locks`
+   advisory-lock model has no direct Snowflake equivalent; the executor must
+   use an optimistic lock via `MERGE ON CONFLICT` + a heartbeat TASK (a
+   Snowflake scheduled task that updates `acquired_at` periodically).
+
+4. **In-place column-add.** Snowflake Dynamic Tables do not support
+   `ALTER ... ADD COLUMN` while the table is active — the table must be
+   recreated. This means the in-place migration class is largely unavailable
+   on Snowflake. The executor should report `ExecutorCapabilities` without
+   `DIFFERENTIAL_REFRESH` flags that depend on in-place alter, and the
+   classifier will fall back to Rebuild for column additions. This is a
+   significant limitation — the executor profile in the plan renderer should
+   display a prominent note: "In-place migrations are not supported for
+   Snowflake Dynamic Tables; all column changes require Rebuild class."
+
+5. **No `pgtrickle.*` schema.** `live_state` queries
+   `INFORMATION_SCHEMA.DYNAMIC_TABLES` (or `SNOWFLAKE.ACCOUNT_USAGE.DYNAMIC_TABLES`
+   for historical data). The `aqueduct import` path needs a Snowflake-specific
+   catalog reader that maps Dynamic Table metadata to `StreamTableSpec`.
+
+6. **Timing.** The Snowflake executor is the most complex of the four
+   candidates: non-libpq connection, warehouse management, in-place
+   limitations, and advisory-lock adaptation. It is recommended as the last
+   of the four to implement, after the three PostgreSQL-wire-compatible
+   executors have validated the trait design.
+
+---
+
+#### 10.24.5 Trait stability requirements
+
+The four profiles above surface several areas where the `StreamExecutor`
+trait (§7.7) must be flexible enough to accommodate divergent semantics:
+
+| Requirement | Needed by |
+|---|---|
+| Batch DDL deploy (multiple changes in one call) | Feldera (pipeline recompile) |
+| Non-libpq `ExecutorConnection` | Feldera (HTTP REST), Snowflake (proprietary connector) |
+| External catalog DSN | Feldera, Materialize (optional) |
+| Executor-specific front-matter directives | Materialize (`cluster`), Snowflake (`warehouse`) |
+| Resolved schedule instead of `CALCULATED` | Snowflake |
+| Per-target `ExecutorCapabilities` bitflags | All four differ from pg_trickle |
+
+The trait in §7.7 as written accommodates all of these requirements:
+`ExecutorCapabilities` bitflags gate which plan steps the planner may emit;
+the `ExecutorConnection` trait is transport-agnostic; the `alter` call
+accepts a structured `AlterChange` enum that a batch executor can buffer and
+flush. The Feldera batch-deploy requirement may warrant an optional
+`fn batch_apply(&self, steps: &[PlanStep], conn: &dyn ExecutorConnection)` method
+with a default implementation that calls `create`/`alter`/`drop` sequentially
+(the default) and a Feldera override that batches them into a single pipeline
+redeploy.
 
 ---
 

--- a/roadmap/v0.62.0.md
+++ b/roadmap/v0.62.0.md
@@ -1,0 +1,81 @@
+# v0.62.0 — Scheduler Throughput & `pg_aqueduct` Prerequisites
+
+> **Full details:** [v0.62.0.md-full.md](v0.62.0.md-full.md)
+
+## What's New
+
+v0.62.0 delivers two independent but complementary improvements: a
+change-buffer fan-out optimisation that eliminates redundant scans in
+multi-consumer DAGs, and the three SQL API additions required by the
+planned `pg_aqueduct` migration tool (see
+[plans/pg-aqueduct-plan.md](../plans/pg-aqueduct-plan.md) §9).
+
+### PERF-1: Change-Buffer Fan-Out (P-1)
+
+The scheduler now scans each source's `changes_<oid>` change buffer
+**once per tick** and routes the resulting delta to every dependent
+stream table, rather than each dependent node re-scanning the buffer
+independently.  For a DAG with N consumers of the same source table
+this reduces change-buffer I/O from O(N) to O(1).
+
+The improvement is largest for diamond-topology DAGs where multiple
+branches converge on the same upstream source.  Benchmark gate: the
+TPC-H 22-node DAG at Δ = 10 K rows must show ≥ 30 % reduction in
+total change-buffer scan time vs. v0.61.0 baseline.
+
+No user-facing API change.  The fan-out is enabled automatically and
+controlled by a new GUC `pg_trickle.enable_change_buffer_fanout`
+(default: `true`).
+
+### API-1: `pgtrickle.pause_scheduler(nodes text[])` (A-1)
+
+Pauses the differential refresh scheduler for the listed stream
+tables.  Prevents the scheduler from *starting* new refreshes for
+those nodes until `pgtrickle.resume_scheduler()` is called.
+In-flight refreshes are drained before the function returns (up to
+`pg_trickle.scheduler_drain_timeout`, default 30 s).
+
+Required by `pg_aqueduct apply` to hold the pipeline steady during
+schema migrations.  Also useful for operators performing manual
+maintenance.
+
+```sql
+SELECT pgtrickle.pause_scheduler(ARRAY['public.order_totals', 'public.customer_summary']);
+```
+
+### API-2: `pgtrickle.resume_scheduler(nodes text[])` (A-2)
+
+Counterpart to `pause_scheduler()`.  Restores normal scheduling for
+the listed nodes.  Called automatically on clean exit and on
+`aqueduct apply --resume` after a crash.
+
+```sql
+SELECT pgtrickle.resume_scheduler(ARRAY['public.order_totals', 'public.customer_summary']);
+```
+
+### API-3: `pgtrickle.stream_table_spec(relid oid) RETURNS jsonb` (A-3)
+
+Returns a stable JSON projection of a single stream table's
+specification — the canonical representation needed by `pg_aqueduct`
+for `import`, drift detection, and the spec-hash in
+`aqueduct.dag_versions`.
+
+```json
+{
+  "name": "order_totals",
+  "schema": "public",
+  "query": "SELECT customer_id, sum(amount) FROM orders GROUP BY 1",
+  "refresh_mode": "DIFFERENTIAL",
+  "schedule": "30s",
+  "cdc_mode": "trigger",
+  "oid": 12345,
+  "diamond_group": null,
+  "attach_outbox": null,
+  "cdc_slot_name": null
+}
+```
+
+Field stability is guaranteed across minor versions; new optional
+fields may be added in future releases.  Useful beyond `pg_aqueduct`:
+operators can query this function directly from dashboards and `psql`
+sessions for a canonical view of a stream table's live configuration.

--- a/roadmap/v0.62.0.md-full.md
+++ b/roadmap/v0.62.0.md-full.md
@@ -1,0 +1,141 @@
+# v0.62.0 — Scheduler Throughput & `pg_aqueduct` Prerequisites (Full Details)
+
+> **Summary:** [v0.62.0.md](v0.62.0.md)
+
+---
+
+## Performance
+
+### PERF-1: Change-Buffer Fan-Out
+
+**Motivation:** Every stream table that depends on source table T must process
+T's change buffer on each scheduler tick.  Before this release each dependent
+node issues an independent `SELECT` against `pgtrickle_changes.changes_<oid>`,
+resulting in O(N) scans for N dependents.  For diamond-topology DAGs this cost
+is paid multiple times even when every branch ultimately processes the same
+rows.
+
+**Implementation:**
+
+1. The scheduler's per-tick dispatch loop collects all source OIDs whose change
+   buffers are non-empty (single `pg_class` + buffer-size check, already
+   exists).
+2. For each non-empty source OID, a single read of `changes_<oid>` materialises
+   the delta rows into a `Vec<ChangeRow>` in the BGW's local memory.
+3. The delta is cloned (shallow — rows are `Arc`-wrapped) and dispatched to
+   each dependent node's refresh task, replacing the per-node buffer scan.
+4. The buffer is compacted once after all dependents have acknowledged
+   processing — not once per dependent.
+
+**GUC:** `pg_trickle.enable_change_buffer_fanout` (bool, default `true`).
+Setting to `false` restores pre-v0.62.0 per-node scan behaviour for
+diagnostic purposes.
+
+**Benchmark gate:**
+
+```
+cargo bench --bench refresh_bench -- diamond_fanout
+```
+
+The `diamond_fanout` benchmark runs a 6-node diamond DAG (1 source → 2 middle
+nodes → 2 leaf nodes → 1 convergence node) with Δ = 10 K inserted rows and
+measures total change-buffer scan time.  Gate: ≥ 30 % reduction vs. v0.61.0
+baseline.  A regression that fails this gate blocks the release.
+
+**Test coverage:** New E2E test `test_scheduler_fanout_deduplicates_buffer_scan`
+asserts that with N dependents on one source, `pg_stat_user_tables.seq_scan`
+on the change-buffer table increments by 1 per tick (not N).
+
+---
+
+## New SQL API
+
+### API-1 & API-2: `pause_scheduler` / `resume_scheduler`
+
+**Files:** `src/api/scheduler_control.rs` (new), `src/lib.rs` (registration)
+
+```sql
+pgtrickle.pause_scheduler(nodes text[]) RETURNS void
+pgtrickle.resume_scheduler(nodes text[]) RETURNS void
+```
+
+**Behaviour of `pause_scheduler`:**
+
+1. For each name in `nodes`, set a `paused = true` flag in the shared-memory
+   scheduler state for that stream table (new field in `StreamTableState`).
+2. Poll `pgtrickle.pgt_stream_tables` for `refresh_status = 'running'` on the
+   affected nodes every 100 ms, up to `pg_trickle.scheduler_drain_timeout`
+   (default 30 s, GUC-configurable).
+3. Return once all in-flight refreshes have completed or the timeout expires.
+   On timeout, raise a `WARNING` and return — the caller (`pg_aqueduct`) is
+   responsible for deciding whether to abort or proceed.
+
+**Behaviour of `resume_scheduler`:**
+
+Clears the `paused` flag for each listed node.  The scheduler picks up those
+nodes on the next tick.  Safe to call multiple times (idempotent).
+
+**Error handling:** Raises `ERROR` if any name in `nodes` does not exist in
+`pgtrickle.pgt_stream_tables`.  Does not raise on names that are already
+paused/resumed.
+
+**Security:** `SECURITY DEFINER` with `SET search_path = pgtrickle, pg_catalog`.
+Requires `USAGE` on the `pgtrickle` schema (same as `create_stream_table`).
+
+**New GUC:** `pg_trickle.scheduler_drain_timeout` (interval, default `'30s'`).
+
+---
+
+### API-3: `stream_table_spec`
+
+**Files:** `src/api/spec.rs` (new), `src/lib.rs` (registration)
+
+```sql
+pgtrickle.stream_table_spec(relid oid) RETURNS jsonb
+```
+
+Queries `pgtrickle.pgt_stream_tables` and related catalog tables for `relid`
+and assembles the canonical JSON projection.  Returns `NULL` if `relid` is not
+a managed stream table.
+
+**Field stability contract:**
+
+- All fields in the v0.62.0 response are stable across future minor releases.
+- New optional fields may be added; no existing fields will be removed or
+  renamed before v2.0.
+- The response is always a JSON object (never null) when `relid` is a valid
+  stream table OID.
+
+**Convenience overload:**
+
+```sql
+pgtrickle.stream_table_spec(qualified_name text) RETURNS jsonb
+```
+
+Accepts `'schema.name'` or `'name'` (resolves via `to_regclass`).
+
+**Test coverage:** Unit test in `src/api/spec.rs` verifying field presence and
+types.  Integration test asserting round-trip fidelity: `import` a stream table,
+call `stream_table_spec`, compare hash against `spec_hash` produced by
+`pg_aqueduct import`.
+
+---
+
+## Test Coverage
+
+| Test | Location | What it covers |
+|------|----------|----------------|
+| `test_scheduler_fanout_deduplicates_buffer_scan` | `tests/e2e_scheduler_tests.rs` | seq_scan count = 1 per tick with 4 dependents |
+| `test_pause_resume_scheduler_basic` | `tests/e2e_scheduler_tests.rs` | pause blocks new refreshes; resume restores them |
+| `test_pause_scheduler_drain_timeout` | `tests/e2e_scheduler_tests.rs` | timeout returns WARNING, does not hang |
+| `test_stream_table_spec_fields` | `src/api/spec.rs` (#[cfg(test)]) | all required fields present, correct types |
+| `test_stream_table_spec_unknown_oid` | `src/api/spec.rs` (#[cfg(test)]) | returns NULL for unknown OID |
+
+---
+
+## Upgrade Notes
+
+No breaking changes.  Two new functions (`pause_scheduler`,
+`resume_scheduler`, `stream_table_spec`) are additive.  The fan-out
+optimisation is transparent; set `pg_trickle.enable_change_buffer_fanout = false`
+to revert to the pre-v0.62.0 scan behaviour if needed.

--- a/roadmap/v0.63.0.md
+++ b/roadmap/v0.63.0.md
@@ -1,0 +1,46 @@
+# v0.63.0 — Fused Multi-Node Refresh
+
+> **Full details:** [v0.63.0.md-full.md](v0.63.0.md-full.md)
+
+## What's New
+
+v0.63.0 implements fused multi-node refresh: when the scheduler has a
+batch of stream tables ready to refresh in the same tick, it emits a
+single CTE chain rather than N sequential statements.  This is the
+Postgres-native analogue of DBSP's single-pass evaluation — one
+transaction, one planner invocation, one round-trip to the server.
+
+### PERF-2: Fused CTE Refresh (P-2)
+
+When two or more nodes in the same DAG are scheduled to refresh in the
+same tick, the scheduler composes their delta SQL into a single
+`WITH … INSERT` CTE chain:
+
+```sql
+WITH
+  b_delta AS (/* delta SQL for order_totals */),
+  c_delta AS (/* delta SQL for customer_summary, reading b_delta */),
+  …
+INSERT INTO order_totals …  SELECT * FROM b_delta;
+INSERT INTO customer_summary … SELECT * FROM c_delta;
+```
+
+The DVM engine already generates correct per-node delta SQL; this
+release composes those fragments in topological order within a single
+statement.  Cross-node optimisation by the Postgres query planner is
+now possible for nodes that share sub-expressions.
+
+**Benchmark gate (blocking):** The TPC-H 22-node DAG at Δ = 10 K rows
+must show ≥ 20 % reduction in total refresh wall time vs. v0.62.0
+(which already has fan-out).  Measured by the existing
+`refresh_bench::tpch_differential_22` criterion benchmark.
+
+**Opt-out GUC:** `pg_trickle.enable_fused_refresh` (bool, default
+`true`).  Set to `false` to restore the pre-v0.63.0 sequential
+per-node statement behaviour — useful when a complex DAG shape
+produces a query the Postgres planner cannot handle efficiently.
+
+**Correctness gate (blocking):** The existing plan→apply→plan
+property test is extended to assert that fused and sequential refresh
+produce byte-identical materialized state for all 22 TPC-H stream
+tables across 50 random Δ batches.

--- a/roadmap/v0.63.0.md-full.md
+++ b/roadmap/v0.63.0.md-full.md
@@ -1,0 +1,142 @@
+# v0.63.0 — Fused Multi-Node Refresh (Full Details)
+
+> **Summary:** [v0.63.0.md](v0.63.0.md)
+
+---
+
+## Motivation
+
+After v0.62.0's change-buffer fan-out eliminates redundant buffer scans,
+the next bottleneck is the per-node statement boundary.  For a DAG where
+nodes B and C both depend on source A, a typical refresh tick today looks
+like:
+
+```sql
+-- statement 1 (separate round-trip + planner invocation)
+WITH a_delta AS (SELECT ... FROM pgtrickle_changes.changes_12345 ...)
+MERGE INTO public.order_totals USING a_delta ...;
+
+-- statement 2 (separate round-trip + planner invocation)
+WITH a_delta AS (SELECT ... FROM pgtrickle_changes.changes_12345 ...),
+     b_delta AS (SELECT ... FROM public.order_totals ...)
+MERGE INTO public.customer_summary USING b_delta ...;
+```
+
+Even with fan-out, these are two separate statements: two planner
+invocations, two executor setups, two transaction commits (or two
+sub-transaction boundaries).  Fused refresh collapses them:
+
+```sql
+-- one statement, one planner invocation, one commit
+WITH
+  a_delta AS (SELECT ... FROM pgtrickle_changes.changes_12345 ...),
+  order_totals_delta AS (/* full delta CTE for order_totals, reading a_delta */),
+  customer_summary_delta AS (/* full delta CTE for customer_summary */),
+  _apply_order_totals AS (
+    MERGE INTO public.order_totals USING order_totals_delta ...
+    RETURNING 1
+  )
+MERGE INTO public.customer_summary USING customer_summary_delta ...;
+```
+
+The Postgres query planner now has visibility across all nodes in the
+batch and can share sub-expressions, re-order joins, and avoid redundant
+sorts.
+
+---
+
+## Implementation
+
+### Fusion Eligibility
+
+Not all nodes can be fused in a given tick.  A node is fusion-eligible if:
+
+1. Its refresh mode is `DIFFERENTIAL` (FULL-refresh nodes are always
+   executed as separate statements — they do not benefit from CTE fusion
+   and the large result sets make a single mega-statement undesirable).
+2. Its direct upstream nodes are either base tables (sources) or other
+   nodes that are also fusion-eligible in the same tick.
+3. Its estimated delta size (from the cost model) is below
+   `pg_trickle.fused_refresh_max_delta_rows` (default: 500 000).  Very
+   large deltas produce very large CTEs; the planner may choose a worse
+   plan for the composed statement than for two independent statements.
+4. The node is not currently paused (via `pgtrickle.pause_scheduler()`).
+
+The scheduler computes the maximal fusion-eligible subgraph for each tick
+using a topological scan of the ready set.  Nodes that fall outside the
+eligible subgraph are refreshed in the standard sequential mode.
+
+### SQL Generation
+
+The existing `differentiate()` function in `src/refresh/diff.rs` produces
+a `DiffOutput { cte_sql: String, apply_sql: String }` for a single node.
+v0.63.0 adds a new `fuse_diff_batch(nodes: &[NodeSpec], ctx: &DiffContext) -> FusedOutput`
+function in `src/refresh/fused.rs` that:
+
+1. Calls `differentiate()` for each node in topological order.
+2. Merges the CTE lists, deduplicating shared source-delta CTEs by name.
+3. Composes the apply statements into a single `WITH … MERGE; MERGE; …`
+   chain using wrapping CTEs (`_apply_<node>`) for all but the final node.
+4. Returns a `FusedOutput { sql: String, node_count: usize }`.
+
+The merged CTE list uses the existing `cte_counter` namespace
+(`__pgt_cte_scan_1`, `__pgt_cte_scan_2`, …) with a per-batch offset to
+prevent name collisions across nodes.
+
+### Correctness
+
+The correctness guarantee is unchanged: each node's delta is computed from
+the same snapshot as the sequential case.  The CTE `MATERIALIZED` hint is
+applied to shared delta CTEs to prevent the planner from inlining them
+multiple times (which would re-evaluate non-deterministic expressions).
+
+**Property test extension:** `tests/property/fused_vs_sequential.rs` runs
+50 random Δ batches against a 22-node TPC-H DAG, applies them first with
+fused refresh and then with sequential refresh against a fresh replica, and
+asserts that every stream table's row multiset is identical.  This test
+runs as part of `just test-integration` (Testcontainers, no custom image).
+
+### Benchmark Gate
+
+```
+cargo bench --bench refresh_bench -- tpch_differential_22
+```
+
+Gate: ≥ 20 % wall-time reduction vs. v0.62.0 at Δ = 10 K rows.
+The benchmark is added to the CI regression check
+(`scripts/criterion_regression_check.py`) with a 15 % allowance.
+
+---
+
+## New GUCs
+
+| GUC | Type | Default | Description |
+|-----|------|---------|-------------|
+| `pg_trickle.enable_fused_refresh` | bool | `true` | Enable CTE-fused multi-node refresh |
+| `pg_trickle.fused_refresh_max_delta_rows` | int | `500000` | Max estimated delta rows for a node to be fusion-eligible |
+
+---
+
+## Test Coverage
+
+| Test | Location | What it covers |
+|------|----------|----------------|
+| `test_fused_refresh_tpch_22` | `tests/e2e_refresh_tests.rs` | End-to-end fused refresh of all 22 TPC-H nodes |
+| `test_fused_vs_sequential_parity` | `tests/property/fused_vs_sequential.rs` | Byte-identical output for 50 random Δ batches |
+| `test_fused_refresh_guc_disable` | `tests/e2e_refresh_tests.rs` | `enable_fused_refresh=false` falls back to sequential |
+| `test_fused_refresh_full_node_excluded` | `tests/e2e_refresh_tests.rs` | FULL-mode nodes are never fused |
+| `test_fused_refresh_large_delta_excluded` | `tests/e2e_refresh_tests.rs` | Nodes above `fused_refresh_max_delta_rows` are excluded |
+| `fuse_diff_batch_cte_dedup` | `src/refresh/fused.rs` (#[cfg(test)]) | Shared source-delta CTEs are deduplicated |
+| `fuse_diff_batch_name_collision_free` | `src/refresh/fused.rs` (#[cfg(test)]) | CTE names are unique across all nodes in a batch |
+
+---
+
+## Upgrade Notes
+
+No breaking changes.  Fused refresh is enabled by default.  Set
+`pg_trickle.enable_fused_refresh = false` in `postgresql.conf` or via
+`ALTER SYSTEM SET` to revert to sequential mode if a specific DAG shape
+causes unexpected planner behaviour.  Please file an issue with the
+problematic query if you need to disable fusion — we want to understand
+and fix planner interaction problems rather than leave them as permanent
+opt-outs.


### PR DESCRIPTION
## Summary

Adds roadmap entries for two new planned releases that form the **Scheduler Throughput Arc**, derived from the performance improvement recommendations discussed in the pg_aqueduct planning session.

- **v0.62.0** eliminates redundant change-buffer scans via fan-out (O(N)→O(1) for multi-consumer DAGs) and adds the three SQL API functions required as prerequisites by the planned `pg_aqueduct` migration tool: `pause_scheduler()`, `resume_scheduler()`, and `stream_table_spec()`.
- **v0.63.0** implements fused multi-node refresh — composing per-node delta SQL into a single CTE-chain statement — the Postgres-native analogue of DBSP single-pass evaluation, with a hard correctness gate (byte-identical output vs sequential) and a benchmark gate (≥ 20% wall-time reduction on TPC-H 22-node DAG).

## Changes

- `roadmap/v0.62.0.md` — summary file for v0.62.0
- `roadmap/v0.62.0.md-full.md` — full implementation details for v0.62.0
- `roadmap/v0.63.0.md` — summary file for v0.63.0
- `roadmap/v0.63.0.md-full.md` — full implementation details for v0.63.0
- `ROADMAP.md` — new "Scheduler Throughput Arc (v0.62.x–v0.63.x)" section + two entries in the version-history diagram

## Testing

Documentation-only change. No code changes — no tests to run.

## Notes

These releases slot between v0.61.0 (planned Final Pre-1.0 Polish) and v1.0.0.

The items in v0.62.0 are independently motivated:
- The fan-out optimisation has been identified as the highest-impact, lowest-risk scheduler improvement (no API change, pure internal).
- `pause_scheduler` / `resume_scheduler` are useful for manual operator maintenance today and are a hard prerequisite for `pg_aqueduct apply`.
- `stream_table_spec()` is useful for dashboards and psql introspection today and is a hard prerequisite for `pg_aqueduct import` and drift detection.

v0.63.0 is kept separate because fused refresh touches the SQL generation path and warrants dedicated correctness and benchmark coverage rather than being bundled with the fan-out work.

Ephemeral intermediate nodes (`materialized = false`) are intentionally left out of both releases — that feature changes the semantics of what a node is and belongs in v1.1+ after fused refresh has proven stable.
