### PR TITLE
fix(ci): backfill storage_fillfactor for 0.75.0→0.76.0 upgrade

### DIFF
--- a/sql/pg_trickle--0.75.0--0.76.0.sql
+++ b/sql/pg_trickle--0.75.0--0.76.0.sql
@@ -17,6 +17,15 @@ UPDATE pgtrickle.pgt_stream_tables
 SET    storage_backend = 'heap'
 WHERE  storage_backend = 'pg_mooncake';
 
+-- HOT-1 compatibility backfill:
+-- The archived 0.75.0 install SQL predates storage_fillfactor. Ensure direct
+-- 0.75.0 -> 0.76.0 upgrades add the column so catalog reads/writes succeed.
+ALTER TABLE pgtrickle.pgt_stream_tables
+    ADD COLUMN IF NOT EXISTS storage_fillfactor INT
+        CONSTRAINT pgt_storage_fillfactor_range
+        CHECK (storage_fillfactor IS NULL OR
+               (storage_fillfactor >= 10 AND storage_fillfactor <= 100));
+
 -- ── DuckLake integration removal ──────────────────────────────────────────
 -- All DuckLake sink and change-feed source integration has been removed in
 -- v0.76.0. The pg_ducklake extension uses a native table AM (not FDW), making


### PR DESCRIPTION
## Summary
- fix Upgrade E2E regression for `0.75.0 -> 0.76.0` where `create_stream_table()` failed after upgrade with `column "storage_fillfactor" does not exist`
- add an idempotent backfill in [sql/pg_trickle--0.75.0--0.76.0.sql](sql/pg_trickle--0.75.0--0.76.0.sql):
  - `ALTER TABLE pgtrickle.pgt_stream_tables ADD COLUMN IF NOT EXISTS storage_fillfactor INT`
  - same range constraint used by HOT-1 (`10..100`)

## Root Cause
The archived install script [sql/archive/pg_trickle--0.75.0.sql](sql/archive/pg_trickle--0.75.0.sql) predates HOT-1 and does not contain `storage_fillfactor`.
Upgrade tests that start at `CREATE EXTENSION ... VERSION '0.75.0'` therefore produce a catalog without this column, and the `0.75.0 -> 0.76.0` migration previously did not add it.

## Validation
- `just fmt`
- `just lint`
- targeted Upgrade E2E repro/fix check:
  - `./tests/build_e2e_image.sh`
  - `./tests/build_e2e_upgrade_image.sh 0.75.0 0.76.0`
  - `PGS_E2E_IMAGE=pg_trickle_upgrade_e2e:latest PGS_UPGRADE_FROM=0.75.0 PGS_UPGRADE_TO=0.76.0 cargo nextest run --profile ci --test e2e_upgrade_tests --run-ignored all -E 'test(test_upgrade_chain_stream_tables_survive)'`
  - result: **PASS**

## CI Failure Reference
- https://github.com/trickle-labs/pg-trickle/actions/runs/26592840518
