### PR TITLE
fix(ci): add continue-on-error to GHCR login steps (transient timeout fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,7 @@ jobs:
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
+        continue-on-error: true  # GHCR login is optional (cache pull only); transient timeouts must not fail the job
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -340,6 +341,7 @@ jobs:
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
+        continue-on-error: true  # GHCR login is optional (cache pull only); transient timeouts must not fail the job
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -600,6 +602,7 @@ jobs:
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
+        continue-on-error: true  # GHCR login is optional (cache pull only); transient timeouts must not fail the job
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -1256,6 +1259,7 @@ jobs:
 
       - name: Log in to GHCR
         uses: docker/login-action@v4
+        continue-on-error: true  # GHCR login is optional (cache pull only); transient timeouts must not fail the job
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

Fixes the transient CI failure seen in [run #2285](https://github.com/trickle-labs/pg-trickle/actions/runs/26087442625) where the `Upgrade E2E (0.51.0 → 0.52.0)` job failed because the GHCR Docker registry returned a network timeout:

```
Error response from daemon: Get "https://ghcr.io/v2/":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

## Root Cause

The `Log in to GHCR` step uses `docker/login-action@v4` to authenticate with `ghcr.io` before pulling a cached builder image. This login step can fail with a transient network timeout on CI runners, which immediately marks the entire job as failed.

## Fix

Add `continue-on-error: true` to all 4 `Log in to GHCR` steps in `ci.yml`.

This is safe because:

1. **The login is optional.** It is only needed to pull the pre-built builder cache image from `ghcr.io/trickle-labs/pg-trickle/builder:pg18`.
2. **The pull step already has a graceful fallback.** If `docker pull` fails (because login timed out), the step falls back to a local build:
   ```bash
   if docker pull ghcr.io/trickle-labs/pg-trickle/builder:pg18 2>/dev/null; then
     ...
   else
     echo "::warning::Builder image not in GHCR. Will build locally."
   fi
   ```
3. **No jobs push to GHCR in `ci.yml`.** All 4 login instances are cache-pull only, confirmed by the absence of any `docker push` in the workflow.

## Jobs affected

| Job | Line |
|-----|------|
| E2E tests (light, 1/3) | ~271 |
| E2E tests (light, 2/3+) | ~342 |
| Upgrade E2E tests | ~603 |
| Soak / long-running tests | ~1260 |
