### PR TITLE
fix(upgrade-e2e): regenerate 0.76.0 and 0.77.0 archive SQL to fix CI failures

### DIFF
--- a/sql/archive/pg_trickle--0.76.0.sql
+++ b/sql/archive/pg_trickle--0.76.0.sql
@@ -7,7 +7,7 @@ The ordering of items is not stable, it is driven by a dependency graph.
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:219
+-- src/lib.rs:218
 -- bootstrap
 
 -- Extension schemas
@@ -100,6 +100,8 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_stream_tables (
     column_lineage  JSONB,
     -- v0.59.0 PERF-2: hash of defining_query to skip recomputation on every refresh
     defining_query_hash BIGINT NOT NULL DEFAULT 0,
+    -- v0.73.0 HOT-1: fillfactor for storage heap (NULL = PG default 100). Range 10-100.
+    storage_fillfactor INT DEFAULT NULL CHECK (storage_fillfactor IS NULL OR (storage_fillfactor >= 10 AND storage_fillfactor <= 100)),
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -331,7 +333,81 @@ CREATE UNLOGGED TABLE IF NOT EXISTS pgtrickle.pgt_template_cache (
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:820
+-- src/lib.rs:1050
+
+-- VH-2 (v0.48.0): Distance-predicate subscription catalog.
+-- Stores per-(stream_table, channel) vector distance subscriptions.
+-- After each non-empty refresh the background worker evaluates the predicate
+-- and emits pg_notify(channel, payload) when matched_rows > 0.
+CREATE TABLE IF NOT EXISTS pgtrickle.pgt_distance_subscriptions (
+    stream_table    TEXT NOT NULL,
+    channel         TEXT NOT NULL,
+    vector_column   TEXT NOT NULL,
+    query_vector    TEXT NOT NULL,
+    op              TEXT NOT NULL
+        CHECK (op IN ('<->', '<=>', '<#>', '<+>', '<<->>', '<<%>>')),
+    threshold       DOUBLE PRECISION NOT NULL CHECK (threshold > 0),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (stream_table, channel)
+);
+
+COMMENT ON TABLE pgtrickle.pgt_distance_subscriptions IS
+    'VH-2 (v0.48.0): Distance-predicate NOTIFY subscriptions per stream table. '
+    'Populated via pgtrickle.subscribe_distance() / pgtrickle.unsubscribe_distance().';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:1024
+
+-- v0.46.0: Slim outbox attachment catalog.
+-- Maps stream tables to their pg_tide outbox names.
+-- The full outbox/inbox/relay stack lives in pg_tide (trickle-labs/pg-tide).
+CREATE TABLE IF NOT EXISTS pgtrickle.pgt_outbox_config (
+    stream_table_oid         OID         NOT NULL PRIMARY KEY,
+    stream_table_name        TEXT        NOT NULL,
+    tide_outbox_name         TEXT        NOT NULL,
+    -- VA-4 (v0.48.0): optional vector column name for embedding outbox events.
+    embedding_vector_column  TEXT,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pgt_outbox_config_name
+    ON pgtrickle.pgt_outbox_config (stream_table_name);
+
+COMMENT ON TABLE pgtrickle.pgt_outbox_config IS
+    'v0.46.0: Catalog of stream tables with a pg_tide outbox attached via attach_outbox(). '
+    'v0.48.0: embedding_vector_column set when attached via attach_embedding_outbox().';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:604
+
+-- Create event trigger functions with correct RETURNS event_trigger type.
+-- pgrx's #[pg_extern] generates RETURNS void, which PostgreSQL rejects for
+-- event triggers. We create them manually here with the correct return type.
+CREATE FUNCTION pgtrickle."_on_ddl_end"()
+    RETURNS event_trigger
+    LANGUAGE c
+    AS 'MODULE_PATHNAME', 'pg_trickle_on_ddl_end_wrapper';
+
+CREATE FUNCTION pgtrickle."_on_sql_drop"()
+    RETURNS event_trigger
+    LANGUAGE c
+    AS 'MODULE_PATHNAME', 'pg_trickle_on_sql_drop_wrapper';
+
+-- Event trigger: track ALTER TABLE on upstream sources
+CREATE EVENT TRIGGER pg_trickle_ddl_tracker
+    ON ddl_command_end
+    EXECUTE FUNCTION pgtrickle._on_ddl_end();
+
+-- Event trigger: track DROP TABLE on upstream sources / ST storage tables
+CREATE EVENT TRIGGER pg_trickle_drop_tracker
+    ON sql_drop
+    EXECUTE FUNCTION pgtrickle._on_sql_drop();
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:761
 
 CREATE OR REPLACE FUNCTION pgtrickle."pause_all"()
 RETURNS void
@@ -366,58 +442,7 @@ COMMENT ON FUNCTION pgtrickle."resume_all"() IS
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:663
-
--- Create event trigger functions with correct RETURNS event_trigger type.
--- pgrx's #[pg_extern] generates RETURNS void, which PostgreSQL rejects for
--- event triggers. We create them manually here with the correct return type.
-CREATE FUNCTION pgtrickle."_on_ddl_end"()
-    RETURNS event_trigger
-    LANGUAGE c
-    AS 'MODULE_PATHNAME', 'pg_trickle_on_ddl_end_wrapper';
-
-CREATE FUNCTION pgtrickle."_on_sql_drop"()
-    RETURNS event_trigger
-    LANGUAGE c
-    AS 'MODULE_PATHNAME', 'pg_trickle_on_sql_drop_wrapper';
-
--- Event trigger: track ALTER TABLE on upstream sources
-CREATE EVENT TRIGGER pg_trickle_ddl_tracker
-    ON ddl_command_end
-    EXECUTE FUNCTION pgtrickle._on_ddl_end();
-
--- Event trigger: track DROP TABLE on upstream sources / ST storage tables
-CREATE EVENT TRIGGER pg_trickle_drop_tracker
-    ON sql_drop
-    EXECUTE FUNCTION pgtrickle._on_sql_drop();
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:1109
-
--- VH-2 (v0.48.0): Distance-predicate subscription catalog.
--- Stores per-(stream_table, channel) vector distance subscriptions.
--- After each non-empty refresh the background worker evaluates the predicate
--- and emits pg_notify(channel, payload) when matched_rows > 0.
-CREATE TABLE IF NOT EXISTS pgtrickle.pgt_distance_subscriptions (
-    stream_table    TEXT NOT NULL,
-    channel         TEXT NOT NULL,
-    vector_column   TEXT NOT NULL,
-    query_vector    TEXT NOT NULL,
-    op              TEXT NOT NULL
-        CHECK (op IN ('<->', '<=>', '<#>', '<+>', '<<->>', '<<%>>')),
-    threshold       DOUBLE PRECISION NOT NULL CHECK (threshold > 0),
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    PRIMARY KEY (stream_table, channel)
-);
-
-COMMENT ON TABLE pgtrickle.pgt_distance_subscriptions IS
-    'VH-2 (v0.48.0): Distance-predicate NOTIFY subscriptions per stream table. '
-    'Populated via pgtrickle.subscribe_distance() / pgtrickle.unsubscribe_distance().';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:630
+-- src/lib.rs:571
 -- requires:
 --   pg_trickle_catalog
 
@@ -449,270 +474,213 @@ WHERE ct.source_placement = 'distributed';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:1083
-
--- v0.46.0: Slim outbox attachment catalog.
--- Maps stream tables to their pg_tide outbox names.
--- The full outbox/inbox/relay stack lives in pg_tide (trickle-labs/pg-tide).
-CREATE TABLE IF NOT EXISTS pgtrickle.pgt_outbox_config (
-    stream_table_oid         OID         NOT NULL PRIMARY KEY,
-    stream_table_name        TEXT        NOT NULL,
-    tide_outbox_name         TEXT        NOT NULL,
-    -- VA-4 (v0.48.0): optional vector column name for embedding outbox events.
-    embedding_vector_column  TEXT,
-    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS idx_pgt_outbox_config_name
-    ON pgtrickle.pgt_outbox_config (stream_table_name);
-
-COMMENT ON TABLE pgtrickle.pgt_outbox_config IS
-    'v0.46.0: Catalog of stream tables with a pg_tide outbox attached via attach_outbox(). '
-    'v0.48.0: embedding_vector_column set when attached via attach_embedding_outbox().';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:56
+-- src/lib.rs:55
 CREATE SCHEMA IF NOT EXISTS pgtrickle; /* pg_trickle::pgtrickle */
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor/mod.rs:2190
--- pg_trickle::monitor::history_prune_status
-CREATE  FUNCTION pgtrickle."history_prune_status"() RETURNS TABLE (
-	"prune_error_count" bigint,  /* i64 */
-	"last_prune_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"last_rows_deleted" bigint  /* Option < i64 > */
+-- src/api/alter.rs:2407
+-- pg_trickle::api::alter::repair_stream_table
+CREATE  FUNCTION pgtrickle."repair_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS TEXT /* String */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'repair_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:212
+-- pg_trickle::api::snapshot::snapshot_stream_table
+CREATE  FUNCTION pgtrickle."snapshot_stream_table"(
+	"p_name" TEXT, /* & str */
+	"p_target" TEXT DEFAULT NULL /* Option < & str > */
+) RETURNS TEXT /* String */
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'snapshot_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:545
+-- pg_trickle::api::diagnostics::shared_buffer_stats
+CREATE  FUNCTION pgtrickle."shared_buffer_stats"() RETURNS TABLE (
+	"source_oid" bigint,  /* i64 */
+	"source_table" TEXT,  /* String */
+	"consumer_count" INT,  /* i32 */
+	"consumers" TEXT,  /* String */
+	"columns_tracked" INT,  /* i32 */
+	"safe_frontier_lsn" TEXT,  /* Option < String > */
+	"buffer_rows" bigint,  /* i64 */
+	"is_partitioned" bool  /* bool */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'history_prune_status_wrapper';
+AS 'MODULE_PATHNAME', 'shared_buffer_stats_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:1892
--- pg_trickle::api::embedding_stream_table
-CREATE  FUNCTION pgtrickle."embedding_stream_table"(
-	"name" TEXT, /* & str */
-	"source_table" TEXT, /* & str */
-	"vector_column" TEXT, /* & str */
-	"extra_columns" TEXT DEFAULT NULL, /* Option < & str > */
-	"refresh_interval" TEXT DEFAULT '1m', /* & str */
-	"index_type" TEXT DEFAULT 'hnsw', /* & str */
-	"dry_run" bool DEFAULT false /* bool */
-) RETURNS TABLE (
-	"action" TEXT  /* Option < String > */
+-- src/api/diagnostics.rs:819
+-- pg_trickle::api::diagnostics::diamond_groups
+CREATE  FUNCTION pgtrickle."diamond_groups"() RETURNS TABLE (
+	"group_id" INT,  /* i32 */
+	"member_name" TEXT,  /* String */
+	"member_schema" TEXT,  /* String */
+	"is_convergence" bool,  /* bool */
+	"epoch" bigint,  /* i64 */
+	"schedule_policy" TEXT  /* String */
 )
-
+STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'embedding_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'diamond_groups_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/ivm.rs:834
--- pg_trickle::ivm::pgt_ivm_apply_delta_enr
-CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta_enr"(
-	"pgt_id" bigint, /* i64 */
-	"source_oid" INT, /* i32 */
-	"has_new" bool, /* bool */
-	"has_old" bool /* bool */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
+-- src/monitor/tree.rs:18
+-- pg_trickle::monitor::tree::dependency_tree
+CREATE  FUNCTION pgtrickle."dependency_tree"() RETURNS TABLE (
+	"tree_line" TEXT,  /* String */
+	"node" TEXT,  /* String */
+	"node_type" TEXT,  /* String */
+	"depth" INT,  /* i32 */
+	"status" TEXT,  /* Option < String > */
+	"refresh_mode" TEXT  /* Option < String > */
+)
+STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_enr_wrapper';
+AS 'MODULE_PATHNAME', 'dependency_tree_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/create.rs:84
--- pg_trickle::api::create::create_stream_table_if_not_exists
-CREATE  FUNCTION pgtrickle."create_stream_table_if_not_exists"(
-	"name" TEXT, /* & str */
-	"query" TEXT, /* & str */
-	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
-	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
-	"initialize" bool DEFAULT true, /* bool */
-	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
-	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
-	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
-	"append_only" bool DEFAULT false, /* bool */
-	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
-	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
-	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
-	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
-	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
-	"temporal" bool DEFAULT false, /* bool */
-	"storage_backend" TEXT DEFAULT NULL, /* Option < & str > */
-	"fillfactor" INT DEFAULT NULL /* Option < i32 > */
+-- src/monitor/mod.rs:675
+-- pg_trickle::monitor::slot_health
+CREATE  FUNCTION pgtrickle."slot_health"() RETURNS TABLE (
+	"slot_name" TEXT,  /* String */
+	"source_relid" bigint,  /* i64 */
+	"active" bool,  /* bool */
+	"retained_wal_bytes" bigint,  /* i64 */
+	"wal_status" TEXT  /* String */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'slot_health_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:652
+-- pg_trickle::monitor::get_staleness
+CREATE  FUNCTION pgtrickle."get_staleness"(
+	"name" TEXT /* & str */
+) RETURNS double precision /* Option < f64 > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'get_staleness_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:550
+-- pg_trickle::api::snapshot::drop_snapshot
+CREATE  FUNCTION pgtrickle."drop_snapshot"(
+	"p_snapshot_table" TEXT /* & str */
 ) RETURNS void
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_stream_table_if_not_exists_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1091
--- pg_trickle::api::diagnostics::advance_watermark
-CREATE  FUNCTION pgtrickle."advance_watermark"(
-	"source" TEXT, /* & str */
-	"watermark" timestamp with time zone /* TimestampWithTimeZone */
-) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'advance_watermark_wrapper';
+AS 'MODULE_PATHNAME', 'drop_snapshot_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:1600
--- pg_trickle::api::unsubscribe
-CREATE  FUNCTION pgtrickle."unsubscribe"(
-	"stream_table" TEXT, /* & str */
-	"channel" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'unsubscribe_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:407
--- pg_trickle::api::diagnostics::explain_delta
-CREATE  FUNCTION pgtrickle."explain_delta"(
+-- src/api/alter.rs:2168
+-- pg_trickle::api::alter::drop_stream_table
+CREATE  FUNCTION pgtrickle."drop_stream_table"(
 	"name" TEXT, /* & str */
-	"format" TEXT DEFAULT 'text' /* & str */
-) RETURNS SETOF TEXT /* String */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_delta_text_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/planner.rs:186
--- pg_trickle::api::planner::schedule_recommendations
-CREATE  FUNCTION pgtrickle."schedule_recommendations"() RETURNS TABLE (
-	"name" TEXT,  /* Option < String > */
-	"current_interval_seconds" double precision,  /* Option < f64 > */
-	"recommended_interval_seconds" double precision,  /* Option < f64 > */
-	"delta_pct" double precision,  /* Option < f64 > */
-	"confidence" double precision,  /* Option < f64 > */
-	"reasoning" TEXT  /* Option < String > */
-)
+	"cascade" bool DEFAULT false /* bool */
+) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'schedule_recommendations_wrapper';
+AS 'MODULE_PATHNAME', 'drop_stream_table_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/citus.rs:103
--- pg_trickle::citus::source_stable_name
-CREATE  FUNCTION pgtrickle."source_stable_name"(
-	"source_oid" oid /* pg_sys :: Oid */
-) RETURNS TEXT /* Option < String > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'sql_stable_name_for_oid_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1805
--- pg_trickle::api::diagnostics::vector_status
-CREATE  FUNCTION pgtrickle."vector_status"() RETURNS TABLE (
-	"name" TEXT,  /* String */
-	"post_refresh_action" TEXT,  /* String */
-	"reindex_drift_threshold" double precision,  /* Option < f64 > */
-	"rows_changed_since_last_reindex" bigint,  /* i64 */
-	"last_reindex_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"data_timestamp" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"embedding_lag" interval,  /* Option < pgrx :: datum :: Interval > */
-	"estimated_rows" bigint,  /* Option < i64 > */
-	"drift_pct" double precision  /* Option < f64 > */
+-- src/monitor/mod.rs:698
+-- pg_trickle::monitor::cache_stats
+CREATE  FUNCTION pgtrickle."cache_stats"() RETURNS TABLE (
+	"l1_hits" bigint,  /* i64 */
+	"l2_hits" bigint,  /* i64 */
+	"misses" bigint,  /* i64 */
+	"evictions" bigint,  /* i64 */
+	"l1_size" INT,  /* i32 */
+	"l1_bytes" bigint  /* i64 */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'vector_status_wrapper';
+AS 'MODULE_PATHNAME', 'cache_stats_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2575
--- pg_trickle::api::bulk_alter_stream_tables
-CREATE  FUNCTION pgtrickle."bulk_alter_stream_tables"(
-	"names" TEXT[], /* Vec < Option < String > > */
-	"params" json /* pgrx :: Json */
-) RETURNS INT /* i32 */
+-- src/api/diagnostics.rs:61
+-- pg_trickle::api::diagnostics::migrate
+CREATE  FUNCTION pgtrickle."migrate"() RETURNS TEXT /* String */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bulk_alter_stream_tables_wrapper';
+AS 'MODULE_PATHNAME', 'migrate_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/create.rs:172
--- pg_trickle::api::create::bulk_create
-CREATE  FUNCTION pgtrickle."bulk_create"(
-	"definitions" jsonb /* pgrx :: JsonB */
-) RETURNS jsonb /* pgrx :: JsonB */
+-- src/citus.rs:806
+-- pg_trickle::citus::handle_vp_promoted
+CREATE  FUNCTION pgtrickle."handle_vp_promoted"(
+	"payload" TEXT /* & str */
+) RETURNS bool /* bool */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'sql_handle_vp_promoted_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/spec.rs:57
+-- pg_trickle::api::spec::stream_table_spec
+CREATE  FUNCTION pgtrickle."stream_table_spec"(
+	"relid" oid /* pg_sys :: Oid */
+) RETURNS jsonb /* Option < pgrx :: JsonB > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bulk_create_wrapper';
+AS 'MODULE_PATHNAME', 'stream_table_spec_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:1377
--- pg_trickle::api::diagnostics::create_refresh_group
-CREATE  FUNCTION pgtrickle."create_refresh_group"(
-	"group_name" TEXT, /* & str */
-	"members" TEXT[], /* Vec < String > */
-	"isolation" TEXT DEFAULT 'read_committed' /* & str */
-) RETURNS INT /* Result < i32, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_refresh_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/alter.rs:2432
--- pg_trickle::api::alter::resume_stream_table
-CREATE  FUNCTION pgtrickle."resume_stream_table"(
+-- src/api/publication.rs:78
+-- pg_trickle::api::publication::drop_stream_table_publication
+CREATE  FUNCTION pgtrickle."drop_stream_table_publication"(
 	"name" TEXT /* & str */
 ) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'resume_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'drop_stream_table_publication_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/create.rs:330
--- pg_trickle::api::create::create_or_replace_stream_table
-CREATE  FUNCTION pgtrickle."create_or_replace_stream_table"(
-	"name" TEXT, /* & str */
-	"query" TEXT, /* & str */
-	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
-	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
-	"initialize" bool DEFAULT true, /* bool */
-	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
-	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
-	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
-	"append_only" bool DEFAULT false, /* bool */
-	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
-	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
-	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
-	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
-	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
-	"temporal" bool DEFAULT false, /* bool */
-	"storage_backend" TEXT DEFAULT NULL /* Option < & str > */
-) RETURNS void
-
+-- src/api/mod.rs:2503
+-- pg_trickle::api::is_drained
+CREATE  FUNCTION pgtrickle."is_drained"() RETURNS bool /* bool */
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_or_replace_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'is_drained_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/hash.rs:54
--- pg_trickle::hash::pg_trickle_hash_multi
-CREATE  FUNCTION pgtrickle."pg_trickle_hash_multi"(
-	"inputs" TEXT[] /* Vec < Option < String > > */
-) RETURNS bigint /* i64 */
-IMMUTABLE STRICT PARALLEL SAFE 
+-- src/api/diagnostics.rs:958
+-- pg_trickle::api::diagnostics::source_gates
+CREATE  FUNCTION pgtrickle."source_gates"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"schema_name" TEXT,  /* String */
+	"gated" bool,  /* bool */
+	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"gated_by" TEXT  /* Option < String > */
+)
+STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pg_trickle_hash_multi_wrapper';
+AS 'MODULE_PATHNAME', 'source_gates_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -735,82 +703,6 @@ AS 'MODULE_PATHNAME', 'wal_source_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2468
--- pg_trickle::api::drain
-CREATE  FUNCTION pgtrickle."drain"(
-	"timeout_s" INT DEFAULT 60 /* i32 */
-) RETURNS bool /* bool */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drain_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1508
--- pg_trickle::api::diagnostics::worker_allocation_status
-CREATE  FUNCTION pgtrickle."worker_allocation_status"() RETURNS TABLE (
-	"db_name" TEXT,  /* String */
-	"workers_used" bigint,  /* i64 */
-	"workers_quota" bigint,  /* i64 */
-	"workers_queued" bigint,  /* i64 */
-	"cluster_active" bigint,  /* i64 */
-	"cluster_max" bigint  /* i64 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'worker_allocation_status_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/hash.rs:33
--- pg_trickle::hash::pg_trickle_hash
-CREATE  FUNCTION pgtrickle."pg_trickle_hash"(
-	"input" TEXT /* Option < & str > */
-) RETURNS bigint /* i64 */
-IMMUTABLE PARALLEL SAFE 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pg_trickle_hash_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/ivm.rs:1160
--- pg_trickle::ivm::pgt_ivm_handle_truncate
-CREATE  FUNCTION pgtrickle."pgt_ivm_handle_truncate"(
-	"pgt_id" bigint /* i64 */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_ivm_handle_truncate_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/create.rs:25
--- pg_trickle::api::create::create_stream_table
-CREATE  FUNCTION pgtrickle."create_stream_table"(
-	"name" TEXT, /* & str */
-	"query" TEXT, /* & str */
-	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
-	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
-	"initialize" bool DEFAULT true, /* bool */
-	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
-	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
-	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
-	"append_only" bool DEFAULT false, /* bool */
-	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
-	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
-	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
-	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
-	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
-	"temporal" bool DEFAULT false, /* bool */
-	"storage_backend" TEXT DEFAULT NULL, /* Option < & str > */
-	"fillfactor" INT DEFAULT NULL /* Option < i32 > */
-) RETURNS void
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
 -- src/api/diagnostics.rs:1221
 -- pg_trickle::api::diagnostics::watermark_groups
 CREATE  FUNCTION pgtrickle."watermark_groups"() RETURNS TABLE (
@@ -825,192 +717,18 @@ AS 'MODULE_PATHNAME', 'watermark_groups_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:61
--- pg_trickle::api::diagnostics::migrate
-CREATE  FUNCTION pgtrickle."migrate"() RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'migrate_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/snapshot.rs:550
--- pg_trickle::api::snapshot::drop_snapshot
-CREATE  FUNCTION pgtrickle."drop_snapshot"(
-	"p_snapshot_table" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_snapshot_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:958
--- pg_trickle::api::diagnostics::source_gates
-CREATE  FUNCTION pgtrickle."source_gates"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"schema_name" TEXT,  /* String */
-	"gated" bool,  /* bool */
-	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"gated_by" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'source_gates_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/outbox.rs:103
--- pg_trickle::api::outbox::attach_outbox
-CREATE  FUNCTION pgtrickle."attach_outbox"(
-	"p_name" TEXT, /* & str */
-	"p_retention_hours" INT DEFAULT 24, /* i32 */
-	"p_inline_threshold_rows" INT DEFAULT 10000 /* i32 */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'attach_outbox_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/citus.rs:806
--- pg_trickle::citus::handle_vp_promoted
-CREATE  FUNCTION pgtrickle."handle_vp_promoted"(
-	"payload" TEXT /* & str */
-) RETURNS bool /* bool */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'sql_handle_vp_promoted_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1599
--- pg_trickle::api::diagnostics::preflight
-CREATE  FUNCTION pgtrickle."preflight"() RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'preflight_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:912
--- pg_trickle::api::diagnostics::gate_source
-CREATE  FUNCTION pgtrickle."gate_source"(
-	"source" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'gate_source_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/diagnostics.rs:570
--- pg_trickle::diagnostics::list_auxiliary_columns
-CREATE  FUNCTION pgtrickle."list_auxiliary_columns"(
+-- src/api/diagnostics.rs:296
+-- pg_trickle::api::diagnostics::explain_refresh_mode
+CREATE  FUNCTION pgtrickle."explain_refresh_mode"(
 	"name" TEXT /* & str */
 ) RETURNS TABLE (
-	"column_name" TEXT,  /* String */
-	"data_type" TEXT,  /* String */
-	"purpose" TEXT  /* String */
+	"configured_mode" TEXT,  /* String */
+	"effective_mode" TEXT,  /* Option < String > */
+	"downgrade_reason" TEXT  /* Option < String > */
 )
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_auxiliary_columns_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:675
--- pg_trickle::monitor::slot_health
-CREATE  FUNCTION pgtrickle."slot_health"() RETURNS TABLE (
-	"slot_name" TEXT,  /* String */
-	"source_relid" bigint,  /* i64 */
-	"active" bool,  /* bool */
-	"retained_wal_bytes" bigint,  /* i64 */
-	"wal_status" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'slot_health_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:109
--- pg_trickle::api::diagnostics::rebuild_cdc_triggers
-CREATE  FUNCTION pgtrickle."rebuild_cdc_triggers"() RETURNS TEXT /* & '_ str */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'rebuild_cdc_triggers_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2638
--- pg_trickle::api::bulk_drop_stream_tables
-CREATE  FUNCTION pgtrickle."bulk_drop_stream_tables"(
-	"names" TEXT[] /* Vec < Option < String > > */
-) RETURNS INT /* i32 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bulk_drop_stream_tables_wrapper';
-/* </end connected objects> */
-
-
-/* <begin connected objects> */
--- src/api/mod.rs:1615
--- pg_trickle::api::list_subscriptions
-CREATE  FUNCTION pgtrickle."list_subscriptions"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"channel" TEXT,  /* Option < String > */
-	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_subscriptions_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:1711
--- pg_trickle::api::unsubscribe_distance
-CREATE  FUNCTION pgtrickle."unsubscribe_distance"(
-	"stream_table" TEXT, /* & str */
-	"channel" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:778
--- pg_trickle::monitor::pgtrickle_refresh_stats
-CREATE  FUNCTION pgtrickle."pgtrickle_refresh_stats"() RETURNS TABLE (
-	"stream_table" TEXT,  /* String */
-	"mode" TEXT,  /* String */
-	"avg_ms" double precision,  /* f64 */
-	"p95_ms" double precision,  /* f64 */
-	"p99_ms" double precision,  /* f64 */
-	"refresh_count" bigint,  /* i64 */
-	"last_refresh_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgtrickle_refresh_stats_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:819
--- pg_trickle::api::diagnostics::diamond_groups
-CREATE  FUNCTION pgtrickle."diamond_groups"() RETURNS TABLE (
-	"group_id" INT,  /* i32 */
-	"member_name" TEXT,  /* String */
-	"member_schema" TEXT,  /* String */
-	"is_convergence" bool,  /* bool */
-	"epoch" bigint,  /* i64 */
-	"schedule_policy" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'diamond_groups_wrapper';
+AS 'MODULE_PATHNAME', 'explain_refresh_mode_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1045,212 +763,117 @@ AS 'MODULE_PATHNAME', 'st_refresh_stats_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/alter.rs:2244
--- pg_trickle::api::alter::drop_stream_table
-CREATE  FUNCTION pgtrickle."drop_stream_table"(
-	"name" TEXT, /* & str */
-	"cascade" bool DEFAULT false /* bool */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:545
--- pg_trickle::api::diagnostics::shared_buffer_stats
-CREATE  FUNCTION pgtrickle."shared_buffer_stats"() RETURNS TABLE (
-	"source_oid" bigint,  /* i64 */
-	"source_table" TEXT,  /* String */
-	"consumer_count" INT,  /* i32 */
-	"consumers" TEXT,  /* String */
-	"columns_tracked" INT,  /* i32 */
-	"safe_frontier_lsn" TEXT,  /* Option < String > */
-	"buffer_rows" bigint,  /* i64 */
-	"is_partitioned" bool  /* bool */
+-- src/monitor/health.rs:757
+-- pg_trickle::monitor::health::worker_pool_status
+CREATE  FUNCTION pgtrickle."worker_pool_status"() RETURNS TABLE (
+	"active_workers" INT,  /* i32 */
+	"max_workers" INT,  /* i32 */
+	"per_db_cap" INT,  /* i32 */
+	"parallel_mode" TEXT,  /* String */
+	"idle_workers" INT,  /* i32 */
+	"last_scheduler_tick_unix" bigint,  /* i64 */
+	"ring_overflow_count" bigint,  /* i64 */
+	"citus_failure_total" bigint  /* i64 */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'shared_buffer_stats_fn_wrapper';
+AS 'MODULE_PATHNAME', 'worker_pool_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/hooks.rs:1097
--- pg_trickle::hooks::pg_trickle_on_sql_drop
--- Skipped due to `#[pgrx(sql = false)]`
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1160
--- pg_trickle::api::diagnostics::drop_watermark_group
-CREATE  FUNCTION pgtrickle."drop_watermark_group"(
-	"group_name" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_watermark_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/publication.rs:16
--- pg_trickle::api::publication::stream_table_to_publication
-CREATE  FUNCTION pgtrickle."stream_table_to_publication"(
+-- src/api/mod.rs:2767
+-- pg_trickle::api::stream_table_lineage
+CREATE  FUNCTION pgtrickle."stream_table_lineage"(
 	"name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_to_publication_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2556
--- pg_trickle::api::helpers::export_definition
-CREATE  FUNCTION pgtrickle."export_definition"(
-	"st_name" TEXT /* & str */
-) RETURNS TEXT /* Result < String, PgTrickleError > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'export_definition_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:898
--- requires:
---   export_definition
-
-
-CREATE OR REPLACE FUNCTION pgtrickle."stream_table_definition"(
-    p_name text
-)
-RETURNS text
-LANGUAGE sql
-STABLE
-AS $$
-    SELECT pgtrickle.export_definition(p_name);
-$$;
-
-COMMENT ON FUNCTION pgtrickle."stream_table_definition"(text) IS
-    'Return the CREATE STREAM TABLE DDL for the named stream table. '
-    'Equivalent to pgtrickle.export_definition(name) — provided as a '
-    'more discoverable alias.';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/refresh_ops.rs:8
--- pg_trickle::api::refresh_ops::refresh_stream_table
-CREATE  FUNCTION pgtrickle."refresh_stream_table"(
-	"name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:858
--- requires:
---   refresh_stream_table
-
-
-CREATE OR REPLACE FUNCTION pgtrickle."refresh_if_stale"(
-    p_name   text,
-    p_max_age interval DEFAULT '5 minutes'::interval
-)
-RETURNS boolean
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    v_last_end timestamp with time zone;
-    v_refreshed boolean := false;
-BEGIN
-    SELECT MAX(end_time)
-      INTO v_last_end
-      FROM pgtrickle.pgt_refresh_history h
-      JOIN pgtrickle.pgt_stream_tables   s USING (pgt_id)
-     WHERE s.pgt_name = p_name
-       AND h.status = 'COMPLETED';
-
-    IF v_last_end IS NULL OR (now() - v_last_end) > p_max_age THEN
-        PERFORM pgtrickle.refresh_stream_table(p_name);
-        v_refreshed := true;
-    END IF;
-
-    RETURN v_refreshed;
-END;
-$$;
-
-COMMENT ON FUNCTION pgtrickle."refresh_if_stale"(text, interval) IS
-    'Refresh the named stream table only when the most recent completed '
-    'refresh is older than max_age.  Returns TRUE when a refresh was '
-    'triggered, FALSE when the table was fresh enough.';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:453
--- pg_trickle::api::self_monitoring::scheduler_overhead
-CREATE  FUNCTION pgtrickle."scheduler_overhead"() RETURNS TABLE (
-	"total_refreshes_1h" bigint,  /* i64 */
-	"df_refreshes_1h" bigint,  /* i64 */
-	"df_refresh_fraction" double precision,  /* Option < f64 > */
-	"avg_refresh_ms" double precision,  /* Option < f64 > */
-	"avg_df_refresh_ms" double precision,  /* Option < f64 > */
-	"total_refresh_time_s" double precision,  /* Option < f64 > */
-	"df_refresh_time_s" double precision  /* Option < f64 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'scheduler_overhead_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:855
--- pg_trickle::monitor::explain_st
-CREATE  FUNCTION pgtrickle."explain_st"(
-	"name" TEXT, /* & str */
-	"with_analyze" bool DEFAULT false /* bool */
 ) RETURNS TABLE (
-	"property" TEXT,  /* String */
-	"value" TEXT  /* String */
+	"output_col" TEXT,  /* Option < String > */
+	"source_table" TEXT,  /* Option < String > */
+	"source_col" TEXT  /* Option < String > */
 )
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_st_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2217
--- pg_trickle::api::explain_stream_table
-CREATE  FUNCTION pgtrickle."explain_stream_table"(
-	"name" TEXT /* & str */
-) RETURNS TEXT /* Result < String, PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'stream_table_lineage_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor/health.rs:647
--- pg_trickle::monitor::health::trigger_inventory
-CREATE  FUNCTION pgtrickle."trigger_inventory"() RETURNS TABLE (
+-- src/api/mod.rs:1611
+-- pg_trickle::api::list_subscriptions
+CREATE  FUNCTION pgtrickle."list_subscriptions"() RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"channel" TEXT,  /* Option < String > */
+	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_subscriptions_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:633
+-- pg_trickle::monitor::st_auto_threshold
+CREATE  FUNCTION pgtrickle."st_auto_threshold"(
+	"name" TEXT /* & str */
+) RETURNS double precision /* Option < f64 > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'st_auto_threshold_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2405
+-- pg_trickle::api::view_evolution_status
+CREATE  FUNCTION pgtrickle."view_evolution_status"() RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"in_shadow_build" bool,  /* Option < bool > */
+	"shadow_table_name" TEXT,  /* Option < String > */
+	"status" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'view_evolution_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:1918
+-- pg_trickle::monitor::change_buffer_sizes
+CREATE  FUNCTION pgtrickle."change_buffer_sizes"() RETURNS TABLE (
+	"stream_table" TEXT,  /* String */
 	"source_table" TEXT,  /* String */
 	"source_oid" bigint,  /* i64 */
-	"trigger_name" TEXT,  /* String */
-	"trigger_type" TEXT,  /* String */
-	"present" bool,  /* bool */
-	"enabled" bool  /* bool */
+	"cdc_mode" TEXT,  /* String */
+	"pending_rows" bigint,  /* i64 */
+	"buffer_bytes" bigint  /* i64 */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'trigger_inventory_wrapper';
+AS 'MODULE_PATHNAME', 'change_buffer_sizes_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/self_monitoring.rs:305
--- pg_trickle::api::self_monitoring::teardown_self_monitoring
-CREATE  FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
-STRICT 
+-- src/api/create.rs:80
+-- pg_trickle::api::create::create_stream_table_if_not_exists
+CREATE  FUNCTION pgtrickle."create_stream_table_if_not_exists"(
+	"name" TEXT, /* & str */
+	"query" TEXT, /* & str */
+	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
+	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
+	"initialize" bool DEFAULT true, /* bool */
+	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
+	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
+	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
+	"append_only" bool DEFAULT false, /* bool */
+	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
+	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
+	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
+	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
+	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
+	"temporal" bool DEFAULT false, /* bool */
+	"storage_backend" TEXT DEFAULT NULL, /* Option < & str > */
+	"fillfactor" INT DEFAULT NULL /* Option < i32 > */
+) RETURNS void
+
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
+AS 'MODULE_PATHNAME', 'create_stream_table_if_not_exists_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1269,7 +892,7 @@ AS 'MODULE_PATHNAME', 'explain_query_rewrite_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:1666
+-- src/api/mod.rs:1662
 -- pg_trickle::api::subscribe_distance
 CREATE  FUNCTION pgtrickle."subscribe_distance"(
 	"stream_table" TEXT, /* & str */
@@ -1285,19 +908,62 @@ AS 'MODULE_PATHNAME', 'subscribe_distance_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/diagnostics.rs:395
--- pg_trickle::diagnostics::diagnose_errors
-CREATE  FUNCTION pgtrickle."diagnose_errors"(
-	"name" TEXT /* & str */
+-- src/monitor/health.rs:799
+-- pg_trickle::monitor::health::parallel_job_status
+CREATE  FUNCTION pgtrickle."parallel_job_status"(
+	"max_age_seconds" INT DEFAULT 300 /* i32 */
 ) RETURNS TABLE (
-	"event_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"error_type" TEXT,  /* String */
-	"error_message" TEXT,  /* String */
-	"remediation" TEXT  /* String */
+	"job_id" bigint,  /* i64 */
+	"unit_key" TEXT,  /* String */
+	"unit_kind" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"member_count" INT,  /* i32 */
+	"attempt_no" INT,  /* i32 */
+	"scheduler_pid" INT,  /* i32 */
+	"worker_pid" INT,  /* Option < i32 > */
+	"enqueued_at" timestamp with time zone,  /* TimestampWithTimeZone */
+	"started_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"finished_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"duration_ms" double precision  /* Option < f64 > */
 )
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'parallel_job_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2634
+-- pg_trickle::api::bulk_drop_stream_tables
+CREATE  FUNCTION pgtrickle."bulk_drop_stream_tables"(
+	"names" TEXT[] /* Vec < Option < String > > */
+) RETURNS INT /* i32 */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'diagnose_errors_wrapper';
+AS 'MODULE_PATHNAME', 'bulk_drop_stream_tables_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:744
+-- pg_trickle::monitor::reliability_counters
+CREATE  FUNCTION pgtrickle."reliability_counters"() RETURNS TABLE (
+	"invalidation_ring_overflows" bigint,  /* i64 */
+	"dag_cycles_detected" bigint,  /* i64 */
+	"template_cache_stale_evictions" bigint  /* i64 */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'reliability_counters_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1160
+-- pg_trickle::api::diagnostics::drop_watermark_group
+CREATE  FUNCTION pgtrickle."drop_watermark_group"(
+	"group_name" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drop_watermark_group_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1320,7 +986,247 @@ AS 'MODULE_PATHNAME', 'pgt_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:1589
+-- src/citus.rs:103
+-- pg_trickle::citus::source_stable_name
+CREATE  FUNCTION pgtrickle."source_stable_name"(
+	"source_oid" oid /* pg_sys :: Oid */
+) RETURNS TEXT /* Option < String > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'sql_stable_name_for_oid_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/health.rs:647
+-- pg_trickle::monitor::health::trigger_inventory
+CREATE  FUNCTION pgtrickle."trigger_inventory"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"source_oid" bigint,  /* i64 */
+	"trigger_name" TEXT,  /* String */
+	"trigger_type" TEXT,  /* String */
+	"present" bool,  /* bool */
+	"enabled" bool  /* bool */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'trigger_inventory_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2134
+-- pg_trickle::api::sla_summary
+CREATE  FUNCTION pgtrickle."sla_summary"() RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"p50_ms" double precision,  /* Option < f64 > */
+	"p99_ms" double precision,  /* Option < f64 > */
+	"freshness_lag_s" double precision,  /* Option < f64 > */
+	"error_rate" double precision,  /* Option < f64 > */
+	"error_budget_remaining" double precision  /* Option < f64 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'sla_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:1405
+-- pg_trickle::monitor::check_cdc_health
+CREATE  FUNCTION pgtrickle."check_cdc_health"() RETURNS TABLE (
+	"source_relid" bigint,  /* i64 */
+	"source_table" TEXT,  /* String */
+	"cdc_mode" TEXT,  /* String */
+	"slot_name" TEXT,  /* Option < String > */
+	"lag_bytes" bigint,  /* Option < i64 > */
+	"confirmed_lsn" TEXT,  /* Option < String > */
+	"alert" TEXT,  /* Option < String > */
+	"selective_capture" bool  /* bool */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'check_cdc_health_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/cluster.rs:18
+-- pg_trickle::api::cluster::cluster_worker_summary
+CREATE  FUNCTION pgtrickle."cluster_worker_summary"() RETURNS TABLE (
+	"db_oid" bigint,  /* Option < i64 > */
+	"db_name" TEXT,  /* Option < String > */
+	"active_workers" INT,  /* Option < i32 > */
+	"scheduler_pid" INT,  /* Option < i32 > */
+	"scheduler_running" bool,  /* Option < bool > */
+	"total_active_workers" INT  /* Option < i32 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'cluster_worker_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1123
+-- pg_trickle::api::diagnostics::create_watermark_group
+CREATE  FUNCTION pgtrickle."create_watermark_group"(
+	"group_name" TEXT, /* & str */
+	"sources" TEXT[], /* Vec < String > */
+	"tolerance_secs" double precision DEFAULT 0.0 /* f64 */
+) RETURNS INT /* Result < i32, PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_watermark_group_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:305
+-- pg_trickle::api::self_monitoring::teardown_self_monitoring
+CREATE  FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:321
+-- pg_trickle::api::snapshot::restore_from_snapshot
+CREATE  FUNCTION pgtrickle."restore_from_snapshot"(
+	"p_name" TEXT, /* & str */
+	"p_source" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'restore_from_snapshot_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/health.rs:414
+-- pg_trickle::monitor::health::health_summary
+CREATE  FUNCTION pgtrickle."health_summary"() RETURNS TABLE (
+	"total_stream_tables" INT,  /* i32 */
+	"active_count" INT,  /* i32 */
+	"error_count" INT,  /* i32 */
+	"suspended_count" INT,  /* i32 */
+	"stale_count" INT,  /* i32 */
+	"reinit_pending" INT,  /* i32 */
+	"max_staleness_seconds" double precision,  /* Option < f64 > */
+	"scheduler_status" TEXT,  /* String */
+	"cache_hit_rate" double precision  /* Option < f64 > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'health_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:1722
+-- pg_trickle::api::list_distance_subscriptions
+CREATE  FUNCTION pgtrickle."list_distance_subscriptions"(
+	"p_stream_table" TEXT DEFAULT NULL /* Option < & str > */
+) RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"channel" TEXT,  /* Option < String > */
+	"vector_column" TEXT,  /* Option < String > */
+	"op" TEXT,  /* Option < String > */
+	"threshold" double precision,  /* Option < f64 > */
+	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
+)
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2689
+-- pg_trickle::api::exec_stream_ddl
+CREATE  FUNCTION pgtrickle."exec_stream_ddl"(
+	"cmd" TEXT /* & str */
+) RETURNS bool /* bool */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'exec_stream_ddl_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:778
+-- pg_trickle::monitor::pgtrickle_refresh_stats
+CREATE  FUNCTION pgtrickle."pgtrickle_refresh_stats"() RETURNS TABLE (
+	"stream_table" TEXT,  /* String */
+	"mode" TEXT,  /* String */
+	"avg_ms" double precision,  /* f64 */
+	"p95_ms" double precision,  /* f64 */
+	"p99_ms" double precision,  /* f64 */
+	"refresh_count" bigint,  /* i64 */
+	"last_refresh_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgtrickle_refresh_stats_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/create.rs:25
+-- pg_trickle::api::create::create_stream_table
+CREATE  FUNCTION pgtrickle."create_stream_table"(
+	"name" TEXT, /* & str */
+	"query" TEXT, /* & str */
+	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
+	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
+	"initialize" bool DEFAULT true, /* bool */
+	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
+	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
+	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
+	"append_only" bool DEFAULT false, /* bool */
+	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
+	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
+	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
+	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
+	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
+	"temporal" bool DEFAULT false, /* bool */
+	"storage_backend" TEXT DEFAULT NULL, /* Option < & str > */
+	"fillfactor" INT DEFAULT NULL /* Option < i32 > */
+) RETURNS void
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:95
+-- pg_trickle::api::diagnostics::_signal_launcher_rescan
+CREATE  FUNCTION pgtrickle."_signal_launcher_rescan"() RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', '_signal_launcher_rescan_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:1999
+-- pg_trickle::monitor::list_sources
+CREATE  FUNCTION pgtrickle."list_sources"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"source_oid" bigint,  /* i64 */
+	"source_type" TEXT,  /* String */
+	"cdc_mode" TEXT,  /* String */
+	"columns_used" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_sources_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2213
+-- pg_trickle::api::explain_stream_table
+CREATE  FUNCTION pgtrickle."explain_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS TEXT /* Result < String, PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:1585
 -- pg_trickle::api::subscribe
 CREATE  FUNCTION pgtrickle."subscribe"(
 	"stream_table" TEXT, /* & str */
@@ -1332,58 +1238,778 @@ AS 'MODULE_PATHNAME', 'subscribe_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor/mod.rs:652
--- pg_trickle::monitor::get_staleness
-CREATE  FUNCTION pgtrickle."get_staleness"(
-	"name" TEXT /* & str */
-) RETURNS double precision /* Option < f64 > */
-STRICT  
+-- src/api/mod.rs:1596
+-- pg_trickle::api::unsubscribe
+CREATE  FUNCTION pgtrickle."unsubscribe"(
+	"stream_table" TEXT, /* & str */
+	"channel" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'get_staleness_wrapper';
+AS 'MODULE_PATHNAME', 'unsubscribe_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor/mod.rs:1931
--- pg_trickle::monitor::change_buffer_sizes
-CREATE  FUNCTION pgtrickle."change_buffer_sizes"() RETURNS TABLE (
-	"stream_table" TEXT,  /* String */
-	"source_table" TEXT,  /* String */
-	"source_oid" bigint,  /* i64 */
-	"cdc_mode" TEXT,  /* String */
-	"pending_rows" bigint,  /* i64 */
-	"buffer_bytes" bigint  /* i64 */
+-- src/api/helpers.rs:2402
+-- pg_trickle::api::helpers::recommend_refresh_mode
+CREATE  FUNCTION pgtrickle."recommend_refresh_mode"(
+	"st_name" TEXT DEFAULT NULL /* Option < String > */
+) RETURNS TABLE (
+	"pgt_schema" TEXT,  /* String */
+	"pgt_name" TEXT,  /* String */
+	"current_mode" TEXT,  /* String */
+	"effective_mode" TEXT,  /* Option < String > */
+	"recommended_mode" TEXT,  /* String */
+	"confidence" TEXT,  /* String */
+	"reason" TEXT,  /* String */
+	"signals" jsonb  /* pgrx :: JsonB */
+)
+ 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'recommend_refresh_mode_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/outbox.rs:103
+-- pg_trickle::api::outbox::attach_outbox
+CREATE  FUNCTION pgtrickle."attach_outbox"(
+	"p_name" TEXT, /* & str */
+	"p_retention_hours" INT DEFAULT 24, /* i32 */
+	"p_inline_threshold_rows" INT DEFAULT 10000 /* i32 */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'attach_outbox_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:855
+-- pg_trickle::monitor::explain_st
+CREATE  FUNCTION pgtrickle."explain_st"(
+	"name" TEXT, /* & str */
+	"with_analyze" bool DEFAULT false /* bool */
+) RETURNS TABLE (
+	"property" TEXT,  /* String */
+	"value" TEXT  /* String */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'change_buffer_sizes_wrapper';
+AS 'MODULE_PATHNAME', 'explain_st_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:296
--- pg_trickle::api::diagnostics::explain_refresh_mode
-CREATE  FUNCTION pgtrickle."explain_refresh_mode"(
-	"name" TEXT /* & str */
+-- src/hash.rs:33
+-- pg_trickle::hash::pg_trickle_hash
+CREATE  FUNCTION pgtrickle."pg_trickle_hash"(
+	"input" TEXT /* Option < & str > */
+) RETURNS bigint /* i64 */
+IMMUTABLE PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pg_trickle_hash_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:2079
+-- pg_trickle::monitor::history_prune_status
+CREATE  FUNCTION pgtrickle."history_prune_status"() RETURNS TABLE (
+	"prune_error_count" bigint,  /* i64 */
+	"last_prune_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"last_rows_deleted" bigint  /* Option < i64 > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'history_prune_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/scheduler_control.rs:132
+-- pg_trickle::api::scheduler_control::resume_scheduler
+CREATE  FUNCTION pgtrickle."resume_scheduler"(
+	"nodes" TEXT[] /* pgrx :: Array < & str > */
+) RETURNS TEXT /* & '_ str */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'resume_scheduler_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/hooks.rs:51
+-- pg_trickle::hooks::pg_trickle_on_ddl_end
+-- Skipped due to `#[pgrx(sql = false)]`
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:525
+-- pg_trickle::monitor::get_refresh_history
+CREATE  FUNCTION pgtrickle."get_refresh_history"(
+	"name" TEXT, /* & str */
+	"max_rows" INT DEFAULT 20 /* i32 */
 ) RETURNS TABLE (
-	"configured_mode" TEXT,  /* String */
-	"effective_mode" TEXT,  /* Option < String > */
-	"downgrade_reason" TEXT  /* Option < String > */
+	"refresh_id" bigint,  /* i64 */
+	"data_timestamp" timestamp with time zone,  /* TimestampWithTimeZone */
+	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
+	"end_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"action" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"rows_inserted" bigint,  /* i64 */
+	"rows_deleted" bigint,  /* i64 */
+	"duration_ms" double precision,  /* Option < f64 > */
+	"error_message" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'get_refresh_history_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:358
+-- pg_trickle::api::self_monitoring::self_monitoring_status
+CREATE  FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
+	"st_name" TEXT,  /* String */
+	"exists" bool,  /* bool */
+	"status" TEXT,  /* Option < String > */
+	"refresh_mode" TEXT,  /* Option < String > */
+	"last_refresh_at" TEXT,  /* Option < String > */
+	"total_refreshes" bigint  /* Option < i64 > */
 )
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_refresh_mode_wrapper';
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:516
--- pg_trickle::api::diagnostics::dedup_stats
-CREATE  FUNCTION pgtrickle."dedup_stats"() RETURNS TABLE (
-	"total_diff_refreshes" bigint,  /* i64 */
-	"dedup_needed" bigint,  /* i64 */
-	"dedup_ratio_pct" double precision  /* f64 */
+-- src/api/planner.rs:186
+-- pg_trickle::api::planner::schedule_recommendations
+CREATE  FUNCTION pgtrickle."schedule_recommendations"() RETURNS TABLE (
+	"name" TEXT,  /* Option < String > */
+	"current_interval_seconds" double precision,  /* Option < f64 > */
+	"recommended_interval_seconds" double precision,  /* Option < f64 > */
+	"delta_pct" double precision,  /* Option < f64 > */
+	"confidence" double precision,  /* Option < f64 > */
+	"reasoning" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'schedule_recommendations_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/ivm.rs:712
+-- pg_trickle::ivm::pgt_ivm_apply_delta
+CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta"(
+	"pgt_id" bigint, /* i64 */
+	"source_oid" INT, /* i32 */
+	"has_new" bool, /* bool */
+	"has_old" bool /* bool */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/alter.rs:2351
+-- pg_trickle::api::alter::resume_stream_table
+CREATE  FUNCTION pgtrickle."resume_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'resume_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:109
+-- pg_trickle::api::diagnostics::rebuild_cdc_triggers
+CREATE  FUNCTION pgtrickle."rebuild_cdc_triggers"() RETURNS TEXT /* & '_ str */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'rebuild_cdc_triggers_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1459
+-- pg_trickle::api::diagnostics::refresh_groups
+CREATE  FUNCTION pgtrickle."refresh_groups"() RETURNS TABLE (
+	"group_id" INT,  /* i32 */
+	"group_name" TEXT,  /* String */
+	"member_count" INT,  /* i32 */
+	"isolation" TEXT,  /* String */
+	"created_at" timestamp with time zone  /* TimestampWithTimeZone */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dedup_stats_fn_wrapper';
+AS 'MODULE_PATHNAME', 'refresh_groups_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1769
+-- pg_trickle::api::diagnostics::clear_caches
+CREATE  FUNCTION pgtrickle."clear_caches"() RETURNS bigint /* i64 */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'clear_caches_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2507
+-- pg_trickle::api::helpers::refresh_efficiency
+CREATE  FUNCTION pgtrickle."refresh_efficiency"() RETURNS TABLE (
+	"pgt_schema" TEXT,  /* String */
+	"pgt_name" TEXT,  /* String */
+	"refresh_mode" TEXT,  /* String */
+	"total_refreshes" bigint,  /* i64 */
+	"diff_count" bigint,  /* i64 */
+	"full_count" bigint,  /* i64 */
+	"avg_diff_ms" double precision,  /* Option < f64 > */
+	"avg_full_ms" double precision,  /* Option < f64 > */
+	"avg_change_ratio" double precision,  /* Option < f64 > */
+	"diff_speedup" TEXT,  /* Option < String > */
+	"last_refresh_at" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'refresh_efficiency_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/scheduler_control.rs:61
+-- pg_trickle::api::scheduler_control::pause_scheduler
+CREATE  FUNCTION pgtrickle."pause_scheduler"(
+	"nodes" TEXT[] /* pgrx :: Array < & str > */
+) RETURNS TEXT /* & '_ str */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pause_scheduler_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/outbox.rs:190
+-- pg_trickle::api::outbox::detach_outbox
+CREATE  FUNCTION pgtrickle."detach_outbox"(
+	"p_name" TEXT, /* & str */
+	"p_if_exists" bool DEFAULT false /* bool */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'detach_outbox_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1019
+-- pg_trickle::api::diagnostics::bootstrap_gate_status
+CREATE  FUNCTION pgtrickle."bootstrap_gate_status"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"schema_name" TEXT,  /* String */
+	"gated" bool,  /* bool */
+	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"gated_by" TEXT,  /* Option < String > */
+	"gate_duration" interval,  /* Option < pgrx :: datum :: Interval > */
+	"affected_stream_tables" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bootstrap_gate_status_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/planner.rs:117
+-- pg_trickle::api::planner::recommend_schedule
+CREATE  FUNCTION pgtrickle."recommend_schedule"(
+	"p_name" TEXT /* & str */
+) RETURNS jsonb /* pgrx :: JsonB */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'recommend_schedule_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/hash.rs:54
+-- pg_trickle::hash::pg_trickle_hash_multi
+CREATE  FUNCTION pgtrickle."pg_trickle_hash_multi"(
+	"inputs" TEXT[] /* Vec < Option < String > > */
+) RETURNS bigint /* i64 */
+IMMUTABLE STRICT PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pg_trickle_hash_multi_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/create.rs:164
+-- pg_trickle::api::create::bulk_create
+CREATE  FUNCTION pgtrickle."bulk_create"(
+	"definitions" jsonb /* pgrx :: JsonB */
+) RETURNS jsonb /* pgrx :: JsonB */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bulk_create_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:407
+-- pg_trickle::api::diagnostics::explain_delta
+CREATE  FUNCTION pgtrickle."explain_delta"(
+	"name" TEXT, /* & str */
+	"format" TEXT DEFAULT 'text' /* & str */
+) RETURNS SETOF TEXT /* String */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_delta_text_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/refresh_ops.rs:36
+-- pg_trickle::api::refresh_ops::write_and_refresh
+CREATE  FUNCTION pgtrickle."write_and_refresh"(
+	"sql" TEXT, /* & str */
+	"stream_table_name" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:8
+-- pg_trickle::api::diagnostics::version
+CREATE  FUNCTION pgtrickle."version"() RETURNS TEXT /* & '_ str */
+IMMUTABLE STRICT PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'version_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1447
+-- pg_trickle::api::diagnostics::drop_refresh_group
+CREATE  FUNCTION pgtrickle."drop_refresh_group"(
+	"group_name" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drop_refresh_group_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1168
+-- pg_trickle::api::diagnostics::watermarks
+CREATE  FUNCTION pgtrickle."watermarks"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"schema_name" TEXT,  /* String */
+	"watermark" timestamp with time zone,  /* TimestampWithTimeZone */
+	"updated_at" timestamp with time zone,  /* TimestampWithTimeZone */
+	"advanced_by" TEXT,  /* Option < String > */
+	"wal_lsn" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'watermarks_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:935
+-- pg_trickle::api::diagnostics::ungate_source
+CREATE  FUNCTION pgtrickle."ungate_source"(
+	"source" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'ungate_source_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:566
+-- pg_trickle::api::self_monitoring::explain_dag
+CREATE  FUNCTION pgtrickle."explain_dag"(
+	"format" TEXT DEFAULT 'mermaid' /* Option < & str > */
+) RETURNS TEXT /* Option < String > */
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_dag_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:912
+-- pg_trickle::api::diagnostics::gate_source
+CREATE  FUNCTION pgtrickle."gate_source"(
+	"source" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'gate_source_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:676
+-- pg_trickle::api::diagnostics::reset_fuse
+CREATE  FUNCTION pgtrickle."reset_fuse"(
+	"name" TEXT, /* & str */
+	"action" TEXT DEFAULT 'apply' /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'reset_fuse_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:748
+-- pg_trickle::api::diagnostics::fuse_status
+CREATE  FUNCTION pgtrickle."fuse_status"() RETURNS TABLE (
+	"stream_table" TEXT,  /* String */
+	"fuse_mode" TEXT,  /* String */
+	"fuse_state" TEXT,  /* String */
+	"fuse_ceiling" bigint,  /* Option < i64 > */
+	"effective_ceiling" bigint,  /* Option < i64 > */
+	"fuse_sensitivity" INT,  /* Option < i32 > */
+	"blown_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"blow_reason" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuse_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1805
+-- pg_trickle::api::diagnostics::vector_status
+CREATE  FUNCTION pgtrickle."vector_status"() RETURNS TABLE (
+	"name" TEXT,  /* String */
+	"post_refresh_action" TEXT,  /* String */
+	"reindex_drift_threshold" double precision,  /* Option < f64 > */
+	"rows_changed_since_last_reindex" bigint,  /* i64 */
+	"last_reindex_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"data_timestamp" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"embedding_lag" interval,  /* Option < pgrx :: datum :: Interval > */
+	"estimated_rows" bigint,  /* Option < i64 > */
+	"drift_pct" double precision  /* Option < f64 > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'vector_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/create.rs:321
+-- pg_trickle::api::create::create_or_replace_stream_table
+CREATE  FUNCTION pgtrickle."create_or_replace_stream_table"(
+	"name" TEXT, /* & str */
+	"query" TEXT, /* & str */
+	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
+	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
+	"initialize" bool DEFAULT true, /* bool */
+	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
+	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
+	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
+	"append_only" bool DEFAULT false, /* bool */
+	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
+	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
+	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
+	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
+	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
+	"temporal" bool DEFAULT false, /* bool */
+	"storage_backend" TEXT DEFAULT NULL /* Option < & str > */
+) RETURNS void
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_or_replace_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:1144
+-- pg_trickle::monitor::explain_diff_sql
+CREATE  FUNCTION pgtrickle."explain_diff_sql"(
+	"name" TEXT /* & str */
+) RETURNS TEXT /* Option < String > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_diff_sql_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/ivm.rs:1160
+-- pg_trickle::ivm::pgt_ivm_handle_truncate
+CREATE  FUNCTION pgtrickle."pgt_ivm_handle_truncate"(
+	"pgt_id" bigint /* i64 */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_ivm_handle_truncate_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:19
+-- pg_trickle::api::diagnostics::version_check
+CREATE  FUNCTION pgtrickle."version_check"() RETURNS TEXT /* String */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'version_check_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:767
+-- pg_trickle::diagnostics::validate_query
+CREATE  FUNCTION pgtrickle."validate_query"(
+	"query" TEXT /* & str */
+) RETURNS TABLE (
+	"check_name" TEXT,  /* String */
+	"result" TEXT,  /* String */
+	"severity" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'validate_query_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2322
+-- pg_trickle::api::helpers::convert_buffers_to_unlogged
+CREATE  FUNCTION pgtrickle."convert_buffers_to_unlogged"() RETURNS bigint /* Result < i64, PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'convert_buffers_to_unlogged_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/hooks.rs:1094
+-- pg_trickle::hooks::pg_trickle_on_sql_drop
+-- Skipped due to `#[pgrx(sql = false)]`
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2520
+-- pg_trickle::api::cdc_pause_status
+CREATE  FUNCTION pgtrickle."cdc_pause_status"() RETURNS TABLE (
+	"paused" bool,  /* bool */
+	"capture_mode" TEXT,  /* String */
+	"note" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'cdc_pause_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2566
+-- pg_trickle::api::helpers::export_definition
+CREATE  FUNCTION pgtrickle."export_definition"(
+	"st_name" TEXT /* & str */
+) RETURNS TEXT /* Result < String, PgTrickleError > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'export_definition_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:839
+-- requires:
+--   export_definition
+
+
+CREATE OR REPLACE FUNCTION pgtrickle."stream_table_definition"(
+    p_name text
+)
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT pgtrickle.export_definition(p_name);
+$$;
+
+COMMENT ON FUNCTION pgtrickle."stream_table_definition"(text) IS
+    'Return the CREATE STREAM TABLE DDL for the named stream table. '
+    'Equivalent to pgtrickle.export_definition(name) — provided as a '
+    'more discoverable alias.';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/ivm.rs:834
+-- pg_trickle::ivm::pgt_ivm_apply_delta_enr
+CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta_enr"(
+	"pgt_id" bigint, /* i64 */
+	"source_oid" INT, /* i32 */
+	"has_new" bool, /* bool */
+	"has_old" bool /* bool */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_enr_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/health.rs:561
+-- pg_trickle::monitor::health::refresh_timeline
+CREATE  FUNCTION pgtrickle."refresh_timeline"(
+	"max_rows" INT DEFAULT 50 /* i32 */
+) RETURNS TABLE (
+	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
+	"stream_table" TEXT,  /* String */
+	"action" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"rows_inserted" bigint,  /* i64 */
+	"rows_deleted" bigint,  /* i64 */
+	"duration_ms" double precision,  /* Option < f64 > */
+	"error_message" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'refresh_timeline_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:154
+-- pg_trickle::api::diagnostics::parse_duration_seconds
+CREATE  FUNCTION pgtrickle."parse_duration_seconds"(
+	"input" TEXT /* & str */
+) RETURNS bigint /* Option < i64 > */
+IMMUTABLE STRICT PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'parse_duration_seconds_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:634
+-- requires:
+--   parse_duration_seconds
+
+
+-- Convenience view: pg_stat_stream_tables
+-- Combines catalog metadata with aggregate refresh statistics.
+CREATE OR REPLACE VIEW pgtrickle.pg_stat_stream_tables AS
+SELECT
+    st.pgt_id,
+    st.pgt_schema,
+    st.pgt_name,
+    st.status,
+    st.refresh_mode,
+    st.is_populated,
+    st.data_timestamp,
+    st.schedule,
+    now() - st.last_refresh_at AS staleness,
+    CASE WHEN st.schedule IS NOT NULL AND st.last_refresh_at IS NOT NULL
+              AND st.schedule !~ '[\s@]'
+         THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
+              pgtrickle.parse_duration_seconds(st.schedule)
+         ELSE NULL::boolean
+    END AS stale,
+    st.consecutive_errors,
+    st.needs_reinit,
+    st.last_refresh_at,
+    COALESCE(stats.total_refreshes, 0) AS total_refreshes,
+    COALESCE(stats.successful_refreshes, 0) AS successful_refreshes,
+    COALESCE(stats.failed_refreshes, 0) AS failed_refreshes,
+    COALESCE(stats.total_rows_inserted, 0) AS total_rows_inserted,
+    COALESCE(stats.total_rows_deleted, 0) AS total_rows_deleted,
+    stats.avg_duration_ms,
+    stats.last_action,
+    stats.last_status,
+    (SELECT array_agg(DISTINCT d.cdc_mode ORDER BY d.cdc_mode)
+     FROM pgtrickle.pgt_dependencies d
+     WHERE d.pgt_id = st.pgt_id AND d.source_type = 'TABLE') AS cdc_modes,
+    st.scc_id,
+    st.last_fixpoint_iterations,
+    st.refresh_tier
+FROM pgtrickle.pgt_stream_tables st
+LEFT JOIN LATERAL (
+    SELECT
+        count(*)::bigint AS total_refreshes,
+        count(*) FILTER (WHERE h.status = 'COMPLETED')::bigint AS successful_refreshes,
+        count(*) FILTER (WHERE h.status = 'FAILED')::bigint AS failed_refreshes,
+        COALESCE(sum(h.rows_inserted), 0)::bigint AS total_rows_inserted,
+        COALESCE(sum(h.rows_deleted), 0)::bigint AS total_rows_deleted,
+        CASE WHEN count(*) FILTER (WHERE h.end_time IS NOT NULL) > 0
+             THEN avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000)
+                  FILTER (WHERE h.end_time IS NOT NULL)
+             ELSE NULL
+        END::float8 AS avg_duration_ms,
+        (SELECT h2.action FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_action,
+        (SELECT h2.status FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_status,
+        (SELECT h2.initiated_by FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_initiated_by,
+        (SELECT h2.freshness_deadline FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS freshness_deadline
+    FROM pgtrickle.pgt_refresh_history h
+    WHERE h.pgt_id = st.pgt_id
+) stats ON true;
+
+-- Per-source CDC status view (G5): exposes cdc_mode, slot names, and
+-- transition timestamps for every TABLE dependency of a stream table.
+CREATE OR REPLACE VIEW pgtrickle.pgt_cdc_status AS
+SELECT
+    st.pgt_schema,
+    st.pgt_name,
+    d.source_relid,
+    c.relname        AS source_name,
+    n.nspname        AS source_schema,
+    d.cdc_mode,
+    d.slot_name,
+    d.decoder_confirmed_lsn,
+    d.transition_started_at
+FROM pgtrickle.pgt_dependencies d
+JOIN pgtrickle.pgt_stream_tables st ON st.pgt_id = d.pgt_id
+JOIN pg_class c ON c.oid = d.source_relid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE d.source_type = 'TABLE';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:549
+-- requires:
+--   parse_duration_seconds
+
+
+-- Status overview view (ERR-1d: last_error_message and last_error_at are
+-- included via st.* from pgt_stream_tables)
+CREATE OR REPLACE VIEW pgtrickle.stream_tables_info AS
+SELECT st.*,
+       now() - st.last_refresh_at AS staleness,
+       CASE WHEN st.schedule IS NOT NULL
+                 AND st.schedule !~ '[\s@]'
+            THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
+                 pgtrickle.parse_duration_seconds(st.schedule)
+            ELSE NULL::boolean
+       END AS stale,
+       CASE WHEN st.topk_limit IS NOT NULL THEN TRUE ELSE FALSE END AS is_topk
+FROM pgtrickle.pgt_stream_tables st;
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:722
+-- requires:
+--   parse_duration_seconds
+
+
+-- ERG-E: One-row health summary for dashboards and alerting.
+CREATE OR REPLACE VIEW pgtrickle.quick_health AS
+SELECT
+    (SELECT count(*) FROM pgtrickle.pgt_stream_tables)::bigint
+        AS total_stream_tables,
+    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
+     WHERE status = 'ERROR' OR consecutive_errors > 0)::bigint
+        AS error_tables,
+    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
+     WHERE schedule IS NOT NULL
+       AND schedule !~ '[\s@]'
+       AND last_refresh_at IS NOT NULL
+       AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
+           pgtrickle.parse_duration_seconds(schedule))::bigint
+        AS stale_tables,
+    (SELECT count(*) > 0 FROM pg_stat_activity
+     WHERE backend_type = 'pg_trickle scheduler')
+        AS scheduler_running,
+    CASE
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables) = 0 THEN 'EMPTY'
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'SUSPENDED') > 0 THEN 'CRITICAL'
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'ERROR' OR consecutive_errors > 0) > 0 THEN 'WARNING'
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables
+              WHERE schedule IS NOT NULL
+                AND schedule !~ '[\s@]'
+                AND last_refresh_at IS NOT NULL
+                AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
+                    pgtrickle.parse_duration_seconds(schedule)) > 0 THEN 'WARNING'
+        ELSE 'OK'
+    END AS status;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1404,61 +2030,201 @@ AS 'MODULE_PATHNAME', 'list_snapshots_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/planner.rs:117
--- pg_trickle::api::planner::recommend_schedule
-CREATE  FUNCTION pgtrickle."recommend_schedule"(
-	"p_name" TEXT /* & str */
-) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'recommend_schedule_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:935
--- pg_trickle::api::diagnostics::ungate_source
-CREATE  FUNCTION pgtrickle."ungate_source"(
-	"source" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ungate_source_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2392
--- pg_trickle::api::helpers::recommend_refresh_mode
-CREATE  FUNCTION pgtrickle."recommend_refresh_mode"(
-	"st_name" TEXT DEFAULT NULL /* Option < String > */
-) RETURNS TABLE (
-	"pgt_schema" TEXT,  /* String */
-	"pgt_name" TEXT,  /* String */
-	"current_mode" TEXT,  /* String */
-	"effective_mode" TEXT,  /* Option < String > */
-	"recommended_mode" TEXT,  /* String */
-	"confidence" TEXT,  /* String */
-	"reason" TEXT,  /* String */
-	"signals" jsonb  /* pgrx :: JsonB */
+-- src/api/self_monitoring.rs:453
+-- pg_trickle::api::self_monitoring::scheduler_overhead
+CREATE  FUNCTION pgtrickle."scheduler_overhead"() RETURNS TABLE (
+	"total_refreshes_1h" bigint,  /* i64 */
+	"df_refreshes_1h" bigint,  /* i64 */
+	"df_refresh_fraction" double precision,  /* Option < f64 > */
+	"avg_refresh_ms" double precision,  /* Option < f64 > */
+	"avg_df_refresh_ms" double precision,  /* Option < f64 > */
+	"total_refresh_time_s" double precision,  /* Option < f64 > */
+	"df_refresh_time_s" double precision  /* Option < f64 > */
 )
- 
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'recommend_refresh_mode_wrapper';
+AS 'MODULE_PATHNAME', 'scheduler_overhead_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:676
--- pg_trickle::api::diagnostics::reset_fuse
-CREATE  FUNCTION pgtrickle."reset_fuse"(
-	"name" TEXT, /* & str */
-	"action" TEXT DEFAULT 'apply' /* & str */
+-- src/api/publication.rs:16
+-- pg_trickle::api::publication::stream_table_to_publication
+CREATE  FUNCTION pgtrickle."stream_table_to_publication"(
+	"name" TEXT /* & str */
 ) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'reset_fuse_wrapper';
+AS 'MODULE_PATHNAME', 'stream_table_to_publication_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/alter.rs:1629
+-- src/monitor/health.rs:23
+-- pg_trickle::monitor::health::health_check
+CREATE  FUNCTION pgtrickle."health_check"() RETURNS TABLE (
+	"check_name" TEXT,  /* String */
+	"severity" TEXT,  /* String */
+	"detail" TEXT  /* String */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'health_check_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:240
+-- pg_trickle::api::self_monitoring::setup_self_monitoring
+CREATE  FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:395
+-- pg_trickle::diagnostics::diagnose_errors
+CREATE  FUNCTION pgtrickle."diagnose_errors"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"event_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"error_type" TEXT,  /* String */
+	"error_message" TEXT,  /* String */
+	"remediation" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'diagnose_errors_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1508
+-- pg_trickle::api::diagnostics::worker_allocation_status
+CREATE  FUNCTION pgtrickle."worker_allocation_status"() RETURNS TABLE (
+	"db_name" TEXT,  /* String */
+	"workers_used" bigint,  /* i64 */
+	"workers_quota" bigint,  /* i64 */
+	"workers_queued" bigint,  /* i64 */
+	"cluster_active" bigint,  /* i64 */
+	"cluster_max" bigint  /* i64 */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'worker_allocation_status_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:1888
+-- pg_trickle::api::embedding_stream_table
+CREATE  FUNCTION pgtrickle."embedding_stream_table"(
+	"name" TEXT, /* & str */
+	"source_table" TEXT, /* & str */
+	"vector_column" TEXT, /* & str */
+	"extra_columns" TEXT DEFAULT NULL, /* Option < & str > */
+	"refresh_interval" TEXT DEFAULT '1m', /* & str */
+	"index_type" TEXT DEFAULT 'hnsw', /* & str */
+	"dry_run" bool DEFAULT false /* bool */
+) RETURNS TABLE (
+	"action" TEXT  /* Option < String > */
+)
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'embedding_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/metrics_ext.rs:25
+-- pg_trickle::api::metrics_ext::metrics_summary
+CREATE  FUNCTION pgtrickle."metrics_summary"() RETURNS TABLE (
+	"db_name" TEXT,  /* Option < String > */
+	"total_stream_tables" bigint,  /* Option < i64 > */
+	"active_stream_tables" bigint,  /* Option < i64 > */
+	"suspended_stream_tables" bigint,  /* Option < i64 > */
+	"total_refreshes" bigint,  /* Option < i64 > */
+	"successful_refreshes" bigint,  /* Option < i64 > */
+	"failed_refreshes" bigint,  /* Option < i64 > */
+	"total_rows_processed" bigint,  /* Option < i64 > */
+	"active_workers" INT,  /* Option < i32 > */
+	"ivm_lock_parse_error_count" bigint,  /* Option < i64 > */
+	"holdback_probe_calls" bigint,  /* Option < i64 > */
+	"holdback_probe_cache_hits" bigint,  /* Option < i64 > */
+	"holdback_probe_avg_ms" double precision  /* Option < f64 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'metrics_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/publication.rs:135
+-- pg_trickle::api::publication::set_stream_table_sla
+CREATE  FUNCTION pgtrickle."set_stream_table_sla"(
+	"name" TEXT, /* & str */
+	"sla" interval /* Interval */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'set_stream_table_sla_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2464
+-- pg_trickle::api::drain
+CREATE  FUNCTION pgtrickle."drain"(
+	"timeout_s" INT DEFAULT 60 /* i32 */
+) RETURNS bool /* bool */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drain_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1599
+-- pg_trickle::api::diagnostics::preflight
+CREATE  FUNCTION pgtrickle."preflight"() RETURNS TEXT /* String */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'preflight_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:570
+-- pg_trickle::diagnostics::list_auxiliary_columns
+CREATE  FUNCTION pgtrickle."list_auxiliary_columns"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"column_name" TEXT,  /* String */
+	"data_type" TEXT,  /* String */
+	"purpose" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_auxiliary_columns_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2571
+-- pg_trickle::api::bulk_alter_stream_tables
+CREATE  FUNCTION pgtrickle."bulk_alter_stream_tables"(
+	"names" TEXT[], /* Vec < Option < String > > */
+	"params" json /* pgrx :: Json */
+) RETURNS INT /* i32 */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bulk_alter_stream_tables_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/spec.rs:74
+-- pg_trickle::api::spec::stream_table_spec
+CREATE  FUNCTION pgtrickle."stream_table_spec"(
+	"qualified_name" TEXT /* & str */
+) RETURNS jsonb /* Option < pgrx :: JsonB > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'stream_table_spec_by_name_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/alter.rs:1583
 -- pg_trickle::api::alter::alter_stream_table
 CREATE  FUNCTION pgtrickle."alter_stream_table"(
 	"name" TEXT, /* & str */
@@ -1479,7 +2245,7 @@ CREATE  FUNCTION pgtrickle."alter_stream_table"(
 	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
 	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
 	"post_refresh_action" TEXT DEFAULT NULL, /* Option < & str > */
-	"reindex_drift_threshold" double precision DEFAULT NULL, /* Option < f64 > */
+	"reindex_drift_threshold" double precision DEFAULT NULL /* Option < f64 > */
 ) RETURNS void
 
 LANGUAGE c /* Rust */
@@ -1487,7 +2253,7 @@ AS 'MODULE_PATHNAME', 'alter_stream_table_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:921
+-- src/lib.rs:862
 -- requires:
 --   create_stream_table
 --   drop_stream_table
@@ -1650,284 +2416,6 @@ COMMENT ON FUNCTION pgtrickle."canary_promote"(text) IS
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2693
--- pg_trickle::api::exec_stream_ddl
-CREATE  FUNCTION pgtrickle."exec_stream_ddl"(
-	"cmd" TEXT /* & str */
-) RETURNS bool /* bool */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'exec_stream_ddl_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:240
--- pg_trickle::api::self_monitoring::setup_self_monitoring
-CREATE  FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2312
--- pg_trickle::api::helpers::convert_buffers_to_unlogged
-CREATE  FUNCTION pgtrickle."convert_buffers_to_unlogged"() RETURNS bigint /* Result < i64, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'convert_buffers_to_unlogged_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:757
--- pg_trickle::monitor::health::worker_pool_status
-CREATE  FUNCTION pgtrickle."worker_pool_status"() RETURNS TABLE (
-	"active_workers" INT,  /* i32 */
-	"max_workers" INT,  /* i32 */
-	"per_db_cap" INT,  /* i32 */
-	"parallel_mode" TEXT,  /* String */
-	"idle_workers" INT,  /* i32 */
-	"last_scheduler_tick_unix" bigint,  /* i64 */
-	"ring_overflow_count" bigint,  /* i64 */
-	"citus_failure_total" bigint  /* i64 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'worker_pool_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1019
--- pg_trickle::api::diagnostics::bootstrap_gate_status
-CREATE  FUNCTION pgtrickle."bootstrap_gate_status"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"schema_name" TEXT,  /* String */
-	"gated" bool,  /* bool */
-	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"gated_by" TEXT,  /* Option < String > */
-	"gate_duration" interval,  /* Option < pgrx :: datum :: Interval > */
-	"affected_stream_tables" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bootstrap_gate_status_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/snapshot.rs:212
--- pg_trickle::api::snapshot::snapshot_stream_table
-CREATE  FUNCTION pgtrickle."snapshot_stream_table"(
-	"p_name" TEXT, /* & str */
-	"p_target" TEXT DEFAULT NULL /* Option < & str > */
-) RETURNS TEXT /* String */
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'snapshot_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/scheduler_control.rs:61
--- pg_trickle::api::scheduler_control::pause_scheduler
-CREATE  FUNCTION pgtrickle."pause_scheduler"(
-	"nodes" TEXT[] /* pgrx :: Array < & str > */
-) RETURNS TEXT /* & '_ str */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pause_scheduler_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1769
--- pg_trickle::api::diagnostics::clear_caches
-CREATE  FUNCTION pgtrickle."clear_caches"() RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'clear_caches_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/outbox.rs:190
--- pg_trickle::api::outbox::detach_outbox
-CREATE  FUNCTION pgtrickle."detach_outbox"(
-	"p_name" TEXT, /* & str */
-	"p_if_exists" bool DEFAULT false /* bool */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'detach_outbox_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:154
--- pg_trickle::api::diagnostics::parse_duration_seconds
-CREATE  FUNCTION pgtrickle."parse_duration_seconds"(
-	"input" TEXT /* & str */
-) RETURNS bigint /* Option < i64 > */
-IMMUTABLE STRICT PARALLEL SAFE 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'parse_duration_seconds_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:693
--- requires:
---   parse_duration_seconds
-
-
--- Convenience view: pg_stat_stream_tables
--- Combines catalog metadata with aggregate refresh statistics.
-CREATE OR REPLACE VIEW pgtrickle.pg_stat_stream_tables AS
-SELECT
-    st.pgt_id,
-    st.pgt_schema,
-    st.pgt_name,
-    st.status,
-    st.refresh_mode,
-    st.is_populated,
-    st.data_timestamp,
-    st.schedule,
-    now() - st.last_refresh_at AS staleness,
-    CASE WHEN st.schedule IS NOT NULL AND st.last_refresh_at IS NOT NULL
-              AND st.schedule !~ '[\s@]'
-         THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
-              pgtrickle.parse_duration_seconds(st.schedule)
-         ELSE NULL::boolean
-    END AS stale,
-    st.consecutive_errors,
-    st.needs_reinit,
-    st.last_refresh_at,
-    COALESCE(stats.total_refreshes, 0) AS total_refreshes,
-    COALESCE(stats.successful_refreshes, 0) AS successful_refreshes,
-    COALESCE(stats.failed_refreshes, 0) AS failed_refreshes,
-    COALESCE(stats.total_rows_inserted, 0) AS total_rows_inserted,
-    COALESCE(stats.total_rows_deleted, 0) AS total_rows_deleted,
-    stats.avg_duration_ms,
-    stats.last_action,
-    stats.last_status,
-    (SELECT array_agg(DISTINCT d.cdc_mode ORDER BY d.cdc_mode)
-     FROM pgtrickle.pgt_dependencies d
-     WHERE d.pgt_id = st.pgt_id AND d.source_type = 'TABLE') AS cdc_modes,
-    st.scc_id,
-    st.last_fixpoint_iterations,
-    st.refresh_tier
-FROM pgtrickle.pgt_stream_tables st
-LEFT JOIN LATERAL (
-    SELECT
-        count(*)::bigint AS total_refreshes,
-        count(*) FILTER (WHERE h.status = 'COMPLETED')::bigint AS successful_refreshes,
-        count(*) FILTER (WHERE h.status = 'FAILED')::bigint AS failed_refreshes,
-        COALESCE(sum(h.rows_inserted), 0)::bigint AS total_rows_inserted,
-        COALESCE(sum(h.rows_deleted), 0)::bigint AS total_rows_deleted,
-        CASE WHEN count(*) FILTER (WHERE h.end_time IS NOT NULL) > 0
-             THEN avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000)
-                  FILTER (WHERE h.end_time IS NOT NULL)
-             ELSE NULL
-        END::float8 AS avg_duration_ms,
-        (SELECT h2.action FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_action,
-        (SELECT h2.status FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_status,
-        (SELECT h2.initiated_by FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_initiated_by,
-        (SELECT h2.freshness_deadline FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS freshness_deadline
-    FROM pgtrickle.pgt_refresh_history h
-    WHERE h.pgt_id = st.pgt_id
-) stats ON true;
-
--- Per-source CDC status view (G5): exposes cdc_mode, slot names, and
--- transition timestamps for every TABLE dependency of a stream table.
-CREATE OR REPLACE VIEW pgtrickle.pgt_cdc_status AS
-SELECT
-    st.pgt_schema,
-    st.pgt_name,
-    d.source_relid,
-    c.relname        AS source_name,
-    n.nspname        AS source_schema,
-    d.cdc_mode,
-    d.slot_name,
-    d.decoder_confirmed_lsn,
-    d.transition_started_at
-FROM pgtrickle.pgt_dependencies d
-JOIN pgtrickle.pgt_stream_tables st ON st.pgt_id = d.pgt_id
-JOIN pg_class c ON c.oid = d.source_relid
-JOIN pg_namespace n ON n.oid = c.relnamespace
-WHERE d.source_type = 'TABLE';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:608
--- requires:
---   parse_duration_seconds
-
-
--- Status overview view (ERR-1d: last_error_message and last_error_at are
--- included via st.* from pgt_stream_tables)
-CREATE OR REPLACE VIEW pgtrickle.stream_tables_info AS
-SELECT st.*,
-       now() - st.last_refresh_at AS staleness,
-       CASE WHEN st.schedule IS NOT NULL
-                 AND st.schedule !~ '[\s@]'
-            THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
-                 pgtrickle.parse_duration_seconds(st.schedule)
-            ELSE NULL::boolean
-       END AS stale,
-       CASE WHEN st.topk_limit IS NOT NULL THEN TRUE ELSE FALSE END AS is_topk
-FROM pgtrickle.pgt_stream_tables st;
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:781
--- requires:
---   parse_duration_seconds
-
-
--- ERG-E: One-row health summary for dashboards and alerting.
-CREATE OR REPLACE VIEW pgtrickle.quick_health AS
-SELECT
-    (SELECT count(*) FROM pgtrickle.pgt_stream_tables)::bigint
-        AS total_stream_tables,
-    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
-     WHERE status = 'ERROR' OR consecutive_errors > 0)::bigint
-        AS error_tables,
-    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
-     WHERE schedule IS NOT NULL
-       AND schedule !~ '[\s@]'
-       AND last_refresh_at IS NOT NULL
-       AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
-           pgtrickle.parse_duration_seconds(schedule))::bigint
-        AS stale_tables,
-    (SELECT count(*) > 0 FROM pg_stat_activity
-     WHERE backend_type = 'pg_trickle scheduler')
-        AS scheduler_running,
-    CASE
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables) = 0 THEN 'EMPTY'
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'SUSPENDED') > 0 THEN 'CRITICAL'
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'ERROR' OR consecutive_errors > 0) > 0 THEN 'WARNING'
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables
-              WHERE schedule IS NOT NULL
-                AND schedule !~ '[\s@]'
-                AND last_refresh_at IS NOT NULL
-                AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
-                    pgtrickle.parse_duration_seconds(schedule)) > 0 THEN 'WARNING'
-        ELSE 'OK'
-    END AS status;
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/refresh_ops.rs:36
--- pg_trickle::api::refresh_ops::write_and_refresh
-CREATE  FUNCTION pgtrickle."write_and_refresh"(
-	"sql" TEXT, /* & str */
-	"stream_table_name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
 -- src/api/outbox.rs:297
 -- pg_trickle::api::outbox::attach_embedding_outbox
 CREATE  FUNCTION pgtrickle."attach_embedding_outbox"(
@@ -1942,242 +2430,16 @@ AS 'MODULE_PATHNAME', 'attach_embedding_outbox_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/cluster.rs:18
--- pg_trickle::api::cluster::cluster_worker_summary
-CREATE  FUNCTION pgtrickle."cluster_worker_summary"() RETURNS TABLE (
-	"db_oid" bigint,  /* Option < i64 > */
-	"db_name" TEXT,  /* Option < String > */
-	"active_workers" INT,  /* Option < i32 > */
-	"scheduler_pid" INT,  /* Option < i32 > */
-	"scheduler_running" bool,  /* Option < bool > */
-	"total_active_workers" INT  /* Option < i32 > */
-)
+-- src/api/diagnostics.rs:1377
+-- pg_trickle::api::diagnostics::create_refresh_group
+CREATE  FUNCTION pgtrickle."create_refresh_group"(
+	"group_name" TEXT, /* & str */
+	"members" TEXT[], /* Vec < String > */
+	"isolation" TEXT DEFAULT 'read_committed' /* & str */
+) RETURNS INT /* Result < i32, PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'cluster_worker_summary_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1459
--- pg_trickle::api::diagnostics::refresh_groups
-CREATE  FUNCTION pgtrickle."refresh_groups"() RETURNS TABLE (
-	"group_id" INT,  /* i32 */
-	"group_name" TEXT,  /* String */
-	"member_count" INT,  /* i32 */
-	"isolation" TEXT,  /* String */
-	"created_at" timestamp with time zone  /* TimestampWithTimeZone */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_groups_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/tree.rs:18
--- pg_trickle::monitor::tree::dependency_tree
-CREATE  FUNCTION pgtrickle."dependency_tree"() RETURNS TABLE (
-	"tree_line" TEXT,  /* String */
-	"node" TEXT,  /* String */
-	"node_type" TEXT,  /* String */
-	"depth" INT,  /* i32 */
-	"status" TEXT,  /* Option < String > */
-	"refresh_mode" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dependency_tree_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:748
--- pg_trickle::api::diagnostics::fuse_status
-CREATE  FUNCTION pgtrickle."fuse_status"() RETURNS TABLE (
-	"stream_table" TEXT,  /* String */
-	"fuse_mode" TEXT,  /* String */
-	"fuse_state" TEXT,  /* String */
-	"fuse_ceiling" bigint,  /* Option < i64 > */
-	"effective_ceiling" bigint,  /* Option < i64 > */
-	"fuse_sensitivity" INT,  /* Option < i32 > */
-	"blown_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"blow_reason" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'fuse_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/hooks.rs:51
--- pg_trickle::hooks::pg_trickle_on_ddl_end
--- Skipped due to `#[pgrx(sql = false)]`
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:561
--- pg_trickle::monitor::health::refresh_timeline
-CREATE  FUNCTION pgtrickle."refresh_timeline"(
-	"max_rows" INT DEFAULT 50 /* i32 */
-) RETURNS TABLE (
-	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
-	"stream_table" TEXT,  /* String */
-	"action" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"rows_inserted" bigint,  /* i64 */
-	"rows_deleted" bigint,  /* i64 */
-	"duration_ms" double precision,  /* Option < f64 > */
-	"error_message" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_timeline_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/alter.rs:2488
--- pg_trickle::api::alter::repair_stream_table
-CREATE  FUNCTION pgtrickle."repair_stream_table"(
-	"name" TEXT /* & str */
-) RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'repair_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:698
--- pg_trickle::monitor::cache_stats
-CREATE  FUNCTION pgtrickle."cache_stats"() RETURNS TABLE (
-	"l1_hits" bigint,  /* i64 */
-	"l2_hits" bigint,  /* i64 */
-	"misses" bigint,  /* i64 */
-	"evictions" bigint,  /* i64 */
-	"l1_size" INT,  /* i32 */
-	"l1_bytes" bigint  /* i64 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'cache_stats_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:1144
--- pg_trickle::monitor::explain_diff_sql
-CREATE  FUNCTION pgtrickle."explain_diff_sql"(
-	"name" TEXT /* & str */
-) RETURNS TEXT /* Option < String > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_diff_sql_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:1405
--- pg_trickle::monitor::check_cdc_health
-CREATE  FUNCTION pgtrickle."check_cdc_health"() RETURNS TABLE (
-	"source_relid" bigint,  /* i64 */
-	"source_table" TEXT,  /* String */
-	"cdc_mode" TEXT,  /* String */
-	"slot_name" TEXT,  /* Option < String > */
-	"lag_bytes" bigint,  /* Option < i64 > */
-	"confirmed_lsn" TEXT,  /* Option < String > */
-	"alert" TEXT,  /* Option < String > */
-	"selective_capture" bool  /* bool */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'check_cdc_health_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2673
--- pg_trickle::api::helpers::restore_stream_tables
-CREATE  FUNCTION pgtrickle."restore_stream_tables"() RETURNS VOID /* Result < (), crate :: error :: PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'restore_stream_tables_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:633
--- pg_trickle::monitor::st_auto_threshold
-CREATE  FUNCTION pgtrickle."st_auto_threshold"(
-	"name" TEXT /* & str */
-) RETURNS double precision /* Option < f64 > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'st_auto_threshold_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/scheduler_control.rs:132
--- pg_trickle::api::scheduler_control::resume_scheduler
-CREATE  FUNCTION pgtrickle."resume_scheduler"(
-	"nodes" TEXT[] /* pgrx :: Array < & str > */
-) RETURNS TEXT /* & '_ str */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'resume_scheduler_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1447
--- pg_trickle::api::diagnostics::drop_refresh_group
-CREATE  FUNCTION pgtrickle."drop_refresh_group"(
-	"group_name" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_refresh_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:525
--- pg_trickle::monitor::get_refresh_history
-CREATE  FUNCTION pgtrickle."get_refresh_history"(
-	"name" TEXT, /* & str */
-	"max_rows" INT DEFAULT 20 /* i32 */
-) RETURNS TABLE (
-	"refresh_id" bigint,  /* i64 */
-	"data_timestamp" timestamp with time zone,  /* TimestampWithTimeZone */
-	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
-	"end_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"action" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"rows_inserted" bigint,  /* i64 */
-	"rows_deleted" bigint,  /* i64 */
-	"duration_ms" double precision,  /* Option < f64 > */
-	"error_message" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'get_refresh_history_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2524
--- pg_trickle::api::cdc_pause_status
-CREATE  FUNCTION pgtrickle."cdc_pause_status"() RETURNS TABLE (
-	"paused" bool,  /* bool */
-	"capture_mode" TEXT,  /* String */
-	"note" TEXT  /* String */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'cdc_pause_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/ivm.rs:712
--- pg_trickle::ivm::pgt_ivm_apply_delta
-CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta"(
-	"pgt_id" bigint, /* i64 */
-	"source_oid" INT, /* i32 */
-	"has_new" bool, /* bool */
-	"has_old" bool /* bool */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_wrapper';
+AS 'MODULE_PATHNAME', 'create_refresh_group_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2196,121 +2458,53 @@ AS 'MODULE_PATHNAME', 'pgt_scc_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/snapshot.rs:321
--- pg_trickle::api::snapshot::restore_from_snapshot
-CREATE  FUNCTION pgtrickle."restore_from_snapshot"(
-	"p_name" TEXT, /* & str */
-	"p_source" TEXT /* & str */
+-- src/api/refresh_ops.rs:8
+-- pg_trickle::api::refresh_ops::refresh_stream_table
+CREATE  FUNCTION pgtrickle."refresh_stream_table"(
+	"name" TEXT /* & str */
 ) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'restore_from_snapshot_wrapper';
+AS 'MODULE_PATHNAME', 'refresh_stream_table_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2138
--- pg_trickle::api::sla_summary
-CREATE  FUNCTION pgtrickle."sla_summary"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"p50_ms" double precision,  /* Option < f64 > */
-	"p99_ms" double precision,  /* Option < f64 > */
-	"freshness_lag_s" double precision,  /* Option < f64 > */
-	"error_rate" double precision,  /* Option < f64 > */
-	"error_budget_remaining" double precision  /* Option < f64 > */
+-- src/lib.rs:799
+-- requires:
+--   refresh_stream_table
+
+
+CREATE OR REPLACE FUNCTION pgtrickle."refresh_if_stale"(
+    p_name   text,
+    p_max_age interval DEFAULT '5 minutes'::interval
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'sla_summary_wrapper';
-/* </end connected objects> */
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_last_end timestamp with time zone;
+    v_refreshed boolean := false;
+BEGIN
+    SELECT MAX(end_time)
+      INTO v_last_end
+      FROM pgtrickle.pgt_refresh_history h
+      JOIN pgtrickle.pgt_stream_tables   s USING (pgt_id)
+     WHERE s.pgt_name = p_name
+       AND h.status = 'COMPLETED';
 
-/* <begin connected objects> */
--- src/api/spec.rs:57
--- pg_trickle::api::spec::stream_table_spec
-CREATE  FUNCTION pgtrickle."stream_table_spec"(
-	"relid" oid /* pg_sys :: Oid */
-) RETURNS jsonb /* Option < pgrx :: JsonB > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_spec_wrapper';
-/* </end connected objects> */
+    IF v_last_end IS NULL OR (now() - v_last_end) > p_max_age THEN
+        PERFORM pgtrickle.refresh_stream_table(p_name);
+        v_refreshed := true;
+    END IF;
 
-/* <begin connected objects> */
--- src/api/diagnostics.rs:95
--- pg_trickle::api::diagnostics::_signal_launcher_rescan
-CREATE  FUNCTION pgtrickle."_signal_launcher_rescan"() RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', '_signal_launcher_rescan_wrapper';
-/* </end connected objects> */
+    RETURN v_refreshed;
+END;
+$$;
 
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:566
--- pg_trickle::api::self_monitoring::explain_dag
-CREATE  FUNCTION pgtrickle."explain_dag"(
-	"format" TEXT DEFAULT 'mermaid' /* Option < & str > */
-) RETURNS TEXT /* Option < String > */
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_dag_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:23
--- pg_trickle::monitor::health::health_check
-CREATE  FUNCTION pgtrickle."health_check"() RETURNS TABLE (
-	"check_name" TEXT,  /* String */
-	"severity" TEXT,  /* String */
-	"detail" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'health_check_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/spec.rs:74
--- pg_trickle::api::spec::stream_table_spec
-CREATE  FUNCTION pgtrickle."stream_table_spec"(
-	"qualified_name" TEXT /* & str */
-) RETURNS jsonb /* Option < pgrx :: JsonB > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_spec_by_name_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1168
--- pg_trickle::api::diagnostics::watermarks
-CREATE  FUNCTION pgtrickle."watermarks"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"schema_name" TEXT,  /* String */
-	"watermark" timestamp with time zone,  /* TimestampWithTimeZone */
-	"updated_at" timestamp with time zone,  /* TimestampWithTimeZone */
-	"advanced_by" TEXT,  /* Option < String > */
-	"wal_lsn" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'watermarks_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:414
--- pg_trickle::monitor::health::health_summary
-CREATE  FUNCTION pgtrickle."health_summary"() RETURNS TABLE (
-	"total_stream_tables" INT,  /* i32 */
-	"active_count" INT,  /* i32 */
-	"error_count" INT,  /* i32 */
-	"suspended_count" INT,  /* i32 */
-	"stale_count" INT,  /* i32 */
-	"reinit_pending" INT,  /* i32 */
-	"max_staleness_seconds" double precision,  /* Option < f64 > */
-	"scheduler_status" TEXT,  /* String */
-	"cache_hit_rate" double precision  /* Option < f64 > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'health_summary_wrapper';
+COMMENT ON FUNCTION pgtrickle."refresh_if_stale"(text, interval) IS
+    'Refresh the named stream table only when the most recent completed '
+    'refresh is older than max_age.  Returns TRUE when a refresh was '
+    'triggered, FALSE when the table was fresh enough.';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2331,246 +2525,53 @@ AS 'MODULE_PATHNAME', 'watermark_status_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/publication.rs:78
--- pg_trickle::api::publication::drop_stream_table_publication
-CREATE  FUNCTION pgtrickle."drop_stream_table_publication"(
-	"name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_stream_table_publication_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:744
--- pg_trickle::monitor::reliability_counters
-CREATE  FUNCTION pgtrickle."reliability_counters"() RETURNS TABLE (
-	"invalidation_ring_overflows" bigint,  /* i64 */
-	"dag_cycles_detected" bigint,  /* i64 */
-	"template_cache_stale_evictions" bigint  /* i64 */
+-- src/api/diagnostics.rs:516
+-- pg_trickle::api::diagnostics::dedup_stats
+CREATE  FUNCTION pgtrickle."dedup_stats"() RETURNS TABLE (
+	"total_diff_refreshes" bigint,  /* i64 */
+	"dedup_needed" bigint,  /* i64 */
+	"dedup_ratio_pct" double precision  /* f64 */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'reliability_counters_wrapper';
+AS 'MODULE_PATHNAME', 'dedup_stats_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/diagnostics.rs:767
--- pg_trickle::diagnostics::validate_query
-CREATE  FUNCTION pgtrickle."validate_query"(
-	"query" TEXT /* & str */
-) RETURNS TABLE (
-	"check_name" TEXT,  /* String */
-	"result" TEXT,  /* String */
-	"severity" TEXT  /* String */
-)
+-- src/api/diagnostics.rs:1091
+-- pg_trickle::api::diagnostics::advance_watermark
+CREATE  FUNCTION pgtrickle."advance_watermark"(
+	"source" TEXT, /* & str */
+	"watermark" timestamp with time zone /* TimestampWithTimeZone */
+) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'validate_query_wrapper';
+AS 'MODULE_PATHNAME', 'advance_watermark_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:8
--- pg_trickle::api::diagnostics::version
-CREATE  FUNCTION pgtrickle."version"() RETURNS TEXT /* & '_ str */
-IMMUTABLE STRICT PARALLEL SAFE 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'version_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2507
--- pg_trickle::api::is_drained
-CREATE  FUNCTION pgtrickle."is_drained"() RETURNS bool /* bool */
+-- src/api/mod.rs:1707
+-- pg_trickle::api::unsubscribe_distance
+CREATE  FUNCTION pgtrickle."unsubscribe_distance"(
+	"stream_table" TEXT, /* & str */
+	"channel" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'is_drained_wrapper';
+AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/publication.rs:135
--- pg_trickle::api::publication::set_stream_table_sla
-CREATE  FUNCTION pgtrickle."set_stream_table_sla"(
-	"name" TEXT, /* & str */
-	"sla" interval /* Interval */
-) RETURNS void
+-- src/api/helpers.rs:2683
+-- pg_trickle::api::helpers::restore_stream_tables
+CREATE  FUNCTION pgtrickle."restore_stream_tables"() RETURNS VOID /* Result < (), crate :: error :: PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'set_stream_table_sla_wrapper';
+AS 'MODULE_PATHNAME', 'restore_stream_tables_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2409
--- pg_trickle::api::view_evolution_status
-CREATE  FUNCTION pgtrickle."view_evolution_status"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"in_shadow_build" bool,  /* Option < bool > */
-	"shadow_table_name" TEXT,  /* Option < String > */
-	"status" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'view_evolution_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/metrics_ext.rs:25
--- pg_trickle::api::metrics_ext::metrics_summary
-CREATE  FUNCTION pgtrickle."metrics_summary"() RETURNS TABLE (
-	"db_name" TEXT,  /* Option < String > */
-	"total_stream_tables" bigint,  /* Option < i64 > */
-	"active_stream_tables" bigint,  /* Option < i64 > */
-	"suspended_stream_tables" bigint,  /* Option < i64 > */
-	"total_refreshes" bigint,  /* Option < i64 > */
-	"successful_refreshes" bigint,  /* Option < i64 > */
-	"failed_refreshes" bigint,  /* Option < i64 > */
-	"total_rows_processed" bigint,  /* Option < i64 > */
-	"active_workers" INT,  /* Option < i32 > */
-	"ivm_lock_parse_error_count" bigint,  /* Option < i64 > */
-	"holdback_probe_calls" bigint,  /* Option < i64 > */
-	"holdback_probe_cache_hits" bigint,  /* Option < i64 > */
-	"holdback_probe_avg_ms" double precision  /* Option < f64 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'metrics_summary_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2497
--- pg_trickle::api::helpers::refresh_efficiency
-CREATE  FUNCTION pgtrickle."refresh_efficiency"() RETURNS TABLE (
-	"pgt_schema" TEXT,  /* String */
-	"pgt_name" TEXT,  /* String */
-	"refresh_mode" TEXT,  /* String */
-	"total_refreshes" bigint,  /* i64 */
-	"diff_count" bigint,  /* i64 */
-	"full_count" bigint,  /* i64 */
-	"avg_diff_ms" double precision,  /* Option < f64 > */
-	"avg_full_ms" double precision,  /* Option < f64 > */
-	"avg_change_ratio" double precision,  /* Option < f64 > */
-	"diff_speedup" TEXT,  /* Option < String > */
-	"last_refresh_at" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_efficiency_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:358
--- pg_trickle::api::self_monitoring::self_monitoring_status
-CREATE  FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
-	"st_name" TEXT,  /* String */
-	"exists" bool,  /* bool */
-	"status" TEXT,  /* Option < String > */
-	"refresh_mode" TEXT,  /* Option < String > */
-	"last_refresh_at" TEXT,  /* Option < String > */
-	"total_refreshes" bigint  /* Option < i64 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2771
--- pg_trickle::api::stream_table_lineage
-CREATE  FUNCTION pgtrickle."stream_table_lineage"(
-	"name" TEXT /* & str */
-) RETURNS TABLE (
-	"output_col" TEXT,  /* Option < String > */
-	"source_table" TEXT,  /* Option < String > */
-	"source_col" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_lineage_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:799
--- pg_trickle::monitor::health::parallel_job_status
-CREATE  FUNCTION pgtrickle."parallel_job_status"(
-	"max_age_seconds" INT DEFAULT 300 /* i32 */
-) RETURNS TABLE (
-	"job_id" bigint,  /* i64 */
-	"unit_key" TEXT,  /* String */
-	"unit_kind" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"member_count" INT,  /* i32 */
-	"attempt_no" INT,  /* i32 */
-	"scheduler_pid" INT,  /* i32 */
-	"worker_pid" INT,  /* Option < i32 > */
-	"enqueued_at" timestamp with time zone,  /* TimestampWithTimeZone */
-	"started_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"finished_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"duration_ms" double precision  /* Option < f64 > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'parallel_job_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:19
--- pg_trickle::api::diagnostics::version_check
-CREATE  FUNCTION pgtrickle."version_check"() RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'version_check_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:2012
--- pg_trickle::monitor::list_sources
-CREATE  FUNCTION pgtrickle."list_sources"(
-	"name" TEXT /* & str */
-) RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"source_oid" bigint,  /* i64 */
-	"source_type" TEXT,  /* String */
-	"cdc_mode" TEXT,  /* String */
-	"columns_used" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_sources_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1123
--- pg_trickle::api::diagnostics::create_watermark_group
-CREATE  FUNCTION pgtrickle."create_watermark_group"(
-	"group_name" TEXT, /* & str */
-	"sources" TEXT[], /* Vec < String > */
-	"tolerance_secs" double precision DEFAULT 0.0 /* f64 */
-) RETURNS INT /* Result < i32, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_watermark_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:1726
--- pg_trickle::api::list_distance_subscriptions
-CREATE  FUNCTION pgtrickle."list_distance_subscriptions"(
-	"p_stream_table" TEXT DEFAULT NULL /* Option < & str > */
-) RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"channel" TEXT,  /* Option < String > */
-	"vector_column" TEXT,  /* Option < String > */
-	"op" TEXT,  /* Option < String > */
-	"threshold" double precision,  /* Option < f64 > */
-	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
-)
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:1143
+-- src/lib.rs:1084
 -- requires:
 --   _signal_launcher_rescan
 

--- a/sql/archive/pg_trickle--0.77.0.sql
+++ b/sql/archive/pg_trickle--0.77.0.sql
@@ -7,7 +7,7 @@ The ordering of items is not stable, it is driven by a dependency graph.
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:219
+-- src/lib.rs:218
 -- bootstrap
 
 -- Extension schemas
@@ -100,6 +100,8 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_stream_tables (
     column_lineage  JSONB,
     -- v0.59.0 PERF-2: hash of defining_query to skip recomputation on every refresh
     defining_query_hash BIGINT NOT NULL DEFAULT 0,
+    -- v0.73.0 HOT-1: fillfactor for storage heap (NULL = PG default 100). Range 10-100.
+    storage_fillfactor INT DEFAULT NULL CHECK (storage_fillfactor IS NULL OR (storage_fillfactor >= 10 AND storage_fillfactor <= 100)),
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -331,7 +333,81 @@ CREATE UNLOGGED TABLE IF NOT EXISTS pgtrickle.pgt_template_cache (
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:820
+-- src/lib.rs:1050
+
+-- VH-2 (v0.48.0): Distance-predicate subscription catalog.
+-- Stores per-(stream_table, channel) vector distance subscriptions.
+-- After each non-empty refresh the background worker evaluates the predicate
+-- and emits pg_notify(channel, payload) when matched_rows > 0.
+CREATE TABLE IF NOT EXISTS pgtrickle.pgt_distance_subscriptions (
+    stream_table    TEXT NOT NULL,
+    channel         TEXT NOT NULL,
+    vector_column   TEXT NOT NULL,
+    query_vector    TEXT NOT NULL,
+    op              TEXT NOT NULL
+        CHECK (op IN ('<->', '<=>', '<#>', '<+>', '<<->>', '<<%>>')),
+    threshold       DOUBLE PRECISION NOT NULL CHECK (threshold > 0),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (stream_table, channel)
+);
+
+COMMENT ON TABLE pgtrickle.pgt_distance_subscriptions IS
+    'VH-2 (v0.48.0): Distance-predicate NOTIFY subscriptions per stream table. '
+    'Populated via pgtrickle.subscribe_distance() / pgtrickle.unsubscribe_distance().';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:1024
+
+-- v0.46.0: Slim outbox attachment catalog.
+-- Maps stream tables to their pg_tide outbox names.
+-- The full outbox/inbox/relay stack lives in pg_tide (trickle-labs/pg-tide).
+CREATE TABLE IF NOT EXISTS pgtrickle.pgt_outbox_config (
+    stream_table_oid         OID         NOT NULL PRIMARY KEY,
+    stream_table_name        TEXT        NOT NULL,
+    tide_outbox_name         TEXT        NOT NULL,
+    -- VA-4 (v0.48.0): optional vector column name for embedding outbox events.
+    embedding_vector_column  TEXT,
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_pgt_outbox_config_name
+    ON pgtrickle.pgt_outbox_config (stream_table_name);
+
+COMMENT ON TABLE pgtrickle.pgt_outbox_config IS
+    'v0.46.0: Catalog of stream tables with a pg_tide outbox attached via attach_outbox(). '
+    'v0.48.0: embedding_vector_column set when attached via attach_embedding_outbox().';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:604
+
+-- Create event trigger functions with correct RETURNS event_trigger type.
+-- pgrx's #[pg_extern] generates RETURNS void, which PostgreSQL rejects for
+-- event triggers. We create them manually here with the correct return type.
+CREATE FUNCTION pgtrickle."_on_ddl_end"()
+    RETURNS event_trigger
+    LANGUAGE c
+    AS 'MODULE_PATHNAME', 'pg_trickle_on_ddl_end_wrapper';
+
+CREATE FUNCTION pgtrickle."_on_sql_drop"()
+    RETURNS event_trigger
+    LANGUAGE c
+    AS 'MODULE_PATHNAME', 'pg_trickle_on_sql_drop_wrapper';
+
+-- Event trigger: track ALTER TABLE on upstream sources
+CREATE EVENT TRIGGER pg_trickle_ddl_tracker
+    ON ddl_command_end
+    EXECUTE FUNCTION pgtrickle._on_ddl_end();
+
+-- Event trigger: track DROP TABLE on upstream sources / ST storage tables
+CREATE EVENT TRIGGER pg_trickle_drop_tracker
+    ON sql_drop
+    EXECUTE FUNCTION pgtrickle._on_sql_drop();
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:761
 
 CREATE OR REPLACE FUNCTION pgtrickle."pause_all"()
 RETURNS void
@@ -366,58 +442,7 @@ COMMENT ON FUNCTION pgtrickle."resume_all"() IS
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:663
-
--- Create event trigger functions with correct RETURNS event_trigger type.
--- pgrx's #[pg_extern] generates RETURNS void, which PostgreSQL rejects for
--- event triggers. We create them manually here with the correct return type.
-CREATE FUNCTION pgtrickle."_on_ddl_end"()
-    RETURNS event_trigger
-    LANGUAGE c
-    AS 'MODULE_PATHNAME', 'pg_trickle_on_ddl_end_wrapper';
-
-CREATE FUNCTION pgtrickle."_on_sql_drop"()
-    RETURNS event_trigger
-    LANGUAGE c
-    AS 'MODULE_PATHNAME', 'pg_trickle_on_sql_drop_wrapper';
-
--- Event trigger: track ALTER TABLE on upstream sources
-CREATE EVENT TRIGGER pg_trickle_ddl_tracker
-    ON ddl_command_end
-    EXECUTE FUNCTION pgtrickle._on_ddl_end();
-
--- Event trigger: track DROP TABLE on upstream sources / ST storage tables
-CREATE EVENT TRIGGER pg_trickle_drop_tracker
-    ON sql_drop
-    EXECUTE FUNCTION pgtrickle._on_sql_drop();
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:1109
-
--- VH-2 (v0.48.0): Distance-predicate subscription catalog.
--- Stores per-(stream_table, channel) vector distance subscriptions.
--- After each non-empty refresh the background worker evaluates the predicate
--- and emits pg_notify(channel, payload) when matched_rows > 0.
-CREATE TABLE IF NOT EXISTS pgtrickle.pgt_distance_subscriptions (
-    stream_table    TEXT NOT NULL,
-    channel         TEXT NOT NULL,
-    vector_column   TEXT NOT NULL,
-    query_vector    TEXT NOT NULL,
-    op              TEXT NOT NULL
-        CHECK (op IN ('<->', '<=>', '<#>', '<+>', '<<->>', '<<%>>')),
-    threshold       DOUBLE PRECISION NOT NULL CHECK (threshold > 0),
-    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-    PRIMARY KEY (stream_table, channel)
-);
-
-COMMENT ON TABLE pgtrickle.pgt_distance_subscriptions IS
-    'VH-2 (v0.48.0): Distance-predicate NOTIFY subscriptions per stream table. '
-    'Populated via pgtrickle.subscribe_distance() / pgtrickle.unsubscribe_distance().';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:630
+-- src/lib.rs:571
 -- requires:
 --   pg_trickle_catalog
 
@@ -449,270 +474,213 @@ WHERE ct.source_placement = 'distributed';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:1083
-
--- v0.46.0: Slim outbox attachment catalog.
--- Maps stream tables to their pg_tide outbox names.
--- The full outbox/inbox/relay stack lives in pg_tide (trickle-labs/pg-tide).
-CREATE TABLE IF NOT EXISTS pgtrickle.pgt_outbox_config (
-    stream_table_oid         OID         NOT NULL PRIMARY KEY,
-    stream_table_name        TEXT        NOT NULL,
-    tide_outbox_name         TEXT        NOT NULL,
-    -- VA-4 (v0.48.0): optional vector column name for embedding outbox events.
-    embedding_vector_column  TEXT,
-    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
-);
-
-CREATE INDEX IF NOT EXISTS idx_pgt_outbox_config_name
-    ON pgtrickle.pgt_outbox_config (stream_table_name);
-
-COMMENT ON TABLE pgtrickle.pgt_outbox_config IS
-    'v0.46.0: Catalog of stream tables with a pg_tide outbox attached via attach_outbox(). '
-    'v0.48.0: embedding_vector_column set when attached via attach_embedding_outbox().';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:56
+-- src/lib.rs:55
 CREATE SCHEMA IF NOT EXISTS pgtrickle; /* pg_trickle::pgtrickle */
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor/mod.rs:2190
--- pg_trickle::monitor::history_prune_status
-CREATE  FUNCTION pgtrickle."history_prune_status"() RETURNS TABLE (
-	"prune_error_count" bigint,  /* i64 */
-	"last_prune_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"last_rows_deleted" bigint  /* Option < i64 > */
+-- src/api/alter.rs:2407
+-- pg_trickle::api::alter::repair_stream_table
+CREATE  FUNCTION pgtrickle."repair_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS TEXT /* String */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'repair_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:212
+-- pg_trickle::api::snapshot::snapshot_stream_table
+CREATE  FUNCTION pgtrickle."snapshot_stream_table"(
+	"p_name" TEXT, /* & str */
+	"p_target" TEXT DEFAULT NULL /* Option < & str > */
+) RETURNS TEXT /* String */
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'snapshot_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:545
+-- pg_trickle::api::diagnostics::shared_buffer_stats
+CREATE  FUNCTION pgtrickle."shared_buffer_stats"() RETURNS TABLE (
+	"source_oid" bigint,  /* i64 */
+	"source_table" TEXT,  /* String */
+	"consumer_count" INT,  /* i32 */
+	"consumers" TEXT,  /* String */
+	"columns_tracked" INT,  /* i32 */
+	"safe_frontier_lsn" TEXT,  /* Option < String > */
+	"buffer_rows" bigint,  /* i64 */
+	"is_partitioned" bool  /* bool */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'history_prune_status_wrapper';
+AS 'MODULE_PATHNAME', 'shared_buffer_stats_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:1892
--- pg_trickle::api::embedding_stream_table
-CREATE  FUNCTION pgtrickle."embedding_stream_table"(
-	"name" TEXT, /* & str */
-	"source_table" TEXT, /* & str */
-	"vector_column" TEXT, /* & str */
-	"extra_columns" TEXT DEFAULT NULL, /* Option < & str > */
-	"refresh_interval" TEXT DEFAULT '1m', /* & str */
-	"index_type" TEXT DEFAULT 'hnsw', /* & str */
-	"dry_run" bool DEFAULT false /* bool */
-) RETURNS TABLE (
-	"action" TEXT  /* Option < String > */
+-- src/api/diagnostics.rs:819
+-- pg_trickle::api::diagnostics::diamond_groups
+CREATE  FUNCTION pgtrickle."diamond_groups"() RETURNS TABLE (
+	"group_id" INT,  /* i32 */
+	"member_name" TEXT,  /* String */
+	"member_schema" TEXT,  /* String */
+	"is_convergence" bool,  /* bool */
+	"epoch" bigint,  /* i64 */
+	"schedule_policy" TEXT  /* String */
 )
-
+STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'embedding_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'diamond_groups_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/ivm.rs:834
--- pg_trickle::ivm::pgt_ivm_apply_delta_enr
-CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta_enr"(
-	"pgt_id" bigint, /* i64 */
-	"source_oid" INT, /* i32 */
-	"has_new" bool, /* bool */
-	"has_old" bool /* bool */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
+-- src/monitor/tree.rs:18
+-- pg_trickle::monitor::tree::dependency_tree
+CREATE  FUNCTION pgtrickle."dependency_tree"() RETURNS TABLE (
+	"tree_line" TEXT,  /* String */
+	"node" TEXT,  /* String */
+	"node_type" TEXT,  /* String */
+	"depth" INT,  /* i32 */
+	"status" TEXT,  /* Option < String > */
+	"refresh_mode" TEXT  /* Option < String > */
+)
+STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_enr_wrapper';
+AS 'MODULE_PATHNAME', 'dependency_tree_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/create.rs:84
--- pg_trickle::api::create::create_stream_table_if_not_exists
-CREATE  FUNCTION pgtrickle."create_stream_table_if_not_exists"(
-	"name" TEXT, /* & str */
-	"query" TEXT, /* & str */
-	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
-	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
-	"initialize" bool DEFAULT true, /* bool */
-	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
-	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
-	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
-	"append_only" bool DEFAULT false, /* bool */
-	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
-	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
-	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
-	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
-	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
-	"temporal" bool DEFAULT false, /* bool */
-	"storage_backend" TEXT DEFAULT NULL, /* Option < & str > */
-	"fillfactor" INT DEFAULT NULL /* Option < i32 > */
+-- src/monitor/mod.rs:675
+-- pg_trickle::monitor::slot_health
+CREATE  FUNCTION pgtrickle."slot_health"() RETURNS TABLE (
+	"slot_name" TEXT,  /* String */
+	"source_relid" bigint,  /* i64 */
+	"active" bool,  /* bool */
+	"retained_wal_bytes" bigint,  /* i64 */
+	"wal_status" TEXT  /* String */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'slot_health_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:652
+-- pg_trickle::monitor::get_staleness
+CREATE  FUNCTION pgtrickle."get_staleness"(
+	"name" TEXT /* & str */
+) RETURNS double precision /* Option < f64 > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'get_staleness_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:550
+-- pg_trickle::api::snapshot::drop_snapshot
+CREATE  FUNCTION pgtrickle."drop_snapshot"(
+	"p_snapshot_table" TEXT /* & str */
 ) RETURNS void
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_stream_table_if_not_exists_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1091
--- pg_trickle::api::diagnostics::advance_watermark
-CREATE  FUNCTION pgtrickle."advance_watermark"(
-	"source" TEXT, /* & str */
-	"watermark" timestamp with time zone /* TimestampWithTimeZone */
-) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'advance_watermark_wrapper';
+AS 'MODULE_PATHNAME', 'drop_snapshot_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:1600
--- pg_trickle::api::unsubscribe
-CREATE  FUNCTION pgtrickle."unsubscribe"(
-	"stream_table" TEXT, /* & str */
-	"channel" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'unsubscribe_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:407
--- pg_trickle::api::diagnostics::explain_delta
-CREATE  FUNCTION pgtrickle."explain_delta"(
+-- src/api/alter.rs:2168
+-- pg_trickle::api::alter::drop_stream_table
+CREATE  FUNCTION pgtrickle."drop_stream_table"(
 	"name" TEXT, /* & str */
-	"format" TEXT DEFAULT 'text' /* & str */
-) RETURNS SETOF TEXT /* String */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_delta_text_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/planner.rs:186
--- pg_trickle::api::planner::schedule_recommendations
-CREATE  FUNCTION pgtrickle."schedule_recommendations"() RETURNS TABLE (
-	"name" TEXT,  /* Option < String > */
-	"current_interval_seconds" double precision,  /* Option < f64 > */
-	"recommended_interval_seconds" double precision,  /* Option < f64 > */
-	"delta_pct" double precision,  /* Option < f64 > */
-	"confidence" double precision,  /* Option < f64 > */
-	"reasoning" TEXT  /* Option < String > */
-)
+	"cascade" bool DEFAULT false /* bool */
+) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'schedule_recommendations_wrapper';
+AS 'MODULE_PATHNAME', 'drop_stream_table_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/citus.rs:103
--- pg_trickle::citus::source_stable_name
-CREATE  FUNCTION pgtrickle."source_stable_name"(
-	"source_oid" oid /* pg_sys :: Oid */
-) RETURNS TEXT /* Option < String > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'sql_stable_name_for_oid_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1805
--- pg_trickle::api::diagnostics::vector_status
-CREATE  FUNCTION pgtrickle."vector_status"() RETURNS TABLE (
-	"name" TEXT,  /* String */
-	"post_refresh_action" TEXT,  /* String */
-	"reindex_drift_threshold" double precision,  /* Option < f64 > */
-	"rows_changed_since_last_reindex" bigint,  /* i64 */
-	"last_reindex_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"data_timestamp" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"embedding_lag" interval,  /* Option < pgrx :: datum :: Interval > */
-	"estimated_rows" bigint,  /* Option < i64 > */
-	"drift_pct" double precision  /* Option < f64 > */
+-- src/monitor/mod.rs:698
+-- pg_trickle::monitor::cache_stats
+CREATE  FUNCTION pgtrickle."cache_stats"() RETURNS TABLE (
+	"l1_hits" bigint,  /* i64 */
+	"l2_hits" bigint,  /* i64 */
+	"misses" bigint,  /* i64 */
+	"evictions" bigint,  /* i64 */
+	"l1_size" INT,  /* i32 */
+	"l1_bytes" bigint  /* i64 */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'vector_status_wrapper';
+AS 'MODULE_PATHNAME', 'cache_stats_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2575
--- pg_trickle::api::bulk_alter_stream_tables
-CREATE  FUNCTION pgtrickle."bulk_alter_stream_tables"(
-	"names" TEXT[], /* Vec < Option < String > > */
-	"params" json /* pgrx :: Json */
-) RETURNS INT /* i32 */
+-- src/api/diagnostics.rs:61
+-- pg_trickle::api::diagnostics::migrate
+CREATE  FUNCTION pgtrickle."migrate"() RETURNS TEXT /* String */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bulk_alter_stream_tables_wrapper';
+AS 'MODULE_PATHNAME', 'migrate_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/create.rs:172
--- pg_trickle::api::create::bulk_create
-CREATE  FUNCTION pgtrickle."bulk_create"(
-	"definitions" jsonb /* pgrx :: JsonB */
-) RETURNS jsonb /* pgrx :: JsonB */
+-- src/citus.rs:806
+-- pg_trickle::citus::handle_vp_promoted
+CREATE  FUNCTION pgtrickle."handle_vp_promoted"(
+	"payload" TEXT /* & str */
+) RETURNS bool /* bool */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'sql_handle_vp_promoted_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/spec.rs:57
+-- pg_trickle::api::spec::stream_table_spec
+CREATE  FUNCTION pgtrickle."stream_table_spec"(
+	"relid" oid /* pg_sys :: Oid */
+) RETURNS jsonb /* Option < pgrx :: JsonB > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bulk_create_wrapper';
+AS 'MODULE_PATHNAME', 'stream_table_spec_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:1377
--- pg_trickle::api::diagnostics::create_refresh_group
-CREATE  FUNCTION pgtrickle."create_refresh_group"(
-	"group_name" TEXT, /* & str */
-	"members" TEXT[], /* Vec < String > */
-	"isolation" TEXT DEFAULT 'read_committed' /* & str */
-) RETURNS INT /* Result < i32, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_refresh_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/alter.rs:2432
--- pg_trickle::api::alter::resume_stream_table
-CREATE  FUNCTION pgtrickle."resume_stream_table"(
+-- src/api/publication.rs:78
+-- pg_trickle::api::publication::drop_stream_table_publication
+CREATE  FUNCTION pgtrickle."drop_stream_table_publication"(
 	"name" TEXT /* & str */
 ) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'resume_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'drop_stream_table_publication_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/create.rs:330
--- pg_trickle::api::create::create_or_replace_stream_table
-CREATE  FUNCTION pgtrickle."create_or_replace_stream_table"(
-	"name" TEXT, /* & str */
-	"query" TEXT, /* & str */
-	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
-	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
-	"initialize" bool DEFAULT true, /* bool */
-	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
-	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
-	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
-	"append_only" bool DEFAULT false, /* bool */
-	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
-	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
-	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
-	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
-	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
-	"temporal" bool DEFAULT false, /* bool */
-	"storage_backend" TEXT DEFAULT NULL /* Option < & str > */
-) RETURNS void
-
+-- src/api/mod.rs:2503
+-- pg_trickle::api::is_drained
+CREATE  FUNCTION pgtrickle."is_drained"() RETURNS bool /* bool */
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_or_replace_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'is_drained_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/hash.rs:54
--- pg_trickle::hash::pg_trickle_hash_multi
-CREATE  FUNCTION pgtrickle."pg_trickle_hash_multi"(
-	"inputs" TEXT[] /* Vec < Option < String > > */
-) RETURNS bigint /* i64 */
-IMMUTABLE STRICT PARALLEL SAFE 
+-- src/api/diagnostics.rs:958
+-- pg_trickle::api::diagnostics::source_gates
+CREATE  FUNCTION pgtrickle."source_gates"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"schema_name" TEXT,  /* String */
+	"gated" bool,  /* bool */
+	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"gated_by" TEXT  /* Option < String > */
+)
+STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pg_trickle_hash_multi_wrapper';
+AS 'MODULE_PATHNAME', 'source_gates_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -735,82 +703,6 @@ AS 'MODULE_PATHNAME', 'wal_source_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2468
--- pg_trickle::api::drain
-CREATE  FUNCTION pgtrickle."drain"(
-	"timeout_s" INT DEFAULT 60 /* i32 */
-) RETURNS bool /* bool */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drain_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1508
--- pg_trickle::api::diagnostics::worker_allocation_status
-CREATE  FUNCTION pgtrickle."worker_allocation_status"() RETURNS TABLE (
-	"db_name" TEXT,  /* String */
-	"workers_used" bigint,  /* i64 */
-	"workers_quota" bigint,  /* i64 */
-	"workers_queued" bigint,  /* i64 */
-	"cluster_active" bigint,  /* i64 */
-	"cluster_max" bigint  /* i64 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'worker_allocation_status_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/hash.rs:33
--- pg_trickle::hash::pg_trickle_hash
-CREATE  FUNCTION pgtrickle."pg_trickle_hash"(
-	"input" TEXT /* Option < & str > */
-) RETURNS bigint /* i64 */
-IMMUTABLE PARALLEL SAFE 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pg_trickle_hash_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/ivm.rs:1160
--- pg_trickle::ivm::pgt_ivm_handle_truncate
-CREATE  FUNCTION pgtrickle."pgt_ivm_handle_truncate"(
-	"pgt_id" bigint /* i64 */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_ivm_handle_truncate_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/create.rs:25
--- pg_trickle::api::create::create_stream_table
-CREATE  FUNCTION pgtrickle."create_stream_table"(
-	"name" TEXT, /* & str */
-	"query" TEXT, /* & str */
-	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
-	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
-	"initialize" bool DEFAULT true, /* bool */
-	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
-	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
-	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
-	"append_only" bool DEFAULT false, /* bool */
-	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
-	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
-	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
-	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
-	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
-	"temporal" bool DEFAULT false, /* bool */
-	"storage_backend" TEXT DEFAULT NULL, /* Option < & str > */
-	"fillfactor" INT DEFAULT NULL /* Option < i32 > */
-) RETURNS void
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
 -- src/api/diagnostics.rs:1221
 -- pg_trickle::api::diagnostics::watermark_groups
 CREATE  FUNCTION pgtrickle."watermark_groups"() RETURNS TABLE (
@@ -825,192 +717,18 @@ AS 'MODULE_PATHNAME', 'watermark_groups_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:61
--- pg_trickle::api::diagnostics::migrate
-CREATE  FUNCTION pgtrickle."migrate"() RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'migrate_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/snapshot.rs:550
--- pg_trickle::api::snapshot::drop_snapshot
-CREATE  FUNCTION pgtrickle."drop_snapshot"(
-	"p_snapshot_table" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_snapshot_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:958
--- pg_trickle::api::diagnostics::source_gates
-CREATE  FUNCTION pgtrickle."source_gates"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"schema_name" TEXT,  /* String */
-	"gated" bool,  /* bool */
-	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"gated_by" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'source_gates_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/outbox.rs:103
--- pg_trickle::api::outbox::attach_outbox
-CREATE  FUNCTION pgtrickle."attach_outbox"(
-	"p_name" TEXT, /* & str */
-	"p_retention_hours" INT DEFAULT 24, /* i32 */
-	"p_inline_threshold_rows" INT DEFAULT 10000 /* i32 */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'attach_outbox_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/citus.rs:806
--- pg_trickle::citus::handle_vp_promoted
-CREATE  FUNCTION pgtrickle."handle_vp_promoted"(
-	"payload" TEXT /* & str */
-) RETURNS bool /* bool */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'sql_handle_vp_promoted_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1599
--- pg_trickle::api::diagnostics::preflight
-CREATE  FUNCTION pgtrickle."preflight"() RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'preflight_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:912
--- pg_trickle::api::diagnostics::gate_source
-CREATE  FUNCTION pgtrickle."gate_source"(
-	"source" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'gate_source_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/diagnostics.rs:570
--- pg_trickle::diagnostics::list_auxiliary_columns
-CREATE  FUNCTION pgtrickle."list_auxiliary_columns"(
+-- src/api/diagnostics.rs:296
+-- pg_trickle::api::diagnostics::explain_refresh_mode
+CREATE  FUNCTION pgtrickle."explain_refresh_mode"(
 	"name" TEXT /* & str */
 ) RETURNS TABLE (
-	"column_name" TEXT,  /* String */
-	"data_type" TEXT,  /* String */
-	"purpose" TEXT  /* String */
+	"configured_mode" TEXT,  /* String */
+	"effective_mode" TEXT,  /* Option < String > */
+	"downgrade_reason" TEXT  /* Option < String > */
 )
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_auxiliary_columns_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:675
--- pg_trickle::monitor::slot_health
-CREATE  FUNCTION pgtrickle."slot_health"() RETURNS TABLE (
-	"slot_name" TEXT,  /* String */
-	"source_relid" bigint,  /* i64 */
-	"active" bool,  /* bool */
-	"retained_wal_bytes" bigint,  /* i64 */
-	"wal_status" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'slot_health_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:109
--- pg_trickle::api::diagnostics::rebuild_cdc_triggers
-CREATE  FUNCTION pgtrickle."rebuild_cdc_triggers"() RETURNS TEXT /* & '_ str */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'rebuild_cdc_triggers_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2638
--- pg_trickle::api::bulk_drop_stream_tables
-CREATE  FUNCTION pgtrickle."bulk_drop_stream_tables"(
-	"names" TEXT[] /* Vec < Option < String > > */
-) RETURNS INT /* i32 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bulk_drop_stream_tables_wrapper';
-/* </end connected objects> */
-
-
-/* <begin connected objects> */
--- src/api/mod.rs:1615
--- pg_trickle::api::list_subscriptions
-CREATE  FUNCTION pgtrickle."list_subscriptions"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"channel" TEXT,  /* Option < String > */
-	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_subscriptions_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:1711
--- pg_trickle::api::unsubscribe_distance
-CREATE  FUNCTION pgtrickle."unsubscribe_distance"(
-	"stream_table" TEXT, /* & str */
-	"channel" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:778
--- pg_trickle::monitor::pgtrickle_refresh_stats
-CREATE  FUNCTION pgtrickle."pgtrickle_refresh_stats"() RETURNS TABLE (
-	"stream_table" TEXT,  /* String */
-	"mode" TEXT,  /* String */
-	"avg_ms" double precision,  /* f64 */
-	"p95_ms" double precision,  /* f64 */
-	"p99_ms" double precision,  /* f64 */
-	"refresh_count" bigint,  /* i64 */
-	"last_refresh_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgtrickle_refresh_stats_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:819
--- pg_trickle::api::diagnostics::diamond_groups
-CREATE  FUNCTION pgtrickle."diamond_groups"() RETURNS TABLE (
-	"group_id" INT,  /* i32 */
-	"member_name" TEXT,  /* String */
-	"member_schema" TEXT,  /* String */
-	"is_convergence" bool,  /* bool */
-	"epoch" bigint,  /* i64 */
-	"schedule_policy" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'diamond_groups_wrapper';
+AS 'MODULE_PATHNAME', 'explain_refresh_mode_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1045,212 +763,117 @@ AS 'MODULE_PATHNAME', 'st_refresh_stats_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/alter.rs:2244
--- pg_trickle::api::alter::drop_stream_table
-CREATE  FUNCTION pgtrickle."drop_stream_table"(
-	"name" TEXT, /* & str */
-	"cascade" bool DEFAULT false /* bool */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:545
--- pg_trickle::api::diagnostics::shared_buffer_stats
-CREATE  FUNCTION pgtrickle."shared_buffer_stats"() RETURNS TABLE (
-	"source_oid" bigint,  /* i64 */
-	"source_table" TEXT,  /* String */
-	"consumer_count" INT,  /* i32 */
-	"consumers" TEXT,  /* String */
-	"columns_tracked" INT,  /* i32 */
-	"safe_frontier_lsn" TEXT,  /* Option < String > */
-	"buffer_rows" bigint,  /* i64 */
-	"is_partitioned" bool  /* bool */
+-- src/monitor/health.rs:757
+-- pg_trickle::monitor::health::worker_pool_status
+CREATE  FUNCTION pgtrickle."worker_pool_status"() RETURNS TABLE (
+	"active_workers" INT,  /* i32 */
+	"max_workers" INT,  /* i32 */
+	"per_db_cap" INT,  /* i32 */
+	"parallel_mode" TEXT,  /* String */
+	"idle_workers" INT,  /* i32 */
+	"last_scheduler_tick_unix" bigint,  /* i64 */
+	"ring_overflow_count" bigint,  /* i64 */
+	"citus_failure_total" bigint  /* i64 */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'shared_buffer_stats_fn_wrapper';
+AS 'MODULE_PATHNAME', 'worker_pool_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/hooks.rs:1097
--- pg_trickle::hooks::pg_trickle_on_sql_drop
--- Skipped due to `#[pgrx(sql = false)]`
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1160
--- pg_trickle::api::diagnostics::drop_watermark_group
-CREATE  FUNCTION pgtrickle."drop_watermark_group"(
-	"group_name" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_watermark_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/publication.rs:16
--- pg_trickle::api::publication::stream_table_to_publication
-CREATE  FUNCTION pgtrickle."stream_table_to_publication"(
+-- src/api/mod.rs:2767
+-- pg_trickle::api::stream_table_lineage
+CREATE  FUNCTION pgtrickle."stream_table_lineage"(
 	"name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_to_publication_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2556
--- pg_trickle::api::helpers::export_definition
-CREATE  FUNCTION pgtrickle."export_definition"(
-	"st_name" TEXT /* & str */
-) RETURNS TEXT /* Result < String, PgTrickleError > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'export_definition_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:898
--- requires:
---   export_definition
-
-
-CREATE OR REPLACE FUNCTION pgtrickle."stream_table_definition"(
-    p_name text
-)
-RETURNS text
-LANGUAGE sql
-STABLE
-AS $$
-    SELECT pgtrickle.export_definition(p_name);
-$$;
-
-COMMENT ON FUNCTION pgtrickle."stream_table_definition"(text) IS
-    'Return the CREATE STREAM TABLE DDL for the named stream table. '
-    'Equivalent to pgtrickle.export_definition(name) — provided as a '
-    'more discoverable alias.';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/refresh_ops.rs:8
--- pg_trickle::api::refresh_ops::refresh_stream_table
-CREATE  FUNCTION pgtrickle."refresh_stream_table"(
-	"name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:858
--- requires:
---   refresh_stream_table
-
-
-CREATE OR REPLACE FUNCTION pgtrickle."refresh_if_stale"(
-    p_name   text,
-    p_max_age interval DEFAULT '5 minutes'::interval
-)
-RETURNS boolean
-LANGUAGE plpgsql
-AS $$
-DECLARE
-    v_last_end timestamp with time zone;
-    v_refreshed boolean := false;
-BEGIN
-    SELECT MAX(end_time)
-      INTO v_last_end
-      FROM pgtrickle.pgt_refresh_history h
-      JOIN pgtrickle.pgt_stream_tables   s USING (pgt_id)
-     WHERE s.pgt_name = p_name
-       AND h.status = 'COMPLETED';
-
-    IF v_last_end IS NULL OR (now() - v_last_end) > p_max_age THEN
-        PERFORM pgtrickle.refresh_stream_table(p_name);
-        v_refreshed := true;
-    END IF;
-
-    RETURN v_refreshed;
-END;
-$$;
-
-COMMENT ON FUNCTION pgtrickle."refresh_if_stale"(text, interval) IS
-    'Refresh the named stream table only when the most recent completed '
-    'refresh is older than max_age.  Returns TRUE when a refresh was '
-    'triggered, FALSE when the table was fresh enough.';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:453
--- pg_trickle::api::self_monitoring::scheduler_overhead
-CREATE  FUNCTION pgtrickle."scheduler_overhead"() RETURNS TABLE (
-	"total_refreshes_1h" bigint,  /* i64 */
-	"df_refreshes_1h" bigint,  /* i64 */
-	"df_refresh_fraction" double precision,  /* Option < f64 > */
-	"avg_refresh_ms" double precision,  /* Option < f64 > */
-	"avg_df_refresh_ms" double precision,  /* Option < f64 > */
-	"total_refresh_time_s" double precision,  /* Option < f64 > */
-	"df_refresh_time_s" double precision  /* Option < f64 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'scheduler_overhead_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:855
--- pg_trickle::monitor::explain_st
-CREATE  FUNCTION pgtrickle."explain_st"(
-	"name" TEXT, /* & str */
-	"with_analyze" bool DEFAULT false /* bool */
 ) RETURNS TABLE (
-	"property" TEXT,  /* String */
-	"value" TEXT  /* String */
+	"output_col" TEXT,  /* Option < String > */
+	"source_table" TEXT,  /* Option < String > */
+	"source_col" TEXT  /* Option < String > */
 )
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_st_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2217
--- pg_trickle::api::explain_stream_table
-CREATE  FUNCTION pgtrickle."explain_stream_table"(
-	"name" TEXT /* & str */
-) RETURNS TEXT /* Result < String, PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_stream_table_wrapper';
+AS 'MODULE_PATHNAME', 'stream_table_lineage_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor/health.rs:647
--- pg_trickle::monitor::health::trigger_inventory
-CREATE  FUNCTION pgtrickle."trigger_inventory"() RETURNS TABLE (
+-- src/api/mod.rs:1611
+-- pg_trickle::api::list_subscriptions
+CREATE  FUNCTION pgtrickle."list_subscriptions"() RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"channel" TEXT,  /* Option < String > */
+	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_subscriptions_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:633
+-- pg_trickle::monitor::st_auto_threshold
+CREATE  FUNCTION pgtrickle."st_auto_threshold"(
+	"name" TEXT /* & str */
+) RETURNS double precision /* Option < f64 > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'st_auto_threshold_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2405
+-- pg_trickle::api::view_evolution_status
+CREATE  FUNCTION pgtrickle."view_evolution_status"() RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"in_shadow_build" bool,  /* Option < bool > */
+	"shadow_table_name" TEXT,  /* Option < String > */
+	"status" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'view_evolution_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:1918
+-- pg_trickle::monitor::change_buffer_sizes
+CREATE  FUNCTION pgtrickle."change_buffer_sizes"() RETURNS TABLE (
+	"stream_table" TEXT,  /* String */
 	"source_table" TEXT,  /* String */
 	"source_oid" bigint,  /* i64 */
-	"trigger_name" TEXT,  /* String */
-	"trigger_type" TEXT,  /* String */
-	"present" bool,  /* bool */
-	"enabled" bool  /* bool */
+	"cdc_mode" TEXT,  /* String */
+	"pending_rows" bigint,  /* i64 */
+	"buffer_bytes" bigint  /* i64 */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'trigger_inventory_wrapper';
+AS 'MODULE_PATHNAME', 'change_buffer_sizes_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/self_monitoring.rs:305
--- pg_trickle::api::self_monitoring::teardown_self_monitoring
-CREATE  FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
-STRICT 
+-- src/api/create.rs:80
+-- pg_trickle::api::create::create_stream_table_if_not_exists
+CREATE  FUNCTION pgtrickle."create_stream_table_if_not_exists"(
+	"name" TEXT, /* & str */
+	"query" TEXT, /* & str */
+	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
+	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
+	"initialize" bool DEFAULT true, /* bool */
+	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
+	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
+	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
+	"append_only" bool DEFAULT false, /* bool */
+	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
+	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
+	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
+	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
+	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
+	"temporal" bool DEFAULT false, /* bool */
+	"storage_backend" TEXT DEFAULT NULL, /* Option < & str > */
+	"fillfactor" INT DEFAULT NULL /* Option < i32 > */
+) RETURNS void
+
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
+AS 'MODULE_PATHNAME', 'create_stream_table_if_not_exists_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1269,7 +892,7 @@ AS 'MODULE_PATHNAME', 'explain_query_rewrite_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:1666
+-- src/api/mod.rs:1662
 -- pg_trickle::api::subscribe_distance
 CREATE  FUNCTION pgtrickle."subscribe_distance"(
 	"stream_table" TEXT, /* & str */
@@ -1285,19 +908,62 @@ AS 'MODULE_PATHNAME', 'subscribe_distance_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/diagnostics.rs:395
--- pg_trickle::diagnostics::diagnose_errors
-CREATE  FUNCTION pgtrickle."diagnose_errors"(
-	"name" TEXT /* & str */
+-- src/monitor/health.rs:799
+-- pg_trickle::monitor::health::parallel_job_status
+CREATE  FUNCTION pgtrickle."parallel_job_status"(
+	"max_age_seconds" INT DEFAULT 300 /* i32 */
 ) RETURNS TABLE (
-	"event_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"error_type" TEXT,  /* String */
-	"error_message" TEXT,  /* String */
-	"remediation" TEXT  /* String */
+	"job_id" bigint,  /* i64 */
+	"unit_key" TEXT,  /* String */
+	"unit_kind" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"member_count" INT,  /* i32 */
+	"attempt_no" INT,  /* i32 */
+	"scheduler_pid" INT,  /* i32 */
+	"worker_pid" INT,  /* Option < i32 > */
+	"enqueued_at" timestamp with time zone,  /* TimestampWithTimeZone */
+	"started_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"finished_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"duration_ms" double precision  /* Option < f64 > */
 )
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'parallel_job_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2634
+-- pg_trickle::api::bulk_drop_stream_tables
+CREATE  FUNCTION pgtrickle."bulk_drop_stream_tables"(
+	"names" TEXT[] /* Vec < Option < String > > */
+) RETURNS INT /* i32 */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'diagnose_errors_wrapper';
+AS 'MODULE_PATHNAME', 'bulk_drop_stream_tables_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:744
+-- pg_trickle::monitor::reliability_counters
+CREATE  FUNCTION pgtrickle."reliability_counters"() RETURNS TABLE (
+	"invalidation_ring_overflows" bigint,  /* i64 */
+	"dag_cycles_detected" bigint,  /* i64 */
+	"template_cache_stale_evictions" bigint  /* i64 */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'reliability_counters_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1160
+-- pg_trickle::api::diagnostics::drop_watermark_group
+CREATE  FUNCTION pgtrickle."drop_watermark_group"(
+	"group_name" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drop_watermark_group_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1320,7 +986,247 @@ AS 'MODULE_PATHNAME', 'pgt_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:1589
+-- src/citus.rs:103
+-- pg_trickle::citus::source_stable_name
+CREATE  FUNCTION pgtrickle."source_stable_name"(
+	"source_oid" oid /* pg_sys :: Oid */
+) RETURNS TEXT /* Option < String > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'sql_stable_name_for_oid_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/health.rs:647
+-- pg_trickle::monitor::health::trigger_inventory
+CREATE  FUNCTION pgtrickle."trigger_inventory"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"source_oid" bigint,  /* i64 */
+	"trigger_name" TEXT,  /* String */
+	"trigger_type" TEXT,  /* String */
+	"present" bool,  /* bool */
+	"enabled" bool  /* bool */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'trigger_inventory_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2134
+-- pg_trickle::api::sla_summary
+CREATE  FUNCTION pgtrickle."sla_summary"() RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"p50_ms" double precision,  /* Option < f64 > */
+	"p99_ms" double precision,  /* Option < f64 > */
+	"freshness_lag_s" double precision,  /* Option < f64 > */
+	"error_rate" double precision,  /* Option < f64 > */
+	"error_budget_remaining" double precision  /* Option < f64 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'sla_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:1405
+-- pg_trickle::monitor::check_cdc_health
+CREATE  FUNCTION pgtrickle."check_cdc_health"() RETURNS TABLE (
+	"source_relid" bigint,  /* i64 */
+	"source_table" TEXT,  /* String */
+	"cdc_mode" TEXT,  /* String */
+	"slot_name" TEXT,  /* Option < String > */
+	"lag_bytes" bigint,  /* Option < i64 > */
+	"confirmed_lsn" TEXT,  /* Option < String > */
+	"alert" TEXT,  /* Option < String > */
+	"selective_capture" bool  /* bool */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'check_cdc_health_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/cluster.rs:18
+-- pg_trickle::api::cluster::cluster_worker_summary
+CREATE  FUNCTION pgtrickle."cluster_worker_summary"() RETURNS TABLE (
+	"db_oid" bigint,  /* Option < i64 > */
+	"db_name" TEXT,  /* Option < String > */
+	"active_workers" INT,  /* Option < i32 > */
+	"scheduler_pid" INT,  /* Option < i32 > */
+	"scheduler_running" bool,  /* Option < bool > */
+	"total_active_workers" INT  /* Option < i32 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'cluster_worker_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1123
+-- pg_trickle::api::diagnostics::create_watermark_group
+CREATE  FUNCTION pgtrickle."create_watermark_group"(
+	"group_name" TEXT, /* & str */
+	"sources" TEXT[], /* Vec < String > */
+	"tolerance_secs" double precision DEFAULT 0.0 /* f64 */
+) RETURNS INT /* Result < i32, PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_watermark_group_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:305
+-- pg_trickle::api::self_monitoring::teardown_self_monitoring
+CREATE  FUNCTION pgtrickle."teardown_self_monitoring"() RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'teardown_self_monitoring_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/snapshot.rs:321
+-- pg_trickle::api::snapshot::restore_from_snapshot
+CREATE  FUNCTION pgtrickle."restore_from_snapshot"(
+	"p_name" TEXT, /* & str */
+	"p_source" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'restore_from_snapshot_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/health.rs:414
+-- pg_trickle::monitor::health::health_summary
+CREATE  FUNCTION pgtrickle."health_summary"() RETURNS TABLE (
+	"total_stream_tables" INT,  /* i32 */
+	"active_count" INT,  /* i32 */
+	"error_count" INT,  /* i32 */
+	"suspended_count" INT,  /* i32 */
+	"stale_count" INT,  /* i32 */
+	"reinit_pending" INT,  /* i32 */
+	"max_staleness_seconds" double precision,  /* Option < f64 > */
+	"scheduler_status" TEXT,  /* String */
+	"cache_hit_rate" double precision  /* Option < f64 > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'health_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:1722
+-- pg_trickle::api::list_distance_subscriptions
+CREATE  FUNCTION pgtrickle."list_distance_subscriptions"(
+	"p_stream_table" TEXT DEFAULT NULL /* Option < & str > */
+) RETURNS TABLE (
+	"stream_table" TEXT,  /* Option < String > */
+	"channel" TEXT,  /* Option < String > */
+	"vector_column" TEXT,  /* Option < String > */
+	"op" TEXT,  /* Option < String > */
+	"threshold" double precision,  /* Option < f64 > */
+	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
+)
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2689
+-- pg_trickle::api::exec_stream_ddl
+CREATE  FUNCTION pgtrickle."exec_stream_ddl"(
+	"cmd" TEXT /* & str */
+) RETURNS bool /* bool */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'exec_stream_ddl_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:778
+-- pg_trickle::monitor::pgtrickle_refresh_stats
+CREATE  FUNCTION pgtrickle."pgtrickle_refresh_stats"() RETURNS TABLE (
+	"stream_table" TEXT,  /* String */
+	"mode" TEXT,  /* String */
+	"avg_ms" double precision,  /* f64 */
+	"p95_ms" double precision,  /* f64 */
+	"p99_ms" double precision,  /* f64 */
+	"refresh_count" bigint,  /* i64 */
+	"last_refresh_at" timestamp with time zone  /* Option < TimestampWithTimeZone > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgtrickle_refresh_stats_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/create.rs:25
+-- pg_trickle::api::create::create_stream_table
+CREATE  FUNCTION pgtrickle."create_stream_table"(
+	"name" TEXT, /* & str */
+	"query" TEXT, /* & str */
+	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
+	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
+	"initialize" bool DEFAULT true, /* bool */
+	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
+	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
+	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
+	"append_only" bool DEFAULT false, /* bool */
+	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
+	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
+	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
+	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
+	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
+	"temporal" bool DEFAULT false, /* bool */
+	"storage_backend" TEXT DEFAULT NULL, /* Option < & str > */
+	"fillfactor" INT DEFAULT NULL /* Option < i32 > */
+) RETURNS void
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:95
+-- pg_trickle::api::diagnostics::_signal_launcher_rescan
+CREATE  FUNCTION pgtrickle."_signal_launcher_rescan"() RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', '_signal_launcher_rescan_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:1999
+-- pg_trickle::monitor::list_sources
+CREATE  FUNCTION pgtrickle."list_sources"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"source_oid" bigint,  /* i64 */
+	"source_type" TEXT,  /* String */
+	"cdc_mode" TEXT,  /* String */
+	"columns_used" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_sources_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2213
+-- pg_trickle::api::explain_stream_table
+CREATE  FUNCTION pgtrickle."explain_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS TEXT /* Result < String, PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:1585
 -- pg_trickle::api::subscribe
 CREATE  FUNCTION pgtrickle."subscribe"(
 	"stream_table" TEXT, /* & str */
@@ -1332,58 +1238,778 @@ AS 'MODULE_PATHNAME', 'subscribe_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor/mod.rs:652
--- pg_trickle::monitor::get_staleness
-CREATE  FUNCTION pgtrickle."get_staleness"(
-	"name" TEXT /* & str */
-) RETURNS double precision /* Option < f64 > */
-STRICT  
+-- src/api/mod.rs:1596
+-- pg_trickle::api::unsubscribe
+CREATE  FUNCTION pgtrickle."unsubscribe"(
+	"stream_table" TEXT, /* & str */
+	"channel" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'get_staleness_wrapper';
+AS 'MODULE_PATHNAME', 'unsubscribe_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/monitor/mod.rs:1931
--- pg_trickle::monitor::change_buffer_sizes
-CREATE  FUNCTION pgtrickle."change_buffer_sizes"() RETURNS TABLE (
-	"stream_table" TEXT,  /* String */
-	"source_table" TEXT,  /* String */
-	"source_oid" bigint,  /* i64 */
-	"cdc_mode" TEXT,  /* String */
-	"pending_rows" bigint,  /* i64 */
-	"buffer_bytes" bigint  /* i64 */
+-- src/api/helpers.rs:2402
+-- pg_trickle::api::helpers::recommend_refresh_mode
+CREATE  FUNCTION pgtrickle."recommend_refresh_mode"(
+	"st_name" TEXT DEFAULT NULL /* Option < String > */
+) RETURNS TABLE (
+	"pgt_schema" TEXT,  /* String */
+	"pgt_name" TEXT,  /* String */
+	"current_mode" TEXT,  /* String */
+	"effective_mode" TEXT,  /* Option < String > */
+	"recommended_mode" TEXT,  /* String */
+	"confidence" TEXT,  /* String */
+	"reason" TEXT,  /* String */
+	"signals" jsonb  /* pgrx :: JsonB */
+)
+ 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'recommend_refresh_mode_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/outbox.rs:103
+-- pg_trickle::api::outbox::attach_outbox
+CREATE  FUNCTION pgtrickle."attach_outbox"(
+	"p_name" TEXT, /* & str */
+	"p_retention_hours" INT DEFAULT 24, /* i32 */
+	"p_inline_threshold_rows" INT DEFAULT 10000 /* i32 */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'attach_outbox_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:855
+-- pg_trickle::monitor::explain_st
+CREATE  FUNCTION pgtrickle."explain_st"(
+	"name" TEXT, /* & str */
+	"with_analyze" bool DEFAULT false /* bool */
+) RETURNS TABLE (
+	"property" TEXT,  /* String */
+	"value" TEXT  /* String */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'change_buffer_sizes_wrapper';
+AS 'MODULE_PATHNAME', 'explain_st_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:296
--- pg_trickle::api::diagnostics::explain_refresh_mode
-CREATE  FUNCTION pgtrickle."explain_refresh_mode"(
-	"name" TEXT /* & str */
+-- src/hash.rs:33
+-- pg_trickle::hash::pg_trickle_hash
+CREATE  FUNCTION pgtrickle."pg_trickle_hash"(
+	"input" TEXT /* Option < & str > */
+) RETURNS bigint /* i64 */
+IMMUTABLE PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pg_trickle_hash_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:2079
+-- pg_trickle::monitor::history_prune_status
+CREATE  FUNCTION pgtrickle."history_prune_status"() RETURNS TABLE (
+	"prune_error_count" bigint,  /* i64 */
+	"last_prune_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"last_rows_deleted" bigint  /* Option < i64 > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'history_prune_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/scheduler_control.rs:132
+-- pg_trickle::api::scheduler_control::resume_scheduler
+CREATE  FUNCTION pgtrickle."resume_scheduler"(
+	"nodes" TEXT[] /* pgrx :: Array < & str > */
+) RETURNS TEXT /* & '_ str */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'resume_scheduler_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/hooks.rs:51
+-- pg_trickle::hooks::pg_trickle_on_ddl_end
+-- Skipped due to `#[pgrx(sql = false)]`
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:525
+-- pg_trickle::monitor::get_refresh_history
+CREATE  FUNCTION pgtrickle."get_refresh_history"(
+	"name" TEXT, /* & str */
+	"max_rows" INT DEFAULT 20 /* i32 */
 ) RETURNS TABLE (
-	"configured_mode" TEXT,  /* String */
-	"effective_mode" TEXT,  /* Option < String > */
-	"downgrade_reason" TEXT  /* Option < String > */
+	"refresh_id" bigint,  /* i64 */
+	"data_timestamp" timestamp with time zone,  /* TimestampWithTimeZone */
+	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
+	"end_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"action" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"rows_inserted" bigint,  /* i64 */
+	"rows_deleted" bigint,  /* i64 */
+	"duration_ms" double precision,  /* Option < f64 > */
+	"error_message" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'get_refresh_history_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:358
+-- pg_trickle::api::self_monitoring::self_monitoring_status
+CREATE  FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
+	"st_name" TEXT,  /* String */
+	"exists" bool,  /* bool */
+	"status" TEXT,  /* Option < String > */
+	"refresh_mode" TEXT,  /* Option < String > */
+	"last_refresh_at" TEXT,  /* Option < String > */
+	"total_refreshes" bigint  /* Option < i64 > */
 )
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_refresh_mode_wrapper';
+AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:516
--- pg_trickle::api::diagnostics::dedup_stats
-CREATE  FUNCTION pgtrickle."dedup_stats"() RETURNS TABLE (
-	"total_diff_refreshes" bigint,  /* i64 */
-	"dedup_needed" bigint,  /* i64 */
-	"dedup_ratio_pct" double precision  /* f64 */
+-- src/api/planner.rs:186
+-- pg_trickle::api::planner::schedule_recommendations
+CREATE  FUNCTION pgtrickle."schedule_recommendations"() RETURNS TABLE (
+	"name" TEXT,  /* Option < String > */
+	"current_interval_seconds" double precision,  /* Option < f64 > */
+	"recommended_interval_seconds" double precision,  /* Option < f64 > */
+	"delta_pct" double precision,  /* Option < f64 > */
+	"confidence" double precision,  /* Option < f64 > */
+	"reasoning" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'schedule_recommendations_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/ivm.rs:712
+-- pg_trickle::ivm::pgt_ivm_apply_delta
+CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta"(
+	"pgt_id" bigint, /* i64 */
+	"source_oid" INT, /* i32 */
+	"has_new" bool, /* bool */
+	"has_old" bool /* bool */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/alter.rs:2351
+-- pg_trickle::api::alter::resume_stream_table
+CREATE  FUNCTION pgtrickle."resume_stream_table"(
+	"name" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'resume_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:109
+-- pg_trickle::api::diagnostics::rebuild_cdc_triggers
+CREATE  FUNCTION pgtrickle."rebuild_cdc_triggers"() RETURNS TEXT /* & '_ str */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'rebuild_cdc_triggers_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1459
+-- pg_trickle::api::diagnostics::refresh_groups
+CREATE  FUNCTION pgtrickle."refresh_groups"() RETURNS TABLE (
+	"group_id" INT,  /* i32 */
+	"group_name" TEXT,  /* String */
+	"member_count" INT,  /* i32 */
+	"isolation" TEXT,  /* String */
+	"created_at" timestamp with time zone  /* TimestampWithTimeZone */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dedup_stats_fn_wrapper';
+AS 'MODULE_PATHNAME', 'refresh_groups_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1769
+-- pg_trickle::api::diagnostics::clear_caches
+CREATE  FUNCTION pgtrickle."clear_caches"() RETURNS bigint /* i64 */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'clear_caches_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2507
+-- pg_trickle::api::helpers::refresh_efficiency
+CREATE  FUNCTION pgtrickle."refresh_efficiency"() RETURNS TABLE (
+	"pgt_schema" TEXT,  /* String */
+	"pgt_name" TEXT,  /* String */
+	"refresh_mode" TEXT,  /* String */
+	"total_refreshes" bigint,  /* i64 */
+	"diff_count" bigint,  /* i64 */
+	"full_count" bigint,  /* i64 */
+	"avg_diff_ms" double precision,  /* Option < f64 > */
+	"avg_full_ms" double precision,  /* Option < f64 > */
+	"avg_change_ratio" double precision,  /* Option < f64 > */
+	"diff_speedup" TEXT,  /* Option < String > */
+	"last_refresh_at" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'refresh_efficiency_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/scheduler_control.rs:61
+-- pg_trickle::api::scheduler_control::pause_scheduler
+CREATE  FUNCTION pgtrickle."pause_scheduler"(
+	"nodes" TEXT[] /* pgrx :: Array < & str > */
+) RETURNS TEXT /* & '_ str */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pause_scheduler_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/outbox.rs:190
+-- pg_trickle::api::outbox::detach_outbox
+CREATE  FUNCTION pgtrickle."detach_outbox"(
+	"p_name" TEXT, /* & str */
+	"p_if_exists" bool DEFAULT false /* bool */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'detach_outbox_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1019
+-- pg_trickle::api::diagnostics::bootstrap_gate_status
+CREATE  FUNCTION pgtrickle."bootstrap_gate_status"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"schema_name" TEXT,  /* String */
+	"gated" bool,  /* bool */
+	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"gated_by" TEXT,  /* Option < String > */
+	"gate_duration" interval,  /* Option < pgrx :: datum :: Interval > */
+	"affected_stream_tables" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bootstrap_gate_status_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/planner.rs:117
+-- pg_trickle::api::planner::recommend_schedule
+CREATE  FUNCTION pgtrickle."recommend_schedule"(
+	"p_name" TEXT /* & str */
+) RETURNS jsonb /* pgrx :: JsonB */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'recommend_schedule_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/hash.rs:54
+-- pg_trickle::hash::pg_trickle_hash_multi
+CREATE  FUNCTION pgtrickle."pg_trickle_hash_multi"(
+	"inputs" TEXT[] /* Vec < Option < String > > */
+) RETURNS bigint /* i64 */
+IMMUTABLE STRICT PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pg_trickle_hash_multi_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/create.rs:164
+-- pg_trickle::api::create::bulk_create
+CREATE  FUNCTION pgtrickle."bulk_create"(
+	"definitions" jsonb /* pgrx :: JsonB */
+) RETURNS jsonb /* pgrx :: JsonB */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bulk_create_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:407
+-- pg_trickle::api::diagnostics::explain_delta
+CREATE  FUNCTION pgtrickle."explain_delta"(
+	"name" TEXT, /* & str */
+	"format" TEXT DEFAULT 'text' /* & str */
+) RETURNS SETOF TEXT /* String */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_delta_text_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/refresh_ops.rs:36
+-- pg_trickle::api::refresh_ops::write_and_refresh
+CREATE  FUNCTION pgtrickle."write_and_refresh"(
+	"sql" TEXT, /* & str */
+	"stream_table_name" TEXT /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:8
+-- pg_trickle::api::diagnostics::version
+CREATE  FUNCTION pgtrickle."version"() RETURNS TEXT /* & '_ str */
+IMMUTABLE STRICT PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'version_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1447
+-- pg_trickle::api::diagnostics::drop_refresh_group
+CREATE  FUNCTION pgtrickle."drop_refresh_group"(
+	"group_name" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drop_refresh_group_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1168
+-- pg_trickle::api::diagnostics::watermarks
+CREATE  FUNCTION pgtrickle."watermarks"() RETURNS TABLE (
+	"source_table" TEXT,  /* String */
+	"schema_name" TEXT,  /* String */
+	"watermark" timestamp with time zone,  /* TimestampWithTimeZone */
+	"updated_at" timestamp with time zone,  /* TimestampWithTimeZone */
+	"advanced_by" TEXT,  /* Option < String > */
+	"wal_lsn" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'watermarks_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:935
+-- pg_trickle::api::diagnostics::ungate_source
+CREATE  FUNCTION pgtrickle."ungate_source"(
+	"source" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'ungate_source_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:566
+-- pg_trickle::api::self_monitoring::explain_dag
+CREATE  FUNCTION pgtrickle."explain_dag"(
+	"format" TEXT DEFAULT 'mermaid' /* Option < & str > */
+) RETURNS TEXT /* Option < String > */
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_dag_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:912
+-- pg_trickle::api::diagnostics::gate_source
+CREATE  FUNCTION pgtrickle."gate_source"(
+	"source" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'gate_source_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:676
+-- pg_trickle::api::diagnostics::reset_fuse
+CREATE  FUNCTION pgtrickle."reset_fuse"(
+	"name" TEXT, /* & str */
+	"action" TEXT DEFAULT 'apply' /* & str */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'reset_fuse_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:748
+-- pg_trickle::api::diagnostics::fuse_status
+CREATE  FUNCTION pgtrickle."fuse_status"() RETURNS TABLE (
+	"stream_table" TEXT,  /* String */
+	"fuse_mode" TEXT,  /* String */
+	"fuse_state" TEXT,  /* String */
+	"fuse_ceiling" bigint,  /* Option < i64 > */
+	"effective_ceiling" bigint,  /* Option < i64 > */
+	"fuse_sensitivity" INT,  /* Option < i32 > */
+	"blown_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"blow_reason" TEXT  /* Option < String > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'fuse_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1805
+-- pg_trickle::api::diagnostics::vector_status
+CREATE  FUNCTION pgtrickle."vector_status"() RETURNS TABLE (
+	"name" TEXT,  /* String */
+	"post_refresh_action" TEXT,  /* String */
+	"reindex_drift_threshold" double precision,  /* Option < f64 > */
+	"rows_changed_since_last_reindex" bigint,  /* i64 */
+	"last_reindex_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"data_timestamp" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"embedding_lag" interval,  /* Option < pgrx :: datum :: Interval > */
+	"estimated_rows" bigint,  /* Option < i64 > */
+	"drift_pct" double precision  /* Option < f64 > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'vector_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/create.rs:321
+-- pg_trickle::api::create::create_or_replace_stream_table
+CREATE  FUNCTION pgtrickle."create_or_replace_stream_table"(
+	"name" TEXT, /* & str */
+	"query" TEXT, /* & str */
+	"schedule" TEXT DEFAULT 'calculated', /* Option < & str > */
+	"refresh_mode" TEXT DEFAULT 'AUTO', /* & str */
+	"initialize" bool DEFAULT true, /* bool */
+	"diamond_consistency" TEXT DEFAULT NULL, /* Option < & str > */
+	"diamond_schedule_policy" TEXT DEFAULT NULL, /* Option < & str > */
+	"cdc_mode" TEXT DEFAULT NULL, /* Option < & str > */
+	"append_only" bool DEFAULT false, /* bool */
+	"pooler_compatibility_mode" bool DEFAULT false, /* bool */
+	"partition_by" TEXT DEFAULT NULL, /* Option < & str > */
+	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
+	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
+	"output_distribution_column" TEXT DEFAULT NULL, /* Option < & str > */
+	"temporal" bool DEFAULT false, /* bool */
+	"storage_backend" TEXT DEFAULT NULL /* Option < & str > */
+) RETURNS void
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'create_or_replace_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/mod.rs:1144
+-- pg_trickle::monitor::explain_diff_sql
+CREATE  FUNCTION pgtrickle."explain_diff_sql"(
+	"name" TEXT /* & str */
+) RETURNS TEXT /* Option < String > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'explain_diff_sql_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/ivm.rs:1160
+-- pg_trickle::ivm::pgt_ivm_handle_truncate
+CREATE  FUNCTION pgtrickle."pgt_ivm_handle_truncate"(
+	"pgt_id" bigint /* i64 */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_ivm_handle_truncate_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:19
+-- pg_trickle::api::diagnostics::version_check
+CREATE  FUNCTION pgtrickle."version_check"() RETURNS TEXT /* String */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'version_check_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:767
+-- pg_trickle::diagnostics::validate_query
+CREATE  FUNCTION pgtrickle."validate_query"(
+	"query" TEXT /* & str */
+) RETURNS TABLE (
+	"check_name" TEXT,  /* String */
+	"result" TEXT,  /* String */
+	"severity" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'validate_query_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2322
+-- pg_trickle::api::helpers::convert_buffers_to_unlogged
+CREATE  FUNCTION pgtrickle."convert_buffers_to_unlogged"() RETURNS bigint /* Result < i64, PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'convert_buffers_to_unlogged_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/hooks.rs:1094
+-- pg_trickle::hooks::pg_trickle_on_sql_drop
+-- Skipped due to `#[pgrx(sql = false)]`
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2520
+-- pg_trickle::api::cdc_pause_status
+CREATE  FUNCTION pgtrickle."cdc_pause_status"() RETURNS TABLE (
+	"paused" bool,  /* bool */
+	"capture_mode" TEXT,  /* String */
+	"note" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'cdc_pause_status_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/helpers.rs:2566
+-- pg_trickle::api::helpers::export_definition
+CREATE  FUNCTION pgtrickle."export_definition"(
+	"st_name" TEXT /* & str */
+) RETURNS TEXT /* Result < String, PgTrickleError > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'export_definition_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:839
+-- requires:
+--   export_definition
+
+
+CREATE OR REPLACE FUNCTION pgtrickle."stream_table_definition"(
+    p_name text
+)
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $$
+    SELECT pgtrickle.export_definition(p_name);
+$$;
+
+COMMENT ON FUNCTION pgtrickle."stream_table_definition"(text) IS
+    'Return the CREATE STREAM TABLE DDL for the named stream table. '
+    'Equivalent to pgtrickle.export_definition(name) — provided as a '
+    'more discoverable alias.';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/ivm.rs:834
+-- pg_trickle::ivm::pgt_ivm_apply_delta_enr
+CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta_enr"(
+	"pgt_id" bigint, /* i64 */
+	"source_oid" INT, /* i32 */
+	"has_new" bool, /* bool */
+	"has_old" bool /* bool */
+) RETURNS VOID /* Result < (), PgTrickleError > */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_enr_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/monitor/health.rs:561
+-- pg_trickle::monitor::health::refresh_timeline
+CREATE  FUNCTION pgtrickle."refresh_timeline"(
+	"max_rows" INT DEFAULT 50 /* i32 */
+) RETURNS TABLE (
+	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
+	"stream_table" TEXT,  /* String */
+	"action" TEXT,  /* String */
+	"status" TEXT,  /* String */
+	"rows_inserted" bigint,  /* i64 */
+	"rows_deleted" bigint,  /* i64 */
+	"duration_ms" double precision,  /* Option < f64 > */
+	"error_message" TEXT  /* Option < String > */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'refresh_timeline_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:154
+-- pg_trickle::api::diagnostics::parse_duration_seconds
+CREATE  FUNCTION pgtrickle."parse_duration_seconds"(
+	"input" TEXT /* & str */
+) RETURNS bigint /* Option < i64 > */
+IMMUTABLE STRICT PARALLEL SAFE 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'parse_duration_seconds_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:634
+-- requires:
+--   parse_duration_seconds
+
+
+-- Convenience view: pg_stat_stream_tables
+-- Combines catalog metadata with aggregate refresh statistics.
+CREATE OR REPLACE VIEW pgtrickle.pg_stat_stream_tables AS
+SELECT
+    st.pgt_id,
+    st.pgt_schema,
+    st.pgt_name,
+    st.status,
+    st.refresh_mode,
+    st.is_populated,
+    st.data_timestamp,
+    st.schedule,
+    now() - st.last_refresh_at AS staleness,
+    CASE WHEN st.schedule IS NOT NULL AND st.last_refresh_at IS NOT NULL
+              AND st.schedule !~ '[\s@]'
+         THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
+              pgtrickle.parse_duration_seconds(st.schedule)
+         ELSE NULL::boolean
+    END AS stale,
+    st.consecutive_errors,
+    st.needs_reinit,
+    st.last_refresh_at,
+    COALESCE(stats.total_refreshes, 0) AS total_refreshes,
+    COALESCE(stats.successful_refreshes, 0) AS successful_refreshes,
+    COALESCE(stats.failed_refreshes, 0) AS failed_refreshes,
+    COALESCE(stats.total_rows_inserted, 0) AS total_rows_inserted,
+    COALESCE(stats.total_rows_deleted, 0) AS total_rows_deleted,
+    stats.avg_duration_ms,
+    stats.last_action,
+    stats.last_status,
+    (SELECT array_agg(DISTINCT d.cdc_mode ORDER BY d.cdc_mode)
+     FROM pgtrickle.pgt_dependencies d
+     WHERE d.pgt_id = st.pgt_id AND d.source_type = 'TABLE') AS cdc_modes,
+    st.scc_id,
+    st.last_fixpoint_iterations,
+    st.refresh_tier
+FROM pgtrickle.pgt_stream_tables st
+LEFT JOIN LATERAL (
+    SELECT
+        count(*)::bigint AS total_refreshes,
+        count(*) FILTER (WHERE h.status = 'COMPLETED')::bigint AS successful_refreshes,
+        count(*) FILTER (WHERE h.status = 'FAILED')::bigint AS failed_refreshes,
+        COALESCE(sum(h.rows_inserted), 0)::bigint AS total_rows_inserted,
+        COALESCE(sum(h.rows_deleted), 0)::bigint AS total_rows_deleted,
+        CASE WHEN count(*) FILTER (WHERE h.end_time IS NOT NULL) > 0
+             THEN avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000)
+                  FILTER (WHERE h.end_time IS NOT NULL)
+             ELSE NULL
+        END::float8 AS avg_duration_ms,
+        (SELECT h2.action FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_action,
+        (SELECT h2.status FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_status,
+        (SELECT h2.initiated_by FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_initiated_by,
+        (SELECT h2.freshness_deadline FROM pgtrickle.pgt_refresh_history h2
+         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS freshness_deadline
+    FROM pgtrickle.pgt_refresh_history h
+    WHERE h.pgt_id = st.pgt_id
+) stats ON true;
+
+-- Per-source CDC status view (G5): exposes cdc_mode, slot names, and
+-- transition timestamps for every TABLE dependency of a stream table.
+CREATE OR REPLACE VIEW pgtrickle.pgt_cdc_status AS
+SELECT
+    st.pgt_schema,
+    st.pgt_name,
+    d.source_relid,
+    c.relname        AS source_name,
+    n.nspname        AS source_schema,
+    d.cdc_mode,
+    d.slot_name,
+    d.decoder_confirmed_lsn,
+    d.transition_started_at
+FROM pgtrickle.pgt_dependencies d
+JOIN pgtrickle.pgt_stream_tables st ON st.pgt_id = d.pgt_id
+JOIN pg_class c ON c.oid = d.source_relid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE d.source_type = 'TABLE';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:549
+-- requires:
+--   parse_duration_seconds
+
+
+-- Status overview view (ERR-1d: last_error_message and last_error_at are
+-- included via st.* from pgt_stream_tables)
+CREATE OR REPLACE VIEW pgtrickle.stream_tables_info AS
+SELECT st.*,
+       now() - st.last_refresh_at AS staleness,
+       CASE WHEN st.schedule IS NOT NULL
+                 AND st.schedule !~ '[\s@]'
+            THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
+                 pgtrickle.parse_duration_seconds(st.schedule)
+            ELSE NULL::boolean
+       END AS stale,
+       CASE WHEN st.topk_limit IS NOT NULL THEN TRUE ELSE FALSE END AS is_topk
+FROM pgtrickle.pgt_stream_tables st;
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:722
+-- requires:
+--   parse_duration_seconds
+
+
+-- ERG-E: One-row health summary for dashboards and alerting.
+CREATE OR REPLACE VIEW pgtrickle.quick_health AS
+SELECT
+    (SELECT count(*) FROM pgtrickle.pgt_stream_tables)::bigint
+        AS total_stream_tables,
+    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
+     WHERE status = 'ERROR' OR consecutive_errors > 0)::bigint
+        AS error_tables,
+    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
+     WHERE schedule IS NOT NULL
+       AND schedule !~ '[\s@]'
+       AND last_refresh_at IS NOT NULL
+       AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
+           pgtrickle.parse_duration_seconds(schedule))::bigint
+        AS stale_tables,
+    (SELECT count(*) > 0 FROM pg_stat_activity
+     WHERE backend_type = 'pg_trickle scheduler')
+        AS scheduler_running,
+    CASE
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables) = 0 THEN 'EMPTY'
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'SUSPENDED') > 0 THEN 'CRITICAL'
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'ERROR' OR consecutive_errors > 0) > 0 THEN 'WARNING'
+        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables
+              WHERE schedule IS NOT NULL
+                AND schedule !~ '[\s@]'
+                AND last_refresh_at IS NOT NULL
+                AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
+                    pgtrickle.parse_duration_seconds(schedule)) > 0 THEN 'WARNING'
+        ELSE 'OK'
+    END AS status;
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -1404,61 +2030,201 @@ AS 'MODULE_PATHNAME', 'list_snapshots_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/planner.rs:117
--- pg_trickle::api::planner::recommend_schedule
-CREATE  FUNCTION pgtrickle."recommend_schedule"(
-	"p_name" TEXT /* & str */
-) RETURNS jsonb /* pgrx :: JsonB */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'recommend_schedule_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:935
--- pg_trickle::api::diagnostics::ungate_source
-CREATE  FUNCTION pgtrickle."ungate_source"(
-	"source" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'ungate_source_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2392
--- pg_trickle::api::helpers::recommend_refresh_mode
-CREATE  FUNCTION pgtrickle."recommend_refresh_mode"(
-	"st_name" TEXT DEFAULT NULL /* Option < String > */
-) RETURNS TABLE (
-	"pgt_schema" TEXT,  /* String */
-	"pgt_name" TEXT,  /* String */
-	"current_mode" TEXT,  /* String */
-	"effective_mode" TEXT,  /* Option < String > */
-	"recommended_mode" TEXT,  /* String */
-	"confidence" TEXT,  /* String */
-	"reason" TEXT,  /* String */
-	"signals" jsonb  /* pgrx :: JsonB */
+-- src/api/self_monitoring.rs:453
+-- pg_trickle::api::self_monitoring::scheduler_overhead
+CREATE  FUNCTION pgtrickle."scheduler_overhead"() RETURNS TABLE (
+	"total_refreshes_1h" bigint,  /* i64 */
+	"df_refreshes_1h" bigint,  /* i64 */
+	"df_refresh_fraction" double precision,  /* Option < f64 > */
+	"avg_refresh_ms" double precision,  /* Option < f64 > */
+	"avg_df_refresh_ms" double precision,  /* Option < f64 > */
+	"total_refresh_time_s" double precision,  /* Option < f64 > */
+	"df_refresh_time_s" double precision  /* Option < f64 > */
 )
- 
+STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'recommend_refresh_mode_wrapper';
+AS 'MODULE_PATHNAME', 'scheduler_overhead_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:676
--- pg_trickle::api::diagnostics::reset_fuse
-CREATE  FUNCTION pgtrickle."reset_fuse"(
-	"name" TEXT, /* & str */
-	"action" TEXT DEFAULT 'apply' /* & str */
+-- src/api/publication.rs:16
+-- pg_trickle::api::publication::stream_table_to_publication
+CREATE  FUNCTION pgtrickle."stream_table_to_publication"(
+	"name" TEXT /* & str */
 ) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'reset_fuse_wrapper';
+AS 'MODULE_PATHNAME', 'stream_table_to_publication_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/alter.rs:1629
+-- src/monitor/health.rs:23
+-- pg_trickle::monitor::health::health_check
+CREATE  FUNCTION pgtrickle."health_check"() RETURNS TABLE (
+	"check_name" TEXT,  /* String */
+	"severity" TEXT,  /* String */
+	"detail" TEXT  /* String */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'health_check_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/self_monitoring.rs:240
+-- pg_trickle::api::self_monitoring::setup_self_monitoring
+CREATE  FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:395
+-- pg_trickle::diagnostics::diagnose_errors
+CREATE  FUNCTION pgtrickle."diagnose_errors"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"event_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
+	"error_type" TEXT,  /* String */
+	"error_message" TEXT,  /* String */
+	"remediation" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'diagnose_errors_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1508
+-- pg_trickle::api::diagnostics::worker_allocation_status
+CREATE  FUNCTION pgtrickle."worker_allocation_status"() RETURNS TABLE (
+	"db_name" TEXT,  /* String */
+	"workers_used" bigint,  /* i64 */
+	"workers_quota" bigint,  /* i64 */
+	"workers_queued" bigint,  /* i64 */
+	"cluster_active" bigint,  /* i64 */
+	"cluster_max" bigint  /* i64 */
+)
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'worker_allocation_status_fn_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:1888
+-- pg_trickle::api::embedding_stream_table
+CREATE  FUNCTION pgtrickle."embedding_stream_table"(
+	"name" TEXT, /* & str */
+	"source_table" TEXT, /* & str */
+	"vector_column" TEXT, /* & str */
+	"extra_columns" TEXT DEFAULT NULL, /* Option < & str > */
+	"refresh_interval" TEXT DEFAULT '1m', /* & str */
+	"index_type" TEXT DEFAULT 'hnsw', /* & str */
+	"dry_run" bool DEFAULT false /* bool */
+) RETURNS TABLE (
+	"action" TEXT  /* Option < String > */
+)
+
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'embedding_stream_table_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/metrics_ext.rs:25
+-- pg_trickle::api::metrics_ext::metrics_summary
+CREATE  FUNCTION pgtrickle."metrics_summary"() RETURNS TABLE (
+	"db_name" TEXT,  /* Option < String > */
+	"total_stream_tables" bigint,  /* Option < i64 > */
+	"active_stream_tables" bigint,  /* Option < i64 > */
+	"suspended_stream_tables" bigint,  /* Option < i64 > */
+	"total_refreshes" bigint,  /* Option < i64 > */
+	"successful_refreshes" bigint,  /* Option < i64 > */
+	"failed_refreshes" bigint,  /* Option < i64 > */
+	"total_rows_processed" bigint,  /* Option < i64 > */
+	"active_workers" INT,  /* Option < i32 > */
+	"ivm_lock_parse_error_count" bigint,  /* Option < i64 > */
+	"holdback_probe_calls" bigint,  /* Option < i64 > */
+	"holdback_probe_cache_hits" bigint,  /* Option < i64 > */
+	"holdback_probe_avg_ms" double precision  /* Option < f64 > */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'metrics_summary_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/publication.rs:135
+-- pg_trickle::api::publication::set_stream_table_sla
+CREATE  FUNCTION pgtrickle."set_stream_table_sla"(
+	"name" TEXT, /* & str */
+	"sla" interval /* Interval */
+) RETURNS void
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'set_stream_table_sla_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2464
+-- pg_trickle::api::drain
+CREATE  FUNCTION pgtrickle."drain"(
+	"timeout_s" INT DEFAULT 60 /* i32 */
+) RETURNS bool /* bool */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'drain_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/diagnostics.rs:1599
+-- pg_trickle::api::diagnostics::preflight
+CREATE  FUNCTION pgtrickle."preflight"() RETURNS TEXT /* String */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'preflight_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/diagnostics.rs:570
+-- pg_trickle::diagnostics::list_auxiliary_columns
+CREATE  FUNCTION pgtrickle."list_auxiliary_columns"(
+	"name" TEXT /* & str */
+) RETURNS TABLE (
+	"column_name" TEXT,  /* String */
+	"data_type" TEXT,  /* String */
+	"purpose" TEXT  /* String */
+)
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'list_auxiliary_columns_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/mod.rs:2571
+-- pg_trickle::api::bulk_alter_stream_tables
+CREATE  FUNCTION pgtrickle."bulk_alter_stream_tables"(
+	"names" TEXT[], /* Vec < Option < String > > */
+	"params" json /* pgrx :: Json */
+) RETURNS INT /* i32 */
+STRICT 
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'bulk_alter_stream_tables_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/spec.rs:74
+-- pg_trickle::api::spec::stream_table_spec
+CREATE  FUNCTION pgtrickle."stream_table_spec"(
+	"qualified_name" TEXT /* & str */
+) RETURNS jsonb /* Option < pgrx :: JsonB > */
+STRICT  
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'stream_table_spec_by_name_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/api/alter.rs:1583
 -- pg_trickle::api::alter::alter_stream_table
 CREATE  FUNCTION pgtrickle."alter_stream_table"(
 	"name" TEXT, /* & str */
@@ -1479,7 +2245,7 @@ CREATE  FUNCTION pgtrickle."alter_stream_table"(
 	"max_differential_joins" INT DEFAULT NULL, /* Option < i32 > */
 	"max_delta_fraction" double precision DEFAULT NULL, /* Option < f64 > */
 	"post_refresh_action" TEXT DEFAULT NULL, /* Option < & str > */
-	"reindex_drift_threshold" double precision DEFAULT NULL, /* Option < f64 > */
+	"reindex_drift_threshold" double precision DEFAULT NULL /* Option < f64 > */
 ) RETURNS void
 
 LANGUAGE c /* Rust */
@@ -1487,7 +2253,7 @@ AS 'MODULE_PATHNAME', 'alter_stream_table_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/lib.rs:921
+-- src/lib.rs:862
 -- requires:
 --   create_stream_table
 --   drop_stream_table
@@ -1650,284 +2416,6 @@ COMMENT ON FUNCTION pgtrickle."canary_promote"(text) IS
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2693
--- pg_trickle::api::exec_stream_ddl
-CREATE  FUNCTION pgtrickle."exec_stream_ddl"(
-	"cmd" TEXT /* & str */
-) RETURNS bool /* bool */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'exec_stream_ddl_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:240
--- pg_trickle::api::self_monitoring::setup_self_monitoring
-CREATE  FUNCTION pgtrickle."setup_self_monitoring"() RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'setup_self_monitoring_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2312
--- pg_trickle::api::helpers::convert_buffers_to_unlogged
-CREATE  FUNCTION pgtrickle."convert_buffers_to_unlogged"() RETURNS bigint /* Result < i64, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'convert_buffers_to_unlogged_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:757
--- pg_trickle::monitor::health::worker_pool_status
-CREATE  FUNCTION pgtrickle."worker_pool_status"() RETURNS TABLE (
-	"active_workers" INT,  /* i32 */
-	"max_workers" INT,  /* i32 */
-	"per_db_cap" INT,  /* i32 */
-	"parallel_mode" TEXT,  /* String */
-	"idle_workers" INT,  /* i32 */
-	"last_scheduler_tick_unix" bigint,  /* i64 */
-	"ring_overflow_count" bigint,  /* i64 */
-	"citus_failure_total" bigint  /* i64 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'worker_pool_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1019
--- pg_trickle::api::diagnostics::bootstrap_gate_status
-CREATE  FUNCTION pgtrickle."bootstrap_gate_status"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"schema_name" TEXT,  /* String */
-	"gated" bool,  /* bool */
-	"gated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"ungated_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"gated_by" TEXT,  /* Option < String > */
-	"gate_duration" interval,  /* Option < pgrx :: datum :: Interval > */
-	"affected_stream_tables" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'bootstrap_gate_status_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/snapshot.rs:212
--- pg_trickle::api::snapshot::snapshot_stream_table
-CREATE  FUNCTION pgtrickle."snapshot_stream_table"(
-	"p_name" TEXT, /* & str */
-	"p_target" TEXT DEFAULT NULL /* Option < & str > */
-) RETURNS TEXT /* String */
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'snapshot_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/scheduler_control.rs:61
--- pg_trickle::api::scheduler_control::pause_scheduler
-CREATE  FUNCTION pgtrickle."pause_scheduler"(
-	"nodes" TEXT[] /* pgrx :: Array < & str > */
-) RETURNS TEXT /* & '_ str */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pause_scheduler_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1769
--- pg_trickle::api::diagnostics::clear_caches
-CREATE  FUNCTION pgtrickle."clear_caches"() RETURNS bigint /* i64 */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'clear_caches_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/outbox.rs:190
--- pg_trickle::api::outbox::detach_outbox
-CREATE  FUNCTION pgtrickle."detach_outbox"(
-	"p_name" TEXT, /* & str */
-	"p_if_exists" bool DEFAULT false /* bool */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'detach_outbox_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:154
--- pg_trickle::api::diagnostics::parse_duration_seconds
-CREATE  FUNCTION pgtrickle."parse_duration_seconds"(
-	"input" TEXT /* & str */
-) RETURNS bigint /* Option < i64 > */
-IMMUTABLE STRICT PARALLEL SAFE 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'parse_duration_seconds_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:693
--- requires:
---   parse_duration_seconds
-
-
--- Convenience view: pg_stat_stream_tables
--- Combines catalog metadata with aggregate refresh statistics.
-CREATE OR REPLACE VIEW pgtrickle.pg_stat_stream_tables AS
-SELECT
-    st.pgt_id,
-    st.pgt_schema,
-    st.pgt_name,
-    st.status,
-    st.refresh_mode,
-    st.is_populated,
-    st.data_timestamp,
-    st.schedule,
-    now() - st.last_refresh_at AS staleness,
-    CASE WHEN st.schedule IS NOT NULL AND st.last_refresh_at IS NOT NULL
-              AND st.schedule !~ '[\s@]'
-         THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
-              pgtrickle.parse_duration_seconds(st.schedule)
-         ELSE NULL::boolean
-    END AS stale,
-    st.consecutive_errors,
-    st.needs_reinit,
-    st.last_refresh_at,
-    COALESCE(stats.total_refreshes, 0) AS total_refreshes,
-    COALESCE(stats.successful_refreshes, 0) AS successful_refreshes,
-    COALESCE(stats.failed_refreshes, 0) AS failed_refreshes,
-    COALESCE(stats.total_rows_inserted, 0) AS total_rows_inserted,
-    COALESCE(stats.total_rows_deleted, 0) AS total_rows_deleted,
-    stats.avg_duration_ms,
-    stats.last_action,
-    stats.last_status,
-    (SELECT array_agg(DISTINCT d.cdc_mode ORDER BY d.cdc_mode)
-     FROM pgtrickle.pgt_dependencies d
-     WHERE d.pgt_id = st.pgt_id AND d.source_type = 'TABLE') AS cdc_modes,
-    st.scc_id,
-    st.last_fixpoint_iterations,
-    st.refresh_tier
-FROM pgtrickle.pgt_stream_tables st
-LEFT JOIN LATERAL (
-    SELECT
-        count(*)::bigint AS total_refreshes,
-        count(*) FILTER (WHERE h.status = 'COMPLETED')::bigint AS successful_refreshes,
-        count(*) FILTER (WHERE h.status = 'FAILED')::bigint AS failed_refreshes,
-        COALESCE(sum(h.rows_inserted), 0)::bigint AS total_rows_inserted,
-        COALESCE(sum(h.rows_deleted), 0)::bigint AS total_rows_deleted,
-        CASE WHEN count(*) FILTER (WHERE h.end_time IS NOT NULL) > 0
-             THEN avg(EXTRACT(EPOCH FROM (h.end_time - h.start_time)) * 1000)
-                  FILTER (WHERE h.end_time IS NOT NULL)
-             ELSE NULL
-        END::float8 AS avg_duration_ms,
-        (SELECT h2.action FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_action,
-        (SELECT h2.status FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_status,
-        (SELECT h2.initiated_by FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS last_initiated_by,
-        (SELECT h2.freshness_deadline FROM pgtrickle.pgt_refresh_history h2
-         WHERE h2.pgt_id = st.pgt_id ORDER BY h2.refresh_id DESC LIMIT 1) AS freshness_deadline
-    FROM pgtrickle.pgt_refresh_history h
-    WHERE h.pgt_id = st.pgt_id
-) stats ON true;
-
--- Per-source CDC status view (G5): exposes cdc_mode, slot names, and
--- transition timestamps for every TABLE dependency of a stream table.
-CREATE OR REPLACE VIEW pgtrickle.pgt_cdc_status AS
-SELECT
-    st.pgt_schema,
-    st.pgt_name,
-    d.source_relid,
-    c.relname        AS source_name,
-    n.nspname        AS source_schema,
-    d.cdc_mode,
-    d.slot_name,
-    d.decoder_confirmed_lsn,
-    d.transition_started_at
-FROM pgtrickle.pgt_dependencies d
-JOIN pgtrickle.pgt_stream_tables st ON st.pgt_id = d.pgt_id
-JOIN pg_class c ON c.oid = d.source_relid
-JOIN pg_namespace n ON n.oid = c.relnamespace
-WHERE d.source_type = 'TABLE';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:608
--- requires:
---   parse_duration_seconds
-
-
--- Status overview view (ERR-1d: last_error_message and last_error_at are
--- included via st.* from pgt_stream_tables)
-CREATE OR REPLACE VIEW pgtrickle.stream_tables_info AS
-SELECT st.*,
-       now() - st.last_refresh_at AS staleness,
-       CASE WHEN st.schedule IS NOT NULL
-                 AND st.schedule !~ '[\s@]'
-            THEN EXTRACT(EPOCH FROM (now() - st.last_refresh_at)) >
-                 pgtrickle.parse_duration_seconds(st.schedule)
-            ELSE NULL::boolean
-       END AS stale,
-       CASE WHEN st.topk_limit IS NOT NULL THEN TRUE ELSE FALSE END AS is_topk
-FROM pgtrickle.pgt_stream_tables st;
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:781
--- requires:
---   parse_duration_seconds
-
-
--- ERG-E: One-row health summary for dashboards and alerting.
-CREATE OR REPLACE VIEW pgtrickle.quick_health AS
-SELECT
-    (SELECT count(*) FROM pgtrickle.pgt_stream_tables)::bigint
-        AS total_stream_tables,
-    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
-     WHERE status = 'ERROR' OR consecutive_errors > 0)::bigint
-        AS error_tables,
-    (SELECT count(*) FROM pgtrickle.pgt_stream_tables
-     WHERE schedule IS NOT NULL
-       AND schedule !~ '[\s@]'
-       AND last_refresh_at IS NOT NULL
-       AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
-           pgtrickle.parse_duration_seconds(schedule))::bigint
-        AS stale_tables,
-    (SELECT count(*) > 0 FROM pg_stat_activity
-     WHERE backend_type = 'pg_trickle scheduler')
-        AS scheduler_running,
-    CASE
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables) = 0 THEN 'EMPTY'
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'SUSPENDED') > 0 THEN 'CRITICAL'
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables WHERE status = 'ERROR' OR consecutive_errors > 0) > 0 THEN 'WARNING'
-        WHEN (SELECT count(*) FROM pgtrickle.pgt_stream_tables
-              WHERE schedule IS NOT NULL
-                AND schedule !~ '[\s@]'
-                AND last_refresh_at IS NOT NULL
-                AND EXTRACT(EPOCH FROM (now() - last_refresh_at)) >
-                    pgtrickle.parse_duration_seconds(schedule)) > 0 THEN 'WARNING'
-        ELSE 'OK'
-    END AS status;
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/refresh_ops.rs:36
--- pg_trickle::api::refresh_ops::write_and_refresh
-CREATE  FUNCTION pgtrickle."write_and_refresh"(
-	"sql" TEXT, /* & str */
-	"stream_table_name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'write_and_refresh_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
 -- src/api/outbox.rs:297
 -- pg_trickle::api::outbox::attach_embedding_outbox
 CREATE  FUNCTION pgtrickle."attach_embedding_outbox"(
@@ -1942,242 +2430,16 @@ AS 'MODULE_PATHNAME', 'attach_embedding_outbox_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/cluster.rs:18
--- pg_trickle::api::cluster::cluster_worker_summary
-CREATE  FUNCTION pgtrickle."cluster_worker_summary"() RETURNS TABLE (
-	"db_oid" bigint,  /* Option < i64 > */
-	"db_name" TEXT,  /* Option < String > */
-	"active_workers" INT,  /* Option < i32 > */
-	"scheduler_pid" INT,  /* Option < i32 > */
-	"scheduler_running" bool,  /* Option < bool > */
-	"total_active_workers" INT  /* Option < i32 > */
-)
+-- src/api/diagnostics.rs:1377
+-- pg_trickle::api::diagnostics::create_refresh_group
+CREATE  FUNCTION pgtrickle."create_refresh_group"(
+	"group_name" TEXT, /* & str */
+	"members" TEXT[], /* Vec < String > */
+	"isolation" TEXT DEFAULT 'read_committed' /* & str */
+) RETURNS INT /* Result < i32, PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'cluster_worker_summary_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1459
--- pg_trickle::api::diagnostics::refresh_groups
-CREATE  FUNCTION pgtrickle."refresh_groups"() RETURNS TABLE (
-	"group_id" INT,  /* i32 */
-	"group_name" TEXT,  /* String */
-	"member_count" INT,  /* i32 */
-	"isolation" TEXT,  /* String */
-	"created_at" timestamp with time zone  /* TimestampWithTimeZone */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_groups_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/tree.rs:18
--- pg_trickle::monitor::tree::dependency_tree
-CREATE  FUNCTION pgtrickle."dependency_tree"() RETURNS TABLE (
-	"tree_line" TEXT,  /* String */
-	"node" TEXT,  /* String */
-	"node_type" TEXT,  /* String */
-	"depth" INT,  /* i32 */
-	"status" TEXT,  /* Option < String > */
-	"refresh_mode" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'dependency_tree_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:748
--- pg_trickle::api::diagnostics::fuse_status
-CREATE  FUNCTION pgtrickle."fuse_status"() RETURNS TABLE (
-	"stream_table" TEXT,  /* String */
-	"fuse_mode" TEXT,  /* String */
-	"fuse_state" TEXT,  /* String */
-	"fuse_ceiling" bigint,  /* Option < i64 > */
-	"effective_ceiling" bigint,  /* Option < i64 > */
-	"fuse_sensitivity" INT,  /* Option < i32 > */
-	"blown_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"blow_reason" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'fuse_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/hooks.rs:51
--- pg_trickle::hooks::pg_trickle_on_ddl_end
--- Skipped due to `#[pgrx(sql = false)]`
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:561
--- pg_trickle::monitor::health::refresh_timeline
-CREATE  FUNCTION pgtrickle."refresh_timeline"(
-	"max_rows" INT DEFAULT 50 /* i32 */
-) RETURNS TABLE (
-	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
-	"stream_table" TEXT,  /* String */
-	"action" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"rows_inserted" bigint,  /* i64 */
-	"rows_deleted" bigint,  /* i64 */
-	"duration_ms" double precision,  /* Option < f64 > */
-	"error_message" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_timeline_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/alter.rs:2488
--- pg_trickle::api::alter::repair_stream_table
-CREATE  FUNCTION pgtrickle."repair_stream_table"(
-	"name" TEXT /* & str */
-) RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'repair_stream_table_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:698
--- pg_trickle::monitor::cache_stats
-CREATE  FUNCTION pgtrickle."cache_stats"() RETURNS TABLE (
-	"l1_hits" bigint,  /* i64 */
-	"l2_hits" bigint,  /* i64 */
-	"misses" bigint,  /* i64 */
-	"evictions" bigint,  /* i64 */
-	"l1_size" INT,  /* i32 */
-	"l1_bytes" bigint  /* i64 */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'cache_stats_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:1144
--- pg_trickle::monitor::explain_diff_sql
-CREATE  FUNCTION pgtrickle."explain_diff_sql"(
-	"name" TEXT /* & str */
-) RETURNS TEXT /* Option < String > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_diff_sql_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:1405
--- pg_trickle::monitor::check_cdc_health
-CREATE  FUNCTION pgtrickle."check_cdc_health"() RETURNS TABLE (
-	"source_relid" bigint,  /* i64 */
-	"source_table" TEXT,  /* String */
-	"cdc_mode" TEXT,  /* String */
-	"slot_name" TEXT,  /* Option < String > */
-	"lag_bytes" bigint,  /* Option < i64 > */
-	"confirmed_lsn" TEXT,  /* Option < String > */
-	"alert" TEXT,  /* Option < String > */
-	"selective_capture" bool  /* bool */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'check_cdc_health_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2673
--- pg_trickle::api::helpers::restore_stream_tables
-CREATE  FUNCTION pgtrickle."restore_stream_tables"() RETURNS VOID /* Result < (), crate :: error :: PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'restore_stream_tables_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:633
--- pg_trickle::monitor::st_auto_threshold
-CREATE  FUNCTION pgtrickle."st_auto_threshold"(
-	"name" TEXT /* & str */
-) RETURNS double precision /* Option < f64 > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'st_auto_threshold_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/scheduler_control.rs:132
--- pg_trickle::api::scheduler_control::resume_scheduler
-CREATE  FUNCTION pgtrickle."resume_scheduler"(
-	"nodes" TEXT[] /* pgrx :: Array < & str > */
-) RETURNS TEXT /* & '_ str */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'resume_scheduler_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1447
--- pg_trickle::api::diagnostics::drop_refresh_group
-CREATE  FUNCTION pgtrickle."drop_refresh_group"(
-	"group_name" TEXT /* & str */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_refresh_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:525
--- pg_trickle::monitor::get_refresh_history
-CREATE  FUNCTION pgtrickle."get_refresh_history"(
-	"name" TEXT, /* & str */
-	"max_rows" INT DEFAULT 20 /* i32 */
-) RETURNS TABLE (
-	"refresh_id" bigint,  /* i64 */
-	"data_timestamp" timestamp with time zone,  /* TimestampWithTimeZone */
-	"start_time" timestamp with time zone,  /* TimestampWithTimeZone */
-	"end_time" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"action" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"rows_inserted" bigint,  /* i64 */
-	"rows_deleted" bigint,  /* i64 */
-	"duration_ms" double precision,  /* Option < f64 > */
-	"error_message" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'get_refresh_history_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2524
--- pg_trickle::api::cdc_pause_status
-CREATE  FUNCTION pgtrickle."cdc_pause_status"() RETURNS TABLE (
-	"paused" bool,  /* bool */
-	"capture_mode" TEXT,  /* String */
-	"note" TEXT  /* String */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'cdc_pause_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/ivm.rs:712
--- pg_trickle::ivm::pgt_ivm_apply_delta
-CREATE  FUNCTION pgtrickle."pgt_ivm_apply_delta"(
-	"pgt_id" bigint, /* i64 */
-	"source_oid" INT, /* i32 */
-	"has_new" bool, /* bool */
-	"has_old" bool /* bool */
-) RETURNS VOID /* Result < (), PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'pgt_ivm_apply_delta_wrapper';
+AS 'MODULE_PATHNAME', 'create_refresh_group_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2196,121 +2458,53 @@ AS 'MODULE_PATHNAME', 'pgt_scc_status_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/snapshot.rs:321
--- pg_trickle::api::snapshot::restore_from_snapshot
-CREATE  FUNCTION pgtrickle."restore_from_snapshot"(
-	"p_name" TEXT, /* & str */
-	"p_source" TEXT /* & str */
+-- src/api/refresh_ops.rs:8
+-- pg_trickle::api::refresh_ops::refresh_stream_table
+CREATE  FUNCTION pgtrickle."refresh_stream_table"(
+	"name" TEXT /* & str */
 ) RETURNS void
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'restore_from_snapshot_wrapper';
+AS 'MODULE_PATHNAME', 'refresh_stream_table_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2138
--- pg_trickle::api::sla_summary
-CREATE  FUNCTION pgtrickle."sla_summary"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"p50_ms" double precision,  /* Option < f64 > */
-	"p99_ms" double precision,  /* Option < f64 > */
-	"freshness_lag_s" double precision,  /* Option < f64 > */
-	"error_rate" double precision,  /* Option < f64 > */
-	"error_budget_remaining" double precision  /* Option < f64 > */
+-- src/lib.rs:799
+-- requires:
+--   refresh_stream_table
+
+
+CREATE OR REPLACE FUNCTION pgtrickle."refresh_if_stale"(
+    p_name   text,
+    p_max_age interval DEFAULT '5 minutes'::interval
 )
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'sla_summary_wrapper';
-/* </end connected objects> */
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_last_end timestamp with time zone;
+    v_refreshed boolean := false;
+BEGIN
+    SELECT MAX(end_time)
+      INTO v_last_end
+      FROM pgtrickle.pgt_refresh_history h
+      JOIN pgtrickle.pgt_stream_tables   s USING (pgt_id)
+     WHERE s.pgt_name = p_name
+       AND h.status = 'COMPLETED';
 
-/* <begin connected objects> */
--- src/api/spec.rs:57
--- pg_trickle::api::spec::stream_table_spec
-CREATE  FUNCTION pgtrickle."stream_table_spec"(
-	"relid" oid /* pg_sys :: Oid */
-) RETURNS jsonb /* Option < pgrx :: JsonB > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_spec_wrapper';
-/* </end connected objects> */
+    IF v_last_end IS NULL OR (now() - v_last_end) > p_max_age THEN
+        PERFORM pgtrickle.refresh_stream_table(p_name);
+        v_refreshed := true;
+    END IF;
 
-/* <begin connected objects> */
--- src/api/diagnostics.rs:95
--- pg_trickle::api::diagnostics::_signal_launcher_rescan
-CREATE  FUNCTION pgtrickle."_signal_launcher_rescan"() RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', '_signal_launcher_rescan_wrapper';
-/* </end connected objects> */
+    RETURN v_refreshed;
+END;
+$$;
 
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:566
--- pg_trickle::api::self_monitoring::explain_dag
-CREATE  FUNCTION pgtrickle."explain_dag"(
-	"format" TEXT DEFAULT 'mermaid' /* Option < & str > */
-) RETURNS TEXT /* Option < String > */
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'explain_dag_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:23
--- pg_trickle::monitor::health::health_check
-CREATE  FUNCTION pgtrickle."health_check"() RETURNS TABLE (
-	"check_name" TEXT,  /* String */
-	"severity" TEXT,  /* String */
-	"detail" TEXT  /* String */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'health_check_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/spec.rs:74
--- pg_trickle::api::spec::stream_table_spec
-CREATE  FUNCTION pgtrickle."stream_table_spec"(
-	"qualified_name" TEXT /* & str */
-) RETURNS jsonb /* Option < pgrx :: JsonB > */
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_spec_by_name_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1168
--- pg_trickle::api::diagnostics::watermarks
-CREATE  FUNCTION pgtrickle."watermarks"() RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"schema_name" TEXT,  /* String */
-	"watermark" timestamp with time zone,  /* TimestampWithTimeZone */
-	"updated_at" timestamp with time zone,  /* TimestampWithTimeZone */
-	"advanced_by" TEXT,  /* Option < String > */
-	"wal_lsn" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'watermarks_fn_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:414
--- pg_trickle::monitor::health::health_summary
-CREATE  FUNCTION pgtrickle."health_summary"() RETURNS TABLE (
-	"total_stream_tables" INT,  /* i32 */
-	"active_count" INT,  /* i32 */
-	"error_count" INT,  /* i32 */
-	"suspended_count" INT,  /* i32 */
-	"stale_count" INT,  /* i32 */
-	"reinit_pending" INT,  /* i32 */
-	"max_staleness_seconds" double precision,  /* Option < f64 > */
-	"scheduler_status" TEXT,  /* String */
-	"cache_hit_rate" double precision  /* Option < f64 > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'health_summary_wrapper';
+COMMENT ON FUNCTION pgtrickle."refresh_if_stale"(text, interval) IS
+    'Refresh the named stream table only when the most recent completed '
+    'refresh is older than max_age.  Returns TRUE when a refresh was '
+    'triggered, FALSE when the table was fresh enough.';
 /* </end connected objects> */
 
 /* <begin connected objects> */
@@ -2331,246 +2525,53 @@ AS 'MODULE_PATHNAME', 'watermark_status_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/publication.rs:78
--- pg_trickle::api::publication::drop_stream_table_publication
-CREATE  FUNCTION pgtrickle."drop_stream_table_publication"(
-	"name" TEXT /* & str */
-) RETURNS void
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'drop_stream_table_publication_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:744
--- pg_trickle::monitor::reliability_counters
-CREATE  FUNCTION pgtrickle."reliability_counters"() RETURNS TABLE (
-	"invalidation_ring_overflows" bigint,  /* i64 */
-	"dag_cycles_detected" bigint,  /* i64 */
-	"template_cache_stale_evictions" bigint  /* i64 */
+-- src/api/diagnostics.rs:516
+-- pg_trickle::api::diagnostics::dedup_stats
+CREATE  FUNCTION pgtrickle."dedup_stats"() RETURNS TABLE (
+	"total_diff_refreshes" bigint,  /* i64 */
+	"dedup_needed" bigint,  /* i64 */
+	"dedup_ratio_pct" double precision  /* f64 */
 )
 STRICT  
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'reliability_counters_wrapper';
+AS 'MODULE_PATHNAME', 'dedup_stats_fn_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/diagnostics.rs:767
--- pg_trickle::diagnostics::validate_query
-CREATE  FUNCTION pgtrickle."validate_query"(
-	"query" TEXT /* & str */
-) RETURNS TABLE (
-	"check_name" TEXT,  /* String */
-	"result" TEXT,  /* String */
-	"severity" TEXT  /* String */
-)
+-- src/api/diagnostics.rs:1091
+-- pg_trickle::api::diagnostics::advance_watermark
+CREATE  FUNCTION pgtrickle."advance_watermark"(
+	"source" TEXT, /* & str */
+	"watermark" timestamp with time zone /* TimestampWithTimeZone */
+) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'validate_query_wrapper';
+AS 'MODULE_PATHNAME', 'advance_watermark_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/diagnostics.rs:8
--- pg_trickle::api::diagnostics::version
-CREATE  FUNCTION pgtrickle."version"() RETURNS TEXT /* & '_ str */
-IMMUTABLE STRICT PARALLEL SAFE 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'version_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2507
--- pg_trickle::api::is_drained
-CREATE  FUNCTION pgtrickle."is_drained"() RETURNS bool /* bool */
+-- src/api/mod.rs:1707
+-- pg_trickle::api::unsubscribe_distance
+CREATE  FUNCTION pgtrickle."unsubscribe_distance"(
+	"stream_table" TEXT, /* & str */
+	"channel" TEXT /* & str */
+) RETURNS VOID /* Result < (), PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'is_drained_wrapper';
+AS 'MODULE_PATHNAME', 'unsubscribe_distance_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/publication.rs:135
--- pg_trickle::api::publication::set_stream_table_sla
-CREATE  FUNCTION pgtrickle."set_stream_table_sla"(
-	"name" TEXT, /* & str */
-	"sla" interval /* Interval */
-) RETURNS void
+-- src/api/helpers.rs:2683
+-- pg_trickle::api::helpers::restore_stream_tables
+CREATE  FUNCTION pgtrickle."restore_stream_tables"() RETURNS VOID /* Result < (), crate :: error :: PgTrickleError > */
 STRICT 
 LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'set_stream_table_sla_wrapper';
+AS 'MODULE_PATHNAME', 'restore_stream_tables_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
--- src/api/mod.rs:2409
--- pg_trickle::api::view_evolution_status
-CREATE  FUNCTION pgtrickle."view_evolution_status"() RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"in_shadow_build" bool,  /* Option < bool > */
-	"shadow_table_name" TEXT,  /* Option < String > */
-	"status" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'view_evolution_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/metrics_ext.rs:25
--- pg_trickle::api::metrics_ext::metrics_summary
-CREATE  FUNCTION pgtrickle."metrics_summary"() RETURNS TABLE (
-	"db_name" TEXT,  /* Option < String > */
-	"total_stream_tables" bigint,  /* Option < i64 > */
-	"active_stream_tables" bigint,  /* Option < i64 > */
-	"suspended_stream_tables" bigint,  /* Option < i64 > */
-	"total_refreshes" bigint,  /* Option < i64 > */
-	"successful_refreshes" bigint,  /* Option < i64 > */
-	"failed_refreshes" bigint,  /* Option < i64 > */
-	"total_rows_processed" bigint,  /* Option < i64 > */
-	"active_workers" INT,  /* Option < i32 > */
-	"ivm_lock_parse_error_count" bigint,  /* Option < i64 > */
-	"holdback_probe_calls" bigint,  /* Option < i64 > */
-	"holdback_probe_cache_hits" bigint,  /* Option < i64 > */
-	"holdback_probe_avg_ms" double precision  /* Option < f64 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'metrics_summary_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/helpers.rs:2497
--- pg_trickle::api::helpers::refresh_efficiency
-CREATE  FUNCTION pgtrickle."refresh_efficiency"() RETURNS TABLE (
-	"pgt_schema" TEXT,  /* String */
-	"pgt_name" TEXT,  /* String */
-	"refresh_mode" TEXT,  /* String */
-	"total_refreshes" bigint,  /* i64 */
-	"diff_count" bigint,  /* i64 */
-	"full_count" bigint,  /* i64 */
-	"avg_diff_ms" double precision,  /* Option < f64 > */
-	"avg_full_ms" double precision,  /* Option < f64 > */
-	"avg_change_ratio" double precision,  /* Option < f64 > */
-	"diff_speedup" TEXT,  /* Option < String > */
-	"last_refresh_at" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'refresh_efficiency_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/self_monitoring.rs:358
--- pg_trickle::api::self_monitoring::self_monitoring_status
-CREATE  FUNCTION pgtrickle."self_monitoring_status"() RETURNS TABLE (
-	"st_name" TEXT,  /* String */
-	"exists" bool,  /* bool */
-	"status" TEXT,  /* Option < String > */
-	"refresh_mode" TEXT,  /* Option < String > */
-	"last_refresh_at" TEXT,  /* Option < String > */
-	"total_refreshes" bigint  /* Option < i64 > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'self_monitoring_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:2771
--- pg_trickle::api::stream_table_lineage
-CREATE  FUNCTION pgtrickle."stream_table_lineage"(
-	"name" TEXT /* & str */
-) RETURNS TABLE (
-	"output_col" TEXT,  /* Option < String > */
-	"source_table" TEXT,  /* Option < String > */
-	"source_col" TEXT  /* Option < String > */
-)
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'stream_table_lineage_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/health.rs:799
--- pg_trickle::monitor::health::parallel_job_status
-CREATE  FUNCTION pgtrickle."parallel_job_status"(
-	"max_age_seconds" INT DEFAULT 300 /* i32 */
-) RETURNS TABLE (
-	"job_id" bigint,  /* i64 */
-	"unit_key" TEXT,  /* String */
-	"unit_kind" TEXT,  /* String */
-	"status" TEXT,  /* String */
-	"member_count" INT,  /* i32 */
-	"attempt_no" INT,  /* i32 */
-	"scheduler_pid" INT,  /* i32 */
-	"worker_pid" INT,  /* Option < i32 > */
-	"enqueued_at" timestamp with time zone,  /* TimestampWithTimeZone */
-	"started_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"finished_at" timestamp with time zone,  /* Option < TimestampWithTimeZone > */
-	"duration_ms" double precision  /* Option < f64 > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'parallel_job_status_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:19
--- pg_trickle::api::diagnostics::version_check
-CREATE  FUNCTION pgtrickle."version_check"() RETURNS TEXT /* String */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'version_check_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/monitor/mod.rs:2012
--- pg_trickle::monitor::list_sources
-CREATE  FUNCTION pgtrickle."list_sources"(
-	"name" TEXT /* & str */
-) RETURNS TABLE (
-	"source_table" TEXT,  /* String */
-	"source_oid" bigint,  /* i64 */
-	"source_type" TEXT,  /* String */
-	"cdc_mode" TEXT,  /* String */
-	"columns_used" TEXT  /* Option < String > */
-)
-STRICT  
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_sources_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/diagnostics.rs:1123
--- pg_trickle::api::diagnostics::create_watermark_group
-CREATE  FUNCTION pgtrickle."create_watermark_group"(
-	"group_name" TEXT, /* & str */
-	"sources" TEXT[], /* Vec < String > */
-	"tolerance_secs" double precision DEFAULT 0.0 /* f64 */
-) RETURNS INT /* Result < i32, PgTrickleError > */
-STRICT 
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'create_watermark_group_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/api/mod.rs:1726
--- pg_trickle::api::list_distance_subscriptions
-CREATE  FUNCTION pgtrickle."list_distance_subscriptions"(
-	"p_stream_table" TEXT DEFAULT NULL /* Option < & str > */
-) RETURNS TABLE (
-	"stream_table" TEXT,  /* Option < String > */
-	"channel" TEXT,  /* Option < String > */
-	"vector_column" TEXT,  /* Option < String > */
-	"op" TEXT,  /* Option < String > */
-	"threshold" double precision,  /* Option < f64 > */
-	"created_at" timestamp with time zone  /* Option < pgrx :: datum :: TimestampWithTimeZone > */
-)
-
-LANGUAGE c /* Rust */
-AS 'MODULE_PATHNAME', 'list_distance_subscriptions_wrapper';
-/* </end connected objects> */
-
-/* <begin connected objects> */
--- src/lib.rs:1143
+-- src/lib.rs:1084
 -- requires:
 --   _signal_launcher_rescan
 

--- a/tests/generated/schema.rs
+++ b/tests/generated/schema.rs
@@ -73,6 +73,8 @@ CREATE TABLE IF NOT EXISTS pgtrickle.pgt_stream_tables (
     column_lineage  JSONB,
     
     defining_query_hash BIGINT NOT NULL DEFAULT 0,
+    
+    storage_fillfactor INT DEFAULT NULL CHECK (storage_fillfactor IS NULL OR (storage_fillfactor >= 10 AND storage_fillfactor <= 100)),
     created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
 );


### PR DESCRIPTION
## Problem

The Upgrade E2E CI jobs for `0.75.0 → 0.76.0` and `0.76.0 → 0.77.0` were
failing with:

```
SQL failed: error returned from database: syntax error at or near ")" at line 1236
SQL: CREATE EXTENSION pg_trickle VERSION '0.76.0' CASCADE
```

Both tests exercise `CREATE EXTENSION pg_trickle VERSION '0.76.0' CASCADE` —
one as the starting point of the upgrade, the other as the "fresh install"
baseline for the function-parity comparison test.

## Root Cause

`sql/archive/pg_trickle--0.76.0.sql` was incorrectly generated during commit
`e3dd350` ("refactor: remove all DuckLake integration"). The file contained:

1. **A syntax error** — pgrx's dependency-driven ordering placed objects in a
   different order than what PostgreSQL 18.4 expects for a specific function
   definition near line 1236 of the file.
2. **A missing column** — `storage_fillfactor` (introduced in v0.73.0) was
   absent from the `pgt_stream_tables` table definition.

The `sql/archive/pg_trickle--0.77.0.sql` archive was created by copying the
broken 0.76.0 archive (since v0.77.0 has no schema changes), so it had the
same defect (though it is restored from the correct pgrx-generated SQL inside
the upgrade Dockerfile, so the fresh-install tests were unaffected).

## Fix

Regenerated both archive files using `cargo pgrx schema pg18` against the
current v0.77.0 codebase. Since v0.77.0 introduces **no schema changes**
(the `0.76.0 → 0.77.0` migration script is a `SELECT 1` no-op), both archives
correctly represent the same schema.

The `storage_fillfactor` column is now present in the 0.76.0 archive. The
`0.75.0 → 0.76.0` upgrade script already adds this column via
`ADD COLUMN IF NOT EXISTS` (idempotent), so the upgrade path is unaffected.

`tests/generated/schema.rs` is regenerated automatically by `build.rs` via
`scripts/gen_test_schema.py` whenever the archive SQL changes — it now
includes the previously missing `storage_fillfactor` column.

## Validation

- `just check-upgrade-all` — passes (all 51 upgrade steps, zero new uncovered objects)
- `just lint` — passes (zero warnings, zero errors)
- CI upgrade E2E tests will validate the SQL is accepted by PostgreSQL 18.4

## Files Changed

| File | Change |
|------|--------|
| `sql/archive/pg_trickle--0.76.0.sql` | Regenerated from `cargo pgrx schema pg18` |
| `sql/archive/pg_trickle--0.77.0.sql` | Regenerated from `cargo pgrx schema pg18` |
| `tests/generated/schema.rs` | Auto-updated by `build.rs` to add `storage_fillfactor` |
