### PR TITLE
fix(sink): add pgt_ducklake_sink_delivery to fresh-install schema; fix test timing race

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -532,6 +532,38 @@ CREATE INDEX IF NOT EXISTS idx_provenance_snapshot
 
 SELECT pg_catalog.pg_extension_config_dump('pgtrickle.pgt_ducklake_provenance', '');
 
+-- v0.69.0 ARCH-002/REL-001: per-delivery tracking for the DuckLake sink write path.
+-- Records each sink write attempt with its status and outcome for observability and retry logic.
+-- Only present in migration sql/pg_trickle--0.68.0--0.69.0.sql for upgrades;
+-- added here so fresh installs (CREATE EXTENSION) also get the table.
+CREATE TABLE IF NOT EXISTS pgtrickle.pgt_ducklake_sink_delivery (
+    delivery_id      bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    stream_table_id  bigint NOT NULL
+                       REFERENCES pgtrickle.pgt_stream_tables(pgt_id)
+                       ON DELETE CASCADE,
+    refresh_id       bigint,
+    status           text NOT NULL
+                       CHECK (status IN (
+                           'PENDING',
+                           'WRITING',
+                           'DELIVERED',
+                           'FAILED_RETRYABLE',
+                           'FAILED_PERMANENT'
+                       )),
+    attempt_count    int NOT NULL DEFAULT 0,
+    bytes_written    bigint,
+    rows_written     bigint,
+    started_at       timestamptz NOT NULL DEFAULT now(),
+    finished_at      timestamptz,
+    last_error       text
+);
+
+CREATE INDEX IF NOT EXISTS pgt_ducklake_sink_delivery_st_started
+    ON pgtrickle.pgt_ducklake_sink_delivery (stream_table_id, started_at DESC);
+
+COMMENT ON TABLE pgtrickle.pgt_ducklake_sink_delivery IS
+    'ARCH-002/REL-001 (v0.69.0): per-delivery tracking for the DuckLake sink write path.';
+
 
 "#,
     name = "pg_trickle_catalog",

--- a/tests/e2e_ducklake_tests.rs
+++ b/tests/e2e_ducklake_tests.rs
@@ -104,6 +104,36 @@ async fn wait_for_n_refreshes(
     }
 }
 
