### PR TITLE
fix(upgrade-e2e): replace ducklake_sink_status C stub with SQL stub in archive SQL and upgrade script

### DIFF
--- a/sql/archive/pg_trickle--0.69.0.sql
+++ b/sql/archive/pg_trickle--0.69.0.sql
@@ -2469,9 +2469,8 @@ CREATE  FUNCTION pgtrickle."ducklake_sink_status"() RETURNS TABLE (
 	"failed_attempts" bigint,  /* i64 */
 	"last_error" TEXT  /* Option < String > */
 )
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ducklake_sink_status_wrapper';
+LANGUAGE sql
+AS $$ SELECT NULL::text, NULL::text, NULL::timestamptz, NULL::bigint, NULL::bigint, NULL::bigint, NULL::text WHERE false $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.70.0.sql
+++ b/sql/archive/pg_trickle--0.70.0.sql
@@ -2469,9 +2469,8 @@ CREATE  FUNCTION pgtrickle."ducklake_sink_status"() RETURNS TABLE (
 	"failed_attempts" bigint,  /* i64 */
 	"last_error" TEXT  /* Option < String > */
 )
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ducklake_sink_status_wrapper';
+LANGUAGE sql
+AS $$ SELECT NULL::text, NULL::text, NULL::timestamptz, NULL::bigint, NULL::bigint, NULL::bigint, NULL::text WHERE false $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.71.0.sql
+++ b/sql/archive/pg_trickle--0.71.0.sql
@@ -2469,9 +2469,8 @@ CREATE  FUNCTION pgtrickle."ducklake_sink_status"() RETURNS TABLE (
 	"failed_attempts" bigint,  /* i64 */
 	"last_error" TEXT  /* Option < String > */
 )
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ducklake_sink_status_wrapper';
+LANGUAGE sql
+AS $$ SELECT NULL::text, NULL::text, NULL::timestamptz, NULL::bigint, NULL::bigint, NULL::bigint, NULL::text WHERE false $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.72.0.sql
+++ b/sql/archive/pg_trickle--0.72.0.sql
@@ -1011,9 +1011,8 @@ CREATE  FUNCTION pgtrickle."ducklake_sink_status"() RETURNS TABLE (
 	"failed_attempts" bigint,  /* i64 */
 	"last_error" TEXT  /* Option < String > */
 )
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ducklake_sink_status_wrapper';
+LANGUAGE sql
+AS $$ SELECT NULL::text, NULL::text, NULL::timestamptz, NULL::bigint, NULL::bigint, NULL::bigint, NULL::text WHERE false $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.73.0.sql
+++ b/sql/archive/pg_trickle--0.73.0.sql
@@ -1035,9 +1035,8 @@ CREATE  FUNCTION pgtrickle."ducklake_sink_status"() RETURNS TABLE (
 	"failed_attempts" bigint,  /* i64 */
 	"last_error" TEXT  /* Option < String > */
 )
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ducklake_sink_status_wrapper';
+LANGUAGE sql
+AS $$ SELECT NULL::text, NULL::text, NULL::timestamptz, NULL::bigint, NULL::bigint, NULL::bigint, NULL::text WHERE false $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.74.0.sql
+++ b/sql/archive/pg_trickle--0.74.0.sql
@@ -1032,9 +1032,8 @@ CREATE  FUNCTION pgtrickle."ducklake_sink_status"() RETURNS TABLE (
 	"failed_attempts" bigint,  /* i64 */
 	"last_error" TEXT  /* Option < String > */
 )
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ducklake_sink_status_wrapper';
+LANGUAGE sql
+AS $$ SELECT NULL::text, NULL::text, NULL::timestamptz, NULL::bigint, NULL::bigint, NULL::bigint, NULL::text WHERE false $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/archive/pg_trickle--0.75.0.sql
+++ b/sql/archive/pg_trickle--0.75.0.sql
@@ -1032,9 +1032,8 @@ CREATE  FUNCTION pgtrickle."ducklake_sink_status"() RETURNS TABLE (
 	"failed_attempts" bigint,  /* i64 */
 	"last_error" TEXT  /* Option < String > */
 )
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ducklake_sink_status_wrapper';
+LANGUAGE sql
+AS $$ SELECT NULL::text, NULL::text, NULL::timestamptz, NULL::bigint, NULL::bigint, NULL::bigint, NULL::text WHERE false $$;
 /* </end connected objects> */
 
 /* <begin connected objects> */

--- a/sql/pg_trickle--0.68.0--0.69.0.sql
+++ b/sql/pg_trickle--0.68.0--0.69.0.sql
@@ -76,6 +76,5 @@ RETURNS TABLE (
     "failed_attempts"      bigint,
     "last_error"           TEXT
 )
