### PR TITLE
docs: fix literal \uXXXX escape sequences in tutorial files

### DIFF
--- a/docs/tutorial-ivm-ducklake-before-v2.md
+++ b/docs/tutorial-ivm-ducklake-before-v2.md
@@ -1,6 +1,6 @@
 # Tutorial 2: O(Δ) Refresh on DuckLake Tables
 
-*How pg_trickle's change-feed adapter reads only the rows that changed \u2014 even when the source is a DuckLake foreign table with 10 million rows*
+*How pg_trickle's change-feed adapter reads only the rows that changed — even when the source is a DuckLake foreign table with 10 million rows*
 
 ---
 
@@ -9,7 +9,7 @@
 You'll create a pg_trickle stream table whose **source is a DuckLake table**
 (not a regular PostgreSQL table). You'll see that pg_trickle uses DuckLake's
 `table_changes()` API to read only the rows that changed since the last
-refresh cycle \u2014 an O(\u0394) scan instead of an O(N) full-table scan.
+refresh cycle — an O(Δ) scan instead of an O(N) full-table scan.
 
 ---
 
@@ -21,25 +21,25 @@ Foreign Data Wrapper (FDW) so you can query DuckLake tables using ordinary SQL
 from inside PostgreSQL.
 
 **FDW (Foreign Data Wrapper)** is a PostgreSQL mechanism that lets you access
-external data sources \u2014 including DuckLake tables, files on S3, or remote
-databases \u2014 as if they were regular PostgreSQL tables. They appear in
+external data sources — including DuckLake tables, files on S3, or remote
+databases — as if they were regular PostgreSQL tables. They appear in
 `pg_class` with `relkind = 'f'` (foreign table).
 
 **IVM (Incremental View Maintenance)** means maintaining a precomputed result
-set by applying only the *changes* (\u0394) that occurred since the last refresh,
+set by applying only the *changes* (Δ) that occurred since the last refresh,
 rather than recomputing from scratch every time.
 
 **The problem pg_trickle solves here:** before v0.65.0, the only way to detect
 changes on a DuckLake FDW table was to scan the entire table and compare with a
-snapshot (`EXCEPT ALL`). That is O(N) \u2014 it gets slower as the table grows,
+snapshot (`EXCEPT ALL`). That is O(N) — it gets slower as the table grows,
 regardless of how few rows actually changed. DuckLake 1.x provides
 `table_changes(table, from_snapshot, to_snapshot)` which returns only the delta
 rows. pg_trickle v0.65.0+ uses this API automatically.
 
 | Approach | Work per refresh | When to use |
 |----------|-----------------|-------------|
-| `EXCEPT ALL` polling (\u2264 v0.64.0) | O(N) \u2014 full table scan | DuckLake without `table_changes` |
-| Change-feed adapter (v0.65.0+) | O(\u0394) \u2014 only changed rows | DuckLake 1.x with `table_changes` |
+| `EXCEPT ALL` polling (≤ v0.64.0) | O(N) — full table scan | DuckLake without `table_changes` |
+| Change-feed adapter (v0.65.0+) | O(Δ) — only changed rows | DuckLake 1.x with `table_changes` |
 
 ---
 
@@ -53,7 +53,7 @@ Before starting you need:
   ```sql
   CREATE EXTENSION IF NOT EXISTS ducklake;
   ```
-- A DuckLake catalog initialized \u2014 see Step 1 below
+- A DuckLake catalog initialized — see Step 1 below
 
 ---
 
@@ -61,17 +61,17 @@ Before starting you need:
 
 ```
 DuckLake catalog (PostgreSQL)
-  \u2502  raw_events table  \u2190 batch loads land here
-  \u2502  (exposed as FDW foreign table in pg_class)
-  \u2502
-  \u2514\u2500 pg_trickle stream table: event_summary
-       \u2502  5-minute DIFFERENTIAL refresh
-       \u2502  CDC mode: DUCKLAKE_CHANGE_FEED
-       \u2502  pg_trickle calls table_changes(raw_events, prev_snapshot, latest)
-       \u2502  and processes only the \u0394 rows
-       \u25bc
+  │  raw_events table  ← batch loads land here
+  │  (exposed as FDW foreign table in pg_class)
+  │
+  └─ pg_trickle stream table: event_summary
+       │  5-minute DIFFERENTIAL refresh
+       │  CDC mode: DUCKLAKE_CHANGE_FEED
+       │  pg_trickle calls table_changes(raw_events, prev_snapshot, latest)
+       │  and processes only the Δ rows
+       ▼
   event_summary (PostgreSQL table)
-       \u2514\u2500 SELECT * FROM event_summary  \u2190 always fresh, always fast
+       └─ SELECT * FROM event_summary  ← always fresh, always fast
 ```
 
 ---
