### PR TITLE
fix(dbt): restore catalog to '1m' after T-5 alter test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -991,6 +991,9 @@ jobs:
           dbt run --select order_totals_compat
           dbt test --select assert_compat_alter_applied
           mv models/marts/order_totals_compat.sql.bak models/marts/order_totals_compat.sql
+          # Restore catalog to '1m' so assert_compat_model_created passes in the
+          # general test run (catalog was left at '3m' after the alter above).
+          dbt run --select order_totals_compat
           # assert_compat_alter_applied requires the alter state; exclude it from
           # the general test run where the schedule is back to '1m'.
           dbt test --exclude assert_compat_alter_applied
@@ -1028,6 +1031,9 @@ jobs:
           dbt run --select order_totals_compat
           dbt test --select assert_compat_alter_applied
           mv models/marts/order_totals_compat.sql.bak models/marts/order_totals_compat.sql
+          # Restore catalog to '1m' so assert_compat_model_created passes in the
+          # general test run (catalog was left at '3m' after the alter above).
+          dbt run --select order_totals_compat
           # assert_compat_alter_applied requires the alter state; exclude it from
           # the general test run where the schedule is back to '1m'.
           dbt test --exclude assert_compat_alter_applied


### PR DESCRIPTION
## Summary

Fixes the `assert_compat_model_created` test failure in the dbt integration CI
job first observed in run
[#26681636600](https://github.com/trickle-labs/pg-trickle/actions/runs/26681636600).

---

## Root Cause

The T-5 alter flow in `ci.yml` (added in #881) had a catalog state bug:

1. `dbt run` creates `order_totals_compat` with `schedule = '1m'` ✓
2. T-5 alter: `sed` patches the model to `'3m'`, `dbt run --select` issues an
   `ALTER STREAM TABLE` → catalog now holds `'3m'`
3. `dbt test --select assert_compat_alter_applied` passes ✓
4. Model file is restored to `'1m'` — **but the catalog still has `'3m'`**
5. `dbt test --exclude assert_compat_alter_applied` runs, which includes
   `assert_compat_model_created`
6. `assert_compat_model_created` checks `schedule != '1m'` — catalog has `'3m'`
   → returns 1 row → **FAIL**

The local `run_dbt_tests.sh` script is unaffected because it runs an
unconditional `dbt run` (the "idempotent no-op" step) after the T-5 restore,
which issues an ALTER back to `'1m'` before any further tests run.
`ci.yml` had no such step.

## Fix

After restoring the model file to `'1m'`, add:

```bash
dbt run --select order_totals_compat
```

This issues the reverse ALTER (`'3m'` → `'1m'`) so the catalog is consistent
with the model before the general `dbt test` runs. Applied to both the
dbt 1.9 and dbt 1.10 steps in `ci.yml`.
