### PR TITLE
docs: fix tutorial sidebar groups (use # part headers, not ##)

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -68,16 +68,14 @@
 
 ---
 
-# Tutorials
-
-## Fundamentals
+# Tutorials: Fundamentals
 
 - [What Happens on INSERT](tutorials/WHAT_HAPPENS_ON_INSERT.md)
 - [What Happens on UPDATE](tutorials/WHAT_HAPPENS_ON_UPDATE.md)
 - [What Happens on DELETE](tutorials/WHAT_HAPPENS_ON_DELETE.md)
 - [What Happens on TRUNCATE](tutorials/WHAT_HAPPENS_ON_TRUNCATE.md)
 
-## Data Lake & Real-Time Analytics
+# Tutorials: Data Lake & Analytics
 
 - [Real-Time Analytics Dashboard](tutorials/FIRST_DASHBOARD.md)
 - [The Modern Data Stack in One Box](tutorial-modern-data-stack-one-box.md)
@@ -85,19 +83,19 @@
 - [IVM for DuckLake Before v2.0](tutorial-ivm-ducklake-before-v2.md)
 - [pg-tide DuckLake Pipeline](tutorial-pg-tide-ducklake-pipeline.md)
 
-## Event-Driven Architecture
+# Tutorials: Event-Driven Architecture
 
 - [Event Sourcing / CQRS Read Models](tutorials/EVENT_SOURCING.md)
 - [ETL & Bulk Load Patterns](tutorials/ETL_BULK_LOAD.md)
 
-## CDC & Data Integration
+# Tutorials: CDC & Data Integration
 
 - [Sub-Millisecond Inlined-Data CDC](tutorial-sub-millisecond-inlined-cdc.md)
 - [Foreign Table Sources](tutorials/FOREIGN_TABLE_SOURCES.md)
 - [Migrating from Materialized Views](tutorials/MIGRATING_FROM_MATERIALIZED_VIEWS.md)
 - [Migrating from pg_ivm](tutorials/MIGRATING_FROM_PG_IVM.md)
 
-## Operations & Performance
+# Tutorials: Operations & Performance
 
 - [Tiered Scheduling](tutorials/TIERED_SCHEDULING.md)
 - [Tuning Refresh Mode](tutorials/tuning-refresh-mode.md)
@@ -106,20 +104,20 @@
 - [Monitoring & Alerting](tutorials/MONITORING_AND_ALERTING.md)
 - [Backfill and Migration from Materialized Views](tutorials/BACKFILL_AND_MIGRATION.md)
 
-## Security & Multi-Tenancy
+# Tutorials: Security & Multi-Tenancy
 
 - [Security Hardening](tutorials/SECURITY_HARDENING.md)
 - [Row-Level Security](tutorials/ROW_LEVEL_SECURITY.md)
 - [Per-Tenant ANN Indexing Patterns](tutorials/PER_TENANT_ANN_PATTERNS.md)
 
-## Vector Search & AI/ML
+# Tutorials: Vector Search & AI/ML
 
 - [Hybrid Search Patterns](tutorials/HYBRID_SEARCH_PATTERNS.md)
 - [pgvector RAG Cookbook](tutorials/PGVECTOR_RAG_COOKBOOK.md)
 - [pgVector Embedding Pipelines](tutorials/PGVECTOR_EMBEDDING_PIPELINES.md)
 - [Vector RAG Starter](tutorials/VECTOR_RAG_STARTER.md)
 
-## Advanced Patterns
+# Tutorials: Advanced Patterns
 
 - [Partitioned Tables](tutorials/PARTITIONED_TABLES.md)
 


### PR DESCRIPTION
The previous PR used `##` sub-headings inside a single `# Tutorials` section. mdBook only renders `#` headings as visible sidebar section headers — `##` is silently ignored, leaving tutorials as a flat numbered list.

Fix: replace the `# Tutorials` parent + `## Category` children with `# Tutorials: Category` for each of the 8 groups. These render as distinct collapsible section headers in the mdBook sidebar.