@@ -88,7 +88,7 @@ SELECT ducklake_init('/var/lib/ducklake/events.db');
 ```
 
 Now create a DuckLake table. This table will be the *source* for our stream
-table \u2014 the data that pg_trickle watches for changes:
+table — the data that pg_trickle watches for changes:
 
 ```sql
 -- Create a DuckLake table (this executes DuckLake DDL via the FDW)
@@ -168,11 +168,11 @@ WHERE st.table_name = 'event_summary';
 
 If you see `POLLING` instead of `DUCKLAKE_CHANGE_FEED`, your DuckLake version
 does not have the `table_changes()` function (pre-1.x). The tutorial still
-works but refreshes will be O(N) instead of O(\u0394).
+works but refreshes will be O(N) instead of O(Δ).
 
 ---
 
-## Step 3: Observe O(\u0394) refresh behaviour
+## Step 3: Observe O(Δ) refresh behaviour
 
 Now insert just 100 new rows into the 10-million-row table:
 
@@ -215,7 +215,7 @@ DIFFERENTIAL |           100 |             68 |           3
 ```
 
 `delta_rows_in = 100` means pg_trickle read exactly the 100 new rows via
-`table_changes()` \u2014 not the 10 million rows in the full table. The
+`table_changes()` — not the 10 million rows in the full table. The
 `delta_rows_out = 68` is the number of rows in `event_summary` that changed
 as a result (some `hour` + `event_type` combinations received their first row,
 others updated an existing aggregate).
@@ -224,7 +224,7 @@ others updated an existing aggregate).
 
 ## Step 4: Understand and configure the compaction policy
 
-DuckLake periodically **compacts** old Parquet files \u2014 merging many small
+DuckLake periodically **compacts** old Parquet files — merging many small
 delta files into one large file and deleting the originals. This is a routine
 maintenance operation that improves query performance.
 
@@ -288,17 +288,17 @@ only the rows that appeared after that snapshot.
 ## What you've built
 
 - A stream table that aggregates a 10-million-row DuckLake FDW table into
-  an hourly event summary \u2014 refreshing in milliseconds by reading only the
+  an hourly event summary — refreshing in milliseconds by reading only the
   rows that changed.
 - Automatic compaction resilience: if DuckLake compacts away old snapshots,
-  pg_trickle falls back to a full scan and then resumes O(\u0394) operation.
+  pg_trickle falls back to a full scan and then resumes O(Δ) operation.
 
 ---
 
 ## Next steps
 
-- **[Tutorial 3](tutorial-modern-data-stack-one-box.md)** \u2014 use DuckLake as a
+- **[Tutorial 3](tutorial-modern-data-stack-one-box.md)** — use DuckLake as a
   *sink* (write stream table deltas out to Parquet on S3) in a full docker
   compose stack.
-- **[Tutorial 6](tutorial-sub-millisecond-inlined-cdc.md)** \u2014 sub-millisecond
+- **[Tutorial 6](tutorial-sub-millisecond-inlined-cdc.md)** — sub-millisecond
   CDC on small DuckLake tables that are stored inline in PostgreSQL.

--- a/docs/tutorial-pg-tide-ducklake-pipeline.md
+++ b/docs/tutorial-pg-tide-ducklake-pipeline.md
@@ -1,6 +1,6 @@
 # Tutorial 5: Guaranteed Delivery to DuckLake with pg-tide
 
-*Add a transactional outbox between pg_trickle and DuckLake so every delta reaches S3 \u2014 even through network failures and restarts*
+*Add a transactional outbox between pg_trickle and DuckLake so every delta reaches S3 — even through network failures and restarts*
 
 ---
 
@@ -11,7 +11,7 @@ relay**. Every differential delta is atomically enqueued in a pg-tide outbox
 *in the same database transaction as the refresh*. A background relay worker
 then picks up the outbox messages and writes Parquet files to S3. If the S3
 write fails, the message stays in the outbox and the relay retries
-automatically \u2014 giving you at-least-once delivery with no message loss.
+automatically — giving you at-least-once delivery with no message loss.
 
 **When should you use this instead of the direct sink?**
 
@@ -60,30 +60,30 @@ happen with the direct sink.
 
 ```
 Application
