### PR TITLE
fix(tests): resolve E2E test failures from v0.69.0 release

### DIFF
--- a/src/api/alter.rs
+++ b/src/api/alter.rs
@@ -893,6 +893,12 @@ fn alter_stream_table_query(
     let updated_st = StreamTableMeta::get_by_name(schema, table_name)?;
     execute_manual_full_refresh(&updated_st, schema, table_name, &source_oids)?;
 
+    // ERR-1f: Clear any previous error state now that the query has been fixed
+    // and the refresh succeeded. This ensures alter_stream_table with a fixed
+    // query always produces a clean ACTIVE state, even when called directly on
+    // an ERROR table (without a prior resume_stream_table call).
+    let _ = StreamTableMeta::clear_error_state(st.pgt_id);
+
     // Re-activate the stream table
     StreamTableMeta::update_status(st.pgt_id, StStatus::Active)?;
 

--- a/tests/e2e_ducklake_tests.rs
+++ b/tests/e2e_ducklake_tests.rs
@@ -29,7 +29,11 @@ use std::time::Duration;
 /// `E2eDb::execute`) is a prepared statement and cannot execute multiple
 /// commands at once.  Use `db.execute_seq(DUCKLAKE_CATALOG_DDL)` to run them.
 const DUCKLAKE_CATALOG_DDL: &[&str] = &[
-    "CREATE TABLE IF NOT EXISTS ducklake_data_file (\
+    // SEC-002 (v0.69.0): the sink writes to pg_trickle.ducklake_catalog_schema
+    // which defaults to "main".  Create the schema first so all catalog tables
+    // land there instead of in "public".
+    "CREATE SCHEMA IF NOT EXISTS main",
+    "CREATE TABLE IF NOT EXISTS main.ducklake_data_file (\
         data_file_id    BIGSERIAL PRIMARY KEY,\
         table_id        BIGINT NOT NULL,\
         begin_snapshot  BIGINT NOT NULL,\
@@ -38,12 +42,12 @@ const DUCKLAKE_CATALOG_DDL: &[&str] = &[
         file_size_bytes BIGINT,\
         encryption_key_id TEXT\
     )",
-    "CREATE TABLE IF NOT EXISTS ducklake_table_stats (\
+    "CREATE TABLE IF NOT EXISTS main.ducklake_table_stats (\
         table_id   BIGINT PRIMARY KEY,\
         row_count  BIGINT NOT NULL DEFAULT 0,\
         file_count BIGINT NOT NULL DEFAULT 0\
     )",
-    "CREATE TABLE IF NOT EXISTS ducklake_snapshot (\
+    "CREATE TABLE IF NOT EXISTS main.ducklake_snapshot (\
         table_id      BIGINT NOT NULL,\
         snapshot_id   BIGINT NOT NULL,\
         snapshot_time TIMESTAMPTZ NOT NULL DEFAULT now(),\
@@ -148,7 +152,7 @@ async fn test_ducklake_sink_parquet_file_written_after_refresh() {
 
     // The sink must have registered a file in ducklake_data_file.
     let file_count: i64 = db
-        .query_scalar("SELECT count(*) FROM ducklake_data_file WHERE table_id = 1")
+        .query_scalar("SELECT count(*) FROM main.ducklake_data_file WHERE table_id = 1")
         .await;
     assert!(
         file_count >= 1,
@@ -160,7 +164,7 @@ async fn test_ducklake_sink_parquet_file_written_after_refresh() {
     // Verify the registered path starts with the expected prefix.
     let path: Option<String> = db
         .query_scalar(
-            "SELECT path FROM ducklake_data_file \
+            "SELECT path FROM main.ducklake_data_file \
              WHERE table_id = 1 ORDER BY data_file_id LIMIT 1",
         )
         .await;
@@ -173,7 +177,7 @@ async fn test_ducklake_sink_parquet_file_written_after_refresh() {
 
     // The snapshot table must also have a row.
     let snap_count: i64 = db
-        .query_scalar("SELECT count(*) FROM ducklake_snapshot WHERE table_id = 1")
+        .query_scalar("SELECT count(*) FROM main.ducklake_snapshot WHERE table_id = 1")
         .await;
     assert!(
         snap_count >= 1,
@@ -256,7 +260,7 @@ async fn test_ducklake_sink_catalog_not_modified_when_upload_fails() {
     // CRITICAL: ducklake_data_file and ducklake_snapshot must have ZERO rows
     // for table_id=2, proving the catalog was never touched when upload failed.
     let file_count: i64 = db
-        .query_scalar("SELECT count(*) FROM ducklake_data_file WHERE table_id = 2")
+        .query_scalar("SELECT count(*) FROM main.ducklake_data_file WHERE table_id = 2")
         .await;
     assert_eq!(
         file_count, 0,
@@ -265,7 +269,7 @@ async fn test_ducklake_sink_catalog_not_modified_when_upload_fails() {
     );
 
     let snap_count: i64 = db
-        .query_scalar("SELECT count(*) FROM ducklake_snapshot WHERE table_id = 2")
+        .query_scalar("SELECT count(*) FROM main.ducklake_snapshot WHERE table_id = 2")
         .await;
     assert_eq!(
         snap_count, 0,
@@ -335,7 +339,7 @@ async fn test_ducklake_sink_timestamp_roundtrip() {
     // A row_count of 0 or NULL would indicate all rows were dropped/nullified.
     let row_count: Option<i64> = db
         .query_scalar(
-            "SELECT row_count FROM ducklake_data_file \
+            "SELECT row_count FROM main.ducklake_data_file \
              WHERE table_id = 3 ORDER BY data_file_id LIMIT 1",
         )
         .await;

--- a/tests/e2e_error_state_tests.rs
+++ b/tests/e2e_error_state_tests.rs
@@ -163,11 +163,11 @@ async fn test_permanent_error_sets_error_status_and_alter_clears() {
         "Scheduler should not attempt further refreshes on ERROR table"
     );
 
-    // ── Fix: use resume_stream_table to clear error, then alter the query ──
-    db.execute("SELECT pgtrickle.resume_stream_table('err1e_st')")
-        .await;
-
-    // ALTER to a valid query (without the dropped 'extra' column)
+    // ── Fix: ALTER directly on the ERROR table with the corrected query ──
+    // Do NOT call resume_stream_table first — the scheduler skips ERROR tables,
+    // so issuing alter_stream_table directly is race-free. alter_stream_table
+    // transitions through SUSPENDED → (full refresh) → ACTIVE and now also
+    // clears any previous error state (ERR-1f), so no separate resume is needed.
     db.alter_st("err1e_st", "query => 'SELECT id, val FROM err1e_src'")
         .await;
 


### PR DESCRIPTION
## Summary

Fix three E2E test failures from CI run #26273287678 (v0.69.0 release):
- `test_ducklake_sink_parquet_file_written_after_refresh`
- `test_ducklake_sink_timestamp_roundtrip`
- `test_permanent_error_sets_error_status_and_alter_clears`

The root causes were a DuckLake catalog schema mismatch (SEC-002, v0.69.0) and a race condition in error-state recovery. Both are now fixed.

## Changes

### 1. Fix DuckLake Catalog Schema Mismatch (`tests/e2e_ducklake_tests.rs`)
- Add `CREATE SCHEMA IF NOT EXISTS main` as first DDL entry in `DUCKLAKE_CATALOG_DDL`
- Qualify all three catalog table definitions with `main.` prefix
- Update all six query sites across three test functions to use `main.ducklake_data_file` and `main.ducklake_snapshot`
- **Root cause**: v0.69.0 SEC-002 changed `register_ducklake_data_file` to write into `pg_trickle.ducklake_catalog_schema` (default: `"main"`), but tests were creating stub tables in `public`. The insert failed silently and the catalog remained empty.

### 2. Clear Error State on Successful Query Alter (`src/api/alter.rs`)
- `alter_stream_table_query` Phase 5 now calls `StreamTableMeta::clear_error_state()` before `update_status(Active)`
- Ensures that a successful query-fix alter on an ERROR table always produces a fully clean ACTIVE state with `last_error_message` and `last_error_at` zeroed
- **Ticket**: ERR-1f

### 3. Remove Race Condition in Error State Test (`tests/e2e_error_state_tests.rs`)
- Remove `resume_stream_table` call before `alter_st`
- Update test comment to explain why direct alter on ERROR table is race-free
- **Root cause**: Between `resume_stream_table` (sets status=ACTIVE) and `alter_st` running, the 100 ms scheduler could fire with the stale defining query, re-fail, and set status=ERROR again, causing the assertion to fail
- **Fix rationale**: The scheduler skips ERROR-state tables, making direct `alter_stream_table` race-free. Error-state cleanup is now handled by ERR-1f in the production code.

## Testing

- ✅ `just fmt` — passes (no formatting issues)
- ✅ `just lint` — passes (zero clippy warnings)
- ✅ E2E tests targeted by this fix should now pass:
  - `test_ducklake_sink_parquet_file_written_after_refresh`
  - `test_ducklake_sink_timestamp_roundtrip`
  - `test_permanent_error_sets_error_status_and_alter_clears`

## Notes

- Both fixes are isolated to test-specific or error-recovery paths
- No changes to core refresh, scheduler, or DVM logic
- The DuckLake schema fix is a direct consequence of SEC-002; this PR completes the v0.69.0 test integration
- The error-state fix removes a pre-existing race condition in the test, and the production code change (ERR-1f) is a hardening that makes alter behavior more robust
