### PR TITLE
fix(api): manual refresh QueryTooComplex FULL fallback (fixes sustained churn q12)

### DIFF
--- a/src/api/refresh_ops.rs
+++ b/src/api/refresh_ops.rs
@@ -682,9 +682,35 @@ fn execute_manual_differential_refresh(
     let data_ts = get_data_timestamp_str();
     let new_frontier = version::compute_new_frontier(&slot_positions, &data_ts);
 
-    // Execute the differential refresh via the DVM engine
+    // Execute the differential refresh via the DVM engine.
+    // DI-7: When QueryTooComplex is returned (e.g. join count exceeds
+    // max_differential_joins, or CASE_IN_LIST_DVM_DRIFT_FULL_FALLBACK), fall
+    // back to FULL refresh immediately — mirrors the scheduler path in
+    // scheduler_loop.rs so manual refresh behaves consistently.
     let (rows_inserted, rows_deleted) =
-        refresh::execute_differential_refresh(st, &prev_frontier, &new_frontier)?;
+        match refresh::execute_differential_refresh(st, &prev_frontier, &new_frontier) {
+            Ok(counts) => counts,
+            Err(crate::error::PgTrickleError::QueryTooComplex(ref msg)) => {
+                pgrx::log!(
+                    "[pg_trickle] DI-7 manual fallback for {}.{}: {}; using FULL refresh",
+                    schema,
+                    table_name,
+                    msg
+                );
+                let (ins, del) = refresh::execute_full_refresh(st)?;
+                StreamTableMeta::store_frontier(st.pgt_id, &new_frontier)?;
+                refresh::post_full_refresh_cleanup(st);
+                pgrx::info!(
+                    "Stream table {}.{} refreshed (FULL fallback: +{} -{})",
+                    schema,
+                    table_name,
+                    ins,
+                    del,
+                );
+                return Ok((ins, del));
+            }
+            Err(e) => return Err(e),
+        };
 
     // Store the new frontier and mark refresh complete in a single SPI call (S3).
     // Matches scheduler behavior: only update data_timestamp when rows were


### PR DESCRIPTION
## Problem

`test_tpch_sustained_churn` on `main` fails with invariant violations on `churn_q12`.

The sustained churn test includes q12 and expects it to produce correct results:
the v0.77.0 `CASE_IN_LIST_DVM_DRIFT_FULL_FALLBACK` was meant to transparently fall
back to FULL refresh whenever q12 is refreshed in DIFFERENTIAL mode. But the manual
refresh path (`pgtrickle.refresh_stream_table()`) propagated `QueryTooComplex` as a
PostgreSQL ERROR instead of silently falling back, leaving the stream table stale and
triggering drift after every cycle.

## Root Cause

`execute_manual_differential_refresh` called `refresh::execute_differential_refresh`
with the `?` operator, propagating any error — including `QueryTooComplex` — to the
caller. The background scheduler loop already had a DI-7 fallback that catches
`QueryTooComplex` and calls `execute_full_refresh` instead, but the manual API path
did not.

## Fix

Added a `match` on the return value of `execute_differential_refresh` in
`src/api/refresh_ops.rs`. When `QueryTooComplex` is returned the manual path now
mirrors the scheduler: calls `execute_full_refresh`, stores the frontier, runs
`post_full_refresh_cleanup`, and returns the counts — exactly as the scheduler's
DI-7 fallback does.

## Testing

- 2319 unit tests pass (`just test-unit`)
- Lint and format clean (`just fmt && just lint`)

Fixes: `test_tpch_sustained_churn` INVARIANT VIOLATION on `churn_q12`
CI run: https://github.com/trickle-labs/pg-trickle/actions/runs/26629515652
