### PR TITLE
fix(upgrade): add storage_fillfactor to 0.73.0 archive and 0.73→0.74 migration

### DIFF
--- a/sql/archive/pg_trickle--0.73.0.sql
+++ b/sql/archive/pg_trickle--0.73.0.sql
@@ -100,6 +100,9 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_stream_tables (
     column_lineage  JSONB,
     -- v0.59.0 PERF-2: hash of defining_query to skip recomputation on every refresh
     defining_query_hash BIGINT NOT NULL DEFAULT 0,
+    -- HOT-1 (v0.73.0): fillfactor option for stream table storage heaps
+    storage_fillfactor INT DEFAULT NULL
+                     CHECK (storage_fillfactor IS NULL OR (storage_fillfactor >= 10 AND storage_fillfactor <= 100)),
     -- v0.65.0 CDC-6: DuckLake compaction policy override
     ducklake_compaction_policy TEXT DEFAULT NULL
                      CHECK (ducklake_compaction_policy IN ('fallback', 'error')),

--- a/sql/pg_trickle--0.73.0--0.74.0.sql
+++ b/sql/pg_trickle--0.73.0--0.74.0.sql
@@ -16,4 +16,12 @@
 --   DEVEX-002: just lint-ci recipe
 --   DEVEX-003: Stale version tag updates
 
--- No schema changes in this release.
+-- HOT-1 was introduced in v0.73.0 but the 0.73.0 archive SQL was generated
+-- before the column was added. Apply idempotently so both fresh 0.73.0
+-- installs (missing the column) and upgrade-path installs (already present)
+-- succeed.
+ALTER TABLE pgtrickle.pgt_stream_tables
+    ADD COLUMN IF NOT EXISTS storage_fillfactor INT
+        CONSTRAINT pgt_storage_fillfactor_range
+        CHECK (storage_fillfactor IS NULL OR
+               (storage_fillfactor >= 10 AND storage_fillfactor <= 100));


### PR DESCRIPTION
## Problem

`test_upgrade_chain_stream_tables_survive` fails when upgrading from a **fresh 0.73.0 install** to 0.74.0:

```
SQL failed: error returned from database: column "storage_fillfactor" does not exist
```

The `storage_fillfactor` column (HOT-1, #860) was added via the `0.72→0.73` migration script, but the `sql/archive/pg_trickle--0.73.0.sql` archive was generated **before** that commit landed. This means:

- Users who upgraded `0.72.0 → 0.73.0`: column present ✅
- Users who installed `0.73.0` fresh from the archive: column missing ❌

When those users then upgrade `0.73.0 → 0.74.0`, the migration says "no schema changes" — so the column remains absent, and the 0.74.0 binary fails when it tries to write `storage_fillfactor`.

## Fix

Two idempotent changes:

1. **`sql/archive/pg_trickle--0.73.0.sql`** — add `storage_fillfactor` to the `pgt_stream_tables` CREATE TABLE so the archive reflects the complete 0.73.0 schema.

2. **`sql/pg_trickle--0.73.0--0.74.0.sql`** — add `ALTER TABLE … ADD COLUMN IF NOT EXISTS storage_fillfactor` with the CHECK constraint, covering real installations that used the incomplete archive.

Both changes are safe to apply regardless of whether the column already exists (`IF NOT EXISTS` / `CREATE TABLE IF NOT EXISTS`).

## Testing

CI run that exposed this: https://github.com/trickle-labs/pg-trickle/actions/runs/26508737992

The Upgrade E2E job (`test_upgrade_chain_stream_tables_survive`) should pass once these SQL files are corrected.
