### PR TITLE
roadmap: remove DuckLake sink from pg_trickle (v0.76.1)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -318,9 +318,35 @@ are catalog contract and durability invariants that must be proven before v1.0.
 | [v0.74.0](roadmap/v0.74.0.md) | Test Coverage, CI Integrity & Security Hardening: replace fixed WAL/safety stabilization sleeps with condition-based polling (TEST-002), path-filtered full E2E + reduced TPC-H slice on risky PRs (TEST-004/REL-003), `just coverage-summary` recipe with per-module risk output (TEST-005), `#[cfg(test)]` unit tests for `src/refresh/merge/mod.rs`, `src/refresh/codegen.rs`, `src/api/metrics_ext.rs` (CODE-002), centralize advisory ignores in `deny.toml` and make `just security` reproduce CI (SEC-001/DEVEX-004), restrict IVM AFTER trigger search path or add targeted shadowing tests (SEC-002), SQL builder helpers audit and lint for raw `format!()` SQL (SEC-003), re-enable push-to-main benchmark baselines (DEVEX-001), add `just lint-ci` recipe covering generated doc/schema/version/docs-truth checks (DEVEX-002), replace stale version tags in Dockerfile examples and justfile (DEVEX-003), upgrade deps: sqlx 0.9.0 (query safety), lru 0.18.0, object_store 0.13.2 (DuckLake E2E) (DEP-001/002/003) | ✅ Released | Large | [Full details](roadmap/v0.74.0.md) |
 | [v0.75.0](roadmap/v0.75.0.md) | API Polish, Documentation Excellence & Developer Experience: add `pgtrickle.metrics_summary` full SQL reference section with columns, examples, and cost caveats (API-002/DOC-003), normalize SQL function parameter naming convention and document it (API-003), convert generated API catalog return types to SQL-facing forms (API-004), add schedule-mode comparison table to SQL reference (API-005), introduce typed `PgtId`/`StreamTableOid` wrappers to prevent cross-domain casts (CODE-003), repair corrupted `plans/PLAN.md` architecture-doc table and add fragment-corruption lint (DOC-001), update README GUC count to generated phrase and add stale-version scanner (DOC-002/DOC-004), add `docs/COMPARISONS.md` covering pg_ivm, Materialize, Feldera, DuckDB/DuckLake, and pg_trickle across SQL coverage, consistency, CDC, performance, and operational model (ARCH-004) | ✅ Released | Large | [Full details](roadmap/v0.75.0.md) |
 
-### RockLake Compatibility Arc (v0.76.x)
+### DuckLake Sink Removal & RockLake Compatibility Arc (v0.76.x)
 
