### PR TITLE
fix: remove pg_mooncake storage backend stub (never implemented)

### DIFF
--- a/dbt-pgtrickle/macros/adapters/create_or_replace_stream_table.sql
+++ b/dbt-pgtrickle/macros/adapters/create_or_replace_stream_table.sql
@@ -16,7 +16,7 @@
                              Only applied on creation; ignored if the stream table already exists.
     append_only (bool): Skip delete bookkeeping for insert-only sources (default false)
     temporal (bool): Enable temporal IVM mode (default false)
-    storage_backend (str|none): Columnar backend ('heap','citus','pg_mooncake','unlogged')
+    storage_backend (str|none): Columnar backend ('heap','citus','unlogged')
     diamond_consistency (str|none): Diamond dependency consistency ('STRICT','RELAXED')
     diamond_schedule_policy (str|none): Diamond scheduling policy ('ATOMIC','INDEPENDENT')
     pooler_compatibility_mode (bool): pgBouncer/Odyssey compatibility (default false)

--- a/dbt-pgtrickle/macros/adapters/create_stream_table.sql
+++ b/dbt-pgtrickle/macros/adapters/create_stream_table.sql
@@ -16,7 +16,7 @@
                              Cannot be changed after creation.
     append_only (bool): Skip delete bookkeeping for insert-only sources (default false)
     temporal (bool): Enable temporal IVM mode (default false)
-    storage_backend (str|none): Columnar backend ('heap','citus','pg_mooncake','unlogged')
+    storage_backend (str|none): Columnar backend ('heap','citus','unlogged')
     diamond_consistency (str|none): Diamond dependency consistency ('STRICT','RELAXED')
     diamond_schedule_policy (str|none): Diamond scheduling policy ('ATOMIC','INDEPENDENT')
     pooler_compatibility_mode (bool): pgBouncer/Odyssey compatibility (default false)

--- a/dbt-pgtrickle/macros/materializations/stream_table.sql
+++ b/dbt-pgtrickle/macros/materializations/stream_table.sql
@@ -24,7 +24,7 @@
     fuse_sensitivity: int|null — fuse consecutive-observation threshold
     append_only: bool (default false) — skip delete bookkeeping for insert-only sources
     temporal: bool (default false) — enable temporal IVM mode
-    storage_backend: 'heap'|'citus'|'pg_mooncake'|'unlogged'|null — columnar/storage backend
+    storage_backend: 'heap'|'citus'|'unlogged'|null — columnar/storage backend
     diamond_consistency: 'STRICT'|'RELAXED'|null — diamond dependency consistency policy
     diamond_schedule_policy: 'ATOMIC'|'INDEPENDENT'|null — diamond scheduling policy
     pooler_compatibility_mode: bool (default false) — pgBouncer/Odyssey compatibility

--- a/docs/STORAGE_BACKENDS.md
+++ b/docs/STORAGE_BACKENDS.md
@@ -2,9 +2,6 @@
 
 > **Status per backend** — Heap: **Stable** · Unlogged: **Stable** · columnar/Hydra: **Beta** · DuckDB: **Experimental** · TimescaleDB: **Beta** · pgvector: **Stable**
 
-pg_trickle supports multiple storage backends for stream table output. Each
-backend has different prerequisites, semantics, and performance characteristics.
-
 ---
 
 ## Available Backends
@@ -45,16 +42,6 @@ and fast analytical query performance for time-series and immutable data.
 - **Partitioning support:** Yes (range/list partitioning on columnar tables)
 - **Limitations:** No UPDATE/DELETE, no UNIQUE constraints, no FK constraints
 
-### pg_mooncake Columnstore (`pg_mooncake`)
-
-Columnstore tables via the `pg_mooncake` extension. Similar semantics to Citus
-columnar — append-only with high compression.
-
-- **Required extensions:** `pg_mooncake`
-- **Recommended for:** Analytical workloads requiring fast scans over large data
-- **Refresh mode support:** FULL only
-- **Partitioning support:** Limited (depends on pg_mooncake version)
-
 ---
 
 ## Choosing a Backend
@@ -65,11 +52,11 @@ Is data loss on crash acceptable and write speed critical?
   └─ No  → Continue ↓
 
 Is the output append-only (no deletes/updates in the stream)?
-  └─ Yes → Citus columnar or pg_mooncake (high compression, fast scans)
+  └─ Yes → Citus columnar (high compression, fast scans)
   └─ No  → Heap (default) — supports DIFFERENTIAL refresh
 
 Is high-speed analytical querying over large history the priority?