-  \u2502  INSERT into orders
-  \u25bc
+  │  INSERT into orders
+  ▼
 PostgreSQL
-  \u251c\u2500 orders table
-  \u2502
-  \u251c\u2500 pg_trickle: revenue_by_region stream table
-  \u2502    \u2502  5-second DIFFERENTIAL refresh
-  \u2502    \u25bc
-  \u2514\u2500 pg-tide outbox: revenue_by_region_outbox
-       \u2502  Written in the same transaction as the refresh
-       \u2502  Survives pg_trickle restarts and S3 outages
-       \u25bc
+  ├─ orders table
+  │
+  ├─ pg_trickle: revenue_by_region stream table
+  │    │  5-second DIFFERENTIAL refresh
+  │    ▼
+  └─ pg-tide outbox: revenue_by_region_outbox
+       │  Written in the same transaction as the refresh
+       │  Survives pg_trickle restarts and S3 outages
+       ▼
   pg-tide relay (background worker)
-       \u2502  Polls outbox with SKIP LOCKED
-       \u2502  Serializes delta to Parquet
-       \u2502  Uploads to S3
-       \u2502  On success: marks message delivered
-       \u2502  On failure: leaves message for retry
-       \u25bc
+       │  Polls outbox with SKIP LOCKED
+       │  Serializes delta to Parquet
+       │  Uploads to S3
+       │  On success: marks message delivered
+       │  On failure: leaves message for retry
+       ▼
   S3 / MinIO
-       \u2502  Parquet delta files
-       \u25bc
+       │  Parquet delta files
+       ▼
   DuckLake catalog
-       \u2514\u2500 ducklake_snapshot, ducklake_view
+       └─ ducklake_snapshot, ducklake_view
 ```
 
 ---
@@ -182,7 +182,7 @@ WHERE outbox_name = 'revenue_by_region';
 
 ## Step 5: Configure the relay destination
 
-Tell the pg-tide relay where to send the messages \u2014 in this case, to DuckLake
+Tell the pg-tide relay where to send the messages — in this case, to DuckLake
 on S3:
 
 ```sql