+/// Wait until `main.ducklake_data_file` has at least one row for `table_id`.
+///
+/// `create_stream_table` runs an initial MANUAL refresh (and records a
+/// COMPLETED row in `pgt_refresh_history`) *before* persisting the DuckLake
+/// sink configuration.  `wait_for_n_refreshes` can therefore return after
+/// seeing that early MANUAL record — before the scheduler has had a chance to
+/// run the first SCHEDULED refresh (the one that actually drives the sink).
+///
+/// Polling `ducklake_data_file` directly avoids the race: the scheduler
+/// writes the catalog row in the same transaction as the COMPLETED history
+/// record, so visibility is guaranteed once the row appears.
+async fn wait_for_ducklake_data_file(db: &E2eDb, table_id: i64, timeout: Duration) -> i64 {
+    let start = std::time::Instant::now();
+    loop {
+        let count: i64 = db
+            .query_scalar(&format!(
+                "SELECT count(*) FROM main.ducklake_data_file \
+                 WHERE table_id = {table_id}"
+            ))
+            .await;
+        if count >= 1 {
+            return count;
+        }
+        if start.elapsed() > timeout {
+            return count;
+        }
+        tokio::time::sleep(Duration::from_millis(300)).await;
+    }
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 /// v0.66.0 (F-2/F-4): After a successful scheduler refresh, the DuckLake sink
@@ -150,10 +180,15 @@ async fn test_ducklake_sink_parquet_file_written_after_refresh() {
         "dl_sink_write_st must have at least 1 COMPLETED refresh, got {refreshes}"
     );
 
-    // The sink must have registered a file in ducklake_data_file.
-    let file_count: i64 = db
-        .query_scalar("SELECT count(*) FROM main.ducklake_data_file WHERE table_id = 1")
-        .await;
+    // Wait for the DuckLake sink to write at least one catalog entry.
+    //
+    // `create_stream_table` records a COMPLETED refresh row in
+    // `pgt_refresh_history` during its initial MANUAL refresh — *before* the
+    // DuckLake sink configuration is persisted.  `wait_for_n_refreshes` can
+    // therefore return immediately after seeing that early record, before the
+    // scheduler has executed the first SCHEDULED refresh (which drives the
+    // sink).  Polling `ducklake_data_file` directly avoids the race.
+    let file_count = wait_for_ducklake_data_file(&db, 1, Duration::from_secs(60)).await;
     assert!(
         file_count >= 1,
         "Expected at least 1 ducklake_data_file row for table_id=1, \
@@ -334,6 +369,12 @@ async fn test_ducklake_sink_timestamp_roundtrip() {
         refreshes >= 1,
         "dl_ts_sink_st must refresh at least once, got {refreshes}"
     );
+
+    // Wait for the DuckLake sink to write at least one catalog entry before
+    // reading row_count.  The initial MANUAL refresh (recorded before the sink
+    // config is persisted) causes wait_for_n_refreshes to return early; the
+    // scheduler-driven refresh (which runs the sink) may still be in flight.
+    wait_for_ducklake_data_file(&db, 3, Duration::from_secs(60)).await;
 
     // Verify catalog registration succeeded with row_count = 2.
     // A row_count of 0 or NULL would indicate all rows were dropped/nullified.


### PR DESCRIPTION
## Problem

Two E2E tests have been failing since v0.69.0 because `main.ducklake_data_file` contains 0 rows after a successful refresh:

- `test_ducklake_sink_parquet_file_written_after_refresh`
- `test_ducklake_sink_timestamp_roundtrip`

CI run [#2356 (26285575461)](https://github.com/trickle-labs/pg-trickle/actions/runs/26285575461) confirmed the failures persist even after the ON CONFLICT schema-qualification fix in 8bbc664.

## Root Causes

### 1. `pgt_ducklake_sink_delivery` missing from fresh-install schema

`pgt_ducklake_sink_delivery` was added in v0.69.0 but only appears in the upgrade migration `sql/pg_trickle--0.68.0--0.69.0.sql`. It was never added to `src/lib.rs` (the schema used for `CREATE EXTENSION pg_trickle`).

E2E tests always do a fresh install. Without the table, `create_delivery_row()` in `src/ducklake_sink.rs` fails with a PostgreSQL ERROR (`relation "pgtrickle.pgt_ducklake_sink_delivery" does not exist`). This error propagates as a panic inside `BackgroundWorker::transaction`, aborting the entire background worker transaction — including the COMPLETED refresh record and the `ducklake_data_file` insert.

### 2. Test timing race: `wait_for_n_refreshes` returns after the initial MANUAL refresh

`create_stream_table` runs an initial MANUAL refresh and records a COMPLETED row in `pgt_refresh_history` **before** persisting the DuckLake sink configuration. `wait_for_n_refreshes` counts all COMPLETED records for the stream table, so it returns after seeing that early MANUAL record — before the scheduler has had a chance to run the first SCHEDULED refresh (the one that drives the sink).

## Fix

### `src/lib.rs` — add `pgt_ducklake_sink_delivery` to the install schema

Add the full DDL for `pgt_ducklake_sink_delivery` (table, index, comment) to the `pg_trickle_catalog` extension SQL block, directly after `pgt_ducklake_provenance`. This ensures the table is present in all fresh installs.

### `tests/e2e_ducklake_tests.rs` — poll `ducklake_data_file` directly

Add `wait_for_ducklake_data_file(db, table_id, timeout)`: a new helper that polls `main.ducklake_data_file` directly. Because the scheduler writes the catalog row in the same transaction as the COMPLETED refresh history record, once the row appears the sink has definitely run. Use this helper in both failing tests to wait for the actual catalog entry rather than relying on the refresh history count.

## Testing

- `just fmt && just lint` — passes (0 warnings)
- `just test-unit` — all 2306 tests pass
- Full E2E will be triggered on this PR via `gh workflow run ci.yml --ref fix/ducklake-sink-ci-failures`
