### PR TITLE
fix(ci): split sequential E2E tests into own job, raise main timeout to 120 min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,7 +304,7 @@ jobs:
     name: E2E tests
     runs-on: ubuntu-latest
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    timeout-minutes: 90
+    timeout-minutes: 120
     steps:
       - name: Free up disk space
         run: |
@@ -374,11 +374,93 @@ jobs:
         run: |
           cargo nextest run --profile ci --test e2e_tpch_tests --run-ignored all
 
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v6
+        if: always()
+        with:
+          report_paths: 'target/nextest/ci/junit.xml'
+          commit: ${{github.event.pull_request.head.sha}}
+
+  # ── E2E sequential tests (PGT_PARALLEL_MODE=off) ────────────────────────
+  # Runs the refresh/scheduler/concurrent subset with parallelism disabled.
+  # Split into its own job so the main E2E suite reports results quickly
+  # and this gate gets a fresh timeout budget.
+  e2e-sequential-tests:
+    name: E2E tests (sequential mode)
+    runs-on: ubuntu-latest
+    needs: [e2e-tests]
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    timeout-minutes: 45
+    steps:
+      - name: Free up disk space
+        run: |
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf "/usr/local/share/boost"
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+          docker system prune -af
+          df -h
+
+      - uses: actions/checkout@v5
+
+      - name: Setup pgrx environment
+        uses: ./.github/actions/setup-pgrx
+
+      - name: Restore Docker image cache (postgres:18.3)
+        uses: actions/cache@v5
+        id: cache-docker-postgres-e2e-seq
+        with:
+          path: /tmp/docker-images/postgres-18.3.tar
+          key: docker-postgres-18.3
+
+      - name: Load or pull postgres:18.3
+        run: |
+          if [ -f /tmp/docker-images/postgres-18.3.tar ]; then
+            docker load --input /tmp/docker-images/postgres-18.3.tar
+          else
+            docker pull postgres:18.3
+            mkdir -p /tmp/docker-images
+            docker save postgres:18.3 --output /tmp/docker-images/postgres-18.3.tar
+          fi
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        continue-on-error: true  # GHCR login is optional (cache pull only); transient timeouts must not fail the job
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull builder image from GHCR
+        run: |
+          if docker pull ghcr.io/trickle-labs/pg-trickle/builder:pg18 2>/dev/null; then
+            docker tag ghcr.io/trickle-labs/pg-trickle/builder:pg18 pg_trickle_builder:pg18
+            echo "Builder image pulled from GHCR — skipping local build"
+          else
+            echo "::warning::Builder image not in GHCR (first run?). Will build locally."
+          fi
+
+      - name: Build E2E Docker image
+        run: ./tests/build_e2e_image.sh
+
       - name: Run E2E tests with sequential refresh mode
         env:
           PGT_PARALLEL_MODE: "off"
         run: |
-          cargo nextest run --profile ci --test 'e2e_*'
+          # Only run tests sensitive to parallel vs sequential scheduling.
+          # Running all 125 e2e_* files in sequential mode takes ~90 min;
+          # this targeted subset covers the refresh/scheduler/concurrent paths.
+          cargo nextest run --profile ci \
+            --test e2e_refresh_tests \
+            --test e2e_scheduler_tests \
+            --test e2e_tier_scheduler_tests \
+            --test e2e_bgworker_tests \
+            --test e2e_concurrent_tests \
+            --test e2e_dag_autorefresh_tests \
+            --test e2e_dag_concurrent_tests
+
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@v6
         if: always()


### PR DESCRIPTION
# fix(ci): split sequential E2E tests into own job, raise main timeout to 120 min

## Problem

The `E2E tests` job was hitting its 90-minute `timeout-minutes` limit and being
cancelled mid-run (see
[run 26575180541](https://github.com/trickle-labs/pg-trickle/actions/runs/26575180541)).
The culprit was the final step **"Run E2E tests with sequential refresh mode"**,
which re-ran all 125 `e2e_*` test files with `PGT_PARALLEL_MODE=off` — sharing
the same 90-minute budget as the main suite, TPC-H correctness, and the Phase 9
gate.

## Solution — three changes in one commit

### 1. Raise `e2e-tests` timeout 90 → 120 min
The main suite + TPC-H correctness + Phase 9 gate together comfortably fit in
~75–80 minutes. Raising the limit to 120 min provides safe headroom without
risking runaway jobs.

### 2. Split sequential tests into a new `e2e-sequential-tests` job
The sequential re-run is moved to a new job (`needs: e2e-tests`) that starts
only after the main suite passes and runs with its own **45-minute** timeout.
Benefits:
- Main suite reports results immediately without waiting for sequential mode.
- A sequential-mode failure is clearly labelled, not buried in a timeout.
- Each gate gets independent budget and can be retried separately.

### 3. Narrow the sequential scope from 125 → 7 test files
Running all 125 `e2e_*` files in sequential mode is redundant — most tests are
insensitive to `PGT_PARALLEL_MODE`. The new job runs only the files that
exercise refresh scheduling, concurrency, or background-worker behaviour:

| File | Rationale |
|------|-----------|
| `e2e_refresh_tests` | Core refresh logic, mode-sensitive |
| `e2e_scheduler_tests` | Scheduler depends on worker concurrency |
| `e2e_tier_scheduler_tests` | Tier scheduling, sequential fallback paths |
| `e2e_bgworker_tests` | Background worker startup/shutdown |
| `e2e_concurrent_tests` | Concurrent DDL/DML interactions |
| `e2e_dag_autorefresh_tests` | DAG auto-refresh scheduling |
| `e2e_dag_concurrent_tests` | DAG concurrent refresh ordering |

## Timeline impact

| Before | After |
|--------|-------|
| Single job, 90-min cap → times out | Two jobs, 120 min + 45 min |
| Sequential step blocks all results | Main suite finishes first |
| All 125 files re-tested sequentially | 7 relevant files only |