@@ -200,7 +200,7 @@ SELECT tide.relay_set_outbox(
 ```
 
 > **Tip:** Set `s3_access_key` and `s3_secret_key` to empty strings to reuse
-> the GUC values you set in Step 2 \u2014 that way you only store credentials in
+> the GUC values you set in Step 2 — that way you only store credentials in
 > one place.
 
 ---
@@ -276,7 +276,7 @@ SELECT pg_reload_conf();
 ```
 
 The relay will automatically retry and deliver the pending messages. No data
-was lost \u2014 the deltas are safely in the outbox.
+was lost — the deltas are safely in the outbox.
 
 ---
 
@@ -287,7 +287,7 @@ With `attach_outbox()` + pg-tide relay versus `sink => 'ducklake'`:
 | Aspect | Direct sink | pg-tide relay |
 |--------|------------|---------------|
 | S3 write timing | During the refresh transaction | After the refresh, in a separate relay transaction |
-| Refresh blocked by S3 | Yes \u2014 if S3 is slow, the refresh cycle takes longer | No \u2014 refresh completes as soon as the outbox write succeeds |
+| Refresh blocked by S3 | Yes — if S3 is slow, the refresh cycle takes longer | No — refresh completes as soon as the outbox write succeeds |
 | Retry on S3 failure | Automatic (next refresh cycle) | Automatic (relay retry loop, independent of refresh schedule) |
 | Fan-out to multiple sinks | Not supported | Supported: add multiple relay destinations to the same outbox |
 | Delivery guarantee | Best-effort | At-least-once (outbox survives crashes) |
@@ -319,9 +319,9 @@ SELECT pgtrickle.drop_stream_table('revenue_by_region');
 
 ## Next steps
 
-- **[pg-tide documentation](https://github.com/trickle-labs/pg-tide)** \u2014 fan-out
+- **[pg-tide documentation](https://github.com/trickle-labs/pg-tide)** — fan-out
   configuration, dead-letter queues, and monitoring.
-- **[Tutorial 3](tutorial-modern-data-stack-one-box.md)** \u2014 the full modern data
+- **[Tutorial 3](tutorial-modern-data-stack-one-box.md)** — the full modern data
   stack with a `docker compose` environment.
-- **[Tutorial 4](tutorial-streaming-postgres-to-data-lake.md)** \u2014 using the
+- **[Tutorial 4](tutorial-streaming-postgres-to-data-lake.md)** — using the
   direct DuckLake sink without pg-tide.

--- a/docs/tutorial-sub-millisecond-inlined-cdc.md
+++ b/docs/tutorial-sub-millisecond-inlined-cdc.md
@@ -1,6 +1,6 @@
 # Tutorial 6: Sub-Millisecond CDC on Inlined DuckLake Tables
 
-*When DuckLake stores small tables directly in PostgreSQL, pg_trickle gets trigger-based CDC \u2014 and refresh latency drops to under a millisecond*
+*When DuckLake stores small tables directly in PostgreSQL, pg_trickle gets trigger-based CDC — and refresh latency drops to under a millisecond*
 
 ---
 
@@ -9,7 +9,7 @@
 You'll create a stream table that joins a **small DuckLake lookup table** (stored
 inline in PostgreSQL) with a **large DuckLake event table** (stored in Parquet
 on S3). Because the small table lives in PostgreSQL as a real heap table,
-pg_trickle installs AFTER triggers on it \u2014 making change detection for that
+pg_trickle installs AFTER triggers on it — making change detection for that
 source essentially free. You'll measure the difference and see sub-millisecond
 refresh latency in practice.
 
@@ -21,8 +21,8 @@ DuckLake stores tables in two places depending on their size:
 
 | Size | Storage | How CDC works |
 |------|---------|---------------|
-| Small (below `ducklake_inline_table_max_rows`, default 1 000 rows) | Regular PostgreSQL heap table | Trigger-based CDC \u2014 O(1) per row change |
-| Large (above threshold) | Parquet files on S3, via FDW | Change-feed CDC via `table_changes()` \u2014 O(\u0394) |
+| Small (below `ducklake_inline_table_max_rows`, default 1 000 rows) | Regular PostgreSQL heap table | Trigger-based CDC — O(1) per row change |
+| Large (above threshold) | Parquet files on S3, via FDW | Change-feed CDC via `table_changes()` — O(Δ) |
 
 When DuckLake stores a table inline, it creates a real PostgreSQL table named
 `ducklake_inlined_data_table_<id>_<version>`. pg_trickle detects this pattern,
@@ -56,20 +56,20 @@ triggers and reinstalls the CDC triggers on the new table version automatically.
 
 ```
 DuckLake catalog
-  \u251c\u2500 lake.categories           (small lookup table, \u2264 1 000 rows)
-  \u2502    Stored inline as:
-  \u2502    ducklake_inlined_data_table_42_1  \u2190 real PostgreSQL heap table
-  \u2502    pg_trickle installs AFTER triggers here
-  \u2502
-  \u2514\u2500 lake.raw_events            (large table, Parquet on S3)
+  ├─ lake.categories           (small lookup table, ≤ 1 000 rows)
+  │    Stored inline as:
+  │    ducklake_inlined_data_table_42_1  ← real PostgreSQL heap table
+  │    pg_trickle installs AFTER triggers here
+  │
+  └─ lake.raw_events            (large table, Parquet on S3)
        Exposed as FDW foreign table
        pg_trickle uses change-feed CDC here
 
 pg_trickle stream table: category_stats
-  \u2502  1-minute DIFFERENTIAL refresh
-  \u2502  CDC source 1: ducklake_inlined_data_table_42_1 \u2192 TRIGGER mode (sub-ms)
-  \u2502  CDC source 2: lake.raw_events               \u2192 DUCKLAKE_CHANGE_FEED
-  \u25bc
+  │  1-minute DIFFERENTIAL refresh
+  │  CDC source 1: ducklake_inlined_data_table_42_1 → TRIGGER mode (sub-ms)
+  │  CDC source 2: lake.raw_events               → DUCKLAKE_CHANGE_FEED
+  ▼
 category_stats (PostgreSQL table)
 ```
 
@@ -116,7 +116,7 @@ ORDER BY relname;
 -- The '42' is DuckLake's internal table ID; the '1' is the schema version.
 ```
 
-Remember this name \u2014 you'll need it in Step 3.
+Remember this name — you'll need it in Step 3.
 
 ---
 
@@ -211,7 +211,7 @@ refresh_mode | delta_rows_in | delta_rows_out | duration_ms
 DIFFERENTIAL |             1 |              1 |         0.8
 ```
 
-`duration_ms = 0.8` \u2014 under one millisecond \u2014 because the change was captured
+`duration_ms = 0.8` — under one millisecond — because the change was captured
 by a trigger: no table scan, no FDW round-trip, no Parquet file read.
 
 ---
@@ -223,8 +223,8 @@ lake.categories ADD COLUMN weight NUMERIC`), it creates a new internal version
 of the table:
 
 ```
-ducklake_inlined_data_table_42_1  \u2192  (dropped)
-ducklake_inlined_data_table_42_2  \u2192  (new, with the weight column)
+ducklake_inlined_data_table_42_1  →  (dropped)
+ducklake_inlined_data_table_42_2  →  (new, with the weight column)
 ```
 
 pg_trickle's DDL event trigger fires on the DROP + CREATE, detects that the
@@ -281,8 +281,8 @@ Typical results on a warm system:
 | Source type | Avg latency | Why |
 |-------------|-------------|-----|
 | Trigger CDC (inlined table) | ~0.8 ms | Trigger fires in-process; change already in the buffer |
-| Change-feed CDC (DuckLake FDW) | ~3\u201310 ms | FDW round-trip + `table_changes()` call |
-| `EXCEPT ALL` polling (legacy) | ~50\u2013500 ms | Full table scan of the FDW source |
+| Change-feed CDC (DuckLake FDW) | ~3–10 ms | FDW round-trip + `table_changes()` call |
+| `EXCEPT ALL` polling (legacy) | ~50–500 ms | Full table scan of the FDW source |
 
 ---
 
@@ -301,8 +301,8 @@ Typical results on a warm system:
 
 - A stream table with **mixed CDC modes**: trigger-based for a small inline
   table (sub-millisecond) and change-feed for a large Parquet-backed table
-  (low-latency O(\u0394)).
-- Automatic CDC trigger reinstallation after DuckLake schema evolution \u2014 the
+  (low-latency O(Δ)).
+- Automatic CDC trigger reinstallation after DuckLake schema evolution — the
   stream table keeps working through `ALTER TABLE` without any manual
   intervention.
 
@@ -310,7 +310,7 @@ Typical results on a warm system:
 
 ## Next steps
 
-- **[Tutorial 2](tutorial-ivm-ducklake-before-v2.md)** \u2014 deep-dive into the
+- **[Tutorial 2](tutorial-ivm-ducklake-before-v2.md)** — deep-dive into the
   change-feed CDC adapter for large DuckLake tables.
-- **[Tutorial 3](tutorial-modern-data-stack-one-box.md)** \u2014 use DuckLake as a
+- **[Tutorial 3](tutorial-modern-data-stack-one-box.md)** — use DuckLake as a
   *sink* to write stream table deltas to Parquet on S3.


### PR DESCRIPTION
## Fix literal `\uXXXX` escape sequences in tutorial docs

Three tutorial markdown files contained literal `\uNNNN` escape sequences instead of the actual Unicode characters. These showed up in the rendered documentation as raw escape codes — for example `\u2014` instead of `—`, `\u0394` instead of `Δ`, `\u2502` instead of `│`.

### Affected files

| File | Occurrences fixed |
|------|-------------------|
| `docs/tutorial-ivm-ducklake-before-v2.md` | 20 |
| `docs/tutorial-pg-tide-ducklake-pipeline.md` | 33 |
| `docs/tutorial-sub-millisecond-inlined-cdc.md` | 28 |

### Characters affected

| Escape | Character | Usage |
|--------|-----------|-------|
| `\u2014` | — | Em dash in prose |
| `\u0394` | Δ | Delta symbol in O(Δ) notation |
| `\u2502` | │ | Box-drawing vertical bar in ASCII architecture diagrams |
| `\u2514` | └ | Box-drawing corner in ASCII architecture diagrams |
| `\u2500` | ─ | Box-drawing horizontal bar |
| `\u251c` | ├ | Box-drawing tee |
| `\u25bc` | ▼ | Downward arrow in architecture diagrams |
| `\u2190` | ← | Leftward arrow in architecture diagrams |
| `\u2264` | ≤ | Less-than-or-equal sign |

### Fix

All occurrences replaced with the corresponding Unicode characters using a regex substitution. No content changes — purely character encoding corrections.
