### PR TITLE
roadmap: add RockLake compatibility arc (v0.76.0)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -318,6 +318,20 @@ are catalog contract and durability invariants that must be proven before v1.0.
 | [v0.74.0](roadmap/v0.74.0.md) | Test Coverage, CI Integrity & Security Hardening: replace fixed WAL/safety stabilization sleeps with condition-based polling (TEST-002), path-filtered full E2E + reduced TPC-H slice on risky PRs (TEST-004/REL-003), `just coverage-summary` recipe with per-module risk output (TEST-005), `#[cfg(test)]` unit tests for `src/refresh/merge/mod.rs`, `src/refresh/codegen.rs`, `src/api/metrics_ext.rs` (CODE-002), centralize advisory ignores in `deny.toml` and make `just security` reproduce CI (SEC-001/DEVEX-004), restrict IVM AFTER trigger search path or add targeted shadowing tests (SEC-002), SQL builder helpers audit and lint for raw `format!()` SQL (SEC-003), re-enable push-to-main benchmark baselines (DEVEX-001), add `just lint-ci` recipe covering generated doc/schema/version/docs-truth checks (DEVEX-002), replace stale version tags in Dockerfile examples and justfile (DEVEX-003), upgrade deps: sqlx 0.9.0 (query safety), lru 0.18.0, object_store 0.13.2 (DuckLake E2E) (DEP-001/002/003) | ✅ Released | Large | [Full details](roadmap/v0.74.0.md) |
 | [v0.75.0](roadmap/v0.75.0.md) | API Polish, Documentation Excellence & Developer Experience: add `pgtrickle.metrics_summary` full SQL reference section with columns, examples, and cost caveats (API-002/DOC-003), normalize SQL function parameter naming convention and document it (API-003), convert generated API catalog return types to SQL-facing forms (API-004), add schedule-mode comparison table to SQL reference (API-005), introduce typed `PgtId`/`StreamTableOid` wrappers to prevent cross-domain casts (CODE-003), repair corrupted `plans/PLAN.md` architecture-doc table and add fragment-corruption lint (DOC-001), update README GUC count to generated phrase and add stale-version scanner (DOC-002/DOC-004), add `docs/COMPARISONS.md` covering pg_ivm, Materialize, Feldera, DuckDB/DuckLake, and pg_trickle across SQL coverage, consistency, CDC, performance, and operational model (ARCH-004) | ✅ Released | Large | [Full details](roadmap/v0.75.0.md) |
 
