### PR TITLE
docs(roadmap): add v0.64.0 DuckLake Phase 1 ecosystem arc

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -179,6 +179,20 @@ fused CTE refresh to reduce per-tick statement overhead for multi-node DAGs.
 | [v0.62.0](roadmap/v0.62.0.md) | Scheduler throughput: change-buffer fan-out (O(N)→O(1) scans for multi-consumer DAGs), `pause_scheduler` / `resume_scheduler` per-node SQL functions, `stream_table_spec(oid)` stable JSON projection | Planned | Medium | [Full details](roadmap/v0.62.0.md-full.md) |
 | [v0.63.0](roadmap/v0.63.0.md) | Fused multi-node refresh: CTE-chain composition of per-node delta SQL in a single statement, correctness property test, benchmark regression gate (≥ 20 % wall-time reduction on TPC-H 22-node DAG) | Planned | Large | [Full details](roadmap/v0.63.0.md-full.md) |
 
+### DuckLake Ecosystem Arc (v0.64.x)
+
+Phase 1 of the [DuckLake integration plan](plans/ecosystem/PLAN_DUCKLAKE.md): publish
+tutorials and reference architectures that demonstrate pg_trickle working with
+DuckLake's PostgreSQL catalog today — zero new code required. This establishes
+pg_trickle as the incremental view maintenance layer for data lakes, creates
+thought leadership ahead of the v1.0 stable release, and seeds demand signals
+that will guide whether Phase 2 (DuckLake-optimized change feed polling) is
+worth engineering investment.
+
+| Version | Theme | Status | Scope | Full details |
+|---------|-------|--------|-------|-------------- |
+| [v0.64.0](roadmap/v0.64.0.md) | DuckLake ecosystem: blog posts and tutorials showing pg_trickle + DuckLake working together — foreign table sources, metadata monitoring, one-box data stack reference architecture | Planned | Small | [Full details](plans/ecosystem/PLAN_DUCKLAKE.md) |
+
 
 ### Beyond v1.0
 
@@ -271,6 +285,8 @@ v0.59    ─── Performance & observability: batched monitor SPI, query-hash 
 v0.60    ─── Code quality, test coverage & CI: cdc.rs split, codegen decompose, refresh/CDC/hooks unit tests, idempotence proptest, sleep removal, WAL OID filter, partition-attach rebuild, path-filtered E2E on PRs
     │
 v0.61    ─── DX, docs & pre-1.0 polish: health_check foreign-owner row, SQL_REFERENCE complete, snapshot secondary equality, cte_counter reset, outbox name fix, sublinks decompose, 3 ADRs, LATERAL docs
+    │
+v0.64    ─── DuckLake Phase 1: tutorials + reference architectures (pg_trickle as IVM layer for data lakes)
     │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -182,24 +182,31 @@ fused CTE refresh to reduce per-tick statement overhead for multi-node DAGs.
 ### DuckLake Ecosystem Arc (v0.64.x)
 
 Phase 1 of the [DuckLake integration plan](plans/ecosystem/PLAN_DUCKLAKE.md): publish
-tutorials and reference architectures that demonstrate pg_trickle working with
-DuckLake's PostgreSQL catalog today — zero new code required. This establishes
-pg_trickle as the incremental view maintenance layer for data lakes, creates
-thought leadership ahead of the v1.0 stable release, and seeds demand signals
-that will guide whether Phase 2 (DuckLake-optimized change feed polling) is
-worth engineering investment.
+tutorials, blog posts, containerised demos, and reference architectures that
+demonstrate pg_trickle working with DuckLake's PostgreSQL catalog today — zero new
+extension code required. This establishes pg_trickle as the incremental view
+maintenance layer for data lakes, creates thought leadership ahead of the v1.0
+stable release, and seeds demand signals that will guide whether Phase 2
+(DuckLake-optimised change-feed polling) is worth engineering investment.
+Community outreach to named DuckLake production users (PostHog, Windmill,
+Ascend.io, Sliplane, locals.com, Media Cluster Norway) is explicitly part of this
+release.
 
-Five deliverables, all documentation:
+Nine deliverables, all documentation / community / demo:
 
 1. **Tutorial: "Real-Time Dashboards on Your Data Lake"** — DuckDB writes events to DuckLake; pg_trickle stream tables compute per-minute aggregations; Grafana dashboard powered by PostgreSQL.
 2. **Tutorial: "The Modern Data Stack in One Box"** — OLTP in PostgreSQL + pg_trickle aggregations + DuckLake for historical analytics + DuckDB for ad-hoc queries, all from one instance and an S3 bucket — no Kafka, no Airflow.
 3. **Tutorial: "Monitoring Your DuckLake with pg_trickle"** — stream tables over DuckLake's 28 metadata tables; real-time alerts for small-file proliferation, snapshot rate spikes, and storage growth.
-4. **Blog post: "Why pg_trickle + DuckLake Is the Missing Piece for Lakehouse IVM"** — thought-leadership post for Hacker News / r/dataengineering positioning pg_trickle as the IVM layer DuckLake's v2.0 roadmap is looking for.
-5. **Docs: DuckLake examples in `foreign-table-sources.md`** — concrete code samples for using DuckLake-backed foreign tables as stream table sources.
+4. **Blog post: "Why pg_trickle + DuckLake Is the Missing Piece for Lakehouse IVM"** — thought-leadership post for Hacker News / r/dataengineering positioning pg_trickle as the IVM layer DuckLake's v2.0 roadmap explicitly calls for.
+5. **Blog post: "DuckLake's `table_changes()` Meets pg_trickle's DVM Engine"** — technical deep-dive on how DuckLake's change-feed format maps directly to pg_trickle's change-buffer model; builds credibility with the systems-programming audience.
+6. **Docs: DuckLake examples in `foreign-table-sources.md`** — concrete code samples for using DuckLake-backed foreign tables as stream table sources.
+7. **Demo A: "Five-Second Funnel"** — self-contained `docker-compose up` demo that streams fake e-commerce events into DuckLake and displays a live pg_trickle-powered funnel dashboard; shareable for conference talks and social media.
+8. **Demo D: "DuckLake Observability in a Box"** — pre-packaged Grafana dashboard powered by stream tables over DuckLake metadata; five minutes from `git clone` to operational visibility.
+9. **Community: Named-user outreach + DuckCon/PGConf talk submission** — direct pitches to the named DuckLake production users identified in research, plus CFP submissions to DuckCon and PGConf EU.
 
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|-------|-------------- |
-| [v0.64.0](roadmap/v0.64.0.md) | DuckLake ecosystem (Phase 1): 3 tutorials (real-time dashboards on lake data, one-box data stack, DuckLake ops monitoring) + 1 thought-leadership blog post + DuckLake examples in foreign-table-sources.md — no code changes | Planned | Small | [Full details](plans/ecosystem/PLAN_DUCKLAKE.md) |
+| [v0.64.0](roadmap/v0.64.0.md) | DuckLake ecosystem (Phase 1): 3 tutorials + 2 blog posts + docs + 2 containerised demos + community outreach — no extension code changes | Planned | Small | [Full details](plans/ecosystem/PLAN_DUCKLAKE.md) |
 
 
 ### Beyond v1.0
@@ -294,7 +301,7 @@ v0.60    ─── Code quality, test coverage & CI: cdc.rs split, codegen decom
     │
 v0.61    ─── DX, docs & pre-1.0 polish: health_check foreign-owner row, SQL_REFERENCE complete, snapshot secondary equality, cte_counter reset, outbox name fix, sublinks decompose, 3 ADRs, LATERAL docs
     │
-v0.64    ─── DuckLake Phase 1: tutorials + reference architectures (pg_trickle as IVM layer for data lakes)
+v0.64    ─── DuckLake Phase 1: 3 tutorials + 2 blog posts + 2 containerised demos + named-user outreach (no extension code)
     │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -189,9 +189,17 @@ thought leadership ahead of the v1.0 stable release, and seeds demand signals
 that will guide whether Phase 2 (DuckLake-optimized change feed polling) is
 worth engineering investment.
 
+Five deliverables, all documentation:
+
+1. **Tutorial: "Real-Time Dashboards on Your Data Lake"** — DuckDB writes events to DuckLake; pg_trickle stream tables compute per-minute aggregations; Grafana dashboard powered by PostgreSQL.
+2. **Tutorial: "The Modern Data Stack in One Box"** — OLTP in PostgreSQL + pg_trickle aggregations + DuckLake for historical analytics + DuckDB for ad-hoc queries, all from one instance and an S3 bucket — no Kafka, no Airflow.
+3. **Tutorial: "Monitoring Your DuckLake with pg_trickle"** — stream tables over DuckLake's 28 metadata tables; real-time alerts for small-file proliferation, snapshot rate spikes, and storage growth.
+4. **Blog post: "Why pg_trickle + DuckLake Is the Missing Piece for Lakehouse IVM"** — thought-leadership post for Hacker News / r/dataengineering positioning pg_trickle as the IVM layer DuckLake's v2.0 roadmap is looking for.
+5. **Docs: DuckLake examples in `foreign-table-sources.md`** — concrete code samples for using DuckLake-backed foreign tables as stream table sources.
+
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|-------|-------------- |
-| [v0.64.0](roadmap/v0.64.0.md) | DuckLake ecosystem: blog posts and tutorials showing pg_trickle + DuckLake working together — foreign table sources, metadata monitoring, one-box data stack reference architecture | Planned | Small | [Full details](plans/ecosystem/PLAN_DUCKLAKE.md) |
+| [v0.64.0](roadmap/v0.64.0.md) | DuckLake ecosystem (Phase 1): 3 tutorials (real-time dashboards on lake data, one-box data stack, DuckLake ops monitoring) + 1 thought-leadership blog post + DuckLake examples in foreign-table-sources.md — no code changes | Planned | Small | [Full details](plans/ecosystem/PLAN_DUCKLAKE.md) |
 
 
 ### Beyond v1.0

