### PR TITLE
roadmap(ducklake): add Phase 2 (v0.65) and Phase 3 (v0.66–v0.67) to roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 > For a plain-language description of the problem pg_trickle solves, the differential dataflow approach, and the hybrid CDC architecture, read **[ESSENCE.md](ESSENCE.md)**.
 
-**Latest release: [v0.57.0](CHANGELOG.md#0570--documentation-excellence)** — four new end-to-end tutorials (real-time dashboard, event sourcing, zero-downtime migration, security hardening), world-class docs, and a full terminology consistency pass. See [CHANGELOG.md](CHANGELOG.md) for the full history.
+**Latest release: [v0.64.0](CHANGELOG.md)** — DuckLake ecosystem Phase 1: tutorials, blog posts, containerised demos, and reference architectures for running pg_trickle with DuckLake's PostgreSQL-backed catalog. Also includes v0.63.0 fused multi-node refresh (≥20% wall-time improvement on complex DAGs via single-statement CTE-chain composition) and v0.62.0 scheduler fanout cache with per-node pause/resume. See [CHANGELOG.md](CHANGELOG.md) for the full history.
 
 ## Stream Tables for PostgreSQL 18
 
@@ -135,6 +135,16 @@ aggregates, window functions, multi-table joins, time-series, and EXISTS subquer
 - **Shard rebalance auto-recovery** — topology changes are detected by comparing `pg_dist_node` against `pgt_worker_slots`; stale slots are pruned and new ones inserted without operator intervention.
 - **Worker failure isolation** — per-worker poll failures are logged and skipped; after `pg_trickle.citus_worker_retry_ticks` (default 5) consecutive failures a WARNING is raised while healthy workers continue uninterrupted.
 
+### DuckLake lakehouse integration (v0.64.0+)
+
+pg_trickle is positioning itself as the incremental view maintenance engine for [DuckLake](https://ducklake.select) — the PostgreSQL-catalog-backed lakehouse format from the DuckDB team.
+
+- **Phase 1 (v0.64.0, shipped)** — tutorials, blog posts, and containerised demos for running pg_trickle as the IVM layer for DuckLake-backed data lakes using the existing foreign-table path; zero new extension code required.
+- **Phase 2 (v0.65.0, planned)** — native `CdcMode::DuckLakeChangeFeed` adapter calling DuckLake's `table_changes()` API for O(Δ) change consumption; snapshot-based frontier model; inlined-data trigger adapter; row-ID plumbing for O(1) delta application.
+- **Phase 3 (v0.66.0–v0.67.0, planned)** — DuckLake sink output mode (`sink => 'ducklake'`): stream table results serialised as Parquet via `arrow-rs`, uploaded to S3, and registered in the DuckLake catalog — queryable by DuckDB, Spark, and Trino with no custom export code.
+
+See [DuckLake Integration Plan](plans/ecosystem/PLAN_DUCKLAKE.md) and [ROADMAP.md](ROADMAP.md) for the full roadmap.
+
 ### Production & operations
 
 - **PgBouncer / connection-pool compatible** — works behind PgBouncer in transaction-pool mode (Supabase, Railway, Neon, etc.); row-level locking replaces session locks; per-table `pooler_compatibility_mode` available.
@@ -143,7 +153,7 @@ aggregates, window functions, multi-table joins, time-series, and EXISTS subquer
 - **Self-healing repair** — `pgtrickle.repair_stream_table(name)` rebuilds any missing CDC triggers and change buffer tables, resets the refresh frontier, and clears fuse state — use after PITR restores or operator-level DDL.
 - **CNPG / Kubernetes ready** — purpose-built Docker images and CloudNativePG manifests included; a `lifecycle.preStop` drain hook (`pgtrickle.drain(timeout_s => 120)`) ensures clean rolling upgrades.
 - **SQL-injection safe Citus paths** — all `dblink` call sites escape connection strings and queries via `pg_catalog.quote_literal`, eliminating injection risk through attacker-controlled hostnames or slot names.
-- **Supply-chain hardened Docker images** — all Dockerfiles pin `postgres:18.3-bookworm` to an exact SHA256 digest for reproducible builds; `scripts/update_base_image_digests.sh` automates quarterly refreshes.
+- **Supply-chain hardened Docker images** — all Dockerfiles pin `postgres:18.4-bookworm` to an exact SHA256 digest for reproducible builds; `scripts/update_base_image_digests.sh` automates quarterly refreshes.
 
 ### Observability
 
@@ -257,7 +267,7 @@ Changes propagate through multi-level stream table DAGs efficiently:
 | Wide DAG (3 levels × 20 wide) | 60 | ~2,430 ms |
 | Diamond (4-way fan-out + join) | 5 | ~200 ms |
 
-PARALLEL refresh mode processes independent branches concurrently, reducing wall-clock time for wide DAGs.
+PARALLEL refresh mode processes independent branches concurrently, reducing wall-clock time for wide DAGs. Since v0.63.0, the scheduler composes all per-node delta SQL into a single CTE-chain statement (**fused multi-node refresh**), eliminating round-trips between nodes and achieving a ≥20% wall-time improvement on complex DAGs.
 
 **Tips:** Enable `PARALLEL` refresh mode (`ALTER STREAM TABLE ... SET refresh_mode = 'parallel'`) to process independent DAG branches concurrently. For deep linear chains (> 5 levels), consider consolidating intermediate steps into a single defining query to reduce propagation hops and transaction overhead.
 
@@ -368,7 +378,7 @@ CREATE EXTENSION pg_trickle;
 pg_trickle is distributed as a minimal OCI extension image for [CloudNativePG Image Volume Extensions](https://cloudnative-pg.io/docs/1.28/imagevolume_extensions/). The image is `scratch`-based (< 10 MB) and contains only the extension files — no PostgreSQL server, no OS.
 
 ```bash
-docker pull ghcr.io/trickle-labs/pg_trickle-ext:0.57.0
+docker pull ghcr.io/trickle-labs/pg_trickle-ext:0.64.0
 ```
 
 Deploy with the official CNPG PostgreSQL 18 operand image:
@@ -382,7 +392,7 @@ spec:
     extensions:
       - name: pg-trickle
         image:
-          reference: ghcr.io/trickle-labs/pg_trickle-ext:0.57.0
+          reference: ghcr.io/trickle-labs/pg_trickle-ext:0.64.0
 ```
 
 See [cnpg/cluster-example.yaml](cnpg/cluster-example.yaml) and [cnpg/database-example.yaml](cnpg/database-example.yaml) for complete examples. Requires Kubernetes 1.33+ and CNPG 1.28+.
@@ -491,7 +501,7 @@ The `dbt-pgtrickle` package provides a custom `stream_table` materialization for
 # packages.yml
 packages:
   - git: "https://github.com/trickle-labs/pg-trickle.git"
-    revision: v0.57.0
+    revision: v0.64.0
     subdirectory: "dbt-pgtrickle"
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,6 +208,51 @@ Nine deliverables, all documentation / community / demo:
 |---------|-------|--------|-------|-------------- |
 | [v0.64.0](roadmap/v0.64.0.md) | DuckLake ecosystem (Phase 1): 3 tutorials + 2 blog posts + docs + 2 containerised demos + community outreach — no extension code changes | ✅ Released | Small | [Full details](roadmap/v0.64.0.md-full.md) |
 
+### DuckLake Phase 2 Arc (v0.65.x)
+
+Phase 2 ships the first engineering that makes pg_trickle a first-class DuckLake
+citizen at the code level. The centrepiece is a purpose-built change-feed adapter
+(`CdcMode::DuckLakeChangeFeed`) that calls DuckLake's `table_changes()` API and
+processes O(Δ) rows instead of re-scanning the foreign table on every refresh
+cycle. A snapshot-based frontier model lets a single stream table mix PostgreSQL
+CDC events and DuckLake snapshot IDs in one coherent consistency story. An
+inlined-data trigger adapter covers the fast path for tables small enough to live
+in PostgreSQL, and row-ID plumbing wires DuckLake's `rowid` virtual column
+directly into the DVM engine for O(1) delta application. Compaction-safety logic
+handles the case where a DuckLake snapshot expires before pg_trickle can consume
+it, with a configurable `fallback | error` policy. An integration test suite
+built on DuckDB validates end-to-end correctness, and two new tutorials ship
+alongside the code.
+
+| Version | Theme | Status | Scope | Full details |
+|---------|-------|--------|-------|--------------|
+| [v0.65.0](roadmap/v0.65.0.md) | DuckLake Phase 2: change-feed adapter, snapshot frontier, inlined-data CDC, row-ID plumbing, compaction safety, integration tests, 2 tutorials, 1 demo | Planned | Large | [Full details](roadmap/v0.65.0.md) |
+
+### DuckLake Phase 3 Arc (v0.66.x – v0.67.x)
+
+Phase 3 implements the DuckLake *sink*: the ability for any pg_trickle stream
+table to write its incrementally computed results into a DuckLake-managed Parquet
+table on object storage, making those results immediately queryable from DuckDB,
+Spark, Trino, and every other engine that speaks DuckLake. This closes the full
+bidirectional loop — pg_trickle can now both *read* from DuckLake and *publish*
+back into it.
+
+v0.66.0 delivers the infrastructure layer: Parquet delta serialisation via
+`arrow-rs`, S3 and object-store upload integration, a DuckLake catalog
+transaction writer that atomically records new data files in the PostgreSQL
+catalog, and per-file encryption key pass-through so encrypted lakes work from
+day one. A full E2E test suite validates the write path. v0.67.0 completes the
+arc with discoverability and ecosystem polish: DuckLake view registration
+auto-inserts a `ducklake_view` entry for every stream table so results are
+visible to every DuckLake client as a native object, snapshot provenance (INT-11)
+records which stream table produced each snapshot for end-to-end lineage, and
+four tutorials plus two containerised demos ship with the code.
+
+| Version | Theme | Status | Scope | Full details |
+|---------|-------|--------|-------|--------------|
+| [v0.66.0](roadmap/v0.66.0.md) | DuckLake Phase 3a: Parquet delta export (`arrow-rs`), DuckLake sink output mode, S3 upload, catalog transaction writer, encryption key pass-through, E2E tests | Planned | Large | [Full details](roadmap/v0.66.0.md) |
+| [v0.67.0](roadmap/v0.67.0.md) | DuckLake Phase 3b: view registration, snapshot provenance (INT-11), pg-tide tutorial, 2 tutorials, 2 containerised demos | Planned | Medium | [Full details](roadmap/v0.67.0.md) |
+
 
 ### Beyond v1.0
 
@@ -302,6 +347,12 @@ v0.60    ─── Code quality, test coverage & CI: cdc.rs split, codegen decom
 v0.61    ─── DX, docs & pre-1.0 polish: health_check foreign-owner row, SQL_REFERENCE complete, snapshot secondary equality, cte_counter reset, outbox name fix, sublinks decompose, 3 ADRs, LATERAL docs
     │
 v0.64    ─── DuckLake Phase 1: 3 tutorials + 2 blog posts + 2 containerised demos + named-user outreach (no extension code)
+    │
+v0.65    ─── DuckLake Phase 2: change-feed adapter, snapshot frontier, inlined-data CDC, row-ID plumbing, compaction safety
+    │
+v0.66    ─── DuckLake Phase 3a: Parquet delta export, DuckLake sink output mode, S3 upload, catalog writer, encryption
+    │
+v0.67    ─── DuckLake Phase 3b: view registration, snapshot provenance, pg-tide tutorial, tutorials & demos
     │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```

--- a/roadmap/v0.65.0.md
+++ b/roadmap/v0.65.0.md
@@ -1,0 +1,163 @@
+# v0.65.0 — DuckLake Phase 2: Change-Feed Adapter
+
+**Status:** Planned  
+**Scope:** Large  
+**Theme:** DuckLake-Optimised Polling  
+**Plan reference:** [plans/ecosystem/PLAN_DUCKLAKE.md — Phase 2](../plans/ecosystem/PLAN_DUCKLAKE.md#phase-2-ducklake-optimised-polling-v064v065)
+
+---
+
+## Why This Release
+
+v0.64.0 (Phase 1) established pg_trickle as a DuckLake ecosystem citizen through
+documentation, tutorials, and demos — all without touching extension code. Phase
+2 is where that relationship becomes a first-class engineering story.
+
+Today, using a DuckLake-backed foreign table as a stream table source works via
+the generic polling path: pg_trickle issues a full `EXCEPT ALL` scan on every
+refresh cycle, which does O(N) work regardless of how many rows actually changed.
+For a DuckLake table with millions of rows and only tens of new rows per batch,
+this is wasteful by orders of magnitude.
+
+DuckLake exposes an exact remedy: the `table_changes()` function returns only the
+rows that changed between two snapshot IDs. This release wires that API directly
+into pg_trickle's CDC pipeline so that refreshes do O(Δ) work — proportional to
+the change, not the table size. Everything else follows from that: a
+snapshot-based frontier to track progress, a fast trigger path for inlined data,
+DuckLake `rowid` threading for O(1) delta application, and compaction-safety
+guards so the system degrades gracefully when old snapshots are expired.
+
+---
+
+## Deliverables
+
+### Features (extension code)
+
+| ID | Feature | Effort |
+|----|---------|--------|
+| F-1 | DuckLake change-feed adapter (`CdcMode::DuckLakeChangeFeed`) | 1 week |
+| F-3 | Snapshot-based frontier model (snapshot IDs alongside WAL LSNs) | 3 days |
+| F-5 | Inlined-data trigger adapter (understands `begin_snapshot`/`end_snapshot`) | 3 days |
+| F-7 | Row-ID plumbing (pass DuckLake `rowid` through to DVM engine) | 3 days |
+| F-8 | Snapshot-window compaction safety (`pg_trickle.ducklake_compaction_policy`) | 2 days |
+
+#### F-1: DuckLake Change-Feed Adapter
+
+Replace the generic `EXCEPT ALL` polling for DuckLake foreign tables with a
+snapshot-aware adapter that calls `table_changes(from_snapshot, to_snapshot)` and
+produces O(Δ) work per refresh. The adapter tracks `last_consumed_snapshot_id`
+rather than LSN. Internally this introduces `CdcMode::DuckLakeChangeFeed` as a
+new CDC mode variant in `cdc.rs`, detected automatically when the source table's
+foreign data wrapper is identified as DuckLake.
+
+#### F-3: Snapshot-Based Frontier
+
+Extend the frontier model to carry DuckLake snapshot IDs alongside WAL LSNs and
+clock-based markers. A frontier row for a mixed-source stream table looks like:
+
+```json
+{
+  "ducklake:lake.events":  { "snapshot_id": 42 },
+  "ducklake:lake.users":   { "snapshot_id": 38 },
+  "wal:postgres":          { "lsn": "0/16A4F08" }
+}
+```
+
+This lets a single stream table join a PostgreSQL OLTP table with a DuckLake
+analytics table and still have a coherent, single-transaction consistency
+guarantee.
+
+#### F-5: Inlined-Data Trigger Adapter
+
+DuckLake can store small tables directly in PostgreSQL as
+`ducklake_inlined_data_table_<id>_<version>`. These tables are native PostgreSQL
+tables, so pg_trickle's standard row-level AFTER trigger CDC applies — but the
+schema convention (virtual columns `row_id`, `begin_snapshot`, `end_snapshot`,
+`is_deleted`) differs from a plain OLTP table. This feature adds a specialised
+trigger function that translates those columns into standard INSERT/DELETE
+change-buffer rows, plus a DDL watcher that recreates the trigger each time
+DuckLake rotates the inlined table to a new schema version.
+
+#### F-7: Row-ID Plumbing
+
+The DVM engine's row-identity layer today always derives a stable identifier from
+the row's content or primary key. For DuckLake sources, DuckLake already provides
+a stable `rowid` virtual column — we should use it directly. This feature extends
+the row-identity interface to accept a caller-supplied stable identifier,
+eliminating the hash computation for DuckLake sources and enabling exact O(1)
+delta application.
+
+#### F-8: Snapshot-Window Compaction Safety
+
+DuckLake compaction can expire old snapshots, after which `table_changes()` no
+longer has access to earlier history. If pg_trickle's `last_consumed_snapshot_id`
+falls before the compaction horizon, the next refresh will fail. This feature
+detects that condition and applies the configured policy:
+
+- `fallback` (default): automatically fall back to a full refresh and log a
+  warning so the user knows to extend `ducklake_snapshot_retention`.
+- `error`: raise a clear, actionable error message rather than silently
+  re-scanning.
+
+Configure via `ALTER STREAM TABLE … SET (ducklake_compaction_policy = 'error')`.
+
+### Tests
+
+| Item | Effort |
+|------|--------|
+| Integration test suite: DuckDB + ducklake extension | 3 days |
+| Unit tests for F-1 adapter, F-3 frontier, F-8 policy | 2 days |
+
+The integration tests use Testcontainers to spin up a PostgreSQL + DuckDB
+environment, install the DuckLake extension, write batches of synthetic events,
+and assert that stream tables refresh with exactly the expected delta size (not a
+full scan). A property-based test confirms that the snapshot frontier never moves
+backwards.
+
+### Tutorials
+
+| Item | Effort |
+|------|--------|
+| Tutorial 2: "IVM for DuckLake before v2.0" | 2 days |
+| Tutorial 6: "Sub-millisecond inlined-data CDC" | 2 days |
+
+**Tutorial 2** walks through creating a stream table on a DuckLake foreign table
+and shows the performance difference between the generic polling path (before
+v0.65.0) and the change-feed adapter (after v0.65.0): same result, 100× less
+work on large tables.
+
+**Tutorial 6** targets the inlined-data fast path: a DuckLake table small enough
+to be kept in PostgreSQL, monitored with a trigger adapter, refreshed in
+sub-millisecond time. Useful for high-frequency event streams that do not yet
+need to move to Parquet.
+
+### Demo
+
+| Item | Effort |
+|------|--------|
+| Demo B: Time-travel debugging | 3 days |
+
+Demo B shows a stream table over a DuckLake change-feed being queried at a
+specific past snapshot ID. The demo highlights the snapshot-based frontier: roll
+back `last_consumed_snapshot_id` and the stream table rewinds deterministically.
+Ships as a self-contained `docker-compose up` demo with a README and a short
+screen recording.
+
+---
+
+## Release Gate
+
+This release does **not** ship until:
+
+1. The change-feed adapter integration tests pass with DuckDB 1.x + DuckLake 1.x.
+2. The O(Δ) property is verified by a benchmark: refresh latency must scale with
+   `|Δ|`, not `|table|`, across at least three table sizes (10K, 1M, 100M rows).
+3. `just lint` passes with zero warnings.
+4. `just test-integration` passes.
+
+---
+
+## What Comes Next
+
+[v0.66.0](v0.66.0.md) — DuckLake Phase 3a: Parquet delta export and the DuckLake
+sink output mode. pg_trickle starts writing results *back into* DuckLake.

--- a/roadmap/v0.66.0.md
+++ b/roadmap/v0.66.0.md
@@ -1,0 +1,144 @@
+# v0.66.0 — DuckLake Phase 3a: Parquet Sink Infrastructure
+
+**Status:** Planned  
+**Scope:** Large  
+**Theme:** DuckLake Sink — Core Write Path  
+**Plan reference:** [plans/ecosystem/PLAN_DUCKLAKE.md — Phase 3](../plans/ecosystem/PLAN_DUCKLAKE.md#phase-3-ducklake-sink-and-view-registration-v066v068)
+
+---
+
+## Why This Release
+
+v0.65.0 (Phase 2) made pg_trickle an efficient *reader* of DuckLake — it can
+consume change feeds and maintain stream tables with O(Δ) work. v0.66.0 closes
+the other half of the loop: pg_trickle becomes a *writer* into DuckLake.
+
+The value of this is significant. Any stream table — a per-minute aggregation, a
+running total, a filtered join, a machine-learning feature vector — can now be
+published back into the data lake as a first-class DuckLake table, readable by
+DuckDB, Spark, Trino, and every other analytics engine in the ecosystem. No
+custom ETL, no Kafka, no Airflow: a single `CREATE STREAM TABLE … SINK 'ducklake'`
+call turns any incrementally maintained result set into a live Parquet dataset.
+
+This release implements the write-path plumbing. The next release (v0.67.0) adds
+discoverability and the tutorials that make the feature approachable.
+
+---
+
+## Deliverables
+
+### Features (extension code)
+
+| ID | Feature | Effort |
+|----|---------|--------|
+| F-4 | Parquet delta export via `arrow-rs` | 2 weeks |
+| F-2 | DuckLake sink output mode (`sink => 'ducklake'`) | 2 weeks |
+| —  | S3 / object-store upload integration | 1 week |
+| —  | DuckLake catalog transaction writer | 1 week |
+| F-9 | Encryption key pass-through | 1 week |
+
+#### F-4: Parquet Delta Export
+
+For any stream table, allow the computed delta from each refresh cycle to be
+serialised as a Parquet file and written to a configurable object-store path.
+This is the foundation for F-2 and is also independently useful for users who
+want to keep a change log in their data lake:
+
+```sql
+SELECT pgtrickle.alter_stream_table(
+    'revenue_by_region',
+    delta_export_path => 's3://my-lake/deltas/revenue_by_region/'
+);
+```
+
+Implementation uses the `arrow-rs` crate, which is already a transitive
+dependency of several pgrx-ecosystem crates. Parquet files are written with
+snappy compression by default; `delta_export_compression` GUC allows `gzip`,
+`zstd`, or `none`.
+
+Each file is named `<epoch_ms>_<refresh_id>.parquet` so files sort
+chronologically and are easily consumed by downstream processes.
+
+#### F-2: DuckLake Sink Output Mode
+
+Add a `sink => 'ducklake'` parameter to `pgtrickle.create_stream_table()` and
+`pgtrickle.alter_stream_table()`. When this mode is active, the refresh worker:
+
+1. Runs the differential SQL to produce the Δ result set.
+2. Serialises the delta to Parquet (F-4).
+3. Uploads the Parquet file to object storage.
+4. Opens a DuckLake catalog transaction and records the new data file.
+5. Commits the DuckLake snapshot, making the results visible to all DuckLake
+   clients atomically.
+
+The sink is append-only by default (stream tables produce deltas, and DuckLake
+accumulates them). A `ducklake_sink_mode = 'append' | 'replace'` option is
+provided for users who want to overwrite the full result on each refresh cycle
+instead of accumulating deltas.
+
+#### S3 / Object-Store Upload Integration
+
+A thin upload layer wraps the `object_store` crate (already in the Rust
+ecosystem) to support S3, GCS, Azure Blob, and local-filesystem paths. The
+upload layer:
+
+- Retries on transient network errors (up to a configurable limit).
+- Uses multipart upload for files above a configurable threshold (default 5 MB).
+- Respects the AWS environment-variable credential chain and PostgreSQL secrets
+  stored via `pg_trickle.ducklake_s3_access_key` / `ducklake_s3_secret_key`
+  GUCs (values stored encrypted via `pg_trickle.encryption_key`).
+
+#### DuckLake Catalog Transaction Writer
+
+The catalog writer opens a PostgreSQL transaction, inserts a row into
+`ducklake_data_file`, updates `ducklake_table_stats`, and inserts a new row in
+`ducklake_snapshot`. It uses Spi::connect() with a short-lived connection —
+consistent with existing pg_trickle catalog access patterns — and rolls back
+cleanly if the S3 upload fails so that the catalog never references a file that
+does not exist.
+
+#### F-9: Encryption Key Pass-Through
+
+If the DuckLake catalog has `ducklake_data_file.encryption_key` set for existing
+files, the writer must generate a fresh Parquet encryption key for each new file
+it writes, store that key in `ducklake_data_file.encryption_key` using the same
+format DuckLake itself uses, and apply the key during Parquet serialisation.
+This is a small but essential feature: many production lakes are encrypted from
+day one, and a sink that cannot write to them is not useful.
+
+### Tests
+
+| Item | Effort |
+|------|--------|
+| E2E tests: DuckLake sink (write path) | 1 week |
+| Unit tests: catalog transaction writer rollback on S3 failure | 2 days |
+
+The E2E tests stand up a full stack (PostgreSQL + DuckLake catalog + mock S3
+via `MinIO`) and verify:
+
+- Parquet files appear on object storage after each refresh cycle.
+- DuckLake `SELECT` from the sink table returns the same rows as a direct
+  `SELECT` from the pg_trickle stream table.
+- A simulated S3 failure rolls back the DuckLake catalog transaction and does
+  not leave dangling snapshot records.
+- Encrypted-lake mode round-trips correctly.
+
+---
+
+## Release Gate
+
+This release does **not** ship until:
+
+1. The E2E DuckLake sink tests pass with a live MinIO target.
+2. A catalog-rollback test proves that a failed S3 upload leaves zero stale
+   `ducklake_snapshot` or `ducklake_data_file` rows.
+3. `just lint` passes with zero warnings.
+4. `just test-e2e` passes.
+
+---
+
+## What Comes Next
+
+[v0.67.0](v0.67.0.md) — DuckLake Phase 3b: view registration, snapshot
+provenance, pg-tide pipeline tutorial, and the tutorials and demos that make the
+sink story accessible to a broad audience.

--- a/roadmap/v0.67.0.md
+++ b/roadmap/v0.67.0.md
@@ -1,0 +1,159 @@
+# v0.67.0 — DuckLake Phase 3b: View Registration, Provenance & Ecosystem
+
+**Status:** Planned  
+**Scope:** Medium  
+**Theme:** DuckLake Sink — Discoverability and Ecosystem Polish  
+**Plan reference:** [plans/ecosystem/PLAN_DUCKLAKE.md — Phase 3](../plans/ecosystem/PLAN_DUCKLAKE.md#phase-3-ducklake-sink-and-view-registration-v066v068)
+
+---
+
+## Why This Release
+
+v0.66.0 delivered the DuckLake sink plumbing — pg_trickle can now write its
+incrementally computed results into a DuckLake-managed Parquet table. But writing
+the data is only half the story: users also need to *find* it and *trust* it.
+
+v0.67.0 adds two features that turn the sink from a low-level write mechanism
+into a fully integrated DuckLake citizen:
+
+- **View registration (F-6)** automatically inserts a `ducklake_view` entry for
+  every stream table that has a DuckLake sink, so the result set is immediately
+  visible to every DuckDB, Spark, and Trino client that queries the DuckLake
+  catalog — no manual catalog surgery required.
+- **Snapshot provenance (INT-11)** records which pg_trickle stream table
+  produced each DuckLake snapshot, enabling end-to-end lineage queries: from the
+  raw event in PostgreSQL, through the differential computation, to the Parquet
+  file on S3.
+
+Four tutorials and two containerised demos ship alongside the code, making the
+Phase 3 story accessible to a broad audience ranging from data engineers to
+analytics platform builders.
+
+---
+
+## Deliverables
+
+### Features (extension code)
+
+| ID | Feature | Effort |
+|----|---------|--------|
+| F-6 | DuckLake view registration | 1 week |
+| INT-11 | Snapshot provenance & audit trails | 2 days |
+
+#### F-6: DuckLake View Registration
+
+When a stream table with `sink => 'ducklake'` is created or altered, pg_trickle
+automatically inserts (or updates) a matching row in `ducklake_view` so the
+result is queryable from every DuckLake client as a native catalog object. The
+view entry includes:
+
+- `view_name` — matches the stream table name.
+- `view_definition` — the original `SELECT` query of the stream table, stored as
+  a reference for human readers.
+- `source_table_ids` — the OIDs of the source tables, so DuckLake clients can
+  reason about dependencies.
+
+When the stream table is dropped, the `ducklake_view` row is removed in the same
+transaction.
+
+This feature means that a DuckDB user who has never heard of pg_trickle will
+simply see a new view in their DuckLake catalog and query it — the incremental
+maintenance is completely transparent.
+
+#### INT-11: Snapshot Provenance & Audit Trails
+
+DuckLake's `ducklake_snapshot` table records who wrote each snapshot, but the
+`created_by` field is a free-form string. pg_trickle populates this field with a
+structured identifier:
+
+```
+pg_trickle/<version>/stream_table/<oid>/<name>
+```
+
+In addition, pg_trickle inserts a row into `pgtrickle.pgt_ducklake_provenance`
+for each snapshot it writes:
+
+| Column | Description |
+|--------|-------------|
+| `stream_table_oid` | OID of the producing stream table |
+| `stream_table_name` | Human-readable name |
+| `ducklake_snapshot_id` | The DuckLake snapshot ID |
+| `refresh_id` | pg_trickle's internal refresh sequence number |
+| `delta_row_count` | Rows in the Parquet delta |
+| `written_at` | Timestamp |
+
+This table is itself a PostgreSQL table, so it can be monitored with a stream
+table and surfaced in the DuckLake observability dashboard from Demo D.
+
+### Tutorials
+
+| Item | Effort |
+|------|--------|
+| Tutorial 3: "The Modern Data Stack in One Box" | 2 days |
+| Tutorial 4: "Streaming PostgreSQL to a Data Lake without Kafka" | 2 days |
+| INT-10: pg-tide DuckLake pipeline tutorial | 2 days |
+
+**Tutorial 3** demonstrates the full Phase 3 stack in a single `docker-compose`
+environment: OLTP writes in PostgreSQL, pg_trickle stream tables computing
+rolling aggregations, DuckLake storing the results in Parquet on MinIO, and
+DuckDB querying the results for ad-hoc analytics. No Kafka, no Airflow, no
+separate stream processor.
+
+**Tutorial 4** shows how to replicate a subset of a PostgreSQL OLTP table into
+a DuckLake data lake using the sink output mode. The tutorial covers schema
+mapping, handling deletes (tombstone records), and configuring the
+`ducklake_sink_mode` to either accumulate deltas or replace the full snapshot.
+
+**INT-10 Tutorial** documents the already-working [pg-tide](https://github.com/trickle-labs/pg-tide)
+DuckLake relay pipeline with a step-by-step walkthrough: install pg-tide and
+pg_trickle, call `pgtrickle.attach_outbox()`, configure `tide.relay_set_outbox()`
+with `sink_type => 'ducklake'`, and watch data flow from a stream table into
+DuckLake in real time. Since this integration works today (as of pg-tide v0.22.0),
+the tutorial ships as documentation rather than new code.
+
+### Demos
+
+| Item | Effort |
+|------|--------|
+| Demo C: Multi-engine leaderboard | 4 days |
+| Demo E: OLTP-to-lake loop | 3 days |
+
+**Demo C** runs a real-time game leaderboard that is simultaneously maintained
+as a pg_trickle stream table in PostgreSQL (for the game backend) and published
+as a DuckLake table on MinIO (for the analytics team). It demonstrates that the
+same data, maintained once by pg_trickle, is available to both operational and
+analytical workloads without duplication. Ships as a self-contained
+`docker-compose up` demo.
+
+**Demo E** shows the full OLTP-to-lake loop: synthetic e-commerce orders land in
+a PostgreSQL `orders` table, a pg_trickle stream table computes `revenue_by_region`
+incrementally, the sink publishes each delta to DuckLake, and a DuckDB notebook
+queries the historical Parquet files for trend analysis. The screen recording
+shows end-to-end latency from order insert to DuckLake snapshot visibility:
+typically under two seconds on a laptop.
+
+---
+
+## Release Gate
+
+This release does **not** ship until:
+
+1. View registration is tested: creating and dropping a stream table with
+   `sink => 'ducklake'` correctly inserts and removes the `ducklake_view` row in
+   the same transaction.
+2. Provenance table is populated correctly across at least 10 consecutive refresh
+   cycles in the E2E test environment.
+3. Tutorials 3 and 4 are reviewed by at least one person who is not the author.
+4. Both demos run to completion with `docker-compose up` on a clean macOS and
+   Linux machine.
+5. `just lint` passes with zero warnings.
+6. `just test-e2e` passes.
+
+---
+
+## What Comes Next
+
+[v1.0.0](../ROADMAP.md) — Stable release targeting PostgreSQL 19. After Phase 3,
+pg_trickle has a complete bidirectional DuckLake integration story and is ready
+to pursue the v1.0 stable release milestones. Phase 4 (INT-5 IVM partnership
+with DuckDB Labs) is a post-v1.0 initiative and is tracked separately.


### PR DESCRIPTION
## Summary

Adds DuckLake Phase 2 and Phase 3 to the roadmap, covering the three versions
(v0.65.0, v0.66.0, v0.67.0) that bridge the gap between the documentation-only
Phase 1 (already shipped in v0.64.0) and the v1.0 stable release. All changes
are planning and roadmap documents — no extension code is modified.

## Background

`plans/ecosystem/PLAN_DUCKLAKE.md` already defines four implementation phases:

| Phase | Versions | Summary |
|-------|----------|---------|
| 1 | v0.64.0 | Docs, tutorials, demos — no code (✅ shipped) |
| 2 | v0.65.0 | Change-feed adapter, snapshot frontier, inlined-data CDC |
| 3 | v0.66.0–v0.67.0 | DuckLake sink (Parquet write path) + view registration |
| 4 | v0.70+ | Deep IVM partnership with DuckDB Labs (post-v1.0) |

`ROADMAP.md` previously only had the Phase 1 row and jumped straight to
"Beyond v1.0". This PR adds the three missing rows and their detail files.

## Changes

### `ROADMAP.md`

- New section **"DuckLake Phase 2 Arc (v0.65.x)"** — describes the O(Δ)
  change-feed adapter and the snapshot-frontier model; adds the `v0.65.0` row.
- New section **"DuckLake Phase 3 Arc (v0.66.x – v0.67.x)"** — describes the
  full bidirectional DuckLake integration (write path + view registration); adds
  `v0.66.0` and `v0.67.0` rows.
- Updated ASCII timeline: `v0.65`, `v0.66`, `v0.67` now appear between `v0.64`
  and `v1.0`.

### `roadmap/v0.65.0.md` (new)

Full Phase 2 detail:

- **F-1** `CdcMode::DuckLakeChangeFeed` — calls `table_changes()` for O(Δ) work.
- **F-3** Snapshot-based frontier — snapshot IDs alongside WAL LSNs.
- **F-5** Inlined-data trigger adapter — handles `begin_snapshot`/`end_snapshot`.
- **F-7** Row-ID plumbing — passes DuckLake `rowid` through to the DVM engine.
- **F-8** Compaction safety — configurable `fallback | error` policy.
- DuckDB + DuckLake integration test suite.
- Tutorial 2, Tutorial 6, Demo B (time-travel debugging).

### `roadmap/v0.66.0.md` (new)

Full Phase 3a detail:

- **F-4** Parquet delta export via `arrow-rs`.
- **F-2** `sink => 'ducklake'` output mode for stream tables.
- S3 / object-store upload layer (retries, multipart, credential chain).
- DuckLake catalog transaction writer (atomic snapshot commit / rollback).
- **F-9** Encryption key pass-through for encrypted lakes.
- MinIO-backed E2E test suite with catalog-rollback proof.

### `roadmap/v0.67.0.md` (new)

Full Phase 3b detail:

- **F-6** View registration — auto-inserts `ducklake_view` for every sink stream
  table, making results visible to every DuckLake client as a native object.
- **INT-11** Snapshot provenance — `pgtrickle.pgt_ducklake_provenance` table
  records stream table → DuckLake snapshot lineage.
- Tutorial 3 ("Modern data stack in one box"), Tutorial 4 ("PG to data lake
  without Kafka"), INT-10 pg-tide pipeline tutorial.
- Demo C (multi-engine leaderboard), Demo E (OLTP-to-lake loop).

## Testing

Documentation and planning files only — no Rust code changed.

`just lint` passes (nothing to compile).

## Notes

- Phase 4 (INT-5 IVM partnership with DuckDB Labs) is intentionally kept as a
  post-v1.0 item in `ROADMAP.md` and is not part of this PR.
- The `v0.65.0.md` release gate requires a benchmark proving O(Δ) refresh
  scaling — this is a deliberate hard gate to prevent the feature shipping
  without a verified performance story.