-RockLake (formerly SlateDuck) is the first DuckLake catalog backend that is not PostgreSQL or SQLite: it stores the 28 DuckLake catalog tables in SlateDB on object storage and exposes them over the standard PG-wire protocol. Phase 2 and Phase 3 of the DuckLake integration (v0.65–v0.67) were developed and tested against a PostgreSQL-backed DuckLake catalog. This arc validates and certifies full pg_trickle compatibility with RockLake as the catalog backend, targeting RockLake v0.27.14+.
+This arc has two themes that both flow from the same architectural insight: pg_trickle's DuckLake
+integration has grown in two directions that deserve different homes.
+
+**The source side** (`DUCKLAKE_CHANGE_FEED` CDC mode, `table_changes()` polling, snapshot frontier,
+row-ID plumbing) is core to pg_trickle's mission — it teaches the DVM engine to consume delta feeds
+from a data lake. This stays and is extended by RockLake compatibility work in v0.76.0.
+
+**The sink side** (`ducklake_sink.rs`, Parquet serialisation via `arrow-rs`, S3 object-store upload,
+DuckLake catalog transaction writer, `pgt_ducklake_provenance`, `pgt_ducklake_sink_delivery`) is a
+relay concern — it takes computed results and pushes them to an external storage system. That is
+exactly what `pg_tide` (`trickle-labs/pg-tide`) was extracted to do. Keeping it in pg_trickle
+adds 1,258 lines of Arrow/Parquet/object_store code, three heavy Cargo dependencies
+(`arrow-array`, `arrow-schema`, `parquet`, `object_store`, `bytes`), and an async-in-sync tokio
+shim that fights PostgreSQL's signal handling — all orthogonal to IVM performance.
+
+v0.76.1 removes the sink entirely. Users who need DuckLake egress should use the
+[pg-tide DuckLake sink](https://github.com/trickle-labs/pg-tide) once it ships that feature.
+
+---
+
+**RockLake compatibility (v0.76.0):**
+
+RockLake (formerly SlateDuck) is the first DuckLake catalog backend that is not PostgreSQL or SQLite:
+it stores the 28 DuckLake catalog tables in SlateDB on object storage and exposes them over the
+standard PG-wire protocol. Phase 2 and Phase 3 of the DuckLake integration (v0.65–v0.67) were
+developed and tested against a PostgreSQL-backed DuckLake catalog. This release validates and certifies
+full pg_trickle compatibility with RockLake as the catalog backend, targeting RockLake v0.27.14+.
 
 A deep cross-project compatibility audit ([RockLake plans/pg-trickle-ducklake-support.md](https://github.com/trickle-labs/slateduck/blob/main/plans/pg-trickle-ducklake-support.md)) identified two issues that the Phase 2/3 work did not address:
 
@@ -331,6 +357,7 @@ A deep cross-project compatibility audit ([RockLake plans/pg-trickle-ducklake-su
 | Version | Theme | Status | Scope | Full details |
 |---------|-------|--------|-------|--------------|
 | [v0.76.0](roadmap/v0.76.0.md) | RockLake Compatibility Certification: `ducklake_latest_snapshot_id` CDC startup test + `42883` diagnostic (CDC-001); skip inlined-data trigger attachment for remote FDW catalog backends, force `DUCKLAKE_CHANGE_FEED` polling (CDC-002); Tier A/B/C RockLake integration test suite; `docs/integration/rocklake.md` compatibility guide | Planning | Medium | [Full details](roadmap/v0.76.0.md) |
+| [v0.76.1](roadmap/v0.76.1.md) | DuckLake Sink Removal: delete `src/ducklake_sink.rs` and all sink infrastructure (SINK-001); migrate users with deprecation notice pointing to pg-tide (SINK-002); drop `ducklake_sink_mode`, `ducklake_sink_path`, `ducklake_sink_table_id`, `ducklake_compaction_policy` columns + `pgt_ducklake_provenance` + `pgt_ducklake_sink_delivery` tables with upgrade SQL (SINK-003); remove `arrow-array`, `arrow-schema`, `parquet`, `object_store`, `bytes` Cargo deps + tokio `rt` feature from main crate (SINK-004); update `catalog.rs` `StreamTableMeta`, `refresh_ops.rs`, `lib.rs` (SINK-005); add ADR-006 documenting source/sink boundary decision (SINK-006) | Planning | Medium | [Full details](roadmap/v0.76.1.md) |
 
 ### Beyond v1.0
 
@@ -448,7 +475,9 @@ v0.74    ─── Test coverage, CI integrity & security: path-filtered full E2
     │
 v0.75    ─── API polish & documentation excellence: metrics_summary reference, typed PgtId wrappers, IVM comparison matrix, stale-tag scanner
     │
-v0.76    ─── RockLake compatibility: CDC startup handshake test, 42883 diagnostic, skip FDW inlined-data triggers, force DUCKLAKE_CHANGE_FEED, Tier A/B/C integration suite
+v0.76.0  ─── RockLake compatibility: CDC startup handshake test, 42883 diagnostic, skip FDW inlined-data triggers, force DUCKLAKE_CHANGE_FEED, Tier A/B/C integration suite
+    │
+v0.76.1  ─── DuckLake sink removal: delete ducklake_sink.rs + Arrow/Parquet/object_store deps, drop sink catalog tables/columns, add ADR-006
     │
 v1.0.0   ─── Stable release, PostgreSQL 19, package registries, signed artifacts, SBOMs
 ```

--- a/roadmap/v0.76.0.md
+++ b/roadmap/v0.76.0.md
@@ -1,0 +1,38 @@
+> Plain-language companion for v0.76.0 implementation.
+
+## v0.76.0 — RockLake Compatibility Certification
+
+Status: Planning.
+
+### Context
+
+RockLake (formerly SlateDuck) is the first DuckLake catalog backend that is not PostgreSQL or
+SQLite. It stores the 28 DuckLake catalog tables in SlateDB on object storage and exposes them
+over the PG-wire protocol. The Phase 2 and Phase 3 DuckLake work (v0.65–v0.67) was developed
+and tested exclusively against a PostgreSQL-backed DuckLake catalog. A deep cross-project
+compatibility audit identified two issues that must be resolved before pg_trickle can certify
+support for RockLake v0.27.14+.
+
+### Items
+
+- [ ] **CDC-001**: Add an integration test that starts a real RockLake v0.27.14+ sidecar (via
+  Testcontainers) and verifies the `ducklake_latest_snapshot_id($1::regclass)` startup handshake
+  completes without error. When `SQLSTATE 42883` is returned, pg_trickle must emit a clear
+  diagnostic naming the minimum required RockLake version.
+- [ ] **CDC-002**: Detect when the DuckLake catalog backend is a remote FDW target by checking
+  `pg_foreign_table` membership of the `ducklake_*` tables. Skip inlined-data trigger attachment
+  for remote backends and always use the `DUCKLAKE_CHANGE_FEED` polling path. Add an integration
+  test that exercises this code path against RockLake.
+- [ ] **TEST**: Tier A (positive path), Tier B (error handling), and Tier C (chaos/edge cases)
+  integration test suite covering both CDC-001 and CDC-002 scenarios.
+- [ ] **DOCS**: Add `docs/integration/rocklake.md` — a step-by-step compatibility guide covering
+  minimum version requirements, Docker Compose setup, known limitations, and the detection
+  heuristic for remote vs. local DuckLake catalog backends.
+
+### Notes
+
+- Only the source side of DuckLake integration is in scope for this release. The sink
+  (`ducklake_sink.rs`) is removed in v0.76.1 and should not be patched here.
+- The Testcontainers RockLake image must be pinned to a specific digest in `tests/common/mod.rs`
+  (same pattern as the existing DuckLake container fixture).
+- No SQL schema changes in this release.

--- a/roadmap/v0.76.1.md
+++ b/roadmap/v0.76.1.md
@@ -1,0 +1,103 @@
+> Plain-language companion for v0.76.1 implementation.
+
+## v0.76.1 — DuckLake Sink Removal
+
+Status: Planning.
+
+### Motivation
+
+The DuckLake sink (introduced in v0.66.0–v0.69.0) is a relay concern: it serialises stream table
+results as Parquet deltas, uploads them to S3/object storage, and registers them in the DuckLake
+catalog. That is precisely what `pg_tide` (`trickle-labs/pg-tide`) was extracted to do at v0.46.0.
+
+Keeping the sink in pg_trickle costs:
+- **1,258 lines** of Arrow/Parquet/object_store code in `src/ducklake_sink.rs` with no relation
+  to IVM performance.
+- **Five Cargo dependencies** (`arrow-array`, `arrow-schema`, `parquet`, `object_store`, `bytes`)
+  and the `tokio` `rt` feature in the main library crate — significant binary size and compile
+  time.
+- An **async-in-sync shim** (`tokio::runtime::Builder::new_current_thread()` per call) that
+  fights PostgreSQL's signal handling.
+- **Three catalog artifacts** (`ducklake_sink_mode/path/table_id/compaction_policy` columns,
+  `pgt_ducklake_provenance` table, `pgt_ducklake_sink_delivery` table) that exist solely for
+  the egress path.
+
+The source side of DuckLake integration (`DUCKLAKE_CHANGE_FEED` CDC mode, `table_changes()`
+polling, snapshot frontier, row-ID plumbing) is core to pg_trickle's mission and is **not**
+affected by this release.
+
+### Items
+
+- [ ] **SINK-001**: Delete `src/ducklake_sink.rs`. Remove `pub mod ducklake_sink;` from
+  `src/lib.rs`. Remove the `crate::ducklake_sink::run_ducklake_sink(st)` call from
+  `src/api/refresh_ops.rs`.
+
+- [ ] **SINK-002**: Update `src/catalog.rs` `StreamTableMeta` struct: remove the
+  `ducklake_sink_mode`, `ducklake_sink_path`, `ducklake_sink_table_id`, and
+  `ducklake_compaction_policy` fields and all associated accessor/builder logic.
+
+- [ ] **SINK-003**: Write upgrade SQL migration:
+  ```sql
+  -- Drop sink delivery state machine table
+  DROP TABLE IF EXISTS pgtrickle.pgt_ducklake_sink_delivery;
+  -- Drop provenance audit trail table
+  DROP TABLE IF EXISTS pgtrickle.pgt_ducklake_provenance;
+  -- Drop sink columns from stream table catalog
+  ALTER TABLE pgtrickle.pgt_stream_tables
+    DROP COLUMN IF EXISTS ducklake_sink_mode,
+    DROP COLUMN IF EXISTS ducklake_sink_path,
+    DROP COLUMN IF EXISTS ducklake_sink_table_id,
+    DROP COLUMN IF EXISTS ducklake_compaction_policy;
+  ```
+  Remove the corresponding `CREATE TABLE` / `CREATE INDEX` / `ALTER TABLE ADD COLUMN` DDL from
+  `src/lib.rs`.
+
+- [ ] **SINK-004**: Remove from `Cargo.toml` `[dependencies]`:
+  - `arrow-array`
+  - `arrow-schema`
+  - `parquet`
+  - `object_store`
+  - `bytes`
+  - `tokio = { version = "1", default-features = false, features = ["rt"] }` (the sync runtime
+    shim; the `[dev-dependencies]` tokio entry with `rt-multi-thread` must be kept).
+
+- [ ] **SINK-005**: Remove the DuckLake sink integration tests from
+  `tests/ducklake_integration_tests.rs` — specifically any test that exercises
+  `ducklake_sink_mode`, `ducklake_sink_path`, `pgt_ducklake_provenance`, or
+  `pgt_ducklake_sink_delivery`. Tests covering `DUCKLAKE_CHANGE_FEED` detection and
+  `ducklake_compaction_policy` schema presence must be removed since those columns are dropped.
+  Tests covering `CdcMode::DuckLakeChangeFeed` detection heuristics that do not depend on sink
+  columns may be migrated to a CDC-focused test file.
+
+- [ ] **SINK-006**: Add `plans/adrs/ADR-006-ducklake-sink-boundary.md` documenting the
+  architectural decision: source-side DuckLake integration (CDC adapter, `DUCKLAKE_CHANGE_FEED`
+  mode) belongs in pg_trickle; sink-side egress (Parquet serialisation, object-store upload,
+  catalog writes) belongs in pg_tide. Record the rationale (relay vs. IVM concern, dependency
+  weight, async shim fragility, pg_tide precedent).
+
+- [ ] **SINK-007**: Update documentation:
+  - Add a deprecation / migration notice to `CHANGELOG.md` for v0.76.1.
+  - Update `docs/SQL_REFERENCE.md`: remove the `ducklake_sink_mode`, `ducklake_sink_path`,
+    `ducklake_sink_table_id`, `ducklake_compaction_policy` parameter documentation from the
+    `create_stream_table()` / `alter_stream_table()` sections.
+  - Update `docs/foreign-table-sources.md`: remove the sink-specific DuckLake examples; keep
+    the source-side examples (reading from DuckLake via `DUCKLAKE_CHANGE_FEED`).
+  - Add a one-paragraph pointer to `trickle-labs/pg-tide` for users who need DuckLake egress.
+
+### Breaking Changes
+
+This is a **breaking schema change**. The upgrade SQL migration in SINK-003 drops columns and
+tables that may hold user data. Operators who rely on `ducklake_sink_mode` must migrate to
+pg_tide before upgrading to v0.76.1.
+
+### Notes
+
+- `ducklake_compaction_policy` was introduced in v0.65.0 for the source-side change-feed path
+  (to handle DuckLake snapshot expiry). It was later overloaded for the sink. After the sink is
+  removed, there is no remaining use case for this column; it is dropped.
+- The `DUCKLAKE_CHANGE_FEED` `cdc_mode` enum variant in `pgt_stream_tables` is **kept**. Only
+  sink-specific columns are dropped.
+- Binary size reduction is expected to be significant (~2–4 MB stripped) due to removal of the
+  Arrow IPC and Parquet codec crates.
+- Compile-time reduction on a clean build is expected to be 20–40 s due to removal of the
+  arrow/parquet dependency tree.


### PR DESCRIPTION
## Summary

Adds **v0.76.1** to the roadmap and renames the v0.76.x arc from
"RockLake Compatibility" to "DuckLake Sink Removal & RockLake Compatibility".
Also creates the previously-missing `roadmap/v0.76.0.md` detail file.

No code changes in this PR — roadmap/planning only.

---

## Background

The DuckLake integration in pg_trickle grew in two directions that deserve
different homes:

**Source side** — `DUCKLAKE_CHANGE_FEED` CDC mode, `table_changes()` polling,
snapshot frontier, row-ID plumbing into the DVM engine. This is core IVM work
and stays in pg_trickle.

**Sink side** — `src/ducklake_sink.rs` (1,258 lines), Parquet serialisation
via `arrow-rs`, S3 object-store upload, DuckLake catalog transaction writer,
`pgt_ducklake_provenance`, `pgt_ducklake_sink_delivery`. This is a relay
concern — exactly what `pg_tide` (`trickle-labs/pg-tide`) was extracted to
own at v0.46.0.

Keeping the sink in pg_trickle carries ongoing costs that are orthogonal to
IVM performance:

- Five heavy Cargo deps (`arrow-array`, `arrow-schema`, `parquet`,
  `object_store`, `bytes`) + a `tokio rt` feature in the main library crate.
- An async-in-sync shim (`tokio::runtime::Builder::new_current_thread()` per
  call) that fights PostgreSQL's signal handling.
- Three catalog artifacts — four columns on `pgt_stream_tables` and two
  standalone tables — that exist purely for egress.

---

## Changes

| File | Change |
|------|--------|
| `ROADMAP.md` | Rename v0.76.x arc; expand intro with source/sink rationale; add v0.76.1 table row; update ASCII timeline |
| `roadmap/v0.76.0.md` | New — RockLake compatibility detail (CDC-001, CDC-002, Tier A/B/C tests, docs) |
| `roadmap/v0.76.1.md` | New — DuckLake sink removal detail (SINK-001 through SINK-007, breaking-change notes) |

---

## v0.76.1 scope (planned, not implemented here)

- **SINK-001** Delete `src/ducklake_sink.rs`; remove `pub mod ducklake_sink` from `lib.rs`; remove `run_ducklake_sink()` call from `refresh_ops.rs`.
- **SINK-002** Remove sink fields from `StreamTableMeta` in `catalog.rs`.
- **SINK-003** Upgrade SQL: drop `pgt_ducklake_sink_delivery`, `pgt_ducklake_provenance`; drop four sink columns from `pgt_stream_tables`.
- **SINK-004** Remove `arrow-array`, `arrow-schema`, `parquet`, `object_store`, `bytes`, tokio `rt` from `Cargo.toml`.
- **SINK-005** Remove sink-specific tests from `tests/ducklake_integration_tests.rs`.
- **SINK-006** Add `plans/adrs/ADR-006-ducklake-sink-boundary.md`.
- **SINK-007** Update `CHANGELOG.md`, `docs/SQL_REFERENCE.md`, `docs/foreign-table-sources.md` with deprecation notice and pg-tide pointer.

The `DUCKLAKE_CHANGE_FEED` `cdc_mode` enum variant is **kept**. Only the egress infrastructure is removed.

---

## Breaking changes (v0.76.1, not this PR)

v0.76.1 will be a breaking schema change: the upgrade SQL drops sink columns
and tables. Operators relying on `ducklake_sink_mode` must migrate to pg_tide
before upgrading.