-STRICT
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ducklake_sink_status_wrapper';
+LANGUAGE sql
+AS $$ SELECT NULL::text, NULL::text, NULL::timestamptz, NULL::bigint, NULL::bigint, NULL::bigint, NULL::text WHERE false $$;

--- a/sql/pg_trickle--0.75.0--0.76.0.sql
+++ b/sql/pg_trickle--0.75.0--0.76.0.sql
@@ -55,6 +55,11 @@ ALTER TABLE pgtrickle.pgt_dependencies
 DROP TABLE IF EXISTS pgtrickle.pgt_ducklake_sink_delivery;
 DROP TABLE IF EXISTS pgtrickle.pgt_ducklake_provenance;
 
+-- Remove the ducklake_sink_status() monitoring function (added in v0.69.0).
+-- The C symbol (ducklake_sink_status_wrapper) was removed from the binary in
+-- v0.76.0, so the function would fail if called. Drop it explicitly.
+DROP FUNCTION IF EXISTS pgtrickle.ducklake_sink_status();
+
 -- Migrate any DUCKLAKE_CHANGE_FEED rows back to TRIGGER (safe fallback).
 UPDATE pgtrickle.pgt_dependencies
 SET    cdc_mode = 'TRIGGER'


### PR DESCRIPTION
## Summary

Fixes all 8 failing Upgrade E2E jobs in CI run
[#26559155467](https://github.com/trickle-labs/pg-trickle/actions/runs/26559155467).

The DuckLake integration was removed in v0.76.0 (PR #868), which deleted
`ducklake_sink_status_wrapper` from the compiled binary. However, the archived
SQL snapshots for versions 0.69.0–0.75.0 still contain a `CREATE FUNCTION`
that declares `LANGUAGE c AS 'MODULE_PATHNAME', 'ducklake_sink_status_wrapper'`.
The `0.68.0→0.69.0` upgrade script has the same reference.

When the upgrade E2E tests run `CREATE EXTENSION pg_trickle VERSION '0.X.0'`
(for any X in 0.68–0.75) or `ALTER EXTENSION pg_trickle UPDATE TO '0.69.0'`,
PostgreSQL resolves `MODULE_PATHNAME` to the currently installed `.so` (v0.76.0)
and fails immediately:

```
could not find function "ducklake_sink_status_wrapper" in file
"/usr/lib/postgresql/18/lib/pg_trickle.so"
SQL: CREATE EXTENSION pg_trickle VERSION '0.75.0' CASCADE
```

## Root Cause

PR #868 removed the Rust implementation of `ducklake_sink_status_wrapper` but
did not:

1. Patch the archived full-install SQL files (0.69.0–0.75.0) that register the
   function as a C function.
2. Patch the `0.68.0→0.69.0` upgrade script that introduces the function.
3. Add a `DROP FUNCTION` to the `0.75.0→0.76.0` migration to clean up the
   function when upgrading from a version that has it.

PostgreSQL extensions use a single `.so` for all versions. Old SQL scripts run
against the current binary — so any C symbol referenced by historical SQL must
still be exported by the binary, or the historical SQL must be rewritten to not
require it.

## Fix

- **7 archive SQL files** (`sql/archive/pg_trickle--0.69.0.sql` through
  `0.75.0.sql`): replaced `LANGUAGE c AS 'MODULE_PATHNAME', ...` with a
  `LANGUAGE sql` stub that returns an empty set — no binary symbol required.
- **`sql/pg_trickle--0.68.0--0.69.0.sql`**: same replacement so `ALTER
  EXTENSION UPDATE TO '0.69.0'` no longer references the removed symbol.
- **`sql/pg_trickle--0.75.0--0.76.0.sql`**: added
  `DROP FUNCTION IF EXISTS pgtrickle.ducklake_sink_status()` so users upgrading
  from a real 0.75.0 installation have the stale C function cleanly removed.

## Testing

- `just lint` — passes (0 warnings)
- `just test-unit` — 2307 tests, all pass
- `just check-upgrade 0.68.0 0.69.0` — PASSED (1 new function, covered)
- `just check-upgrade 0.75.0 0.76.0` — PASSED (0 new functions)
- `test_upgrade_chain_function_parity_with_fresh_install` invariant holds:
  - 0.68.0 → 0.69.0: upgrade adds the SQL stub; fresh 0.69.0 install has same
    stub — counts match.
  - 0.75.0 → 0.76.0: migration drops the function; fresh 0.76.0 install has
    no such function — counts match.

## Affected Files

| File | Change |
|------|--------|
| `sql/archive/pg_trickle--0.69.0.sql` … `0.75.0.sql` (7 files) | `LANGUAGE c` → `LANGUAGE sql` stub |
| `sql/pg_trickle--0.68.0--0.69.0.sql` | Same replacement in upgrade script |
| `sql/pg_trickle--0.75.0--0.76.0.sql` | Added `DROP FUNCTION IF EXISTS` |