+### RockLake Compatibility Arc (v0.76.x)
+
+RockLake (formerly SlateDuck) is the first DuckLake catalog backend that is not PostgreSQL or SQLite: it stores the 28 DuckLake catalog tables in SlateDB on object storage and exposes them over the standard PG-wire protocol. Phase 2 and Phase 3 of the DuckLake integration (v0.65–v0.67) were developed and tested against a PostgreSQL-backed DuckLake catalog. This arc validates and certifies full pg_trickle compatibility with RockLake as the catalog backend, targeting RockLake v0.27.14+.
+
+A deep cross-project compatibility audit ([RockLake plans/pg-trickle-ducklake-support.md](https://github.com/trickle-labs/slateduck/blob/main/plans/pg-trickle-ducklake-support.md)) identified two issues that the Phase 2/3 work did not address:
+
+1. **`ducklake_latest_snapshot_id(regclass)` startup handshake (CDC-001):** `src/cdc/polling.rs` calls `SELECT ducklake_latest_snapshot_id($1::regclass)` before ever reaching `table_changes()`. This function is not part of the DuckLake specification and was not in RockLake's bounded SQL dispatcher until RockLake v0.27.11. Any pg_trickle deployment against an older RockLake sidecar silently crashes the CDC engine at registration time with `SQLSTATE 42883` (undefined function). pg_trickle needs an end-to-end test that verifies this handshake completes correctly against a real RockLake sidecar, and a clear diagnostic error message that names the required RockLake version when `42883` is received here.
+
+2. **Inlined-data trigger CDC is impossible for remote RockLake writes (CDC-002):** PostgreSQL `AFTER` triggers only fire when DML is issued locally on the host PostgreSQL server through the SPI interface. When an external client (e.g. DuckDB, another pg_trickle node) writes inlined data directly to RockLake over PG-wire, it bypasses the host PostgreSQL entirely — the FDW trigger registered by pg_trickle's inlined-data adapter (v0.65) will never fire. pg_trickle must skip trigger attachment when the catalog backend is a remote FDW target (detectable by `pg_foreign_table` membership of the `ducklake_*` tables), and instead always use the unified `DUCKLAKE_CHANGE_FEED` polling path for all change detection against RockLake.
+
+| Version | Theme | Status | Scope | Full details |
+|---------|-------|--------|-------|--------------|
+| [v0.76.0](roadmap/v0.76.0.md) | RockLake Compatibility Certification: `ducklake_latest_snapshot_id` CDC startup test + `42883` diagnostic (CDC-001); skip inlined-data trigger attachment for remote FDW catalog backends, force `DUCKLAKE_CHANGE_FEED` polling (CDC-002); Tier A/B/C RockLake integration test suite; `docs/integration/rocklake.md` compatibility guide | Planning | Medium | [Full details](roadmap/v0.76.0.md) |
+
 ### Beyond v1.0
 
 | Version | Theme | Status | Scope | Full details |
@@ -433,6 +447,8 @@ v0.73    ─── Monitoring scalability & operational resilience: O(Δ) histor
 v0.74    ─── Test coverage, CI integrity & security: path-filtered full E2E, per-module coverage, IVM search_path, unified advisory policy, re-enable benchmarks
     │
 v0.75    ─── API polish & documentation excellence: metrics_summary reference, typed PgtId wrappers, IVM comparison matrix, stale-tag scanner
+    │
+v0.76    ─── RockLake compatibility: CDC startup handshake test, 42883 diagnostic, skip FDW inlined-data triggers, force DUCKLAKE_CHANGE_FEED, Tier A/B/C integration suite
     │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```


### PR DESCRIPTION
## Summary

Add a new **RockLake Compatibility Arc** section for v0.76.0, targeting RockLake v0.27.14+ as the first non-PostgreSQL/SQLite DuckLake catalog backend supported by pg-trickle.

A deep cross-project compatibility audit identified two issues that the Phase 2/3 DuckLake work (v0.65–v0.67) did not address for RockLake specifically.

## CDC-001: `ducklake_latest_snapshot_id(regclass)` startup handshake

`src/cdc/polling.rs` calls `SELECT ducklake_latest_snapshot_id($1::regclass)` before ever reaching `table_changes()`. This function was absent from RockLake's bounded SQL dispatcher until RockLake v0.27.11. Any pg-trickle deployment against an older RockLake sidecar crashes the CDC engine at registration time with `SQLSTATE 42883` (undefined function).

v0.76.0 adds an end-to-end test verifying this handshake completes correctly against a real RockLake sidecar, and a targeted diagnostic error message that names the minimum required RockLake version when `42883` is received.

## CDC-002: Inlined-data trigger CDC is impossible for remote RockLake writes

The v0.65 inlined-data CDC adapter registers PostgreSQL `AFTER` triggers on inlined tables. For a remote RockLake backend accessed via FDW, writes from external clients (DuckDB, another pg-trickle node) to RockLake over PG-wire bypass the host PostgreSQL entirely, so those triggers never fire.

v0.76.0 detects when `ducklake_*` tables are foreign tables (via `pg_foreign_table`) and unconditionally selects `DUCKLAKE_CHANGE_FEED` polling mode for those backends, skipping trigger attachment.

## Also included

- v0.76.0 added to the version timeline diagram
- Arc description explains the RockLake architecture and why these two issues were missed during Phase 2/3 development