### PR TITLE
fix(ci): fix tpch-explain-artifacts workflow (exit 127 + upload-artifact@v7)

### DIFF
--- a/.github/workflows/tpch-explain-artifacts.yml
+++ b/.github/workflows/tpch-explain-artifacts.yml
@@ -68,7 +68,7 @@ jobs:
 
       # ── Build E2E Docker image ───────────────────────────────────────────────
       - name: Build E2E Docker image
-        run: just build-e2e-image
+        run: ./tests/build_e2e_image.sh
         timeout-minutes: 30
 
       # ── Install cargo-nextest ────────────────────────────────────────────────
@@ -107,7 +107,7 @@ jobs:
 
       # ── Upload artifacts ─────────────────────────────────────────────────────
       - name: Upload EXPLAIN artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: tpch-explain-artifacts-sf${{ inputs.tpch_scale || '1.0' }}-${{ github.run_number }}


### PR DESCRIPTION
## Summary

Fixes the `tpch-explain-artifacts` scheduled workflow which has been failing with exit code 127 and no uploaded artifacts. Two bugs were introduced when the workflow was originally written.

## Changes

- Replace `just build-e2e-image` with `./tests/build_e2e_image.sh`
  — `just` is not installed on GitHub Actions runners, causing exit code 127 (command not found). All other workflows that build the E2E image call the shell script directly.
- Fix `actions/upload-artifact@v7` → `@v4`
  — v7 does not exist; the artifact upload was silently skipped with a "no files found" warning as a downstream consequence of the build failure.

## Testing

- Verified by reviewing the failing run at https://github.com/trickle-labs/pg-trickle/actions/runs/25985905942
- Confirmed `./tests/build_e2e_image.sh` is the correct invocation used by `ci.yml`, `e2e-benchmarks.yml`, and `stability-tests.yml`
- `actions/upload-artifact@v4` is the current stable release

## Notes

No code changes — CI workflow fix only.