-  └─ Yes → Citus columnar or pg_mooncake
+  └─ Yes → Citus columnar
   └─ No  → Heap (simpler, fully supported)
 ```
 
@@ -97,7 +84,6 @@ the derived stream table output is rebuilt.
 | Unlogged     | Server crash                        | Table truncated on recovery; full rebuild needed |
 | Citus columnar | Citus extension not loaded        | Error at CREATE STREAM TABLE time              |
 | Citus columnar | Full disk                         | Transaction rollback; partial segments may remain |
-| pg_mooncake  | Extension not loaded                | Error at CREATE STREAM TABLE time              |
 
 For UNLOGGED stream tables, pg_trickle detects the truncation during the next
 refresh cycle and performs a full rebuild automatically.
@@ -108,7 +94,7 @@ refresh cycle and performs a full rebuild automatically.
 
 | GUC | Default | Description |
 |-----|---------|-------------|
-| `pg_trickle.columnar_backend` | `none` | Columnar backend: `none`, `citus`, `pg_mooncake` |
+| `pg_trickle.columnar_backend` | `none` | Columnar backend: `none` or `citus` |
 | `pg_trickle.change_buffer_durability` | `unlogged` | Durability of CDC change buffers: `logged` or `unlogged` |
 
 See [docs/CONFIGURATION.md](CONFIGURATION.md) for the full GUC reference.
@@ -120,7 +106,6 @@ See [docs/CONFIGURATION.md](CONFIGURATION.md) for the full GUC reference.
 | Backend      | Extension       | Minimum version | Install command           |
 |-------------|-----------------|-----------------|---------------------------|
 | Citus columnar | `citus`       | 11.0            | `CREATE EXTENSION citus;` |
-| pg_mooncake  | `pg_mooncake`   | 0.1             | `CREATE EXTENSION pg_mooncake;` |
 
 All extensions must be installed in the same database as pg_trickle before
 creating stream tables with that backend.

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -848,7 +848,7 @@ No breaking changes. All v0.34.0 functions continue to work.
 | Column | Type | Default | Purpose |
 |--------|------|---------|---------|
 | `temporal_mode` | `BOOLEAN NOT NULL` | `FALSE` | Enable temporal IVM (SCD Type 2) tracking |
-| `storage_backend` | `TEXT NOT NULL` | `'heap'` | Storage backend: `'heap'`, `'citus'`, or `'pg_mooncake'` |
+| `storage_backend` | `TEXT NOT NULL` | `'heap'` | Storage backend: `'heap'` or `'citus'` |
 | `column_lineage` | `JSONB` | `NULL` | Column-level lineage mapping output columns to source tables/columns |
 
 **New SQL functions:**
@@ -869,7 +869,7 @@ No breaking changes. All v0.34.0 functions continue to work.
 **Behavioral notes:**
 
 - **Temporal IVM (CORR-1):** Stream tables created with `temporal := true` maintain SCD Type 2 history. Each row carries `__pgt_valid_from TIMESTAMPTZ` and `__pgt_valid_to TIMESTAMPTZ`. Existing tables are unaffected.
-- **Alternative storage backends:** `storage_backend = 'citus'` creates the stream table storage as a Citus distributed table; `'pg_mooncake'` uses columnar storage. Both require the respective extensions to be installed.
+- **Alternative storage backends:** `storage_backend = 'citus'` creates the stream table storage as a Citus distributed table. Requires the Citus extension to be installed.
 - **Drain mode (A35):** `pgtrickle.drain()` is a safety mechanism for maintenance windows. The scheduler completes all in-flight refreshes, then stops dispatching new ones until the drain is cancelled or the server restarts.
 - **WAL slot backpressure (A12):** The `pg_trickle.enforce_backpressure` GUC is now wired — when slot lag exceeds `slot_lag_critical_threshold_mb`, CDC writes are suppressed. See `CONFIGURATION.md` for details and the **discard semantics** of `cdc_paused`.
 

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -169,7 +169,7 @@ from O(N) to O(1) (combined with the v0.62 fan-out optimisation).
 - **Temporal IVM**: `temporal := true` on `create_stream_table` adds
   `__pgt_valid_from` / `__pgt_valid_to` columns for SCD Type-2 patterns
 - **Columnar storage backends**: `storage_backend` parameter accepts
-  `'citus'` (Citus columnar) or `'pg_mooncake'`
+  `'citus'` (Citus columnar)
 - **Drain mode**: `pgtrickle.drain()` gracefully quiesces the scheduler
   before maintenance windows or `pg_upgrade`
 - **L0 process-local template cache**: eliminates the ~45 ms cold-start

--- a/sql/pg_trickle--0.75.0--0.76.0.sql
+++ b/sql/pg_trickle--0.75.0--0.76.0.sql
@@ -1,0 +1,18 @@
+-- pg_trickle 0.75.0 -> 0.76.0 upgrade migration
+-- v0.76.0: RockLake Compatibility Certification + pg_mooncake stub removal
+
+-- pg_mooncake removal (v0.76.0):
+-- The pg_mooncake storage backend was never fully implemented — the string was
+-- accepted and stored in pgt_stream_tables.storage_backend but no mooncake-
+-- specific DDL was ever generated.  Any rows with storage_backend = 'pg_mooncake'
+-- silently behaved as standard heap tables.
+--
+-- This migration normalises those rows to 'heap' (their actual behaviour) so
+-- the catalog accurately reflects the storage in use.
+--
+-- If pg_trickle.columnar_backend was set to 'pg_mooncake' in postgresql.conf,
+-- change it to 'none' (or 'citus' if Citus is available) before upgrading.
+
+UPDATE pgtrickle.pgt_stream_tables
+SET    storage_backend = 'heap'
+WHERE  storage_backend = 'pg_mooncake';

--- a/src/api/alter.rs
+++ b/src/api/alter.rs
@@ -1115,7 +1115,7 @@ pub(crate) struct CreateStreamTableOptions<'a> {
     /// CORR-1/UX-1 (v0.36.0): temporal IVM mode.
     pub(crate) temporal_mode: bool,
     /// CORR-2/UX-3 (v0.36.0): columnar storage backend
-    /// (`"heap"`, `"citus"`, `"pg_mooncake"`, or `"none"`).
+    /// (`"heap"`, `"citus"`, or `"none"`).
     pub(crate) storage_backend: Option<&'a str>,
     /// F-2 (v0.66.0): DuckLake sink output mode (`"ducklake"`, `"none"`, or `NULL`).
     pub(crate) ducklake_sink: Option<&'a str>,
@@ -1437,10 +1437,10 @@ pub(crate) fn create_stream_table_impl(
         Some(b) => {
             let b = b.to_lowercase();
             match b.as_str() {
-                "heap" | "citus" | "pg_mooncake" | "none" => b,
+                "heap" | "citus" | "none" => b,
                 other => {
                     return Err(PgTrickleError::InvalidArgument(format!(
-                        "invalid storage_backend '{}': expected 'heap', 'citus', 'pg_mooncake', or 'none'",
+                        "invalid storage_backend '{}': expected 'heap', 'citus', or 'none'",
                         other
                     )));
                 }
@@ -1452,7 +1452,6 @@ pub(crate) fn create_stream_table_impl(
             match pg_trickle_columnar_backend() {
                 ColumnarBackend::None => "heap".to_string(),
                 ColumnarBackend::Citus => "citus".to_string(),
-                ColumnarBackend::PgMooncake => "pg_mooncake".to_string(),
             }
         }
     };

--- a/src/catalog.rs
+++ b/src/catalog.rs
@@ -225,7 +225,6 @@ pub struct StreamTableMeta {
     /// CORR-2 (v0.36.0): Storage backend for the stream table output.
     /// 'heap' = standard PostgreSQL heap (default).
     /// 'citus' = Citus columnar extension.
-    /// 'pg_mooncake' = pg_mooncake columnar tables.
     pub storage_backend: String,
     /// VP-1 (v0.47.0): Action to run after a successful refresh commit.
     /// 'none' = no action (default), 'analyze' = run ANALYZE,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1360,7 +1360,6 @@ pub static PGS_ONLINE_SCHEMA_EVOLUTION: GucSetting<bool> = GucSetting::<bool>::n
 ///
 /// - `"none"` (default): Heap storage (standard PostgreSQL tables).
 /// - `"citus"`: Citus columnar via `CREATE TABLE … USING columnar`.
-/// - `"pg_mooncake"`: pg_mooncake columnar tables.
 ///
 /// When set, `create_stream_table()` uses the specified columnar backend and
 /// routes differential refresh to the `delete_insert` strategy (columnar
@@ -1482,8 +1481,6 @@ pub enum ColumnarBackend {
     None,
     /// Citus columnar extension.
     Citus,
-    /// pg_mooncake columnar tables.
-    PgMooncake,
 }
 
 impl ColumnarBackend {
@@ -1491,20 +1488,18 @@ impl ColumnarBackend {
         match self {
             ColumnarBackend::None => "none",
             ColumnarBackend::Citus => "citus",
-            ColumnarBackend::PgMooncake => "pg_mooncake",
         }
     }
 
     /// Returns `true` if this backend is append-only (requires `delete_insert` strategy).
     pub fn is_append_only(self) -> bool {
-        matches!(self, ColumnarBackend::Citus | ColumnarBackend::PgMooncake)
+        matches!(self, ColumnarBackend::Citus)
     }
 }
 
 pub fn normalize_columnar_backend(value: Option<String>) -> ColumnarBackend {
     match value.as_deref().map(str::to_ascii_lowercase).as_deref() {
         Some("citus") => ColumnarBackend::Citus,
-        Some("pg_mooncake") => ColumnarBackend::PgMooncake,
         _ => ColumnarBackend::None,
     }
 }
@@ -3068,10 +3063,9 @@ pub fn register_gucs() {
     // CORR-2 / UX-3: Columnar storage backend.
     GucRegistry::define_string_guc(
         c"pg_trickle.columnar_backend",
-        c"CORR-2: Columnar storage backend: none (default), citus, or pg_mooncake.",
+        c"CORR-2: Columnar storage backend: none (default) or citus.",
         c"'none' (default) uses standard heap tables. \
           'citus' uses Citus columnar (CREATE TABLE ... USING columnar). \
-          'pg_mooncake' uses pg_mooncake columnar tables. \
           Columnar backends use the delete_insert refresh strategy (append-only).",
         &PGS_COLUMNAR_BACKEND,
         GucContext::Suset,
@@ -4976,13 +4970,10 @@ mod tests {
             normalize_columnar_backend(Some("CITUS".to_string())),
             ColumnarBackend::Citus
         );
+        // Removed variants default to None
         assert_eq!(
             normalize_columnar_backend(Some("pg_mooncake".to_string())),
-            ColumnarBackend::PgMooncake
-        );
-        assert_eq!(
-            normalize_columnar_backend(Some("PG_MOONCAKE".to_string())),
-            ColumnarBackend::PgMooncake
+            ColumnarBackend::None
         );
     }
 
@@ -4990,14 +4981,12 @@ mod tests {
     fn test_columnar_backend_is_append_only() {
         assert!(!ColumnarBackend::None.is_append_only());
         assert!(ColumnarBackend::Citus.is_append_only());
-        assert!(ColumnarBackend::PgMooncake.is_append_only());
     }
 
     #[test]
     fn test_columnar_backend_as_str() {
         assert_eq!(ColumnarBackend::None.as_str(), "none");
         assert_eq!(ColumnarBackend::Citus.as_str(), "citus");
-        assert_eq!(ColumnarBackend::PgMooncake.as_str(), "pg_mooncake");
     }
 
     // ── DucklakeCompactionPolicy tests (v0.65.0) ─────────────────────────


### PR DESCRIPTION
## Summary

Removes the `pg_mooncake` storage backend completely — from source code, docs,
dbt macros, and adds an upgrade SQL migration.

**pg_mooncake was never implemented.** The string `'pg_mooncake'` was accepted as
a valid `storage_backend` value and stored in `pgt_stream_tables`, but
`build_create_table_sql()` never received `storage_backend` as a parameter and
emitted no mooncake-specific DDL. Any user who set `storage_backend = 'pg_mooncake'`
silently got a standard heap table. The pg_mooncake project is now abandoned.

Passes `just fmt && just lint` with zero warnings.

---

## Changes

### Source code

| File | Change |
|------|--------|
| `src/config.rs` | Remove `ColumnarBackend::PgMooncake` variant; update `as_str()`, `is_append_only()`, `normalize_columnar_backend()`; update GUC description strings; remove three unit tests |
| `src/api/alter.rs` | Remove `"pg_mooncake"` from the valid `storage_backend` match arm and error message; remove `PgMooncake` arm from the GUC-based fallback |
| `src/catalog.rs` | Remove pg_mooncake doc comment from `storage_backend` field |

### Docs

| File | Change |
|------|--------|
| `docs/STORAGE_BACKENDS.md` | Remove `### pg_mooncake Columnstore` section; update decision tree, failure-mode table, config table, extension dependency table |
| `docs/UPGRADING.md` | Update v0.36.0 `storage_backend` column description |
| `docs/WHATS_NEW.md` | Update v0.36 columnar backends entry |

### dbt macros

| File | Change |
|------|--------|
| `macros/adapters/create_stream_table.sql` | Remove `pg_mooncake` from `storage_backend` docstring |
| `macros/adapters/create_or_replace_stream_table.sql` | Same |
| `macros/materializations/stream_table.sql` | Same |

### Upgrade SQL

`sql/pg_trickle--0.75.0--0.76.0.sql` — normalises any existing
`storage_backend = 'pg_mooncake'` rows to `'heap'` (their actual runtime
behaviour). No schema changes.

---

## Migration note

If `pg_trickle.columnar_backend = 'pg_mooncake'` is set in `postgresql.conf`,
change it to `'none'` (or `'citus'` if Citus is available) before upgrading to
v0.76.0. The GUC will now log a warning and fall back to `'none'` if an unknown
value is supplied.