--- a/plans/ecosystem/PLAN_DUCKLAKE.md
+++ b/plans/ecosystem/PLAN_DUCKLAKE.md
@@ -1,0 +1,756 @@
+# pg_trickle × DuckLake Integration Plan
+
+Date: 2026-05-19
+Status: PROPOSED
+
+---
+
+## Executive Summary
+
+DuckLake is an open lakehouse format (v1.0 released April 2026) from the DuckDB
+team that stores data in Parquet files and manages all metadata in a standard SQL
+database — most commonly **PostgreSQL**. This architectural choice creates a
+uniquely powerful synergy with pg_trickle: both systems operate inside the same
+PostgreSQL instance, share the same transactional guarantees, and complement each
+other's strengths.
+
+pg_trickle provides world-class incremental view maintenance (IVM) inside
+PostgreSQL. DuckLake provides scalable lakehouse storage and multi-engine
+analytics. Together they can deliver **incrementally maintained materialized views
+over data lake tables** — something no existing system offers today.
+
+DuckLake's own roadmap explicitly lists "Incremental materialized views" as a
+v2.0 goal. pg_trickle is uniquely positioned to deliver this capability.
+
+---
+
+## Table of Contents
+
+- [Background: What Is DuckLake?](#background-what-is-ducklake)
+- [Architectural Synergies](#architectural-synergies)
+- [Integration Opportunities](#integration-opportunities)
+  - [INT-1: DuckLake as Stream Table Source (Foreign Table Path)](#int-1-ducklake-as-stream-table-source-foreign-table-path)
+  - [INT-2: DuckLake Inlined Data as Native CDC Source](#int-2-ducklake-inlined-data-as-native-cdc-source)
+  - [INT-3: DuckLake Change Feed Polling](#int-3-ducklake-change-feed-polling)
+  - [INT-4: Stream Table Results Exported to DuckLake](#int-4-stream-table-results-exported-to-ducklake)
+  - [INT-5: IVM Engine for DuckLake (v2.0 Collaboration)](#int-5-ivm-engine-for-ducklake-v20-collaboration)
+  - [INT-6: DuckLake Metadata Monitoring via Stream Tables](#int-6-ducklake-metadata-monitoring-via-stream-tables)
+  - [INT-7: Hybrid OLTP/OLAP Pipeline](#int-7-hybrid-oltpolap-pipeline)
+- [Feature Ideas for pg_trickle](#feature-ideas-for-pg_trickle)
+- [Blog Post & Tutorial Ideas](#blog-post--tutorial-ideas)
+- [Implementation Roadmap](#implementation-roadmap)
+- [Risks & Considerations](#risks--considerations)
+
+---
+
+## Background: What Is DuckLake?
+
+DuckLake is a lakehouse format that:
+
+1. **Stores data** in immutable Parquet files (local disk, S3, GCS, Azure Blob).
+2. **Stores metadata** (schemas, snapshots, statistics, file locations) in a
+   standard SQL database (PostgreSQL, SQLite, or DuckDB).
+3. **Provides ACID transactions** over multi-table operations using the catalog
+   database's transactional guarantees.
+4. **Supports time travel** via lightweight snapshots (just a few rows in the
+   metadata database per snapshot).
+5. **Provides a Data Change Feed** via `table_changes(table, start_snapshot,
+   end_snapshot)` returning insert/delete/update_preimage/update_postimage rows.
+6. **Supports data inlining** — small changes (≤10 rows by default) are stored
+   directly in PostgreSQL tables within the catalog database, avoiding small
+   Parquet file proliferation.
+7. **Has multiple clients** — DuckDB (reference), Apache DataFusion, Apache
+   Spark, Trino, Pandas, and more.
+
+**Key architecture diagram:**
+```
+┌──────────────────────────────────────────────────────┐
+│              DuckDB / Spark / Trino / ...             │  ← Compute
+├──────────────────────────────────────────────────────┤
+│                    DuckLake Format                    │
+├──────────────┬───────────────────────────────────────┤
+│  PostgreSQL  │          Object Storage (S3)          │
+│  (Catalog)   │          (Parquet files)              │
+│  28 tables   │                                       │
+└──────────────┴───────────────────────────────────────┘
+```
+
+When PostgreSQL is the catalog, the DuckLake metadata tables (prefixed
+`ducklake_`) live in a dedicated database or schema alongside other PostgreSQL
+data. pg_trickle runs in the same PostgreSQL instance and can see these tables.
+
+---
+
+## Architectural Synergies
+
+| Dimension | DuckLake | pg_trickle | Synergy |
+|-----------|----------|------------|---------|
+| **Runs inside PostgreSQL** | Catalog lives in PG | Extension runs in PG | Same process, zero-copy metadata access |
+| **Change tracking** | `table_changes()` provides insert/delete/update deltas between snapshots | CDC (triggers/WAL) captures row-level changes | DuckLake's change feed is a natural delta source for pg_trickle |
+| **Data inlining** | Small changes stored in PG tables (`ducklake_inlined_data_table_*`) | Triggers can watch any PG table | pg_trickle can track inlined DuckLake data natively |
+| **Incremental materialized views** | On roadmap for v2.0, not yet implemented | Core competency, production-ready | pg_trickle can *be* the IVM engine for DuckLake |
+| **Snapshot semantics** | Lightweight snapshots, millions supported | Frontier-based version tracking | Snapshot IDs map naturally to frontier positions |
+| **Multi-engine reads** | DuckDB, Spark, Trino, DataFusion | Exposes results as PostgreSQL tables | Stream table results queryable by all DuckLake clients via `postgres_scanner` |
+| **Statistics** | Table/column/file-level stats in catalog | Uses PG stats for planning | DuckLake stats can guide pg_trickle cost model |
+| **ACID** | Via PG transactions | Via PG transactions | Both participate in same transaction boundaries |
+
+---
+
+## Integration Opportunities
+
+### INT-1: DuckLake as Stream Table Source (Foreign Table Path)
+
+**What:** Use DuckDB's `postgres_scanner` in reverse — expose DuckLake tables as
+PostgreSQL foreign tables via `duckdb_fdw` or `parquet_fdw`, then create
+pg_trickle stream tables over them.
+
+**How it works today:**
+```sql
+-- 1. Install parquet_fdw (or duckdb_fdw)
+CREATE EXTENSION parquet_fdw;
+CREATE SERVER duckdb_server FOREIGN DATA WRAPPER parquet_fdw;
+
+-- 2. Create foreign table pointing to DuckLake Parquet files
+CREATE FOREIGN TABLE events (
+    user_id   INT,
+    event     TEXT,
+    timestamp TIMESTAMPTZ
+) SERVER duckdb_server
+  OPTIONS (filename 's3://my-lake/data_files/*.parquet');
+
+-- 3. Enable polling and create stream table
+SET pg_trickle.foreign_table_polling = on;
+SELECT pgtrickle.create_stream_table(
+    name  => 'events_per_user',
+    query => $$
+        SELECT user_id, COUNT(*) as event_count
+        FROM events
+        GROUP BY user_id
+    $$,
+    schedule     => '30s',
+    refresh_mode => 'DIFFERENTIAL'
+);
+```
+
+**Status:** Already works today with `pg_trickle.foreign_table_polling = on`.
+The polling mechanism does a full scan + EXCEPT ALL diff each cycle.
+
+**Improvement opportunity:** Instead of full-scan polling, use DuckLake's
+`table_changes()` function to obtain only the delta. See INT-3.
+
+**Effort:** Low (documentation/blog post for existing functionality)
+
+---
+
+### INT-2: DuckLake Inlined Data as Native CDC Source
+
+**What:** When DuckLake uses PostgreSQL as its catalog, small writes are stored
+directly in PostgreSQL tables (`ducklake_inlined_data_table_<id>_<version>`).
+pg_trickle can place standard AFTER triggers on these inlined data tables to
+capture changes with zero additional cost.
+
+**How:**
+```sql
+-- DuckLake inlined data tables are regular PG tables with columns:
+--   row_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, <data columns...>
+
+-- pg_trickle could track inserts to these tables:
+-- When begin_snapshot is set → row inserted
+-- When end_snapshot is set  → row deleted
+
+-- Stream table over inlined DuckLake data:
+SELECT pgtrickle.create_stream_table(
+    name  => 'active_lake_orders',
+    query => $$
+        SELECT order_id, customer_id, total
+        FROM ducklake_inlined_data_table_5_1
+        WHERE end_snapshot IS NULL  -- only live rows
+    $$,
+    schedule => 'immediate'  -- real-time as DuckLake commits
+);
+```
+
+**Key insight:** Inlined data tables are standard PostgreSQL heap tables.
+pg_trickle's trigger-based CDC works on them without modification. This gives
+**sub-millisecond latency** on DuckLake changes (as long as they're inlined).
+
+**Limitations:**
+- Only works for small changes (≤ `data_inlining_row_limit` rows)
+- Schema changes create new inlined tables (need to track DDL)
+- DuckLake's `CHECKPOINT`/flush moves inlined data to Parquet (stops tracking)
+
+**Effort:** Medium (need CDC adapter for inlined table schema conventions)
+
+---
+
+### INT-3: DuckLake Change Feed Polling
+
+**What:** Build a dedicated CDC polling adapter that calls DuckLake's
+`table_changes()` function to retrieve deltas between snapshots, converting them
+into pg_trickle's change buffer format.
+
+**Architecture:**
+```
+DuckLake table_changes(tbl, last_snapshot, current_snapshot)
+    │
+    ▼
+┌─────────────────────────────────┐
+│  DuckLake Change Feed Adapter   │  ← New component
+│  (background worker)            │
+│                                 │
+│  • Tracks last-consumed         │
+│    snapshot per DuckLake table   │
+│  • Calls table_changes() via    │
+│    DuckDB's postgres interface   │
+│  • Writes deltas to             │
+│    pgtrickle_changes.changes_*   │
+└─────────────────────────────────┘
+    │
+    ▼
+pg_trickle DVM engine (standard differential refresh path)
+```
+
+**DuckLake's `table_changes()` output:**
+```
+snapshot_id | rowid | change_type        | col1 | col2 | ...
+-----------+-------+--------------------+------+------+----
+3          | 0     | insert             | 42   | foo  |
+4          | 1     | update_preimage    | 43   | bar  |
+4          | 1     | update_postimage   | 43   | baz  |
+5          | 2     | delete             | 44   | qux  |
+```
+
+This maps directly to pg_trickle's change buffer format (I/U/D actions with
+old/new columns). The adapter would:
+
+1. Connect to DuckDB (via `duckdb_fdw` or a background worker with embedded DuckDB)
+2. Track the last-consumed snapshot ID in `pgt_change_tracking`
+3. Periodically call `table_changes(tbl, last_snapshot, current_snapshot())`
+4. Transform results into change buffer rows
+5. Write to `pgtrickle_changes.changes_<foreign_table_oid>`
+
+**Advantages over full-scan polling:**
+- O(delta) instead of O(full table) per refresh cycle
+- DuckLake provides pre-computed change types (insert/delete/update)
+- Snapshot IDs give a clean resumption point (no LSN needed)
+- Works for data stored in Parquet on S3 (not just inlined data)
+
+**Effort:** High (new adapter component, DuckDB connectivity)
+
+---
+
+### INT-4: Stream Table Results Exported to DuckLake
+
+**What:** Instead of (or in addition to) storing stream table results in a
+PostgreSQL heap table, export the delta to a DuckLake-managed table. This
+makes incrementally maintained results available to all DuckLake-compatible
+analytics engines (DuckDB, Spark, Trino, DataFusion).
+
+**Architecture:**
+```
+Source Tables (PG)
+    │  CDC triggers
+    ▼
+pg_trickle DVM Engine
+    │  computes delta
+    ▼
+┌─────────────────────────────────┐
+│  DuckLake Sink Adapter          │  ← New component
+│                                 │
+│  • Receives INSERT/DELETE delta  │
+│  • Writes new Parquet file to   │
+│    object storage                │
+│  • Commits new snapshot to      │
+│    DuckLake catalog (PG tables)  │
+└─────────────────────────────────┘
+    │
+    ▼
+DuckLake (Parquet on S3 + PG catalog)
+    │
+    ▼
+DuckDB / Spark / Trino consumers
+```
+
+**API sketch:**
+```sql
+SELECT pgtrickle.create_stream_table(
+    name     => 'revenue_by_region',
+    query    => $$
+        SELECT region, SUM(amount) as total
+        FROM orders JOIN customers ON ...
+        GROUP BY region
+    $$,
+    schedule => '5s',
+    -- New: sink results to DuckLake instead of (or alongside) PG table
+    sink     => 'ducklake',
+    sink_options => '{
+        "catalog_db": "ducklake_catalog",
+        "data_path": "s3://analytics-lake/stream_tables/",
+        "table_name": "revenue_by_region"
+    }'
+);
+```
+
+**Key value proposition:** "Compute IVM in PostgreSQL, serve results at data lake
+scale." Users get sub-second latency on aggregations while results are
+automatically available as a DuckLake table queryable by any analytics engine.
+
+**DuckLake snapshot integration:** Each pg_trickle refresh cycle creates a new
+DuckLake snapshot. Consumers can use `table_changes()` on the stream table's
+DuckLake output to see what changed in each refresh cycle — enabling downstream
+incremental processing.
+
+**Effort:** Very High (needs Parquet writer, S3 client, DuckLake catalog SQL
+transaction logic)
+
+---
+
+### INT-5: IVM Engine for DuckLake (v2.0 Collaboration)
+
+**What:** DuckLake's roadmap explicitly states "Incremental materialized views"
+as a v2.0 goal. pg_trickle could provide the IVM engine that makes this
+possible, either as a PostgreSQL-side component or by contributing IVM algorithms
+to the DuckDB ecosystem.
+
+**Collaboration models:**
+
+#### Option A: PostgreSQL-side IVM (pg_trickle as DuckLake's IVM backend)
+
+```
+DuckDB client
+    │  CREATE MATERIALIZED VIEW ... WITH INCREMENTAL MAINTENANCE
+    ▼
+DuckLake catalog (PG) ──▶ pg_trickle extension
+    │                          │
+    │  data files (Parquet)    │  monitors ducklake_snapshot_changes
+    │                          │  computes delta via DVM engine
+    ▼                          │  writes result to DuckLake
+Object Storage                 │
+    ▲                          │
+    └──────────────────────────┘
+```
+
+When DuckDB writes data to a DuckLake table, pg_trickle (running in the same
+PostgreSQL catalog database) detects the snapshot change, reads the delta, applies
+the DVM operator tree, and writes the result as a new DuckLake snapshot.
+
+**This is architecturally elegant because:**
+- DuckLake already commits snapshots as PG transactions
+- pg_trickle already watches PG tables for changes
+- Both use the same PostgreSQL instance as their coordination point
+- pg_trickle's background worker can react to DuckLake commits
+
+#### Option B: Contribute IVM algorithms to DuckDB extension ecosystem
+
+Implement pg_trickle's differential dataflow algorithms as a standalone DuckDB
+extension. This would be a separate project but could share the same IVM theory
+and operator tree design.
+
+**Trade-offs:**
+
+| | Option A (PG-side) | Option B (DuckDB extension) |
+|---|---|---|
+| Leverages existing pg_trickle code | ✅ Directly | ❌ Rewrite in C++ |
+| Works with PG catalog DuckLakes | ✅ Native | ✅ Via extension |
+| Works without PostgreSQL | ❌ | ✅ |
+| Performance for large datasets | Moderate (PG) | High (DuckDB columnar) |
+| Time to market | 3–6 months | 12+ months |
+
+**Recommendation:** Pursue Option A first as a proof of concept, then evaluate
+whether the DuckDB community wants a native extension.
+
+**Effort:** Very High (deep integration, specification alignment)
+
+---
+
+### INT-6: DuckLake Metadata Monitoring via Stream Tables
+
+**What:** DuckLake's 28 metadata tables live in PostgreSQL. pg_trickle can
+create stream tables over them to provide real-time operational dashboards.
+
+**Examples:**
+```sql
+-- Real-time snapshot rate monitoring
+SELECT pgtrickle.create_stream_table(
+    name  => 'ducklake_snapshot_rate',
+    query => $$
+        SELECT date_trunc('minute', snapshot_time) as minute,
+               COUNT(*) as snapshots_per_minute,
+               COUNT(DISTINCT table_id) as tables_changed
+        FROM ducklake_snapshot
+        GROUP BY 1
+    $$,
+    schedule => '10s'
+);
+
+-- File growth monitoring
+SELECT pgtrickle.create_stream_table(
+    name  => 'ducklake_storage_growth',
+    query => $$
+        SELECT t.table_name,
+               COUNT(*) as file_count,
+               SUM(ds.file_size_bytes) as total_bytes,
+               MAX(ds.snapshot_id) as latest_snapshot
+        FROM ducklake_data_file ds
+        JOIN ducklake_table t ON t.table_id = ds.table_id
+        WHERE ds.deletion_snapshot_id IS NULL
+        GROUP BY t.table_name
+    $$,
+    schedule => '30s'
+);
+
+-- Compaction candidates (tables with many small files)
+SELECT pgtrickle.create_stream_table(
+    name  => 'ducklake_compaction_candidates',
+    query => $$
+        SELECT t.table_name,
+               COUNT(*) as active_files,
+               AVG(ds.row_count) as avg_rows_per_file,
+               SUM(ds.file_size_bytes) as total_size
+        FROM ducklake_data_file ds
+        JOIN ducklake_table t ON t.table_id = ds.table_id
+        WHERE ds.deletion_snapshot_id IS NULL
+        GROUP BY t.table_name
+        HAVING COUNT(*) > 100
+           AND AVG(ds.row_count) < 10000
+    $$,
+    schedule => '5m'
+);
+```
+
+**Value:** Real-time observability on DuckLake operations without external
+monitoring infrastructure. Especially useful for multi-tenant DuckLake
+deployments where many DuckDB clients are writing concurrently.
+
+**Effort:** Low (just documentation/examples — already works today)
+
+---
+
+### INT-7: Hybrid OLTP/OLAP Pipeline
+
+**What:** A reference architecture combining pg_trickle and DuckLake for the
+common pattern: "OLTP writes to PostgreSQL, analytics runs in DuckDB."
+
+**Architecture:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        PostgreSQL                                │
+│                                                                 │
+│  ┌──────────────┐     ┌──────────────┐     ┌────────────────┐  │
+│  │  OLTP Tables │────▶│  pg_trickle  │────▶│ Stream Tables  │  │
+│  │  (orders,    │ CDC │  DVM Engine  │delta│ (aggregations, │  │
+│  │   products)  │     │              │     │  denormalized)  │  │
+│  └──────────────┘     └──────────────┘     └───────┬────────┘  │
+│                                                     │           │
+│  ┌──────────────────────────────────────────────────┼───────┐   │
+│  │            DuckLake Catalog (PG tables)          │       │   │
+│  │  ducklake_snapshot, ducklake_data_file, ...      │       │   │
+│  └──────────────────────────────────────────────────┼───────┘   │
+└─────────────────────────────────────────────────────┼───────────┘
+                                                      │
+                              ┌────────────────────────┘
+                              │  Export delta as Parquet
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    Object Storage (S3)                           │
+│  s3://lake/stream_tables/revenue_by_region/                     │
+│    ├── data_files/ducklake-abc123.parquet                       │
+│    └── data_files/ducklake-def456.parquet                       │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+              ┌───────────────┼───────────────┐
+              ▼               ▼               ▼
+         ┌─────────┐    ┌─────────┐    ┌─────────┐
+         │ DuckDB  │    │  Spark  │    │  Trino  │
+         │ (local) │    │(cluster)│    │  (BI)   │
+         └─────────┘    └─────────┘    └─────────┘
+```
+
+**User story:** "I have an OLTP PostgreSQL database. I want real-time aggregated
+views that are also queryable from my data lake by BI tools like Metabase,
+Superset, or dbt running on DuckDB."
+
+**This is the killer use case:** pg_trickle handles the hard part (incremental
+computation) while DuckLake handles the distribution part (making results
+available everywhere in an open format).
+
+**Effort:** Medium–High (combines INT-4 with documentation/examples)
+
+---
+
+## Feature Ideas for pg_trickle
+
+Based on this analysis, specific features to add to pg_trickle:
+
+### F-1: DuckLake-Aware Polling Adapter
+
+Replace the generic EXCEPT ALL polling for DuckLake foreign tables with a
+snapshot-aware adapter:
+
+```rust
+// New CDC mode for DuckLake sources
+enum CdcMode {
+    Trigger,
+    Wal,
+    Polling,         // existing: full scan + EXCEPT ALL
+    DuckLakeChangeFeed,  // new: uses table_changes()
+}
+```
+
+Track `last_consumed_snapshot_id` instead of LSN for DuckLake sources.
+
+### F-2: DuckLake Sink Output Mode
+
+Add a new `sink` parameter to `create_stream_table` that writes results to
+DuckLake format instead of (or in addition to) a PostgreSQL heap table:
+
+```sql
+SELECT pgtrickle.create_stream_table(
+    name         => 'events_hourly',
+    query        => $$ ... $$,
+    schedule     => '10s',
+    sink         => 'ducklake',
+    sink_options => '{"catalog_db": "lake", "data_path": "s3://..."}'
+);
+```
+
+### F-3: Snapshot-Based Frontier
+
+Add a frontier type that uses DuckLake snapshot IDs rather than WAL LSNs:
+
+```json
+{
+    "ducklake:lake.events": {"snapshot_id": 42},
+    "ducklake:lake.users":  {"snapshot_id": 38}
+}
+```
+
+### F-4: Parquet Delta Export
+
+For any stream table, allow exporting the computed delta as a Parquet file on
+each refresh cycle. This is a building block for INT-4:
+
+```sql
+SELECT pgtrickle.alter_stream_table(
+    'revenue_by_region',
+    delta_export_path => 's3://lake/deltas/revenue_by_region/'
+);
+```
+
+### F-5: DuckLake Inlined Table Trigger Adapter
+
+Specialized trigger function that understands DuckLake's inlined data table
+conventions (`begin_snapshot`/`end_snapshot` columns) and translates them into
+standard INSERT/DELETE change buffer rows.
+
+---
+
+## Blog Post & Tutorial Ideas
+
+### Tutorial 1: "Real-Time Dashboards on Your Data Lake with pg_trickle + DuckLake"
+
+**Audience:** Data engineers using DuckLake who want fresh aggregations.
+
+**Content:**
+1. Set up PostgreSQL with DuckLake catalog + pg_trickle
+2. DuckDB clients write events to DuckLake
+3. pg_trickle monitors DuckLake metadata tables
+4. Create stream tables for dashboard metrics (events/minute, top users, etc.)
+5. Connect Grafana to PostgreSQL stream tables
+6. Show sub-second refresh latency on metrics derived from lake data
+
+### Tutorial 2: "Incremental Materialized Views for DuckLake (Before v2.0)"
+
+**Audience:** DuckLake users who can't wait for v2.0's native IVM.
+
+**Content:**
+1. Explain DuckLake's current lack of materialized views
+2. Show how pg_trickle in the catalog PostgreSQL fills this gap
+3. End-to-end example: track DuckLake table changes → pg_trickle stream table →
+   results queryable via DuckDB's `postgres_scanner`
+4. Performance comparison: full refresh vs. pg_trickle differential
+
+### Tutorial 3: "The Modern Data Stack in One Box: PostgreSQL + pg_trickle + DuckLake"
+
+**Audience:** Startups/SMBs wanting a complete analytics stack without Kafka,
+Spark, Airflow, etc.
+
+**Content:**
+1. OLTP in PostgreSQL (orders, users, products)
+2. pg_trickle for real-time aggregations (revenue, funnels, cohorts)
+3. DuckLake for historical analytics and time travel
+4. DuckDB for ad-hoc queries over lake data
+5. All in one PostgreSQL instance + S3 bucket — no orchestration
+
+### Tutorial 4: "Streaming PostgreSQL Changes to Your Data Lake"
+
+**Audience:** Engineers wanting CDC-to-lake without Debezium/Kafka.
+
+**Content:**
+1. pg_trickle captures changes to OLTP tables
+2. Stream table computes denormalized/aggregated view
+3. Delta export writes each refresh's changes as Parquet to S3
+4. DuckLake catalogs the exported Parquet files
+5. Compare with Debezium → Kafka → Flink → Iceberg pipeline (10x simpler)
+
+### Tutorial 5: "Monitoring Your DuckLake with pg_trickle"
+
+**Audience:** DuckLake operators managing multi-tenant data lakes.
+
+**Content:**
+1. Create stream tables over DuckLake metadata tables
+2. Real-time alerts: too many small files, snapshot rate spikes, storage growth
+3. Grafana dashboard with pg_trickle-powered metrics
+4. Automated compaction triggers based on stream table thresholds
+
+### Blog Post: "Why pg_trickle + DuckLake Is the Missing Piece for Lakehouse IVM"
+
+**Audience:** Data infrastructure community (Hacker News, /r/dataengineering).
+
+**Content:**
+- Problem: Lakehouse formats (Iceberg, Delta, DuckLake) don't do IVM
+- Existing "solutions": Materialize, Flink, RisingWave — all separate systems
+- Our approach: IVM inside the catalog database that DuckLake already requires
+- Zero additional infrastructure
+- Performance benchmarks
+
+### Blog Post: "DuckLake's table_changes() Meets pg_trickle's DVM Engine"
+
+**Audience:** Technical readers interested in incremental computation.
+
+**Content:**
+- Deep dive into DuckLake's change feed format
+- How it maps to pg_trickle's change buffer model
+- Differential refresh on data lake tables without full scans
+- Benchmarks: 1M-row DuckLake table, 100-row delta → refresh in microseconds
+
+---
+
+## Implementation Roadmap
+
+### Phase 1: Documentation & Awareness (v0.63)
+
+| Item | Type | Effort |
+|------|------|--------|
+| Blog post: INT-1 (DuckLake as foreign table source) | Tutorial | 1 day |
+| Blog post: INT-6 (monitoring DuckLake metadata) | Tutorial | 1 day |
+| Add DuckLake examples to foreign-table-sources.md | Docs | 0.5 day |
+| Blog post: "One-box data stack" tutorial | Tutorial | 2 days |
+
+### Phase 2: DuckLake-Optimized Polling (v0.64–v0.65)
+
+| Item | Type | Effort |
+|------|------|--------|
+| F-1: DuckLake change feed adapter (prototype) | Feature | 1 week |
+| F-3: Snapshot-based frontier for DuckLake sources | Feature | 3 days |
+| F-5: Inlined data table trigger adapter | Feature | 3 days |
+| Integration tests with DuckDB + ducklake extension | Tests | 2 days |
+| Tutorial 2: "Incremental MVs for DuckLake" | Tutorial | 2 days |
+
+### Phase 3: DuckLake Sink (v0.66–v0.68)
+
+| Item | Type | Effort |
+|------|------|--------|
+| F-4: Parquet delta export (using `arrow2` or `parquet` crate) | Feature | 2 weeks |
+| F-2: DuckLake sink mode for stream tables | Feature | 2 weeks |
+| S3 upload integration | Feature | 1 week |
+| DuckLake catalog transaction writer | Feature | 1 week |
+| Tutorial 4: "Streaming PG to data lake" | Tutorial | 2 days |
+| E2E tests with DuckLake sink | Tests | 1 week |
+
+### Phase 4: DuckLake v2.0 IVM Partnership (v0.70+)
+
+| Item | Type | Effort |
+|------|------|--------|
+| INT-5 Option A: Full DuckLake IVM backend | Feature | 2–3 months |
+| Engage DuckDB team for specification alignment | Community | Ongoing |
+| Benchmark suite: IVM over DuckLake at scale | Perf | 2 weeks |
+| Joint announcement / blog post | Community | 1 week |
+
+---
+
+## Risks & Considerations
+
+### Technical Risks
+
+1. **DuckDB connectivity from PostgreSQL:** Calling DuckLake's `table_changes()`
+   requires DuckDB execution. Options:
+   - `duckdb_fdw` extension (exists but maturity varies)
+   - Embedded DuckDB in a background worker (complex but possible via C API)
+   - External sidecar process that bridges the gap
+   - Simply query the DuckLake catalog tables directly (they're in PG)
+
+2. **Parquet writing from Rust/PostgreSQL:** INT-4 requires writing Parquet
+   files. The `parquet` crate (part of `arrow-rs`) is mature and can be used in
+   a pgrx extension. S3 upload via `aws-sdk-rust` or `opendal`.
+
+3. **DuckLake schema evolution:** When DuckLake tables have their schema altered,
+   inlined data tables change. The trigger adapter needs to handle this.
+
+4. **Consistency across boundaries:** If pg_trickle reads DuckLake changes and
+   writes results back to DuckLake, there's a potential for circular
+   dependencies. Must ensure clear DAG boundaries.
+
+### Strategic Risks
+
+1. **DuckLake v2.0 timeline uncertainty:** If DuckLake ships native IVM before we
+   deliver INT-5, our window closes. Mitigated by delivering Phase 1–3 first
+   (useful regardless of DuckLake's native IVM).
+
+2. **Competition with Materialize/RisingWave:** These offer streaming over change
+   feeds too, but require separate infrastructure. Our advantage is
+   co-location with the catalog database.
+
+3. **DuckDB team's openness to collaboration:** INT-5 Option A requires the
+   DuckDB team to endorse pg_trickle as an IVM provider. Early community
+   engagement is essential.
+
+### Mitigation Strategy
+
+- **Start with zero-dependency integrations** (Phase 1): Blog posts and
+  documentation showing what already works require no code changes and no
+  external approval.
+- **Build incrementally:** Each phase delivers standalone value. Phase 3 doesn't
+  depend on Phase 4.
+- **Maintain the "SQL is the API" principle:** All integrations work through
+  standard SQL interfaces, minimizing coupling to DuckLake internals.
+
+---
+
+## Competitive Landscape
+
+| Solution | Approach | vs pg_trickle + DuckLake |
+|----------|----------|--------------------------|
+| **Materialize** | Streaming SQL engine | Separate system, no lakehouse, expensive |
+| **RisingWave** | Streaming SQL engine | Separate system, needs Kafka/Pulsar |
+| **Flink SQL** | Stream processor | Massive infra, JVM, separate cluster |
+| **dbt incremental** | Batch incremental | Not true IVM, full scan on schedule |
+| **Iceberg + Flink** | Lakehouse + stream | 5+ systems to operate |
+| **pg_trickle + DuckLake** | IVM in catalog DB | Zero additional infra, same PG instance |
+
+**Our unique positioning:** The only solution that provides true differential
+IVM *inside* the lakehouse catalog database, requiring zero additional
+infrastructure beyond PostgreSQL + S3.
+
+---
+
+## Summary
+
+The pg_trickle × DuckLake integration represents a strategic opportunity to:
+
+1. **Immediately** (Phase 1): Publish tutorials showing pg_trickle working with
+   DuckLake foreign tables and monitoring DuckLake metadata — establishing
+   thought leadership.
+
+2. **Near-term** (Phase 2): Build DuckLake-optimized CDC adapters that
+   outperform naive polling by orders of magnitude.
+
+3. **Medium-term** (Phase 3): Enable stream table results to flow into DuckLake,
+   making pg_trickle the "real-time computation layer" for data lakes.
+
+4. **Long-term** (Phase 4): Position pg_trickle as the IVM engine for DuckLake
+   v2.0, potentially becoming a standard component of every PostgreSQL-backed
+   DuckLake deployment.
+
+The fundamental insight is simple: **DuckLake chose PostgreSQL as its catalog
+database. pg_trickle lives in PostgreSQL. This co-location is a superpower.**

--- a/plans/ecosystem/PLAN_DUCKLAKE.md
+++ b/plans/ecosystem/PLAN_DUCKLAKE.md
@@ -1,32 +1,65 @@
 # pg_trickle × DuckLake Integration Plan
 
-Date: 2026-05-19
-Status: PROPOSED
+Date: 2026-05-19 (revised)
+Status: PROPOSED — expanded after deeper research into the DuckLake v1.0
+specification, the DuckDB Labs public roadmap, and the wider lakehouse
+ecosystem.
 
 ---
 
-## Executive Summary
+## Executive Summary (for everyone, including non-technical readers)
 
-DuckLake is an open lakehouse format (v1.0 released April 2026) from the DuckDB
-team that stores data in Parquet files and manages all metadata in a standard SQL
-database — most commonly **PostgreSQL**. This architectural choice creates a
-uniquely powerful synergy with pg_trickle: both systems operate inside the same
-PostgreSQL instance, share the same transactional guarantees, and complement each
-other's strengths.
+Imagine that your company keeps two very different kinds of data. Some of it
+lives in PostgreSQL — the operational database that runs your application, holds
+the orders your customers place, and powers the screens employees stare at all
+day. The rest of it lives in a "data lake" — a giant, cheap pile of files on
+Amazon S3 that your analytics team queries with tools like DuckDB, Spark, Trino,
+or whatever the data team happens to love this quarter. These two worlds rarely
+talk to each other in real time. Stitching them together is traditionally an
+expensive engineering project involving Kafka, Debezium, Flink, Airflow, and a
+small army of people who keep that pipeline alive.
 
-pg_trickle provides world-class incremental view maintenance (IVM) inside
-PostgreSQL. DuckLake provides scalable lakehouse storage and multi-engine
-analytics. Together they can deliver **incrementally maintained materialized views
-over data lake tables** — something no existing system offers today.
+**DuckLake**, released as v1.0 in April 2026 by the DuckDB team, changes the
+shape of the problem. It is a new "lakehouse format" — a way to describe data
+that lives in cheap Parquet files on S3 — but with one radically simple twist:
+all the bookkeeping (which files exist, what schemas they have, who wrote them
+when, what the running totals are) lives in a normal SQL database. Most often,
+that SQL database is **PostgreSQL**. Suddenly, the catalog of a data lake is
+just another set of tables in the same Postgres instance you probably already
+run.
 
-DuckLake's own roadmap explicitly lists "Incremental materialized views" as a
-v2.0 goal. pg_trickle is uniquely positioned to deliver this capability.
+**pg_trickle** is a PostgreSQL extension that does something equally simple and
+equally radical: it lets you write a SQL query once and have PostgreSQL keep the
+result up to date automatically, with sub-second latency, by computing only the
+*difference* every time underlying data changes. No external streaming cluster,
+no schedulers, no glue code. Just `CREATE STREAM TABLE … AS SELECT …` and your
+result table is always fresh.
+
+Put these two together inside the same PostgreSQL instance and a remarkable
+thing happens. pg_trickle can *watch* the DuckLake catalog tables, see exactly
+which rows in your data lake just changed, and incrementally update aggregations,
+joins, dashboards, machine-learning features, and search indexes — all in
+PostgreSQL, all in milliseconds, all available to any DuckDB / Spark / Trino
+client that already speaks DuckLake. We can also flip the direction: pg_trickle
+can publish its incrementally maintained results back into DuckLake as a
+brand-new Parquet table, instantly readable by every analytics engine in the
+ecosystem.
+
+The DuckLake team's own published roadmap lists "Materialized views and
+incremental maintenance" as a future feature they are "looking for funding" to
+build. pg_trickle already has a production-grade incremental view maintenance
+engine. **This document lays out how the two projects can fit together — what
+features we should add to pg_trickle, what tutorials and demos we should write,
+and how we can show the DuckLake and broader data-lake community that the
+missing piece they have been waiting for already exists.**
 
 ---
 
 ## Table of Contents
 
+- [Why This Matters: A Plain-English Primer](#why-this-matters-a-plain-english-primer)
 - [Background: What Is DuckLake?](#background-what-is-ducklake)
+- [Who Is Already Using DuckLake?](#who-is-already-using-ducklake)
 - [Architectural Synergies](#architectural-synergies)
 - [Integration Opportunities](#integration-opportunities)
   - [INT-1: DuckLake as Stream Table Source (Foreign Table Path)](#int-1-ducklake-as-stream-table-source-foreign-table-path)
@@ -35,82 +68,204 @@ v2.0 goal. pg_trickle is uniquely positioned to deliver this capability.
   - [INT-4: Stream Table Results Exported to DuckLake](#int-4-stream-table-results-exported-to-ducklake)
   - [INT-5: IVM Engine for DuckLake (v2.0 Collaboration)](#int-5-ivm-engine-for-ducklake-v20-collaboration)
   - [INT-6: DuckLake Metadata Monitoring via Stream Tables](#int-6-ducklake-metadata-monitoring-via-stream-tables)
-  - [INT-7: Hybrid OLTP/OLAP Pipeline](#int-7-hybrid-oltpolap-pipeline)
+  - [INT-7: Hybrid OLTP/OLAP Pipeline (One-Box Modern Stack)](#int-7-hybrid-oltpolap-pipeline-one-box-modern-stack)
+  - [INT-8: Stream Tables Surfaced as DuckLake Views](#int-8-stream-tables-surfaced-as-ducklake-views)
+  - [INT-9: Row-Lineage-Driven Differential Refresh](#int-9-row-lineage-driven-differential-refresh)
+  - [INT-10: pgtrickle-relay DuckLake Backend](#int-10-pgtrickle-relay-ducklake-backend)
+  - [INT-11: Snapshot Provenance & Audit Trails](#int-11-snapshot-provenance--audit-trails)
 - [Feature Ideas for pg_trickle](#feature-ideas-for-pg_trickle)
 - [Blog Post & Tutorial Ideas](#blog-post--tutorial-ideas)
+- [Demo Ideas: Engaging, Shareable, Memorable](#demo-ideas-engaging-shareable-memorable)
 - [Implementation Roadmap](#implementation-roadmap)
 - [Risks & Considerations](#risks--considerations)
+- [Competitive Landscape](#competitive-landscape)
+- [Community Engagement Strategy](#community-engagement-strategy)
+- [Summary](#summary)
+
+---
+
+## Why This Matters: A Plain-English Primer
+
+Modern analytics architectures suffer from what could politely be called a
+"system zoo problem." You start with PostgreSQL because every backend developer
+knows it. Then somebody needs reports, so a data warehouse appears. Then they
+want fresh data, so Kafka and Debezium are added. Then a stream processor like
+Flink is added to compute rolling aggregations. Then a data lake is added to
+keep history cheap. Then a catalog service is added to make the data lake
+queryable from multiple engines. Then a workflow scheduler is added to glue all
+the pieces together. Each of these systems has its own dialect, its own
+operations team, its own failure modes, and its own bill from a cloud vendor.
+
+DuckLake and pg_trickle are part of a small but growing movement that says:
+maybe we do not need most of that. PostgreSQL is genuinely good. Parquet on S3
+is genuinely good. If we use Postgres as both the operational store *and* the
+catalog for the data lake, and we put a tiny but extremely fast incremental
+compute engine right next to it, we can collapse most of the zoo into a single
+boring rectangle on the architecture diagram.
+
+For a non-technical reader, the headline is this: **with pg_trickle and DuckLake
+running together, you get sub-second freshness on metrics derived from a data
+lake the size of Snowflake, using infrastructure no more exotic than a
+PostgreSQL server and an S3 bucket.** That is the story. The rest of this
+document is the engineering plan for telling it convincingly and backing it up
+with real code.
 
 ---
 
 ## Background: What Is DuckLake?
 
-DuckLake is a lakehouse format that:
+DuckLake is a lakehouse format — a specification that describes how to organize
+columnar Parquet files on object storage so that they collectively behave like a
+real database table, complete with transactions, time travel, schema evolution,
+and concurrent multi-engine reads. Where it differs from older lakehouse formats
+like Apache Iceberg and Delta Lake is in *where the bookkeeping lives*. Iceberg
+and Delta encode their metadata as a maze of JSON and Avro files on the same
+blob store as the data, then bolt a catalog database on top to atomically swap
+table-version pointers. DuckLake skips the maze entirely and stores all metadata
+directly in a standard SQL database. That database can be PostgreSQL, SQLite,
+DuckDB, MySQL, or even Google Spanner. The "DuckLake manifesto" sums up the
+philosophy in a single line: **SQL as a Lakehouse Format**.
 
-1. **Stores data** in immutable Parquet files (local disk, S3, GCS, Azure Blob).
-2. **Stores metadata** (schemas, snapshots, statistics, file locations) in a
-   standard SQL database (PostgreSQL, SQLite, or DuckDB).
-3. **Provides ACID transactions** over multi-table operations using the catalog
-   database's transactional guarantees.
-4. **Supports time travel** via lightweight snapshots (just a few rows in the
-   metadata database per snapshot).
-5. **Provides a Data Change Feed** via `table_changes(table, start_snapshot,
-   end_snapshot)` returning insert/delete/update_preimage/update_postimage rows.
-6. **Supports data inlining** — small changes (≤10 rows by default) are stored
-   directly in PostgreSQL tables within the catalog database, avoiding small
-   Parquet file proliferation.
-7. **Has multiple clients** — DuckDB (reference), Apache DataFusion, Apache
-   Spark, Trino, Pandas, and more.
+In practice, a DuckLake deployment with PostgreSQL as catalog looks like this:
 
-**Key architecture diagram:**
 ```
 ┌──────────────────────────────────────────────────────┐
-│              DuckDB / Spark / Trino / ...             │  ← Compute
+│              DuckDB / Spark / Trino / DataFusion      │  ← Compute
 ├──────────────────────────────────────────────────────┤
 │                    DuckLake Format                    │
 ├──────────────┬───────────────────────────────────────┤
 │  PostgreSQL  │          Object Storage (S3)          │
 │  (Catalog)   │          (Parquet files)              │
-│  28 tables   │                                       │
+│  ~28 tables  │                                       │
 └──────────────┴───────────────────────────────────────┘
 ```
 
-When PostgreSQL is the catalog, the DuckLake metadata tables (prefixed
-`ducklake_`) live in a dedicated database or schema alongside other PostgreSQL
-data. pg_trickle runs in the same PostgreSQL instance and can see these tables.
+Every committed transaction in DuckLake is represented as a "snapshot" — a few
+rows added to the metadata database that say "as of this moment, these are the
+files that make up this table." Because snapshots are cheap (just a handful of
+rows, not megabytes of JSON), DuckLake can keep millions of them around at the
+same time and offer time-travel queries like *"show me the table as it was last
+Tuesday at 3pm."*
+
+DuckLake's key features that matter most for the pg_trickle integration are:
+
+- **The `table_changes()` function.** Given a table and two snapshot IDs (or two
+  timestamps), DuckLake returns the rows that were inserted, deleted, or updated
+  between those two points in time, tagged with `insert`, `delete`,
+  `update_preimage`, or `update_postimage`. There are also two cheaper
+  specialised variants, `table_insertions()` and `table_deletions()`, when only
+  one direction is needed. This is, in effect, a built-in change data capture
+  feed sitting on top of the data lake — and it is exactly the shape that
+  pg_trickle's differential refresh engine wants to consume.
+- **Row lineage via a stable `rowid` virtual column.** DuckLake assigns every
+  inserted row a unique identifier that survives updates, compactions, and file
+  movements. This is gold for incremental view maintenance: it gives pg_trickle
+  a reliable way to recognise the "same row" across snapshots without needing
+  primary keys.
+- **Data inlining.** When a write touches fewer than ten rows (configurable),
+  DuckLake skips writing a Parquet file entirely and stores those rows directly
+  in a regular PostgreSQL table named
+  `ducklake_inlined_data_table_<id>_<version>`. This means small DuckLake writes
+  are literally just `INSERT INTO some_pg_table` — which means pg_trickle's
+  standard trigger-based change capture works on them out of the box, with no
+  Parquet reading required.
+- **Lightweight snapshots.** Each snapshot is a handful of rows. There is no
+  expensive snapshot pruning, no manifest rewrite, no compaction cycle required
+  just to keep the catalog healthy. This makes snapshot IDs an excellent stable
+  pointer for resuming a stream — exactly the role that WAL LSNs play in
+  pg_trickle's existing WAL-based CDC path.
+- **Built-in SQL views.** DuckLake supports `CREATE VIEW` and persists the
+  definition in the `ducklake_view` metadata table. This is interesting because
+  it gives us a way to publish pg_trickle stream tables as native DuckLake
+  objects — see INT-8.
+- **Transparent encryption.** DuckLake can encrypt every Parquet file with a
+  per-file key, with the keys stored in the catalog database. If pg_trickle ever
+  writes data into DuckLake, it needs to participate in this key management.
+- **Multi-engine reads.** Anything DuckLake catalogs can be read by DuckDB,
+  Spark, Trino, DataFusion, Pandas, and a growing list of other tools. Whatever
+  pg_trickle produces and publishes to DuckLake instantly becomes available to
+  the entire ecosystem.
+
+---
+
+## Who Is Already Using DuckLake?
+
+The DuckLake homepage lists a striking number of named production deployments
+already — Summer Forever, AlterTable, Windmill, Decision Computing, locals.com,
+Summation, Media Cluster Norway, Ascend.io, **PostHog**, Sliplane, the Austrian
+Supply Chain Intelligence Institute, and Irion, among others. This list matters
+for two reasons. First, it tells us that DuckLake is not a research toy — it is
+already running real workloads less than two months after v1.0. Second, almost
+every name on that list represents a company whose business depends on
+*aggregating events in close-to-real-time* and serving those aggregations to
+either internal dashboards or customers.
+
+PostHog, for example, builds product analytics — counting events per user per
+funnel step. Windmill is a workflow engine that wants to expose run statistics.
+locals.com runs a community platform that surfaces trending content. These are
+exactly the use cases where incremental view maintenance is dramatically more
+efficient than the alternatives (recompute-from-scratch or pay-Snowflake). If we
+can credibly tell each of these companies that pg_trickle gives them
+millisecond-fresh metrics over their existing DuckLake without adding a single
+new piece of infrastructure, we have a very compelling pitch.
 
 ---
 
 ## Architectural Synergies
 
+The two projects share an enormous amount of design DNA, and that overlap is
+what makes the integration feel almost preordained rather than forced. The
+table below maps each dimension where their abstractions meet.
+
 | Dimension | DuckLake | pg_trickle | Synergy |
 |-----------|----------|------------|---------|
 | **Runs inside PostgreSQL** | Catalog lives in PG | Extension runs in PG | Same process, zero-copy metadata access |
-| **Change tracking** | `table_changes()` provides insert/delete/update deltas between snapshots | CDC (triggers/WAL) captures row-level changes | DuckLake's change feed is a natural delta source for pg_trickle |
-| **Data inlining** | Small changes stored in PG tables (`ducklake_inlined_data_table_*`) | Triggers can watch any PG table | pg_trickle can track inlined DuckLake data natively |
-| **Incremental materialized views** | On roadmap for v2.0, not yet implemented | Core competency, production-ready | pg_trickle can *be* the IVM engine for DuckLake |
-| **Snapshot semantics** | Lightweight snapshots, millions supported | Frontier-based version tracking | Snapshot IDs map naturally to frontier positions |
-| **Multi-engine reads** | DuckDB, Spark, Trino, DataFusion | Exposes results as PostgreSQL tables | Stream table results queryable by all DuckLake clients via `postgres_scanner` |
-| **Statistics** | Table/column/file-level stats in catalog | Uses PG stats for planning | DuckLake stats can guide pg_trickle cost model |
-| **ACID** | Via PG transactions | Via PG transactions | Both participate in same transaction boundaries |
+| **Change tracking** | `table_changes()` returns insert/delete/update deltas between snapshots | Trigger / WAL CDC captures row-level changes | DuckLake's change feed is a natural delta source for pg_trickle |
+| **Stable row identity** | `rowid` virtual column, preserved across updates and compactions | Differential refresh needs row identity to reconcile deltas | DuckLake's `rowid` is a drop-in replacement for derived row identity, no PK required |
+| **Data inlining** | Small changes stored in PG tables (`ducklake_inlined_data_table_*`) | Triggers watch any PG table | pg_trickle can track inlined DuckLake data natively, sub-millisecond latency |
+| **Incremental materialized views** | Roadmap item for a future release, currently *"looking for funding"* | Core competency, production-ready | pg_trickle can *be* the IVM engine for DuckLake |
+| **Snapshot semantics** | Lightweight, millions supported, integer IDs | Frontier-based version tracking | Snapshot IDs map naturally to frontier positions |
+| **Multi-engine reads** | DuckDB, Spark, Trino, DataFusion, Pandas | Exposes results as PostgreSQL tables | Stream table results queryable by every DuckLake client via `postgres_scanner` or via published DuckLake tables |
+| **SQL views** | `CREATE VIEW`, stored in `ducklake_view` | Stream tables expose materialised results | We can register a stream table as a DuckLake view that points at the PG result |
+| **Statistics** | Table/column/file-level stats in catalog | Uses PG stats for planning | DuckLake stats can guide pg_trickle cost model and refresh-mode selection |
+| **ACID** | Via PG transactions | Via PG transactions | Both participate in the same transaction boundaries |
+| **Transactional DDL** | Schema changes are snapshots | Stream-table DDL is transactional | Schema evolution can be coordinated atomically |
+| **Encryption** | Per-file Parquet encryption, keys in catalog | Currently unaware | Future writer must integrate with key catalog |
+| **Iceberg compatibility** | Data files written by DuckLake are Iceberg-readable | — | Anything we ship to DuckLake is also indirectly Iceberg-compatible |
+
+The deepest insight buried in this table is the row at the top: **both systems
+already live inside the same PostgreSQL instance.** Every other integration
+benefit cascades from that single architectural fact. There are no network
+hops, no serialisation costs, no separate authentication, no version-skew
+problems between catalog and compute. When DuckLake commits a snapshot,
+pg_trickle can see it in the same transaction context. When pg_trickle
+publishes a stream table, DuckDB can read it via the same Postgres connection
+its catalog already uses.
 
 ---
 
 ## Integration Opportunities
 
+The integrations below are ordered roughly from "works today with no code" to
+"requires substantial new engineering and community alignment." Each one
+delivers standalone value, so the roadmap can pick any subset without
+sacrificing coherence.
+
 ### INT-1: DuckLake as Stream Table Source (Foreign Table Path)
 
-**What:** Use DuckDB's `postgres_scanner` in reverse — expose DuckLake tables as
-PostgreSQL foreign tables via `duckdb_fdw` or `parquet_fdw`, then create
-pg_trickle stream tables over them.
+The first integration is the one that already works without changing a single
+line of pg_trickle code. Using DuckDB's `postgres_scanner` in reverse —
+exposing DuckLake-managed Parquet files as PostgreSQL foreign tables through
+`parquet_fdw` or `duckdb_fdw` — we can immediately wrap any DuckLake table in a
+pg_trickle stream table. The polling-based CDC path picks up changes by
+doing a full scan plus `EXCEPT ALL` diff each cycle.
 
-**How it works today:**
 ```sql
--- 1. Install parquet_fdw (or duckdb_fdw)
+-- 1. Install a Parquet-aware FDW
 CREATE EXTENSION parquet_fdw;
 CREATE SERVER duckdb_server FOREIGN DATA WRAPPER parquet_fdw;
 
--- 2. Create foreign table pointing to DuckLake Parquet files
+-- 2. Map the DuckLake table as a foreign table
 CREATE FOREIGN TABLE events (
     user_id   INT,
     event     TEXT,
@@ -118,12 +273,12 @@ CREATE FOREIGN TABLE events (
 ) SERVER duckdb_server
   OPTIONS (filename 's3://my-lake/data_files/*.parquet');
 
--- 3. Enable polling and create stream table
+-- 3. Enable foreign-table polling and build an incremental aggregation
 SET pg_trickle.foreign_table_polling = on;
 SELECT pgtrickle.create_stream_table(
     name  => 'events_per_user',
     query => $$
-        SELECT user_id, COUNT(*) as event_count
+        SELECT user_id, COUNT(*) AS event_count
         FROM events
         GROUP BY user_id
     $$,
@@ -132,33 +287,37 @@ SELECT pgtrickle.create_stream_table(
 );
 ```
 
-**Status:** Already works today with `pg_trickle.foreign_table_polling = on`.
-The polling mechanism does a full scan + EXCEPT ALL diff each cycle.
+This is genuinely useful as-is for read-heavy use cases where the DuckLake table
+is updated less often than the dashboard polls. The natural improvement is to
+stop relying on full-scan polling and instead consume DuckLake's
+`table_changes()` directly — see INT-3.
 
-**Improvement opportunity:** Instead of full-scan polling, use DuckLake's
-`table_changes()` function to obtain only the delta. See INT-3.
-
-**Effort:** Low (documentation/blog post for existing functionality)
-
----
+**Status:** Works today. **Effort:** Low (a tutorial and a documentation page).
 
 ### INT-2: DuckLake Inlined Data as Native CDC Source
 
-**What:** When DuckLake uses PostgreSQL as its catalog, small writes are stored
-directly in PostgreSQL tables (`ducklake_inlined_data_table_<id>_<version>`).
-pg_trickle can place standard AFTER triggers on these inlined data tables to
-capture changes with zero additional cost.
+When DuckLake is configured for data inlining (the default), small writes never
+touch Parquet at all. They land in a regular PostgreSQL table named
+`ducklake_inlined_data_table_<table_id>_<schema_version>` with this structure:
 
-**How:**
 ```sql
--- DuckLake inlined data tables are regular PG tables with columns:
---   row_id BIGINT, begin_snapshot BIGINT, end_snapshot BIGINT, <data columns...>
+ducklake_inlined_data_table_id_schema_version (
+    row_id         BIGINT,
+    begin_snapshot BIGINT,           -- snapshot when the row was inserted
+    end_snapshot   BIGINT,           -- snapshot when the row was deleted, or NULL
+    -- one column per user column, matching the table schema
+    …
+)
+```
 
--- pg_trickle could track inserts to these tables:
--- When begin_snapshot is set → row inserted
--- When end_snapshot is set  → row deleted
+Because these are *just PostgreSQL heap tables*, pg_trickle's existing
+trigger-based CDC mechanism can attach AFTER triggers to them and capture every
+write with sub-millisecond latency. A pg_trickle stream table over an inlined
+DuckLake table is effectively the same as a stream table over a regular
+PostgreSQL table — the catalog database just happens to be the storage layer
+for the lake too.
 
--- Stream table over inlined DuckLake data:
+```sql
 SELECT pgtrickle.create_stream_table(
     name  => 'active_lake_orders',
     query => $$
@@ -166,53 +325,33 @@ SELECT pgtrickle.create_stream_table(
         FROM ducklake_inlined_data_table_5_1
         WHERE end_snapshot IS NULL  -- only live rows
     $$,
-    schedule => 'immediate'  -- real-time as DuckLake commits
+    schedule => 'immediate'         -- real-time as DuckLake commits
 );
 ```
 
-**Key insight:** Inlined data tables are standard PostgreSQL heap tables.
-pg_trickle's trigger-based CDC works on them without modification. This gives
-**sub-millisecond latency** on DuckLake changes (as long as they're inlined).
+The catch is that this fast path only applies while the data remains inlined.
+When DuckLake's `ducklake_flush_inlined_data` function (or a `CHECKPOINT`) runs,
+the rows move into Parquet files on S3 and the inlined table is truncated.
+A complete adapter therefore needs to also consume the flush event and fall back
+to either the change-feed adapter (INT-3) or a full re-read of the affected
+files. The schema-version suffix also changes whenever the DuckLake table is
+altered, so we need to track which inlined table is current.
 
-**Limitations:**
-- Only works for small changes (≤ `data_inlining_row_limit` rows)
-- Schema changes create new inlined tables (need to track DDL)
-- DuckLake's `CHECKPOINT`/flush moves inlined data to Parquet (stops tracking)
-
-**Effort:** Medium (need CDC adapter for inlined table schema conventions)
-
----
+**Effort:** Medium — a specialised trigger adapter that understands the
+`begin_snapshot` / `end_snapshot` convention plus a small DDL watcher.
 
 ### INT-3: DuckLake Change Feed Polling
 
-**What:** Build a dedicated CDC polling adapter that calls DuckLake's
-`table_changes()` function to retrieve deltas between snapshots, converting them
-into pg_trickle's change buffer format.
+DuckLake's signature feature for change-driven workloads is the family of
+`table_changes(tbl, start, end)`, `table_insertions(tbl, start, end)`, and
+`table_deletions(tbl, start, end)` functions. They return precisely the deltas
+between two snapshots (or two timestamps), with each row tagged as `insert`,
+`delete`, `update_preimage`, or `update_postimage`. The output shape is
+strikingly close to pg_trickle's internal change buffer format, which means the
+translation layer is mostly mechanical.
 
-**Architecture:**
 ```
-DuckLake table_changes(tbl, last_snapshot, current_snapshot)
-    │
-    ▼
-┌─────────────────────────────────┐
-│  DuckLake Change Feed Adapter   │  ← New component
-│  (background worker)            │
-│                                 │
-│  • Tracks last-consumed         │
-│    snapshot per DuckLake table   │
-│  • Calls table_changes() via    │
-│    DuckDB's postgres interface   │
-│  • Writes deltas to             │
-│    pgtrickle_changes.changes_*   │
-└─────────────────────────────────┘
-    │
-    ▼
-pg_trickle DVM engine (standard differential refresh path)
-```
-
-**DuckLake's `table_changes()` output:**
-```
-snapshot_id | rowid | change_type        | col1 | col2 | ...
+snapshot_id | rowid | change_type        | col1 | col2 | …
 -----------+-------+--------------------+------+------+----
 3          | 0     | insert             | 42   | foo  |
 4          | 1     | update_preimage    | 43   | bar  |
@@ -220,33 +359,43 @@ snapshot_id | rowid | change_type        | col1 | col2 | ...
 5          | 2     | delete             | 44   | qux  |
 ```
 
-This maps directly to pg_trickle's change buffer format (I/U/D actions with
-old/new columns). The adapter would:
+A new CDC adapter — call it `DuckLakeChangeFeed` — would do the following on
+each refresh cycle:
 
-1. Connect to DuckDB (via `duckdb_fdw` or a background worker with embedded DuckDB)
-2. Track the last-consumed snapshot ID in `pgt_change_tracking`
-3. Periodically call `table_changes(tbl, last_snapshot, current_snapshot())`
-4. Transform results into change buffer rows
-5. Write to `pgtrickle_changes.changes_<foreign_table_oid>`
+1. Look up the last consumed snapshot ID for the source table in a tracking
+   table.
+2. Invoke `table_changes(tbl, last_consumed_snapshot + 1, current_snapshot())`
+   either through `duckdb_fdw`, through an embedded DuckDB instance in a
+   background worker, or — most elegantly — by reading the DuckLake metadata
+   tables directly with pure SQL (since they all live in the same Postgres
+   instance, we can reconstruct the `table_changes()` result without going
+   through DuckDB at all).
+3. Translate each output row into the appropriate insert/delete/update entries
+   in `pgtrickle_changes.changes_<oid>`.
+4. Advance the frontier.
+5. Let the DVM engine do its normal differential refresh.
 
-**Advantages over full-scan polling:**
-- O(delta) instead of O(full table) per refresh cycle
-- DuckLake provides pre-computed change types (insert/delete/update)
-- Snapshot IDs give a clean resumption point (no LSN needed)
-- Works for data stored in Parquet on S3 (not just inlined data)
+The huge win versus the polling approach in INT-1 is that the cost becomes
+O(delta) per refresh rather than O(full table). For a DuckLake table with a
+billion rows where only a hundred rows changed in the last minute, this is
+literally seven orders of magnitude less work. DuckLake also gives us
+pre-computed update semantics (the preimage/postimage pair), which removes the
+need for pg_trickle to do its own row-matching.
 
-**Effort:** High (new adapter component, DuckDB connectivity)
-
----
+**Effort:** High — a new adapter component with careful snapshot-window
+management, but well within reach because we can avoid the DuckDB dependency by
+querying the catalog tables directly.
 
 ### INT-4: Stream Table Results Exported to DuckLake
 
-**What:** Instead of (or in addition to) storing stream table results in a
-PostgreSQL heap table, export the delta to a DuckLake-managed table. This
-makes incrementally maintained results available to all DuckLake-compatible
-analytics engines (DuckDB, Spark, Trino, DataFusion).
+Reverse the direction: instead of (or in addition to) materialising a stream
+table into a PostgreSQL heap table, write each refresh cycle's delta out as a
+Parquet file on S3 and commit a corresponding snapshot in the DuckLake catalog.
+The end state is that every DuckLake client — DuckDB, Spark, Trino, DataFusion,
+or whatever the analytics team brings next — automatically sees a continuously
+updating DuckLake table whose rows are the result of an incremental computation
+done inside PostgreSQL.
 
-**Architecture:**
 ```
 Source Tables (PG)
     │  CDC triggers
@@ -257,11 +406,11 @@ pg_trickle DVM Engine
 ┌─────────────────────────────────┐
 │  DuckLake Sink Adapter          │  ← New component
 │                                 │
-│  • Receives INSERT/DELETE delta  │
+│  • Receives INSERT/DELETE delta │
 │  • Writes new Parquet file to   │
-│    object storage                │
+│    object storage               │
 │  • Commits new snapshot to      │
-│    DuckLake catalog (PG tables)  │
+│    DuckLake catalog (PG tables) │
 └─────────────────────────────────┘
     │
     ▼
@@ -271,144 +420,131 @@ DuckLake (Parquet on S3 + PG catalog)
 DuckDB / Spark / Trino consumers
 ```
 
-**API sketch:**
+The API would look something like this:
+
 ```sql
 SELECT pgtrickle.create_stream_table(
-    name     => 'revenue_by_region',
-    query    => $$
-        SELECT region, SUM(amount) as total
-        FROM orders JOIN customers ON ...
+    name         => 'revenue_by_region',
+    query        => $$
+        SELECT region, SUM(amount) AS total
+        FROM orders JOIN customers USING (customer_id)
         GROUP BY region
     $$,
-    schedule => '5s',
-    -- New: sink results to DuckLake instead of (or alongside) PG table
-    sink     => 'ducklake',
+    schedule     => '5s',
+    sink         => 'ducklake',
     sink_options => '{
         "catalog_db": "ducklake_catalog",
         "data_path": "s3://analytics-lake/stream_tables/",
-        "table_name": "revenue_by_region"
+        "table_name": "revenue_by_region",
+        "inline_small_changes": true
     }'
 );
 ```
 
-**Key value proposition:** "Compute IVM in PostgreSQL, serve results at data lake
-scale." Users get sub-second latency on aggregations while results are
-automatically available as a DuckLake table queryable by any analytics engine.
+When `inline_small_changes` is true and the delta is below DuckLake's inlining
+threshold, the sink writes directly into the catalog rather than uploading a
+new Parquet file. This avoids the well-known "small files problem" for
+fast-refresh stream tables.
 
-**DuckLake snapshot integration:** Each pg_trickle refresh cycle creates a new
-DuckLake snapshot. Consumers can use `table_changes()` on the stream table's
-DuckLake output to see what changed in each refresh cycle — enabling downstream
-incremental processing.
+The headline value proposition is direct and memorable: **compute incrementally
+in PostgreSQL, serve at data-lake scale.** Each pg_trickle refresh cycle creates
+a new DuckLake snapshot, which means downstream consumers can in turn use
+`table_changes()` on the stream table's DuckLake representation to drive
+*their* incremental processing. The whole architecture starts to compose
+recursively.
 
-**Effort:** Very High (needs Parquet writer, S3 client, DuckLake catalog SQL
-transaction logic)
-
----
+**Effort:** Very High — needs a Parquet writer (`arrow-rs` is the obvious
+choice), an object-store client (`opendal` or `aws-sdk-rust`), encryption
+integration, and careful transaction coordination with the DuckLake catalog.
+This is multi-month work but unlocks an enormous amount of value.
 
 ### INT-5: IVM Engine for DuckLake (v2.0 Collaboration)
 
-**What:** DuckLake's roadmap explicitly states "Incremental materialized views"
-as a v2.0 goal. pg_trickle could provide the IVM engine that makes this
-possible, either as a PostgreSQL-side component or by contributing IVM algorithms
-to the DuckDB ecosystem.
+DuckLake's roadmap page explicitly lists "Materialized views and incremental
+maintenance" under "Future Work / Looking for Funding." This is not a future
+they have started building yet — they are inviting somebody to fund or
+contribute the work. pg_trickle is uniquely positioned to be that somebody, and
+doing so cements pg_trickle as a foundational component of any PostgreSQL-backed
+DuckLake deployment rather than just a clever third-party add-on.
 
-**Collaboration models:**
+There are two viable collaboration models, and they are not mutually exclusive.
 
-#### Option A: PostgreSQL-side IVM (pg_trickle as DuckLake's IVM backend)
+#### Option A: pg_trickle becomes the IVM backend for PG-catalog DuckLakes
 
 ```
 DuckDB client
-    │  CREATE MATERIALIZED VIEW ... WITH INCREMENTAL MAINTENANCE
+    │  CREATE MATERIALIZED VIEW … WITH INCREMENTAL MAINTENANCE
     ▼
 DuckLake catalog (PG) ──▶ pg_trickle extension
     │                          │
     │  data files (Parquet)    │  monitors ducklake_snapshot_changes
     │                          │  computes delta via DVM engine
-    ▼                          │  writes result to DuckLake
+    ▼                          │  writes result back to DuckLake
 Object Storage                 │
     ▲                          │
     └──────────────────────────┘
 ```
 
-When DuckDB writes data to a DuckLake table, pg_trickle (running in the same
-PostgreSQL catalog database) detects the snapshot change, reads the delta, applies
-the DVM operator tree, and writes the result as a new DuckLake snapshot.
+In this model, when DuckDB writes data to a DuckLake table, pg_trickle (running
+in the same PostgreSQL catalog database) detects the snapshot, reads the delta,
+applies its DVM operator tree, and writes the result as a new DuckLake snapshot
+on a materialised-view table. This is architecturally elegant because both
+systems are already coordinated through the same Postgres transaction layer —
+the integration is largely about extending the SQL surface of the DuckDB
+extension to delegate IVM operations to pg_trickle.
 
-**This is architecturally elegant because:**
-- DuckLake already commits snapshots as PG transactions
-- pg_trickle already watches PG tables for changes
-- Both use the same PostgreSQL instance as their coordination point
-- pg_trickle's background worker can react to DuckLake commits
+#### Option B: A DuckDB extension that ports the algorithms
 
-#### Option B: Contribute IVM algorithms to DuckDB extension ecosystem
-
-Implement pg_trickle's differential dataflow algorithms as a standalone DuckDB
-extension. This would be a separate project but could share the same IVM theory
-and operator tree design.
-
-**Trade-offs:**
+The DVM algorithms in pg_trickle — operator-by-operator differentiation rules,
+frontier tracking, DAG management — are general. They could be ported to C++ as
+a native DuckDB extension, which would work for non-PostgreSQL DuckLake
+deployments (SQLite-backed, DuckDB-backed) too. This is a separate project but
+would share the same theory and operator design.
 
 | | Option A (PG-side) | Option B (DuckDB extension) |
 |---|---|---|
-| Leverages existing pg_trickle code | ✅ Directly | ❌ Rewrite in C++ |
-| Works with PG catalog DuckLakes | ✅ Native | ✅ Via extension |
+| Leverages existing pg_trickle code | ✅ Directly | ❌ Requires C++ rewrite |
+| Works with PG-catalog DuckLakes | ✅ Native | ✅ Via extension |
 | Works without PostgreSQL | ❌ | ✅ |
-| Performance for large datasets | Moderate (PG) | High (DuckDB columnar) |
-| Time to market | 3–6 months | 12+ months |
+| Performance for huge analytical scans | Moderate (PG storage) | High (DuckDB columnar engine) |
+| Time to a working prototype | 3–6 months | 12+ months |
 
-**Recommendation:** Pursue Option A first as a proof of concept, then evaluate
-whether the DuckDB community wants a native extension.
-
-**Effort:** Very High (deep integration, specification alignment)
-
----
+**Recommendation:** pursue Option A first as a proof of concept and a
+relationship-builder with the DuckDB Labs team. If the demand and the
+collaboration prove fruitful, Option B becomes the natural next step.
 
 ### INT-6: DuckLake Metadata Monitoring via Stream Tables
 
-**What:** DuckLake's 28 metadata tables live in PostgreSQL. pg_trickle can
-create stream tables over them to provide real-time operational dashboards.
+DuckLake's ~28 metadata tables are themselves a rich source of operational
+intelligence. Stream tables over them give DuckLake operators something that
+does not exist anywhere else today: real-time, SQL-defined observability into
+the lake without bolting on Prometheus, Grafana exporters, or a custom polling
+script.
 
-**Examples:**
 ```sql
 -- Real-time snapshot rate monitoring
 SELECT pgtrickle.create_stream_table(
     name  => 'ducklake_snapshot_rate',
     query => $$
-        SELECT date_trunc('minute', snapshot_time) as minute,
-               COUNT(*) as snapshots_per_minute,
-               COUNT(DISTINCT table_id) as tables_changed
+        SELECT date_trunc('minute', snapshot_time) AS minute,
+               COUNT(*)                            AS snapshots_per_minute,
+               COUNT(DISTINCT table_id)            AS tables_changed
         FROM ducklake_snapshot
         GROUP BY 1
     $$,
     schedule => '10s'
 );
 
--- File growth monitoring
-SELECT pgtrickle.create_stream_table(
-    name  => 'ducklake_storage_growth',
-    query => $$
-        SELECT t.table_name,
-               COUNT(*) as file_count,
-               SUM(ds.file_size_bytes) as total_bytes,
-               MAX(ds.snapshot_id) as latest_snapshot
-        FROM ducklake_data_file ds
-        JOIN ducklake_table t ON t.table_id = ds.table_id
-        WHERE ds.deletion_snapshot_id IS NULL
-        GROUP BY t.table_name
-    $$,
-    schedule => '30s'
-);
-
--- Compaction candidates (tables with many small files)
+-- Compaction candidates (tables accumulating many small files)
 SELECT pgtrickle.create_stream_table(
     name  => 'ducklake_compaction_candidates',
     query => $$
         SELECT t.table_name,
-               COUNT(*) as active_files,
-               AVG(ds.row_count) as avg_rows_per_file,
-               SUM(ds.file_size_bytes) as total_size
+               COUNT(*)                       AS active_files,
+               AVG(ds.row_count)              AS avg_rows_per_file,
+               SUM(ds.file_size_bytes)        AS total_size
         FROM ducklake_data_file ds
-        JOIN ducklake_table t ON t.table_id = ds.table_id
+        JOIN ducklake_table    t  ON t.table_id = ds.table_id
         WHERE ds.deletion_snapshot_id IS NULL
         GROUP BY t.table_name
         HAVING COUNT(*) > 100
@@ -416,37 +552,56 @@ SELECT pgtrickle.create_stream_table(
     $$,
     schedule => '5m'
 );
+
+-- Per-tenant write activity for multi-tenant DuckLakes
+SELECT pgtrickle.create_stream_table(
+    name  => 'ducklake_tenant_activity',
+    query => $$
+        SELECT split_part(t.table_name, '_', 1) AS tenant,
+               COUNT(DISTINCT s.snapshot_id)    AS commits_last_hour,
+               SUM(df.file_size_bytes)          AS bytes_written
+        FROM ducklake_snapshot         s
+        JOIN ducklake_snapshot_changes sc USING (snapshot_id)
+        JOIN ducklake_data_file        df ON df.added_snapshot_id = s.snapshot_id
+        JOIN ducklake_table            t  ON t.table_id = df.table_id
+        WHERE s.snapshot_time > NOW() - INTERVAL '1 hour'
+        GROUP BY 1
+    $$,
+    schedule => '30s'
+);
 ```
 
-**Value:** Real-time observability on DuckLake operations without external
-monitoring infrastructure. Especially useful for multi-tenant DuckLake
-deployments where many DuckDB clients are writing concurrently.
+This is especially powerful for multi-tenant DuckLake deployments where
+hundreds of clients are committing concurrently. Operators get a live, queryable
+view of who is writing, how much, and where the small-files problem is
+brewing.
 
-**Effort:** Low (just documentation/examples — already works today)
+**Effort:** Low — these are stream tables over already-existing PG tables.
+The remaining work is curating a library of useful queries and publishing them
+as documentation and a Grafana dashboard pack.
 
----
+### INT-7: Hybrid OLTP/OLAP Pipeline (One-Box Modern Stack)
 
-### INT-7: Hybrid OLTP/OLAP Pipeline
+The previous integrations combine into a single reference architecture that is
+genuinely novel: an OLTP database, a streaming compute engine, and a lakehouse
+catalog all running inside one PostgreSQL instance, with Parquet on S3 as the
+only external dependency.
 
-**What:** A reference architecture combining pg_trickle and DuckLake for the
-common pattern: "OLTP writes to PostgreSQL, analytics runs in DuckDB."
-
-**Architecture:**
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                        PostgreSQL                                │
 │                                                                 │
 │  ┌──────────────┐     ┌──────────────┐     ┌────────────────┐  │
 │  │  OLTP Tables │────▶│  pg_trickle  │────▶│ Stream Tables  │  │
-│  │  (orders,    │ CDC │  DVM Engine  │delta│ (aggregations, │  │
-│  │   products)  │     │              │     │  denormalized)  │  │
+│  │  (orders,    │ CDC │  DVM Engine  │delta│ (aggregations) │  │
+│  │   products)  │     │              │     │                │  │
 │  └──────────────┘     └──────────────┘     └───────┬────────┘  │
 │                                                     │           │
-│  ┌──────────────────────────────────────────────────┼───────┐   │
-│  │            DuckLake Catalog (PG tables)          │       │   │
-│  │  ducklake_snapshot, ducklake_data_file, ...      │       │   │
-│  └──────────────────────────────────────────────────┼───────┘   │
-└─────────────────────────────────────────────────────┼───────────┘
+│  ┌──────────────────────────────────────────────────┼───────┐  │
+│  │            DuckLake Catalog (PG tables)          │       │  │
+│  │  ducklake_snapshot, ducklake_data_file, …        │       │  │
+│  └──────────────────────────────────────────────────┼───────┘  │
+└─────────────────────────────────────────────────────┼──────────┘
                                                       │
                               ┌────────────────────────┘
                               │  Export delta as Parquet
@@ -466,69 +621,166 @@ common pattern: "OLTP writes to PostgreSQL, analytics runs in DuckDB."
          └─────────┘    └─────────┘    └─────────┘
 ```
 
-**User story:** "I have an OLTP PostgreSQL database. I want real-time aggregated
-views that are also queryable from my data lake by BI tools like Metabase,
-Superset, or dbt running on DuckDB."
+The user story is plain: *"I have an OLTP PostgreSQL database. I want real-time
+aggregated views that are also queryable from my data lake by BI tools like
+Metabase, Superset, or dbt running on DuckDB."* Today that requires a
+five-system pipeline. With pg_trickle and DuckLake it requires one extension
+and an S3 bucket.
 
-**This is the killer use case:** pg_trickle handles the hard part (incremental
-computation) while DuckLake handles the distribution part (making results
-available everywhere in an open format).
+This is the **killer demo** for the integration — see the Demo Ideas section
+below.
 
-**Effort:** Medium–High (combines INT-4 with documentation/examples)
+### INT-8: Stream Tables Surfaced as DuckLake Views
+
+DuckLake supports first-class SQL views: `CREATE VIEW v AS SELECT …` and the
+view definition is persisted in the `ducklake_view` metadata table, after which
+every DuckLake client sees `v` as a queryable object. We can exploit this to
+make pg_trickle stream tables *look like* native DuckLake objects from the
+outside, without any of the consumers needing to know that the underlying
+storage is a PostgreSQL heap rather than a Parquet file.
+
+The idea is straightforward. Whenever a stream table is created (or its
+definition changes), pg_trickle automatically writes a corresponding row into
+`ducklake_view` whose SQL body is something like:
+
+```sql
+SELECT * FROM postgres_scan('postgresql://…', 'pgtrickle', 'stream_<name>')
+```
+
+A DuckDB client doing `SELECT * FROM my_ducklake.revenue_by_region` then
+transparently round-trips through `postgres_scanner` into the live pg_trickle
+result table. Combined with INT-4 (which writes Parquet exports), the user has
+two options per stream table:
+
+1. **Live view mode** (cheap, always fresh): the DuckLake view points at the PG
+   stream table. Reads pull through `postgres_scanner`.
+2. **Materialised mode** (cheap for analytics, slightly stale): the DuckLake
+   table is real Parquet on S3, refreshed by pg_trickle on every cycle.
+
+The user picks per-stream-table which mode they want. Both modes appear in
+DuckLake as ordinary catalog objects.
+
+This is the integration that makes pg_trickle stream tables feel like a native
+part of the DuckLake ecosystem rather than an external system that DuckLake
+clients have to know about.
+
+**Effort:** Low–Medium — requires writing rows into `ducklake_view` and keeping
+them in sync with stream-table DDL.
+
+### INT-9: Row-Lineage-Driven Differential Refresh
+
+One of pg_trickle's harder challenges in differential mode is determining
+**row identity** — figuring out which "new" row corresponds to which "old" row
+when a row is updated. Without a primary key, the engine has to fall back to
+content-hashing or treat updates as delete+insert pairs, both of which are more
+expensive than they need to be.
+
+DuckLake solves this for us. Every row in DuckLake has a stable `rowid` that
+**survives updates, file movements, and compactions**. When pg_trickle consumes
+a delta from `table_changes()`, the `rowid` column gives it exactly the row
+identity it needs — for free, with full correctness, and without requiring the
+user to declare a primary key (which DuckLake tables today cannot even enforce
+yet, since `PRIMARY KEY` constraints are on the roadmap but not implemented).
+
+This makes DuckLake one of the easiest CDC sources pg_trickle could ever
+consume from a differential-mode correctness perspective. We should design the
+DuckLake CDC adapter (INT-3) to plumb `rowid` straight through into the DVM
+engine's row-identity column rather than recomputing it.
+
+**Effort:** Folds naturally into INT-3.
+
+### INT-10: pgtrickle-relay DuckLake Backend
+
+The repository already includes `pgtrickle-relay`, a standalone Rust sidecar
+that bridges pg_trickle outbox and inbox tables with external messaging systems
+like Kafka, NATS, Redis Streams, SQS, RabbitMQ, and HTTP webhooks. Adding
+DuckLake as both a sink and a source backend slots in naturally.
+
+- **Forward (sink) mode**: the relay reads from pg_trickle's outbox, batches
+  rows, writes Parquet, and commits a DuckLake snapshot. This is essentially
+  the INT-4 architecture, but extracted into a sidecar for users who want to
+  keep the Parquet writer and S3 client out of the PostgreSQL process.
+- **Reverse (source) mode**: the relay polls DuckLake's `table_changes()` and
+  writes rows into a pg_trickle inbox table, where they appear to downstream
+  stream tables exactly like CDC events. This is the INT-3 architecture
+  packaged as an opt-in external process.
+
+The sidecar form has two distinct advantages over the in-extension forms.
+First, it isolates expensive operations (Parquet encoding, S3 uploads, network
+retries) from the PostgreSQL backend, where they would otherwise tie up
+connection slots and memory. Second, it gives the user a clean horizontal scale
+unit — they can run more relay replicas as throughput demands grow, without
+touching their PostgreSQL configuration.
+
+**Effort:** Medium — re-uses the existing relay framework, adds a DuckLake
+backend module and a Parquet writer dependency.
+
+### INT-11: Snapshot Provenance & Audit Trails
+
+DuckLake supports per-snapshot commit messages, authors, and arbitrary JSON
+`extra_info` via the `set_commit_message` function. When pg_trickle writes a
+stream-table delta into DuckLake, it should populate these fields with
+operational provenance:
+
+```json
+{
+  "source_stream_table": "revenue_by_region",
+  "pg_trickle_version":  "0.63.0",
+  "refresh_mode":        "DIFFERENTIAL",
+  "refresh_cycle_id":    "01HXYZ…",
+  "delta_rows":          {"insert": 4321, "delete": 12, "update": 7},
+  "source_snapshots":    {"orders": 42, "customers": 38},
+  "wall_clock_ms":       17
+}
+```
+
+This gives DuckLake operators an audit trail per snapshot that traces every
+materialised change back to the pg_trickle refresh cycle that produced it,
+which source-table snapshots fed in, and how long the computation took. It is
+trivial to add but transforms DuckLake from "a series of opaque commits" into
+"a fully documented history of how every value got there."
+
+**Effort:** Trivial once the sink writer (INT-4 / INT-10) exists.
 
 ---
 
 ## Feature Ideas for pg_trickle
 
-Based on this analysis, specific features to add to pg_trickle:
+Building on the integration opportunities, the concrete new features we should
+add to pg_trickle are:
 
-### F-1: DuckLake-Aware Polling Adapter
+### F-1: DuckLake-Aware Polling Adapter (`CdcMode::DuckLakeChangeFeed`)
 
-Replace the generic EXCEPT ALL polling for DuckLake foreign tables with a
-snapshot-aware adapter:
-
-```rust
-// New CDC mode for DuckLake sources
-enum CdcMode {
-    Trigger,
-    Wal,
-    Polling,         // existing: full scan + EXCEPT ALL
-    DuckLakeChangeFeed,  // new: uses table_changes()
-}
-```
-
-Track `last_consumed_snapshot_id` instead of LSN for DuckLake sources.
+Replace the generic `EXCEPT ALL` polling for DuckLake foreign tables with a
+snapshot-aware adapter that calls `table_changes()` (or queries the equivalent
+metadata tables directly) and produces O(delta) work per refresh. Track
+`last_consumed_snapshot_id` instead of LSN.
 
 ### F-2: DuckLake Sink Output Mode
 
-Add a new `sink` parameter to `create_stream_table` that writes results to
-DuckLake format instead of (or in addition to) a PostgreSQL heap table:
-
-```sql
-SELECT pgtrickle.create_stream_table(
-    name         => 'events_hourly',
-    query        => $$ ... $$,
-    schedule     => '10s',
-    sink         => 'ducklake',
-    sink_options => '{"catalog_db": "lake", "data_path": "s3://..."}'
-);
-```
+Add a `sink => 'ducklake'` parameter to `create_stream_table` that writes
+results into DuckLake-managed storage. See INT-4.
 
 ### F-3: Snapshot-Based Frontier
 
-Add a frontier type that uses DuckLake snapshot IDs rather than WAL LSNs:
+Extend the frontier model to carry DuckLake snapshot IDs alongside WAL LSNs
+and clock-based markers:
 
 ```json
 {
-    "ducklake:lake.events": {"snapshot_id": 42},
-    "ducklake:lake.users":  {"snapshot_id": 38}
+  "ducklake:lake.events":   {"snapshot_id": 42},
+  "ducklake:lake.users":    {"snapshot_id": 38},
+  "wal:postgres":           {"lsn": "0/16A4F08"}
 }
 ```
+
+This lets a single stream table mix data from PostgreSQL OLTP tables and
+DuckLake tables and still have a coherent consistency story.
 
 ### F-4: Parquet Delta Export
 
 For any stream table, allow exporting the computed delta as a Parquet file on
-each refresh cycle. This is a building block for INT-4:
+each refresh cycle. This is a building block for both F-2 and INT-10:
 
 ```sql
 SELECT pgtrickle.alter_stream_table(
@@ -539,123 +791,256 @@ SELECT pgtrickle.alter_stream_table(
 
 ### F-5: DuckLake Inlined Table Trigger Adapter
 
-Specialized trigger function that understands DuckLake's inlined data table
-conventions (`begin_snapshot`/`end_snapshot` columns) and translates them into
-standard INSERT/DELETE change buffer rows.
+A specialised trigger function that understands DuckLake's inlined-data table
+schema conventions (`row_id`, `begin_snapshot`, `end_snapshot`) and translates
+the begin/end columns into standard INSERT/DELETE change-buffer rows. Includes
+a DDL watcher that follows schema-version increments.
+
+### F-6: DuckLake View Registration
+
+When a stream table is created or altered, automatically register (or update) a
+matching row in `ducklake_view` so the result is queryable from every DuckLake
+client as a native catalog object. See INT-8.
+
+### F-7: Row-ID Plumbing
+
+Extend the DVM engine's row-identity layer to accept a caller-supplied stable
+identifier instead of always deriving one. When consuming from a DuckLake
+source, plug the DuckLake `rowid` straight through. See INT-9.
+
+### F-8: Snapshot-Window Awareness for Compaction Safety
+
+DuckLake compaction can expire snapshots, after which their changes are no
+longer readable via `table_changes()`. The CDC adapter must therefore detect
+when the requested start snapshot has been compacted away and either fall back
+to a full refresh or raise a clear error so the user can extend the
+snapshot-retention window. Expose this as a configurable policy
+(`pg_trickle.ducklake_compaction_policy = 'fallback' | 'error'`).
+
+### F-9: Encryption Key Pass-Through
+
+If the source DuckLake is encrypted (per-file Parquet encryption with keys in
+`ducklake_data_file.encryption_key`), the writer side of any pg_trickle
+integration must generate fresh keys and store them in the catalog the same
+way DuckLake itself does. This is a small but essential piece for any real
+production user — many lakes will be encrypted from day one.
 
 ---
 
 ## Blog Post & Tutorial Ideas
 
+Each item below is a self-contained story with a clear audience, a clear
+take-away, and an opportunity to publish on Hacker News, /r/dataengineering,
+the DuckDB blog cross-link, and the dbt Slack.
+
 ### Tutorial 1: "Real-Time Dashboards on Your Data Lake with pg_trickle + DuckLake"
 
 **Audience:** Data engineers using DuckLake who want fresh aggregations.
 
-**Content:**
-1. Set up PostgreSQL with DuckLake catalog + pg_trickle
-2. DuckDB clients write events to DuckLake
-3. pg_trickle monitors DuckLake metadata tables
-4. Create stream tables for dashboard metrics (events/minute, top users, etc.)
-5. Connect Grafana to PostgreSQL stream tables
-6. Show sub-second refresh latency on metrics derived from lake data
+Start with an empty DuckLake catalog in PostgreSQL. Spin up a DuckDB client that
+writes 10 000 synthetic events per second. Show that a naive
+`SELECT COUNT(*) GROUP BY user_id` query on DuckLake takes seconds even on a
+small dataset. Then add a single `pgtrickle.create_stream_table(…)` call and
+watch the same aggregation return in two milliseconds, refreshed automatically
+every second. Connect Grafana directly to the PostgreSQL stream table. End with
+a screen capture of the dashboard updating in real time as events flow in.
 
-### Tutorial 2: "Incremental Materialized Views for DuckLake (Before v2.0)"
+### Tutorial 2: "Incremental Materialized Views for DuckLake — Before v2.0"
 
-**Audience:** DuckLake users who can't wait for v2.0's native IVM.
+**Audience:** DuckLake users who want IVM today and cannot wait for the DuckDB
+team to ship native support.
 
-**Content:**
-1. Explain DuckLake's current lack of materialized views
-2. Show how pg_trickle in the catalog PostgreSQL fills this gap
-3. End-to-end example: track DuckLake table changes → pg_trickle stream table →
-   results queryable via DuckDB's `postgres_scanner`
-4. Performance comparison: full refresh vs. pg_trickle differential
+Lead with the DuckLake roadmap quote: *"Materialized views and incremental
+maintenance — looking for funding."* Explain in plain English what IVM is and
+why DuckLake does not have it natively yet. Walk through a full example: a
+DuckLake events table → pg_trickle stream table over it → result published back
+as a DuckLake view (INT-8) → queried from DuckDB exactly as if it were a
+regular table. Include a benchmark comparing a full refresh against the
+differential path on a 100M-row source with a 1 000-row delta.
 
 ### Tutorial 3: "The Modern Data Stack in One Box: PostgreSQL + pg_trickle + DuckLake"
 
-**Audience:** Startups/SMBs wanting a complete analytics stack without Kafka,
-Spark, Airflow, etc.
+**Audience:** Startups and SMBs who want a complete analytics stack without
+Kafka, Spark, Airflow, or a vendor bill that doubles every year.
 
-**Content:**
-1. OLTP in PostgreSQL (orders, users, products)
-2. pg_trickle for real-time aggregations (revenue, funnels, cohorts)
-3. DuckLake for historical analytics and time travel
-4. DuckDB for ad-hoc queries over lake data
-5. All in one PostgreSQL instance + S3 bucket — no orchestration
+Build out the INT-7 reference architecture end-to-end on a single Postgres
+instance. Show OLTP writes, real-time aggregations, time-travel queries, and
+multi-engine reads. Close with an architecture-diagram comparison: the
+traditional five-system pipeline next to the one-box equivalent, and a list of
+ops responsibilities each one removes.
 
-### Tutorial 4: "Streaming PostgreSQL Changes to Your Data Lake"
+### Tutorial 4: "Streaming PostgreSQL Changes to Your Data Lake — Without Kafka"
 
-**Audience:** Engineers wanting CDC-to-lake without Debezium/Kafka.
+**Audience:** Engineers currently running or contemplating a CDC-to-lake
+pipeline (Debezium → Kafka → Flink → Iceberg).
 
-**Content:**
-1. pg_trickle captures changes to OLTP tables
-2. Stream table computes denormalized/aggregated view
-3. Delta export writes each refresh's changes as Parquet to S3
-4. DuckLake catalogs the exported Parquet files
-5. Compare with Debezium → Kafka → Flink → Iceberg pipeline (10x simpler)
+Show the same outcome with a single PostgreSQL instance plus pg_trickle's
+DuckLake sink. Emphasise the operational footprint (one ALTER vs five clusters),
+the failure modes that go away, and the cost difference. Provide a migration
+guide for users coming from Debezium.
 
 ### Tutorial 5: "Monitoring Your DuckLake with pg_trickle"
 
 **Audience:** DuckLake operators managing multi-tenant data lakes.
 
-**Content:**
-1. Create stream tables over DuckLake metadata tables
-2. Real-time alerts: too many small files, snapshot rate spikes, storage growth
-3. Grafana dashboard with pg_trickle-powered metrics
-4. Automated compaction triggers based on stream table thresholds
+Build out a complete Grafana dashboard powered by stream tables over DuckLake
+metadata: snapshot rates, storage growth, compaction candidates, tenant
+activity, schema-evolution events. Include alert rules for "tenant X writing
+abnormally fast" and "table Y accumulating small files."
+
+### Tutorial 6: "Sub-Millisecond DuckLake CDC: The Inlined-Data Fast Path"
+
+**Audience:** Performance-curious engineers who love a deep technical dive.
+
+Walk through how DuckLake inlining works, why the inlined data tables are just
+PostgreSQL heap tables, and how pg_trickle's trigger-based CDC achieves
+sub-millisecond latency on small DuckLake writes. Show benchmarks against the
+Parquet-only path.
 
 ### Blog Post: "Why pg_trickle + DuckLake Is the Missing Piece for Lakehouse IVM"
 
-**Audience:** Data infrastructure community (Hacker News, /r/dataengineering).
+**Audience:** The data-infrastructure community (Hacker News, the dbt Slack,
+/r/dataengineering, the Lakehouse Lakehouse newsletter).
 
-**Content:**
-- Problem: Lakehouse formats (Iceberg, Delta, DuckLake) don't do IVM
-- Existing "solutions": Materialize, Flink, RisingWave — all separate systems
-- Our approach: IVM inside the catalog database that DuckLake already requires
-- Zero additional infrastructure
-- Performance benchmarks
+Frame the lakehouse-IVM gap, walk through how Materialize, RisingWave, and
+Flink each try to solve it with separate infrastructure, and then show how
+pg_trickle + DuckLake solve it by *not* adding new infrastructure. Include the
+benchmark from Tutorial 2.
 
-### Blog Post: "DuckLake's table_changes() Meets pg_trickle's DVM Engine"
+### Blog Post: "DuckLake's `table_changes()` Meets pg_trickle's DVM Engine"
 
-**Audience:** Technical readers interested in incremental computation.
+**Audience:** Technical readers interested in incremental computation theory.
 
-**Content:**
-- Deep dive into DuckLake's change feed format
-- How it maps to pg_trickle's change buffer model
-- Differential refresh on data lake tables without full scans
-- Benchmarks: 1M-row DuckLake table, 100-row delta → refresh in microseconds
+Deep dive into DuckLake's change-feed format and pg_trickle's change-buffer
+format, with the row-by-row translation laid out. Show why the row-lineage
+`rowid` column makes DuckLake one of the most natural CDC sources you could
+imagine.
+
+### Blog Post: "From Trigger to Snapshot: A pg_trickle × DuckLake Wire-Level Tour"
+
+**Audience:** Distributed-systems-curious engineers.
+
+Trace one INSERT all the way through: trigger fires → change buffer → DVM →
+stream-table refresh → Parquet writer → DuckLake snapshot commit → DuckDB
+client read. Include a sequence diagram and a Wireshark-style annotated trace.
+
+---
+
+## Demo Ideas: Engaging, Shareable, Memorable
+
+Documentation tells people what is possible. Demos make them want it. Each
+demo below is designed to be small enough to fit on a developer's laptop, fun
+enough to share on social media, and educational enough to teach the audience
+something real along the way.
+
+### Demo A: "The Five-Second Funnel"
+
+Build a tiny e-commerce demo that streams page-view events into a DuckLake
+table at high throughput. A pg_trickle stream table computes the classic
+funnel — visits → product views → cart adds → checkouts → purchases — with
+five-second freshness. A single-page React dashboard shows the funnel updating
+live as fake users click around in a side-by-side iframe. The whole thing
+fits in a single `docker-compose up` and runs on a laptop. Perfect for
+conference talks and the PostHog crowd.
+
+### Demo B: "Time-Travel Debugging for Stream Tables"
+
+Show off DuckLake's time-travel feature in combination with pg_trickle stream
+tables. The demo writes a stream of orders, occasionally injects a "bad" order
+that breaks a downstream invariant, and then lets the user rewind the stream
+table to the snapshot just before the bad order arrived. Highlights the unique
+combination of incremental freshness and full historical reproducibility — a
+combination no other system on the market offers.
+
+### Demo C: "Multi-Engine Live Leaderboard"
+
+A single stream table maintains the top-100 leaderboard for a fake gaming
+service. The leaderboard is exposed simultaneously as (a) a PostgreSQL view,
+(b) a DuckLake view (INT-8) read by a DuckDB client, (c) a Parquet snapshot
+on S3 read by a Spark notebook, and (d) a Trino query for the BI team. The
+audience watches all four interfaces update in lock-step in real time.
+Visceral demonstration of the "compute once, serve everywhere" promise.
+
+### Demo D: "DuckLake Observability in a Box"
+
+A pre-packaged Grafana dashboard plus stream tables over DuckLake metadata
+(INT-6). The user attaches an existing DuckLake catalog, runs one SQL script,
+and immediately gets a production-quality observability dashboard. The pitch
+is "five minutes from `git clone` to operational visibility."
+
+### Demo E: "The OLTP-to-Lake Loop Without Kafka"
+
+A reference deployment of the INT-7 hybrid architecture. An app writes orders
+to PostgreSQL. pg_trickle computes per-region revenue. The DuckLake sink
+publishes the result as a continuously updating DuckLake table. A
+Metabase-style dashboard reads the DuckLake table via DuckDB. Compare the
+ops checklist to the equivalent Debezium-Kafka-Flink-Iceberg pipeline.
+
+### Demo F: "Bring Your Own DuckLake"
+
+A `pg_trickle-on-DuckLake` template repo — fork it, point it at any existing
+PG-catalog DuckLake, run `just demo`, and watch a curated set of example stream
+tables come online. Designed for DuckLake users to try the integration on
+their *own* data in minutes, without writing any SQL.
+
+### Demo G: "Live Vector Search Over a Lake"
+
+Combines pg_trickle's existing pgvector support with DuckLake. Documents are
+ingested into a DuckLake table; an embedding model writes vector columns to a
+pg_trickle stream table; queries run against the stream table for low-latency
+ANN search. Show how the search index stays fresh in real time as the lake
+grows. Perfect for the RAG and AI crowd.
 
 ---
 
 ## Implementation Roadmap
 
+The roadmap below is intentionally arranged so that every phase delivers
+standalone value. We can stop after any phase and still have shipped something
+useful to the community.
+
 ### Phase 1: Documentation & Awareness (v0.63)
 
 | Item | Type | Effort |
 |------|------|--------|
-| Blog post: INT-1 (DuckLake as foreign table source) | Tutorial | 1 day |
+| Blog post: INT-1 (DuckLake as foreign-table source) | Tutorial | 1 day |
 | Blog post: INT-6 (monitoring DuckLake metadata) | Tutorial | 1 day |
 | Add DuckLake examples to foreign-table-sources.md | Docs | 0.5 day |
-| Blog post: "One-box data stack" tutorial | Tutorial | 2 days |
+| Blog post: "One-box data stack" walkthrough | Tutorial | 2 days |
+| Demo A: Five-Second Funnel (containerised) | Demo | 3 days |
+| Demo D: DuckLake observability dashboard pack | Demo | 2 days |
+| Conference talk submission (DuckCon, PGConf) | Community | 1 day |
 
-### Phase 2: DuckLake-Optimized Polling (v0.64–v0.65)
+### Phase 2: DuckLake-Optimised Polling (v0.64–v0.65)
 
 | Item | Type | Effort |
 |------|------|--------|
-| F-1: DuckLake change feed adapter (prototype) | Feature | 1 week |
+| F-1: DuckLake change-feed adapter (prototype) | Feature | 1 week |
 | F-3: Snapshot-based frontier for DuckLake sources | Feature | 3 days |
-| F-5: Inlined data table trigger adapter | Feature | 3 days |
-| Integration tests with DuckDB + ducklake extension | Tests | 2 days |
-| Tutorial 2: "Incremental MVs for DuckLake" | Tutorial | 2 days |
+| F-5: Inlined-data trigger adapter | Feature | 3 days |
+| F-7: Row-ID plumbing | Feature | 3 days |
+| F-8: Snapshot-window compaction safety | Feature | 2 days |
+| Integration tests with DuckDB + ducklake extension | Tests | 3 days |
+| Tutorial 2: "IVM for DuckLake before v2.0" | Tutorial | 2 days |
+| Tutorial 6: "Sub-millisecond inlined-data CDC" | Tutorial | 2 days |
+| Demo B: Time-travel debugging | Demo | 3 days |
 
-### Phase 3: DuckLake Sink (v0.66–v0.68)
+### Phase 3: DuckLake Sink and View Registration (v0.66–v0.68)
 
 | Item | Type | Effort |
 |------|------|--------|
-| F-4: Parquet delta export (using `arrow2` or `parquet` crate) | Feature | 2 weeks |
+| F-4: Parquet delta export (via `arrow-rs`) | Feature | 2 weeks |
 | F-2: DuckLake sink mode for stream tables | Feature | 2 weeks |
-| S3 upload integration | Feature | 1 week |
+| F-6: DuckLake view registration | Feature | 1 week |
+| F-9: Encryption key pass-through | Feature | 1 week |
+| S3 / object-store upload integration | Feature | 1 week |
 | DuckLake catalog transaction writer | Feature | 1 week |
-| Tutorial 4: "Streaming PG to data lake" | Tutorial | 2 days |
+| INT-10: pgtrickle-relay DuckLake backend (parallel) | Feature | 2 weeks |
+| INT-11: Snapshot provenance | Feature | 2 days |
+| Tutorial 3: "Modern data stack in one box" | Tutorial | 2 days |
+| Tutorial 4: "Streaming PG to data lake without Kafka" | Tutorial | 2 days |
+| Demo C: Multi-engine leaderboard | Demo | 4 days |
+| Demo E: OLTP-to-lake loop | Demo | 3 days |
 | E2E tests with DuckLake sink | Tests | 1 week |
 
 ### Phase 4: DuckLake v2.0 IVM Partnership (v0.70+)
@@ -663,9 +1048,10 @@ Spark, Airflow, etc.
 | Item | Type | Effort |
 |------|------|--------|
 | INT-5 Option A: Full DuckLake IVM backend | Feature | 2–3 months |
-| Engage DuckDB team for specification alignment | Community | Ongoing |
+| Engage DuckDB Labs for specification alignment | Community | Ongoing |
 | Benchmark suite: IVM over DuckLake at scale | Perf | 2 weeks |
-| Joint announcement / blog post | Community | 1 week |
+| Joint announcement / blog post / podcast | Community | 1 week |
+| DuckCon talk (post-implementation) | Community | 1 week |
 
 ---
 
@@ -673,84 +1059,165 @@ Spark, Airflow, etc.
 
 ### Technical Risks
 
-1. **DuckDB connectivity from PostgreSQL:** Calling DuckLake's `table_changes()`
-   requires DuckDB execution. Options:
-   - `duckdb_fdw` extension (exists but maturity varies)
-   - Embedded DuckDB in a background worker (complex but possible via C API)
-   - External sidecar process that bridges the gap
-   - Simply query the DuckLake catalog tables directly (they're in PG)
-
-2. **Parquet writing from Rust/PostgreSQL:** INT-4 requires writing Parquet
-   files. The `parquet` crate (part of `arrow-rs`) is mature and can be used in
-   a pgrx extension. S3 upload via `aws-sdk-rust` or `opendal`.
-
-3. **DuckLake schema evolution:** When DuckLake tables have their schema altered,
-   inlined data tables change. The trigger adapter needs to handle this.
-
-4. **Consistency across boundaries:** If pg_trickle reads DuckLake changes and
-   writes results back to DuckLake, there's a potential for circular
-   dependencies. Must ensure clear DAG boundaries.
+1. **DuckDB connectivity from PostgreSQL.** Calling DuckLake's `table_changes()`
+   normally requires a DuckDB process. Our options, in increasing order of
+   independence: use `duckdb_fdw` (exists but maturity varies); embed DuckDB in
+   a background worker via the C API (complex but doable); run an external
+   sidecar process (this is the relay path, INT-10); or — most elegantly —
+   query the DuckLake metadata tables directly with pure SQL, since they all
+   live in the same Postgres instance. The pure-SQL path is the most attractive
+   long-term answer because it minimises the dependency surface.
+2. **Parquet writing from inside Postgres.** The sink integrations require a
+   Parquet writer in the extension. The Rust `parquet` crate (part of
+   `arrow-rs`) is mature, async-friendly, and works inside pgrx with care.
+   Object-store uploads are handled cleanly by `opendal` or `aws-sdk-rust`.
+3. **DuckLake schema evolution.** When a DuckLake table is altered, a new
+   inlined-data table is created with a fresh `schema_version` suffix. The
+   trigger adapter must follow the version change and rewrite its trigger plan
+   transactionally. Our existing DDL hook framework already handles this kind
+   of transition for native PG tables.
+4. **Snapshot retention windows.** DuckLake compaction expires snapshots and
+   drops the change-feed history for them. A pg_trickle stream table that
+   pauses for longer than the retention window will lose the ability to
+   resume incrementally. We need a clear policy (F-8) and operator-facing
+   monitoring.
+5. **Multi-writer conflicts.** DuckLake uses optimistic concurrency control
+   with retry. A pg_trickle writer competing with DuckDB writers for the same
+   table must implement the standard retry loop. The DuckLake extension already
+   has tunable retry configuration that we should mirror.
+6. **Circular dependencies.** If pg_trickle both reads from and writes back to
+   DuckLake tables (e.g. a stream table that materialises a roll-up of another
+   stream table's DuckLake output), we need clear DAG boundaries to prevent
+   refresh loops. pg_trickle's DAG already enforces acyclicity for native
+   sources; we extend the same model to DuckLake snapshot dependencies.
+7. **Encryption.** Sink writes must mint per-file keys and store them in the
+   catalog. Forgetting this would silently break encrypted DuckLakes.
+8. **Catalog-database load.** DuckLake's design pushes a great deal of work
+   onto the catalog database. pg_trickle running in the same instance must be
+   careful with connection pool consumption, lock contention, and bgworker
+   priorities. The existing scheduler is a sound starting point but will need
+   tuning for the combined workload.
 
 ### Strategic Risks
 
-1. **DuckLake v2.0 timeline uncertainty:** If DuckLake ships native IVM before we
-   deliver INT-5, our window closes. Mitigated by delivering Phase 1–3 first
-   (useful regardless of DuckLake's native IVM).
-
-2. **Competition with Materialize/RisingWave:** These offer streaming over change
-   feeds too, but require separate infrastructure. Our advantage is
-   co-location with the catalog database.
-
-3. **DuckDB team's openness to collaboration:** INT-5 Option A requires the
-   DuckDB team to endorse pg_trickle as an IVM provider. Early community
-   engagement is essential.
+1. **DuckLake v2.0 timeline.** If DuckLake ships native IVM before we deliver
+   INT-5, the deepest collaboration window closes. Mitigated by delivering
+   Phases 1–3 first, since they are useful regardless of whether DuckLake
+   eventually ships native IVM.
+2. **Competing IVM implementations.** Materialize, RisingWave, and Feldera all
+   have streaming SQL engines. None of them sit inside the catalog database
+   today, but any of them could write a DuckLake adapter. Our defensible moat
+   is co-location: nothing else lives *in* the catalog the way pg_trickle does.
+3. **DuckDB Labs collaboration openness.** INT-5 Option A specifically benefits
+   from DuckDB Labs treating pg_trickle as a recommended IVM provider. We
+   should engage early through GitHub Discussions, the DuckDB Slack, and the
+   DuckCon CFP. The DuckLake roadmap's explicit "looking for funding"
+   language for IVM is an open door.
+4. **Brand confusion.** The pitch "PostgreSQL extension for data lakes" can
+   sound to some audiences like "yet another lake catalog." We need clear
+   messaging: pg_trickle is the *incremental compute engine*, DuckLake is the
+   *lakehouse format*, together they are *streaming compute on a data lake
+   without the streaming infrastructure.*
 
 ### Mitigation Strategy
 
-- **Start with zero-dependency integrations** (Phase 1): Blog posts and
-  documentation showing what already works require no code changes and no
-  external approval.
-- **Build incrementally:** Each phase delivers standalone value. Phase 3 doesn't
-  depend on Phase 4.
-- **Maintain the "SQL is the API" principle:** All integrations work through
-  standard SQL interfaces, minimizing coupling to DuckLake internals.
+The mitigation strategy follows directly from the phased roadmap: start with
+zero-code integrations that ship value immediately (Phase 1), then layer in
+optimised adapters that produce big wins on existing setups (Phase 2), then
+ship the sink that enables the killer cross-engine story (Phase 3), and only
+then attempt the deep IVM-backend collaboration (Phase 4). Each phase ships
+working code that is useful on its own. We never bet the project on a single
+multi-month deliverable.
 
 ---
 
 ## Competitive Landscape
 
-| Solution | Approach | vs pg_trickle + DuckLake |
-|----------|----------|--------------------------|
-| **Materialize** | Streaming SQL engine | Separate system, no lakehouse, expensive |
-| **RisingWave** | Streaming SQL engine | Separate system, needs Kafka/Pulsar |
-| **Flink SQL** | Stream processor | Massive infra, JVM, separate cluster |
-| **dbt incremental** | Batch incremental | Not true IVM, full scan on schedule |
-| **Iceberg + Flink** | Lakehouse + stream | 5+ systems to operate |
-| **pg_trickle + DuckLake** | IVM in catalog DB | Zero additional infra, same PG instance |
+| Solution | Approach | Versus pg_trickle + DuckLake |
+|----------|----------|------------------------------|
+| **Materialize** | Streaming SQL engine | Separate cluster, no lakehouse story, commercial |
+| **RisingWave** | Streaming SQL engine | Separate cluster, needs Kafka/Pulsar for ingest |
+| **Feldera** | Streaming SQL engine | Separate cluster, no native PG/DuckLake hook |
+| **Flink SQL** | Stream processor | JVM cluster, complex ops, no PG-native story |
+| **dbt incremental** | Batch incremental | Not true IVM — full scan on a schedule |
+| **Iceberg + Flink + catalog** | Lakehouse + stream + service | 5+ systems to operate |
+| **Delta Live Tables (Databricks)** | Managed streaming | Proprietary, locked to Databricks |
+| **Snowflake Dynamic Tables** | Managed streaming | Proprietary, Snowflake-only |
+| **pg_ivm** | In-PG IVM | No lakehouse story, narrower IVM coverage |
+| **pg_trickle + DuckLake** | IVM in the catalog DB | Zero additional infra, open formats end-to-end |
 
-**Our unique positioning:** The only solution that provides true differential
-IVM *inside* the lakehouse catalog database, requiring zero additional
-infrastructure beyond PostgreSQL + S3.
+The unique positioning is straightforward: **pg_trickle + DuckLake is the only
+combination that delivers true differential IVM inside the lakehouse catalog
+database itself**, with the entire data plane in open formats. Every other
+option on the list either requires running another distributed system or locks
+the user into a proprietary cloud platform.
+
+---
+
+## Community Engagement Strategy
+
+Technical integration on its own is not enough — the integration has to be
+visible to the people who would benefit from it.
+
+1. **Engage DuckDB Labs and the DuckLake maintainers early.** The roadmap's
+   "looking for funding" language on IVM is an explicit invitation. Open a
+   GitHub Discussion on `duckdb/ducklake` summarising this plan and asking for
+   feedback. Offer to co-author a "DuckLake + pg_trickle reference
+   architecture" page on the DuckLake website.
+2. **Target the named production users.** PostHog, Windmill, Ascend.io,
+   Sliplane, locals.com, and Media Cluster Norway are all listed as production
+   DuckLake users on the DuckLake homepage. Reach out individually with a tailored
+   pitch ("your funnel/dashboard/workflow workload would benefit from
+   millisecond IVM on your existing DuckLake — would you like a hands-on demo?")
+3. **Speak at the conferences.** DuckCon (run by the DuckDB Foundation),
+   PGConf, PGCon, P99 CONF, and Data Engineering Open Source Summit are all
+   natural venues. Submit one talk per phase: "Stream tables on DuckLake" for
+   Phase 1, "Differential IVM over DuckLake change feeds" for Phase 2, "The
+   one-box modern data stack" for Phase 3.
+4. **Cross-publish blog posts.** The DuckDB blog regularly features ecosystem
+   integrations. Offer to co-author the "pg_trickle on DuckLake" launch post
+   alongside DuckDB Labs.
+5. **Sponsor a small DuckLake community moment.** A "pg_trickle × DuckLake
+   month" with a daily blog post, a weekly demo livestream, and a community
+   Discord/Slack channel would establish credibility quickly.
+6. **Maintain a "DuckLake integration" badge on the README.** Make it visible
+   that this is a first-class integration, not an afterthought.
 
 ---
 
 ## Summary
 
-The pg_trickle × DuckLake integration represents a strategic opportunity to:
+The pg_trickle × DuckLake integration is unusually well-aligned across every
+axis that matters — architectural, philosophical, and strategic. DuckLake chose
+PostgreSQL as its catalog precisely because PostgreSQL is a great place to
+manage transactional metadata at scale. pg_trickle lives in PostgreSQL
+precisely because PostgreSQL is a great place to do incremental compute at
+scale. The two projects have already, independently, arrived at the same
+fundamental bet: that the modern data stack can be much simpler if PostgreSQL
+is allowed to take on a larger share of the load.
 
-1. **Immediately** (Phase 1): Publish tutorials showing pg_trickle working with
-   DuckLake foreign tables and monitoring DuckLake metadata — establishing
-   thought leadership.
+This document proposes a four-phase roadmap that turns that latent alignment
+into shipped software. **Phase 1** publishes documentation, blog posts, and
+demos that show what already works — establishing pg_trickle as a recognised
+DuckLake collaborator with zero new code. **Phase 2** ships specialised CDC
+adapters that consume DuckLake's change feed and inlined data with O(delta)
+work per refresh, dramatically outperforming any general-purpose approach.
+**Phase 3** introduces the DuckLake sink so that pg_trickle's incrementally
+maintained results flow back into the lake as native DuckLake tables, instantly
+visible to every analytics engine in the ecosystem. **Phase 4** pursues the
+deepest collaboration of all: pg_trickle as the IVM engine that DuckLake's
+roadmap is openly inviting somebody to build.
 
-2. **Near-term** (Phase 2): Build DuckLake-optimized CDC adapters that
-   outperform naive polling by orders of magnitude.
+Along the way, the integration unlocks a string of headline stories: real-time
+dashboards on data-lake tables; sub-millisecond CDC over DuckLake's inlined
+fast path; a one-box modern data stack that replaces the
+Debezium-Kafka-Flink-Iceberg pipeline; cross-engine live leaderboards;
+time-travel-aware stream tables; and a credible answer to the
+"materialised-views-on-the-lake" question that every analytics team eventually
+asks.
 
-3. **Medium-term** (Phase 3): Enable stream table results to flow into DuckLake,
-   making pg_trickle the "real-time computation layer" for data lakes.
-
-4. **Long-term** (Phase 4): Position pg_trickle as the IVM engine for DuckLake
-   v2.0, potentially becoming a standard component of every PostgreSQL-backed
-   DuckLake deployment.
-
-The fundamental insight is simple: **DuckLake chose PostgreSQL as its catalog
-database. pg_trickle lives in PostgreSQL. This co-location is a superpower.**
+The fundamental insight that ties it all together remains the simplest possible
+sentence: **DuckLake chose PostgreSQL as its catalog. pg_trickle lives in
+PostgreSQL. This co-location is a superpower — and the time to exploit it is
+now, while DuckLake is still on the v1.0 → v2.0 ramp and the door to deep
+collaboration is wide open.**

--- a/roadmap/v0.64.0.md
+++ b/roadmap/v0.64.0.md
@@ -1,0 +1,133 @@
+# v0.64.0 — DuckLake Ecosystem Phase 1
+
+> **Full details:** [plans/ecosystem/PLAN_DUCKLAKE.md](../plans/ecosystem/PLAN_DUCKLAKE.md)
+
+## What's New
+
+v0.64.0 is a pure documentation, demo, and community release — no changes to
+the extension itself. It launches pg_trickle as a recognised first-class
+participant in the DuckLake ecosystem, establishing the narrative that
+pg_trickle is the incremental view maintenance engine that every
+PostgreSQL-backed DuckLake deployment has been waiting for.
+
+DuckLake v1.0 (released April 2026) stores all its bookkeeping in a standard
+SQL database — most commonly PostgreSQL. pg_trickle lives in that same
+PostgreSQL instance. That co-location is the architectural superpower that this
+release makes visible to the world.
+
+DuckLake's own public roadmap lists "Materialized views and incremental
+maintenance" as a future item explicitly tagged *"looking for funding."*
+This release plants the flag: pg_trickle already does this, it works today, and
+here is how.
+
+## Deliverables
+
+### Tutorials
+
+**Tutorial T-1: "Real-Time Dashboards on Your Data Lake"**  
+DuckDB writes synthetic events into a DuckLake table at high throughput.
+pg_trickle stream tables compute per-minute and per-user aggregations over the
+lake data using the existing foreign-table polling path. A Grafana dashboard
+connected to the PostgreSQL stream-table results updates in sub-second latency.
+The tutorial covers setup, the stream-table SQL, and a comparison of query times
+before and after.
+
+**Tutorial T-2: "The Modern Data Stack in One Box"**  
+A reference architecture that replaces the classic five-system
+Debezium-Kafka-Flink-Iceberg pipeline with a single PostgreSQL instance plus an
+S3 bucket. OLTP writes in PostgreSQL, pg_trickle computes real-time
+aggregations, DuckLake stores the history in Parquet on S3, DuckDB handles
+ad-hoc analytics. No Kafka, no Airflow, no JVM, no separate clusters.
+
+**Tutorial T-3: "Monitoring Your DuckLake with pg_trickle"**  
+DuckLake's ~28 metadata tables live in PostgreSQL and are rich with operational
+signals. This tutorial builds a set of stream tables that deliver real-time
+operational visibility: snapshot rate per minute, tables with many small files
+(compaction candidates), per-tenant write activity for multi-tenant deployments,
+and storage growth curves. Includes a Grafana dashboard definition.
+
+### Blog Posts
+
+**Blog B-1: "Why pg_trickle + DuckLake Is the Missing Piece for Lakehouse IVM"**  
+Thought-leadership post aimed at Hacker News, /r/dataengineering, and the dbt
+Slack. Frames the lakehouse-IVM gap, shows why existing solutions (Materialize,
+RisingWave, Flink) require separate infrastructure, and explains how pg_trickle
+fills the gap from inside the catalog database — the infrastructure DuckLake
+already requires. Links to DuckLake's own roadmap item as the anchor.
+
+**Blog B-2: "DuckLake's `table_changes()` Meets pg_trickle's DVM Engine"**  
+Technical deep-dive for the systems-programming audience. Explains DuckLake's
+change-feed API (`table_changes()`, `table_insertions()`, `table_deletions()`),
+maps its output format row-by-row to pg_trickle's internal change-buffer
+schema, and discusses why DuckLake's stable `rowid` column makes it one of the
+cleanest CDC sources imaginable for differential IVM.
+
+### Documentation
+
+**Docs D-1: DuckLake examples in `foreign-table-sources.md`**  
+Adds a dedicated DuckLake section to the existing foreign-table-sources
+reference page. Covers attaching a DuckLake-managed table as a PostgreSQL
+foreign table, enabling `pg_trickle.foreign_table_polling`, and wrapping it
+in a stream table. Includes a working code sample with schema, server
+definition, and `create_stream_table` call.
+
+### Demos
+
+**Demo A: "The Five-Second Funnel"**  
+A self-contained `docker-compose up` demo. One container runs PostgreSQL with
+pg_trickle and a DuckLake catalog. A second container runs a DuckDB load
+generator writing synthetic e-commerce events. A third container runs Grafana.
+The Grafana dashboard shows a live visit→product→cart→checkout→purchase funnel
+updating every five seconds from a pg_trickle stream table. Designed to be
+shared at conference talks and on social media; runs on any developer laptop.
+
+**Demo D: "DuckLake Observability in a Box"**  
+A companion to Tutorial T-3. A pre-packaged `docker-compose` stack plus a
+single SQL initialisation script. The user attaches it to an existing DuckLake
+PostgreSQL catalog, runs `psql -f init_monitoring.sql`, and immediately has a
+production-quality Grafana observability dashboard with no further configuration.
+Goal: five minutes from `git clone` to operational visibility.
+
+### Community
+
+**Community C-1: Named-user outreach**  
+Direct contact with the DuckLake production users listed on the DuckLake
+homepage — PostHog, Windmill, Ascend.io, Sliplane, locals.com, and Media
+Cluster Norway — with a tailored pitch explaining how pg_trickle solves the
+incremental-aggregation problem they each face on top of their existing DuckLake
+deployment.
+
+**Community C-2: DuckCon and PGConf talk submissions**  
+CFP submissions: "pg_trickle as the IVM layer for DuckLake" for DuckCon, and
+"Sub-second materialized views on your data lake" for PGConf EU and PGCon.
+
+**Community C-3: DuckLake GitHub engagement**  
+Open a Discussion on `duckdb/ducklake` summarising the integration architecture
+and offering to co-author a "pg_trickle + DuckLake reference architecture" page
+on the DuckLake documentation site.
+
+## Why These Additions Belong in v0.64.0
+
+The original v0.64.0 plan had five documentation deliverables. The deeper
+research conducted during planning uncovered three opportunities that are still
+zero-code but substantially increase the release's impact:
+
+- **Demo A and Demo D** are runnable artefacts rather than prose. They give the
+  DuckLake community something to `git clone` and run, which is far more
+  persuasive than reading a tutorial.
+- **Blog B-2** (the `table_changes()` technical deep-dive) hits a different and
+  more technically engaged audience than Blog B-1. It builds credibility with
+  engineers who will evaluate the Phase 2 feature work.
+- **Community C-1 through C-3** convert the research insight — we now know
+  exactly who is running DuckLake in production and what their workloads are —
+  into a concrete action plan for acquiring early adopters.
+
+All nine deliverables remain zero extension-code changes. The scope is Small.
+
+## What Comes Next
+
+v0.64.0 seeds the demand signals that Phase 2 needs. If the tutorials and demos
+produce community interest, the next arc (starting around v0.65.0) delivers the
+DuckLake change-feed CDC adapter (INT-3 / F-1), the snapshot-based frontier
+(F-3), and the inlined-data trigger adapter (F-5) — turning the documentation
+promise into a production-ready feature.


### PR DESCRIPTION
## Summary

Adds a new `v0.64.0` entry to the roadmap for **DuckLake Phase 1** — a zero-code-change release dedicated to blog posts and tutorials establishing pg_trickle as the incremental view maintenance layer for data lakes. Also adds `plans/ecosystem/PLAN_DUCKLAKE.md`, a comprehensive research document covering all integration opportunities between pg_trickle and DuckLake.

DuckLake v1.0 launched in April 2026 and has chosen **PostgreSQL as its recommended catalog database** for multi-client deployments. Since pg_trickle also lives inside PostgreSQL, the two systems are uniquely co-located — pg_trickle can watch DuckLake's metadata tables with zero additional infrastructure. DuckLake's own roadmap explicitly lists "incremental materialized views" as a v2.0 goal, making pg_trickle a natural candidate for that role.

Phase 1 costs nothing to ship (no code changes, no API additions) but seeds the demand signals needed to decide whether Phases 2–4 warrant engineering investment.

## Changes

- **`ROADMAP.md`** — adds a new "DuckLake Ecosystem Arc (v0.64.x)" section after the Scheduler Throughput Arc, with a `v0.64.0` entry (theme: tutorials + reference architectures, scope: Small) and a corresponding entry in the ASCII version graph
- **`plans/ecosystem/PLAN_DUCKLAKE.md`** — new research document covering:
  - Architectural synergy analysis (DuckLake + pg_trickle share the same PostgreSQL instance)
  - Seven integration opportunities (INT-1 through INT-7) ranging from zero-code to deep partnership
  - Five concrete feature proposals for pg_trickle (F-1 through F-5)
  - Six blog post and tutorial ideas with target audiences
  - Four-phase implementation roadmap with effort estimates
  - Risk analysis and competitive landscape

## What v0.64.0 Delivers (no code)

| Item | Type |
|------|------|
| Blog: "Real-Time Dashboards on Your Data Lake with pg_trickle + DuckLake" | Tutorial |
| Blog: "The Modern Data Stack in One Box: PostgreSQL + pg_trickle + DuckLake" | Tutorial |
| Blog: "Monitoring Your DuckLake with pg_trickle" | Tutorial |
| Extend `docs/blog/foreign-table-sources.md` with DuckLake examples | Docs |

## Testing

- No code changes — pure documentation and roadmap update
- Verified ROADMAP.md renders correctly (no broken table formatting)

## Notes

This PR deliberately commits only Phase 1 (documentation). Phases 2–4 are described in `PLAN_DUCKLAKE.md` but not committed to the roadmap until Phase 1 generates validated user demand:

- **Phase 2** (DuckLake-optimized change feed polling) — after Phase 1 proves demand
- **Phase 3** (Parquet delta export / DuckLake sink) — post-v1.0, if Phase 2 traction warrants it
- **Phase 4** (IVM partnership for DuckLake v2.0) — requires DuckDB team engagement first

See `plans/ecosystem/PLAN_DUCKLAKE.md` for the full analysis.
